### PR TITLE
Require quality gates before main updates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "detach-release/**"
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ the providers separately.
 current-state engineering contracts. Tests and gates are executable evidence;
 they do not make stale prose correct.
 
+Use [ASD-STE100 Issue 9](https://www.asd-ste100.org/) for new or changed
+English text in `README.md` and `docs/`. Use short, direct sentences and one
+term for each meaning. Treat product names, paths, commands, and identifiers as
+project technical terms. Do not claim verified STE compliance without a review
+against the official standard.
+
 ## Context and specification policy
 
 - Keep this file under 200 lines and limited to rules needed on most tasks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,11 @@ the providers separately.
    `--resume latest` after a compatible interrupted or failed run.
 5. Review the final diff and evidence. Update the user contract or durable spec
    in the same change whenever behavior or an invariant changes.
-6. Unless the owner explicitly asks to keep work local, stage only task-scoped
-   files, inspect the staged public diff, commit after readiness passes, push
-   the current branch, and verify it is synchronized with its upstream.
+6. Unless the owner explicitly asks to keep work local, ordinary changes use a
+   topic branch: stage only task-scoped files, inspect the staged public diff,
+   commit after readiness passes, push, and merge only through a PR whose
+   required `quality-gates` job passed. Verify final `main` upstream parity.
+   `scripts/release-version` is the sole direct-`main` path.
 
 `README.md` is the user-facing contract. `docs/specs/` contains durable
 current-state engineering contracts. Tests and gates are executable evidence;

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -386,15 +386,16 @@ local and release readiness still require both. CI publishes its manifest,
 TSV, JUnit report, and logs for 14 days even when the gate passes, and also
 exposes the summary in the workflow UI. It does not copy a separate test matrix.
 
-The repository's active `main` ruleset has no bypass actors and requires the
-`quality-gates` job from the GitHub Actions integration. Pull requests and
-administrator pushes therefore cannot update `main` while that check is
-missing, pending, or failed. Release commits use the same policy rather than a
-bypass: the workflow pushes the exact version commit to
-`detach-release/vX.Y.Z`, waits for the push-triggered repository gate, rechecks
-that remote `main` did not move, and only then atomically advances `main` and
-the annotated tag. A failed run leaves the temporary ref for diagnosis and
-resume; a verified main/tag push removes only that matching ref.
+The active `main` ruleset has no bypass actors. It requires the `quality-gates`
+job from GitHub Actions. A pull request or an administrator push cannot update
+`main` when the check is missing, pending, or failed.
+
+A release commit uses the same policy. The release workflow pushes the exact
+version commit to `detach-release/vX.Y.Z`. It waits for the repository gate on
+that ref. Then it makes sure that remote `main` did not move. It atomically
+updates `main` and the annotated tag only after these checks pass. A failed run
+keeps the temporary ref for diagnosis and resume. A verified push removes only
+the matching temporary ref.
 
 ## Manual release-only gates
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -386,6 +386,16 @@ local and release readiness still require both. CI publishes its manifest,
 TSV, JUnit report, and logs for 14 days even when the gate passes, and also
 exposes the summary in the workflow UI. It does not copy a separate test matrix.
 
+The repository's active `main` ruleset has no bypass actors and requires the
+`quality-gates` job from the GitHub Actions integration. Pull requests and
+administrator pushes therefore cannot update `main` while that check is
+missing, pending, or failed. Release commits use the same policy rather than a
+bypass: the workflow pushes the exact version commit to
+`detach-release/vX.Y.Z`, waits for the push-triggered repository gate, rechecks
+that remote `main` did not move, and only then atomically advances `main` and
+the annotated tag. A failed run leaves the temporary ref for diagnosis and
+resume; a verified main/tag push removes only that matching ref.
+
 ## Manual release-only gates
 
 These are the only checks deliberately outside the automated repository gate:

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -17,6 +17,11 @@ against the same deterministic quality gate.
   crosses real subsystem boundaries.
 - `AGENTS.md` contains one small human-readable context map. There is no second
   routing DSL or tool for an agent to learn.
+- New or changed English text in `README.md` and `docs/` uses
+  [ASD-STE100 Issue 9](https://www.asd-ste100.org/). Product names, paths,
+  commands, and identifiers are project technical terms. A document does not
+  claim verified STE compliance unless a reviewer checks it against the
+  official standard.
 - Durable specs describe current contracts. Ignored `docs/work/` contains
   temporary executable plans. Imports are not used for detailed specs because
   Claude expands imports eagerly.
@@ -35,14 +40,14 @@ against the same deterministic quality gate.
   only for an evidenced unrelated external transient whose cause is recorded.
 - Hosted CI runs every selected functional check and timing-policy ratchet but
   does not enforce reference-machine wall or per-stage timing ceilings.
-- The active GitHub ruleset for `main` has no bypass actors and requires the
-  GitHub Actions `quality-gates` job. An unchecked administrator push is not a
-  substitute for CI; release commits first earn the same check on their
-  temporary release ref.
-- Ready task-scoped changes use a topic branch and are committed and pushed by
-  default after staged public-diff review; an owner request to keep work local
-  is the explicit exception. Successful delivery merges only after the
-  required PR check passes and includes final `main` upstream parity.
+- The active GitHub ruleset for `main` has no bypass actors. It requires the
+  GitHub Actions `quality-gates` job. An administrator cannot use an unchecked
+  push as a substitute for CI. A release commit first gets the same check on
+  its temporary release ref.
+- By default, put a ready task-scoped change on a topic branch. Review the
+  staged public diff, commit it, and push it. Merge it only after the required
+  PR check passes. Then verify that local `main` and upstream `main` are equal.
+  The owner can ask to keep the change local.
 - `tests/docs-contract.sh` enforces this structure and runs inside the
   static quality stage.
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -35,9 +35,14 @@ against the same deterministic quality gate.
   only for an evidenced unrelated external transient whose cause is recorded.
 - Hosted CI runs every selected functional check and timing-policy ratchet but
   does not enforce reference-machine wall or per-stage timing ceilings.
-- Ready task-scoped changes are committed and pushed to the current branch by
+- The active GitHub ruleset for `main` has no bypass actors and requires the
+  GitHub Actions `quality-gates` job. An unchecked administrator push is not a
+  substitute for CI; release commits first earn the same check on their
+  temporary release ref.
+- Ready task-scoped changes use a topic branch and are committed and pushed by
   default after staged public-diff review; an owner request to keep work local
-  is the explicit exception, and successful delivery includes upstream parity.
+  is the explicit exception. Successful delivery merges only after the
+  required PR check passes and includes final `main` upstream parity.
 - `tests/docs-contract.sh` enforces this structure and runs inside the
   static quality stage.
 

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -13,11 +13,11 @@ change real power state, upload assets, or claim publication.
 - Release starts from clean, synchronized `main`. The tracked `BUILD`
   must match the latest published manifest; `VERSION` and `BUILD`
   change together in one release commit.
-- After exact owner confirmation, that release commit is pushed to its unique
-  `detach-release/vX.Y.Z` ref and must pass the official GitHub Actions
-  `quality-gates` job. The workflow then rechecks unchanged remote `main`,
-  atomically pushes the exact approved commit and annotated tag, verifies both,
-  and removes only the matching temporary ref. No actor has a general `main`
+- After exact owner confirmation, push the release commit to its unique
+  `detach-release/vX.Y.Z` ref. The commit must pass the official GitHub Actions
+  `quality-gates` job. Then make sure that remote `main` did not change.
+  Atomically push the approved commit and annotated tag. Verify both refs and
+  remove only the matching temporary ref. No actor has a general `main`
   ruleset bypass.
 - The app, watchdog, bundled tmux, state helper, power client, root helper, and
   Sparkle executables contain only `arm64`. Intel Macs are unsupported.

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -13,6 +13,12 @@ change real power state, upload assets, or claim publication.
 - Release starts from clean, synchronized `main`. The tracked `BUILD`
   must match the latest published manifest; `VERSION` and `BUILD`
   change together in one release commit.
+- After exact owner confirmation, that release commit is pushed to its unique
+  `detach-release/vX.Y.Z` ref and must pass the official GitHub Actions
+  `quality-gates` job. The workflow then rechecks unchanged remote `main`,
+  atomically pushes the exact approved commit and annotated tag, verifies both,
+  and removes only the matching temporary ref. No actor has a general `main`
+  ruleset bypass.
 - The app, watchdog, bundled tmux, state helper, power client, root helper, and
   Sparkle executables contain only `arm64`. Intel Macs are unsupported.
 - The pinned tmux source build may reuse only an arm64 product keyed by the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -125,7 +125,11 @@ ignored owner-only `.env.release`, runs the complete suite before changing Git,
 requires the tracked root `BUILD` to match the latest published manifest,
 increments it together with `VERSION` in one release commit, creates one
 annotated tag, and requires an exact
-`owner/repository@tag` confirmation before an atomic push. It then reuses the
+`owner/repository@tag` confirmation before pushing the commit to a unique
+`detach-release/vX.Y.Z` ref. The official GitHub Actions `quality-gates` job
+must pass for that exact SHA; the workflow rechecks unchanged remote `main`,
+atomically pushes the approved commit and tag, verifies both, and removes the
+matching temporary ref. It then reuses the
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
 the signed candidate, runs the real power smoke, measures a supervised
 closed-lid probe, publishes, and independently downloads and hashes every

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,10 +126,10 @@ requires the tracked root `BUILD` to match the latest published manifest,
 increments it together with `VERSION` in one release commit, creates one
 annotated tag, and requires an exact
 `owner/repository@tag` confirmation before pushing the commit to a unique
-`detach-release/vX.Y.Z` ref. The official GitHub Actions `quality-gates` job
-must pass for that exact SHA; the workflow rechecks unchanged remote `main`,
-atomically pushes the approved commit and tag, verifies both, and removes the
-matching temporary ref. It then reuses the
+`detach-release/vX.Y.Z` ref. The exact commit must pass the official GitHub
+Actions `quality-gates` job. The workflow makes sure that remote `main` did not
+change. Then it atomically pushes the approved commit and tag. It verifies both
+refs and removes the matching temporary ref. It then reuses the
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
 the signed candidate, runs the real power smoke, measures a supervised
 closed-lid probe, publishes, and independently downloads and hashes every

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -193,6 +193,8 @@ validate_configuration() {
     die 'DETACH_GITHUB_REPOSITORY must be owner/repository'
   TAG="v$VERSION"
   [[ "$TAG" =~ ^v[0-9A-Za-z._+-]+$ ]] || die 'invalid release tag'
+  RELEASE_CI_BRANCH="detach-release/$TAG"
+  RELEASE_CI_REF="refs/heads/$RELEASE_CI_BRANCH"
   BUILD=""
   SOURCE_COMMIT=""
   RELEASE_COMMIT=""
@@ -535,24 +537,97 @@ exact_confirmation() {
   [ "$confirmation" = "$expected" ] || die "$purpose confirmation must exactly equal $expected"
 }
 
+release_ci_run_id() {
+  gh run list \
+    --repo "$REPOSITORY" \
+    --workflow quality-gates.yml \
+    --branch "$RELEASE_CI_BRANCH" \
+    --commit "$RELEASE_COMMIT" \
+    --event push \
+    --limit 10 \
+    --json databaseId,headSha \
+    --jq "map(select(.headSha == \"$RELEASE_COMMIT\")) | first | .databaseId // empty"
+}
+
+wait_for_release_ci() {
+  local run_id="" approval attempts=0
+
+  while [ "$attempts" -lt 60 ]; do
+    run_id="$(release_ci_run_id)"
+    [ -z "$run_id" ] || break
+    attempts=$((attempts + 1))
+    sleep 5
+  done
+  [[ "$run_id" =~ ^[1-9][0-9]*$ ]] || \
+    die "GitHub Actions did not start for $RELEASE_CI_BRANCH"
+  write_state_value release-ci-run-id "$run_id"
+  note "waiting for required quality-gates run $run_id on $RELEASE_CI_BRANCH"
+  gh run watch "$run_id" --repo "$REPOSITORY" --exit-status --interval 10 || \
+    die 'release CI did not pass; main and the release tag were not updated'
+  approval="$(gh run view "$run_id" \
+    --repo "$REPOSITORY" \
+    --json conclusion,event,headSha,jobs \
+    --jq "select(.conclusion == \"success\" and .event == \"push\" and .headSha == \"$RELEASE_COMMIT\") | [.jobs[] | select(.name == \"quality-gates\" and .conclusion == \"success\")] | length")"
+  [ "$approval" = 1 ] || \
+    die 'release CI result does not contain the successful required quality-gates job'
+  has_stage ci-approved || record_stage ci-approved
+}
+
+approve_release_source() {
+  local remote_ci
+
+  if has_stage ci-approved; then
+    return
+  fi
+  remote_ci="$(remote_ref_commit "$RELEASE_CI_REF")"
+  if [ -z "$remote_ci" ]; then
+    git -C "$ROOT" push origin "$RELEASE_COMMIT:$RELEASE_CI_REF"
+  else
+    [ "$remote_ci" = "$RELEASE_COMMIT" ] || \
+      die "remote release CI branch already points to a different commit: $RELEASE_CI_BRANCH"
+  fi
+  [ "$(remote_ref_commit "$RELEASE_CI_REF")" = "$RELEASE_COMMIT" ] || \
+    die 'remote release CI branch verification failed after push'
+  wait_for_release_ci
+}
+
+remove_release_ci_branch() {
+  local remote_ci
+
+  remote_ci="$(remote_ref_commit "$RELEASE_CI_REF")"
+  [ -n "$remote_ci" ] || return 0
+  [ "$remote_ci" = "$RELEASE_COMMIT" ] || \
+    die "refusing to remove changed release CI branch: $RELEASE_CI_BRANCH"
+  git -C "$ROOT" push origin ":$RELEASE_CI_REF"
+  [ -z "$(remote_ref_commit "$RELEASE_CI_REF")" ] || \
+    die 'remote release CI branch still exists after cleanup'
+}
+
 push_release_source() {
   local remote_main remote_tag
   remote_main="$(remote_ref_commit refs/heads/main)"
   remote_tag="$(remote_ref_commit "refs/tags/$TAG")"
   if [ "$remote_main" = "$RELEASE_COMMIT" ] && [ "$remote_tag" = "$RELEASE_COMMIT" ]; then
+    remove_release_ci_branch
     has_stage pushed || record_stage pushed
     return
   fi
   [ "$remote_main" = "$SOURCE_COMMIT" ] || die 'remote main changed before release push'
   [ -z "$remote_tag" ] || die 'remote release tag appeared with an unexpected state'
   exact_confirmation DETACH_CONFIRM_RELEASE \
-    "Release commit and annotated tag are ready; the next step pushes and later publishes $REPOSITORY@$TAG."
+    "Release commit and annotated tag are ready; the next step validates the commit in GitHub Actions, pushes it, and later publishes $REPOSITORY@$TAG."
+  approve_release_source
+  remote_main="$(remote_ref_commit refs/heads/main)"
+  remote_tag="$(remote_ref_commit "refs/tags/$TAG")"
+  [ "$remote_main" = "$SOURCE_COMMIT" ] || die 'remote main changed while release CI was running'
+  [ -z "$remote_tag" ] || die 'remote release tag appeared while release CI was running'
   git -C "$ROOT" push --atomic origin \
     "$RELEASE_COMMIT:refs/heads/main" "refs/tags/$TAG:refs/tags/$TAG"
   remote_main="$(remote_ref_commit refs/heads/main)"
   remote_tag="$(remote_ref_commit "refs/tags/$TAG")"
   [ "$remote_main" = "$RELEASE_COMMIT" ] && [ "$remote_tag" = "$RELEASE_COMMIT" ] || \
     die 'remote main/tag verification failed after push'
+  remove_release_ci_branch
   record_stage pushed
 }
 

--- a/tests/docs-contract.sh
+++ b/tests/docs-contract.sh
@@ -29,6 +29,11 @@ agent_bytes="$(wc -c <"$ROOT/AGENTS.md" | tr -d ' ')"
 ! grep -F '@docs/' "$ROOT/AGENTS.md" >/dev/null ||
   fail 'detailed specs must not be eagerly imported'
 
+for file in AGENTS.md docs/specs/documentation.md; do
+  grep -F '[ASD-STE100 Issue 9](https://www.asd-ste100.org/)' "$ROOT/$file" >/dev/null ||
+    fail "$file must define ASD-STE100 Issue 9 as the documentation standard"
+done
+
 required=(
   docs/specs/README.md
   docs/specs/runtime.md

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -77,6 +77,7 @@ production_plan() {
   local release_confirmation="${DETACH_TEST_RELEASE_CONFIRMATION:-$release_override}"
   (
     cd -P "$REPO"
+    GITHUB_ACTIONS= \
     DETACH_RELEASE_TIMING_OVERRIDE="$release_override" \
       DETACH_CONFIRM_RELEASE="$release_confirmation" \
       "$REPO/scripts/quality-gate" "$@"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -15,6 +15,8 @@ grep -F 'run: scripts/quality-gate --base "$BASE_SHA" --without-release-budget' 
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-gate --mode repository --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F -- '- "detach-release/**"' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 
 prepare_template() {
   local stage

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -458,81 +458,101 @@ run_resume_case() {
   [ -z "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
 }
 
-# The resumability matrix and the remaining rejection cases own disjoint
-# repositories below TMP_ROOT. Run the two independent lanes together so
-# the release contract does not serialize unrelated Git and fake-publication work.
-run_resume_case &
-resume_case_pid=$!
+run_timing_override_cases() {
+  setup_fixture timing-override-confirmation
+  expect_failure timing-override-confirmation \
+    "confirmation must exactly equal example/detach@$TARGET_TAG" \
+    run_workflow '' "example/detach@$TARGET_TAG" wrong-confirmation 1
+  [ ! -s "$ACTION_LOG" ]
 
-setup_fixture timing-override-confirmation
-expect_failure timing-override-confirmation \
-  "confirmation must exactly equal example/detach@$TARGET_TAG" \
-  run_workflow '' "example/detach@$TARGET_TAG" wrong-confirmation 1
-[ ! -s "$ACTION_LOG" ]
+  setup_fixture timing-override-invalid
+  expect_failure timing-override-invalid 'DETACH_RELEASE_IGNORE_TIMING must be 0 or 1' \
+    run_workflow '' "example/detach@$TARGET_TAG" "example/detach@$TARGET_TAG" invalid
+  [ ! -s "$ACTION_LOG" ]
 
-setup_fixture timing-override-invalid
-expect_failure timing-override-invalid 'DETACH_RELEASE_IGNORE_TIMING must be 0 or 1' \
-  run_workflow '' "example/detach@$TARGET_TAG" "example/detach@$TARGET_TAG" invalid
-[ ! -s "$ACTION_LOG" ]
-
-setup_fixture timing-override
-expect_failure timing-override 'injected safe failure after preflight' \
-  run_workflow preflight "example/detach@$TARGET_TAG" "example/detach@$TARGET_TAG" 1
-[ "$(<"$REPO/app/build/release-workflow/$TARGET_VERSION/timing-budget-enforced")" = false ]
-grep -F $'release_timing_override\t1' \
-  "$REPO"/app/build/quality-gates/*/environment.tsv >/dev/null
-! grep -F $'\trelease-budget\t' \
-  "$REPO"/app/build/quality-gates/*/summary.tsv >/dev/null
-run_workflow
-[ "$(<"$REPO/VERSION")" = "$TARGET_VERSION" ]
-[ "$(grep -c '^release$' "$ACTION_LOG")" = 1 ]
-[ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
-
-setup_fixture dirty
-printf '%s\n' dirty >"$REPO/untracked-note.txt"
-expect_failure dirty 'release workflow requires a clean worktree' run_workflow
-[ ! -s "$ACTION_LOG" ]
-
-setup_fixture stale-build
-printf '%s\n' 12 >"$REPO/BUILD"
-git -C "$REPO" add BUILD
-git -C "$REPO" commit -qm 'stale tracked build'
-git -C "$REPO" push -q origin main
-expect_failure stale-build 'tracked BUILD 12 does not match published build 13' run_workflow
-
-setup_fixture diverged
-printf '%s\n' local >>"$REPO/README.md"
-git -C "$REPO" add README.md
-git -C "$REPO" commit -qm 'local divergence'
-expect_failure diverged 'main must be synchronized with origin/main' run_workflow
-
-setup_fixture duplicate-tag
-git -C "$REPO" tag -a "$TARGET_TAG" -m duplicate
-expect_failure duplicate-tag "local tag already exists: $TARGET_TAG" run_workflow
-
-setup_fixture duplicate-release
-: >"$RELEASE_EXISTS"
-expect_failure duplicate-release "GitHub release already exists: $TARGET_TAG" run_workflow
-
-setup_fixture hardware-gate
-expect_failure hardware-gate \
-  "closed-lid hardware test confirmation must exactly equal example/detach@$TARGET_TAG" \
-  run_workflow '' wrong-confirmation
-[ ! -f "$RELEASE_EXISTS" ]
-! grep -q '^publish$' "$ACTION_LOG"
-
-setup_fixture remote-hash
-export FAKE_PUBLISH_CORRUPT=1
-expect_failure remote-hash 'published asset hash mismatch: Detach.dmg' run_workflow
-unset FAKE_PUBLISH_CORRUPT
-[ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-published" ]
-[ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
-
-resume_case_status=0
-wait "$resume_case_pid" || resume_case_status=$?
-[ "$resume_case_status" -eq 0 ] || {
-  printf 'release workflow resumability lane failed\n' >&2
-  exit "$resume_case_status"
+  setup_fixture timing-override
+  expect_failure timing-override 'injected safe failure after preflight' \
+    run_workflow preflight "example/detach@$TARGET_TAG" "example/detach@$TARGET_TAG" 1
+  [ "$(<"$REPO/app/build/release-workflow/$TARGET_VERSION/timing-budget-enforced")" = false ]
+  grep -F $'release_timing_override\t1' \
+    "$REPO"/app/build/quality-gates/*/environment.tsv >/dev/null
+  ! grep -F $'\trelease-budget\t' \
+    "$REPO"/app/build/quality-gates/*/summary.tsv >/dev/null
+  run_workflow
+  [ "$(<"$REPO/VERSION")" = "$TARGET_VERSION" ]
+  [ "$(grep -c '^release$' "$ACTION_LOG")" = 1 ]
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
 }
+
+run_preflight_rejection_cases() {
+  setup_fixture dirty
+  printf '%s\n' dirty >"$REPO/untracked-note.txt"
+  expect_failure dirty 'release workflow requires a clean worktree' run_workflow
+  [ ! -s "$ACTION_LOG" ]
+
+  setup_fixture stale-build
+  printf '%s\n' 12 >"$REPO/BUILD"
+  git -C "$REPO" add BUILD
+  git -C "$REPO" commit -qm 'stale tracked build'
+  git -C "$REPO" push -q origin main
+  expect_failure stale-build 'tracked BUILD 12 does not match published build 13' run_workflow
+
+  setup_fixture diverged
+  printf '%s\n' local >>"$REPO/README.md"
+  git -C "$REPO" add README.md
+  git -C "$REPO" commit -qm 'local divergence'
+  expect_failure diverged 'main must be synchronized with origin/main' run_workflow
+
+  setup_fixture duplicate-tag
+  git -C "$REPO" tag -a "$TARGET_TAG" -m duplicate
+  expect_failure duplicate-tag "local tag already exists: $TARGET_TAG" run_workflow
+
+  setup_fixture duplicate-release
+  : >"$RELEASE_EXISTS"
+  expect_failure duplicate-release "GitHub release already exists: $TARGET_TAG" run_workflow
+}
+
+run_hardware_rejection_case() {
+  setup_fixture hardware-gate
+  expect_failure hardware-gate \
+    "closed-lid hardware test confirmation must exactly equal example/detach@$TARGET_TAG" \
+    run_workflow '' wrong-confirmation
+  [ ! -f "$RELEASE_EXISTS" ]
+  ! grep -q '^publish$' "$ACTION_LOG"
+}
+
+run_remote_hash_case() {
+  setup_fixture remote-hash
+  export FAKE_PUBLISH_CORRUPT=1
+  expect_failure remote-hash 'published asset hash mismatch: Detach.dmg' run_workflow
+  unset FAKE_PUBLISH_CORRUPT
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-published" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
+}
+
+# Each lane owns a separate repository below TMP_ROOT. Run the lanes together.
+# This keeps independent Git and fake-publication work out of the critical path.
+release_case_pids=()
+release_case_names=()
+for release_case in \
+  run_resume_case \
+  run_timing_override_cases \
+  run_preflight_rejection_cases \
+  run_hardware_rejection_case \
+  run_remote_hash_case; do
+  "$release_case" &
+  release_case_pids+=("$!")
+  release_case_names+=("$release_case")
+done
+
+release_case_status=0
+for release_case_index in "${!release_case_pids[@]}"; do
+  if ! wait "${release_case_pids[$release_case_index]}"; then
+    printf 'release workflow lane failed: %s\n' \
+      "${release_case_names[$release_case_index]}" >&2
+    release_case_status=1
+  fi
+done
+[ "$release_case_status" -eq 0 ] || exit 1
 
 printf 'Detach release workflow tests passed\n'

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -275,6 +275,18 @@ SH
 set -eu
 case "${1:-} ${2:-}" in
   'auth status') exit 0 ;;
+  'run list') printf '%s\n' 4242 ;;
+  'run watch')
+    if [ "${FAKE_RELEASE_CI_ADVANCE_MAIN:-0}" = 1 ]; then
+      source_commit="$(git rev-parse HEAD^)"
+      source_tree="$(git rev-parse "$source_commit^{tree}")"
+      raced_commit="$(printf '%s\n' 'concurrent main update' | \
+        git commit-tree "$source_tree" -p "$source_commit")"
+      git push -q origin "$raced_commit:refs/heads/main"
+    fi
+    [ "${FAKE_RELEASE_CI_FAIL:-0}" != 1 ] || exit 23
+    ;;
+  'run view') printf '%s\n' 1 ;;
   'release view')
     [ -f "${FAKE_RELEASE_EXISTS:?}" ] || exit 1
     case " $* " in
@@ -395,7 +407,41 @@ expect_failure() {
 
 run_resume_case() {
   setup_fixture resume
-  for stage in preflight prepared pushed artifacts installed power-smoke lid published verified; do
+  for stage in preflight prepared; do
+    expect_failure "resume-$stage" "injected safe failure after $stage" \
+      run_workflow "$stage"
+  done
+  release_ci_source="$(git -C "$REPO" rev-parse HEAD^)"
+
+  git -C "$REPO" push -q origin \
+    "$release_ci_source:refs/heads/detach-release/$TARGET_TAG"
+  expect_failure release-ci-collision \
+    "remote release CI branch already points to a different commit: detach-release/$TARGET_TAG" \
+    run_workflow
+  git -C "$REPO" push -q origin ":refs/heads/detach-release/$TARGET_TAG"
+
+  export FAKE_RELEASE_CI_FAIL=1
+  expect_failure release-ci-failure \
+    'release CI did not pass; main and the release tag were not updated' \
+    run_workflow
+  unset FAKE_RELEASE_CI_FAIL
+  [ "$(git -C "$REPO" ls-remote origin refs/heads/main | awk '{print $1}')" = \
+    "$release_ci_source" ]
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/tags/$TARGET_TAG")" ]
+  [ -n "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-ci-approved" ]
+
+  export FAKE_RELEASE_CI_ADVANCE_MAIN=1
+  expect_failure release-ci-main-race 'remote main changed while release CI was running' \
+    run_workflow
+  unset FAKE_RELEASE_CI_ADVANCE_MAIN
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/tags/$TARGET_TAG")" ]
+  [ -n "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-ci-approved" ]
+
+  git -C "$REPO" push -q --force origin "$release_ci_source:refs/heads/main"
+
+  for stage in pushed artifacts installed power-smoke lid published verified; do
     expect_failure "resume-$stage" "injected safe failure after $stage" \
       run_workflow "$stage"
   done
@@ -409,11 +455,12 @@ run_resume_case() {
   [ "$(grep -c '^power-smoke$' "$ACTION_LOG")" = 1 ]
   [ "$(grep -c '^release-preflight.sh$' "$ACTION_LOG")" = 2 ]
   [ "$(grep -c '^publish-preflight.sh$' "$ACTION_LOG")" = 2 ]
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
 }
 
-# The resumability matrix and the independent rejection cases own disjoint
-# repositories below TMP_ROOT. Run those two lanes together so the release
-# contract does not serialize unrelated Git and fake-publication work.
+# The resumability matrix and the remaining rejection cases own disjoint
+# repositories below TMP_ROOT. Run the two independent lanes together so
+# the release contract does not serialize unrelated Git and fake-publication work.
 run_resume_case &
 resume_case_pid=$!
 


### PR DESCRIPTION
## Summary

- run repository CI for temporary release refs
- require the exact release commit to pass `quality-gates` before the atomic main/tag push
- add failure, collision, race, cleanup, and resume coverage
- document topic-branch and protected-main policy

## Verification

- `scripts/quality-gate --mode repository` — PASS
- release-workflow 58s / 70s budget