### PR TITLE
Harden install and update recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,14 @@ does not roll source code back and does not replace version control or backups.
 Updates are handled in Detach.app. Settings also exposes installation health,
 CLI repair, helper status, and removal of Detach-owned components.
 
+Detach changes the active CLI only after it validates a complete payload. If
+an update fails, the active CLI does not change. Move Detach to `/Applications`
+before you try an update. For a download failure, check the network connection
+and try again. For an archive, signature, or installation failure, download
+the latest DMG. If the CLI does not match the app, open Detach settings, select
+System, and run Repair. A live managed session can block the CLI change. End
+the session and try the update again.
+
 From a terminal:
 
 ```bash

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Delete session “%@”?" = "Delete session “%@”?";
 "Detach Background Service" = "Detach Background Service";
 "Detach background service" = "Detach background service";
+"Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again." = "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again.";
 "Detach checkpoint/state directories will be deleted. The ~/.codex and ~/.claude stores won't be affected." = "Detach checkpoint/state directories will be deleted. The ~/.codex and ~/.claude stores won't be affected.";
+"Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again." = "Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again.";
 "Detach must be in /Applications to update and run in the background." = "Detach must be in /Applications to update and run in the background.";
+"Detach rejected or could not install the update: %@. The active CLI did not change. Download the latest DMG. If the CLI does not match the app, open Detach settings, select System, and run Repair." = "Detach rejected or could not install the update: %@. The active CLI did not change. Download the latest DMG. If the CLI does not match the app, open Detach settings, select System, and run Repair.";
 "Detach uses both components to keep agents running reliably with the lid closed." = "Detach uses both components to keep agents running reliably with the lid closed.";
 "Detach.app is running from /Applications" = "Detach.app is running from /Applications";
 "Detach.app will remain in place and can reinstall the CLI." = "Detach.app will remain in place and can reinstall the CLI.";
@@ -177,7 +180,6 @@
 "Setting Up Detach…" = "Setting Up Detach…";
 "Something went wrong" = "Something went wrong";
 "Sparkle checks in the background on its own schedule." = "Sparkle checks in the background on its own schedule.";
-"Sparkle couldn't complete the update: %@" = "Sparkle couldn't complete the update: %@";
 "Start your first session" = "Start your first session";
 "Stop" = "Stop";
 "Technical Details" = "Technical Details";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Delete session “%@”?" = "Удалить сессию «%@»?";
 "Detach Background Service" = "Фоновая служба Detach";
 "Detach background service" = "Фоновая служба Detach";
+"Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again." = "Detach не может обновиться из текущего расположения. Переместите Detach в /Applications. Активный CLI не изменился. Затем повторите попытку.";
 "Detach checkpoint/state directories will be deleted. The ~/.codex and ~/.claude stores won't be affected." = "Будут удалены checkpoint/state-каталоги Detach. Хранилища ~/.codex и ~/.claude не затрагиваются.";
+"Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again." = "Detach не смог подготовить или скачать обновление: %@. Активный CLI не изменился. Проверьте подключение к сети и свободное место на диске. Затем повторите попытку.";
 "Detach must be in /Applications to update and run in the background." = "Detach должен находиться в /Applications, чтобы обновляться и работать в фоне.";
+"Detach rejected or could not install the update: %@. The active CLI did not change. Download the latest DMG. If the CLI does not match the app, open Detach settings, select System, and run Repair." = "Detach отклонил обновление или не смог его установить: %@. Активный CLI не изменился. Скачайте последний DMG. Если CLI не совпадает с приложением, откройте настройки Detach, выберите «Система» и запустите Repair.";
 "Detach uses both components to keep agents running reliably with the lid closed." = "Detach использует оба компонента для надёжной работы агентов при закрытой крышке.";
 "Detach.app is running from /Applications" = "Detach.app запущен из /Applications";
 "Detach.app will remain in place and can reinstall the CLI." = "Detach.app останется на месте и сможет установить CLI снова.";
@@ -177,7 +180,6 @@
 "Setting Up Detach…" = "Настраиваем Detach…";
 "Something went wrong" = "Не получилось";
 "Sparkle checks in the background on its own schedule." = "Проверки выполняет Sparkle в фоне по собственному расписанию.";
-"Sparkle couldn't complete the update: %@" = "Sparkle не смог завершить обновление: %@";
 "Start your first session" = "Запустите первую сессию";
 "Stop" = "Остановить";
 "Technical Details" = "Технические детали";

--- a/app/Sources/DetachApp/UpdaterService.swift
+++ b/app/Sources/DetachApp/UpdaterService.swift
@@ -29,6 +29,12 @@ final class UpdaterService: ObservableObject {
         case unavailable(reason: String)
     }
 
+    enum UpdateRecovery: Equatable {
+        case moveToApplications
+        case retryDownload
+        case reinstallAndRepair
+    }
+
     let availability: Availability
     let updaterController: SPUStandardUpdaterController
     let manualDownloadURL: URL?
@@ -168,18 +174,45 @@ final class UpdaterService: ObservableObject {
     }
 
     static func fallbackMessage(for error: Error?) -> String? {
+        guard let error, let recovery = recovery(for: error) else { return nil }
+
+        let nsError = error as NSError
+        switch recovery {
+        case .moveToApplications:
+            return L10n.string(
+                "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again.")
+        case .retryDownload:
+            return L10n.format(
+                "Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again.",
+                nsError.localizedDescription)
+        case .reinstallAndRepair:
+            return L10n.format(
+                "Detach rejected or could not install the update: %@. The active CLI did not change. Download the latest DMG. If the CLI does not match the app, open Detach settings, select System, and run Repair.",
+                nsError.localizedDescription)
+        }
+    }
+
+    static func recovery(for error: Error?) -> UpdateRecovery? {
         guard let error else { return nil }
 
         let nsError = error as NSError
-        // A normal "no update" result and explicit user cancellation are not
-        // failures that warrant sending the user to a manual download.
-        let nonActionableSparkleErrorCodes = [1001, 4007, 4008]
-        guard nsError.domain != SUSparkleErrorDomain
-                || !nonActionableSparkleErrorCodes.contains(nsError.code) else {
-            return nil
+        guard nsError.domain == SUSparkleErrorDomain else {
+            return .reinstallAndRepair
         }
-        return L10n.format(
-            "Sparkle couldn't complete the update: %@", nsError.localizedDescription)
+        switch nsError.code {
+        case 1001, 4007, 4008:
+            // No update, user cancellation, and deferred authorization do not
+            // need a recovery action.
+            return nil
+        case 1003, 1005:
+            // The app is on a disk image or in App Translocation.
+            return .moveToApplications
+        case 2000, 2001:
+            // Sparkle could not create its temporary directory or download.
+            return .retryDownload
+        default:
+            return .reinstallAndRepair
+        }
     }
 
 }

--- a/app/Tests/DetachAppTests/UpdaterServiceTests.swift
+++ b/app/Tests/DetachAppTests/UpdaterServiceTests.swift
@@ -25,19 +25,65 @@ final class UpdaterServiceTests: XCTestCase {
         for code in [1001, 4007, 4008] {
             let error = NSError(domain: SUSparkleErrorDomain, code: code)
             XCTAssertNil(UpdaterService.fallbackMessage(for: error))
+            XCTAssertNil(UpdaterService.recovery(for: error))
         }
         XCTAssertNil(UpdaterService.fallbackMessage(for: nil))
+        XCTAssertNil(UpdaterService.recovery(for: nil))
     }
 
-    func testUpdateErrorOffersFallbackWithUsefulMessage() {
+    func testDownloadErrorKeepsTheActiveCLIAndOffersRetry() {
         let error = NSError(
             domain: SUSparkleErrorDomain,
             code: 2001,
             userInfo: [NSLocalizedDescriptionKey: "Download failed"])
 
+        XCTAssertEqual(UpdaterService.recovery(for: error), .retryDownload)
         XCTAssertEqual(
             UpdaterService.fallbackMessage(for: error),
-            L10n.format("Sparkle couldn't complete the update: %@", "Download failed"))
+            L10n.format(
+                "Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again.",
+                "Download failed"))
+    }
+
+    func testFailureMatrixSelectsARecoveryAndDoesNotClaimCurrentVersion() throws {
+        let cases: [(label: String, code: Int, recovery: UpdaterService.UpdateRecovery)] = [
+            ("read-only DMG", 1003, .moveToApplications),
+            ("App Translocation", 1005, .moveToApplications),
+            ("temporary directory", 2000, .retryDownload),
+            ("offline download", 2001, .retryDownload),
+            ("bad archive", 3000, .reinstallAndRepair),
+            ("bad signature", 3001, .reinstallAndRepair),
+            ("failed validation", 3002, .reinstallAndRepair),
+            ("file copy", 4000, .reinstallAndRepair),
+            ("installation", 4005, .reinstallAndRepair),
+            ("invalid update", 4009, .reinstallAndRepair),
+            ("read-only destination", 4012, .reinstallAndRepair),
+        ]
+
+        for item in cases {
+            let error = NSError(
+                domain: SUSparkleErrorDomain,
+                code: item.code,
+                userInfo: [NSLocalizedDescriptionKey: item.label])
+            let message = try XCTUnwrap(
+                UpdaterService.fallbackMessage(for: error),
+                "Missing recovery message for \(item.label)")
+
+            XCTAssertEqual(UpdaterService.recovery(for: error), item.recovery, item.label)
+            XCTAssertTrue(message.contains("The active CLI did not change."), item.label)
+            XCTAssertFalse(UpdaterService.provesApplicationIsCurrent(error), item.label)
+        }
+    }
+
+    func testUnknownErrorUsesReinstallAndRepairRecovery() {
+        let error = NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileWriteUnknownError,
+            userInfo: [NSLocalizedDescriptionKey: "Write failed"])
+
+        XCTAssertEqual(UpdaterService.recovery(for: error), .reinstallAndRepair)
+        XCTAssertTrue(
+            UpdaterService.fallbackMessage(for: error)?.contains("run Repair") == true)
     }
 
     func testOnlyOnLatestVersionReasonsProveTheApplicationIsCurrent() {

--- a/app/Tests/DetachKitTests/LocalizationTests.swift
+++ b/app/Tests/DetachKitTests/LocalizationTests.swift
@@ -116,6 +116,26 @@ final class LocalizationTests: XCTestCase {
         }
     }
 
+    func testUpdateNotificationAndBackgroundFlowsHaveBothLocales() throws {
+        let english = try stringsDictionary(language: "en")
+        let russian = try stringsDictionary(language: "ru")
+        let keys = [
+            "Allow notifications",
+            "Open System Settings",
+            "macOS asks you once to allow Detach to run in the background.",
+            "macOS doesn't show the prompt again after a denial. Allow notifications for Detach in System Settings.",
+            "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again.",
+            "Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again.",
+            "Detach rejected or could not install the update: %@. The active CLI did not change. Download the latest DMG. If the CLI does not match the app, open Detach settings, select System, and run Repair.",
+        ]
+
+        for key in keys {
+            XCTAssertEqual(english[key], key)
+            XCTAssertNotNil(russian[key])
+            XCTAssertNotEqual(russian[key], key)
+        }
+    }
+
     private func stringsDictionary(language: String) throws -> [String: String] {
         let url = resources.bundleURL
             .appendingPathComponent("\(language).lproj/Localizable.strings")

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -175,4 +175,12 @@ in `/Applications` with a valid HTTPS feed URL and 32-byte Ed25519 public key.
 A generated or published appcast must contain exactly one arm64 hardware
 requirement so Intel clients are never offered the unsupported update.
 A Sparkle update replaces only the app; bootstrap atomically activates its new
-immutable CLI payload without rewriting live-session binaries.
+immutable CLI payload without rewriting live-session binaries. Sparkle errors
+for a disk image or App Translocation tell the user to move Detach to
+`/Applications`. Temporary-directory and download errors tell the user to
+check the network and free disk space, then try again. Archive, signature,
+validation, and installation errors provide the manual DMG path and the
+Settings > System Repair path. These errors state that the active CLI did not
+change. If app
+replacement completes but CLI or helper synchronization fails, the prior CLI
+stays active and Repair remains available.

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -31,6 +31,12 @@ change real power state, upload assets, or claim publication.
   closed-lid testing are mandatory release gates and are never inferred from
   unit tests. The protected lid probe must emit its first liveness sample within
   a bounded ten-second launch window before owner confirmation is accepted.
+- Automated release tests cover failed install and update paths. After the
+  signed artifacts exist, the owner must complete the short clean-account or VM
+  checklist in `docs/testing.md`. The workflow requires exact
+  `owner/repository@tag` confirmation before it installs the local candidate or
+  starts the signed power and lid gates. This checklist does not repeat those
+  hardware gates.
 - Publication requires exact `owner/repository@tag` confirmation. After
   upload, every remote asset is downloaded and its digest independently
   matched. Missing, extra, changed, or mismatched assets fail closed.
@@ -48,7 +54,10 @@ change real power state, upload assets, or claim publication.
   arm64 hardware requirement.
 - Distribution bootstrap runs only from `/Applications`, never a DMG or
   App Translocation path. A Sparkle update replaces the app; bootstrap switches
-  the CLI payload without rewriting binaries used by live sessions.
+  the CLI payload without rewriting binaries used by live sessions. A failed
+  download, archive, signature, app installation, CLI synchronization, or
+  helper replacement keeps the prior app or CLI control path usable and
+  provides a Repair path.
 
 ## Owned paths
 

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -2,11 +2,9 @@
 
 ## Installed distribution
 
-The repository copies are not what runs on the machine. Detach.app installs an
-immutable payload under
-`~/.local/libexec/detach/versions/<semver>-<hash>/` and atomically switches
-`~/.local/bin/detach`. The installed payload contains, in fixed manifest and
-hash order:
+Detach.app installs an immutable payload under
+`~/.local/libexec/detach/versions/<semver>-<hash>/`. It switches
+`~/.local/bin/detach` atomically. Order:
 
 1. `detach`
 2. `detach-core`
@@ -15,24 +13,26 @@ hash order:
 5. `detach-power`
 6. `tmux`
 
-Installation owns one idempotent PATH entry for login and interactive shells.
-Uninstall restores an unchanged profile byte-for-byte, or removes only the
-exact Detach-owned entry if the user changed other content. Edits to `bin/` or
-the native helpers take effect only after app synchronization or Repair.
+Install and Repair validate a complete payload before CLI activation. Failure
+keeps the active payload. A live or retained managed session blocks
+replacement; retry can succeed later. One PATH entry supports login
+and interactive modes. `--keep-state` preserves checkpoints across reinstall.
+`--purge-state` removes Detach state, not `~/.codex` or `~/.claude`. Uninstall
+restores an unchanged profile, or removes only the Detach entry from a changed
+profile. Source edits require app sync or Repair.
 
-App installation additionally registers the bundled power LaunchDaemon and
-signed per-user watchdog through `SMAppService`. The root helper needs one-time
-administrator approval. Do not recreate the removed portable CLI LaunchAgent.
+The app registers its power LaunchDaemon and per-user watchdog with
+`SMAppService`. The root helper needs one administrator approval. The portable
+CLI LaunchAgent stays removed.
 
 ## Runtime architecture
 
 ### Shell entry points
 
-- **`bin/detach`** is the only command exposed on PATH. It resolves all owned
-  executables as immutable siblings, selects `codex` or `claude`, owns the
-  cross-provider `list`, UUID-aware `resume`, storage and reconcile previews,
-  `power status`, configuration, doctor, repair, and uninstall surfaces, then
-  invokes the core.
+- **`bin/detach`** is the only command on PATH. It resolves owned executables as
+  immutable siblings and selects `codex` or `claude`. It owns cross-provider
+  `list`, UUID-aware `resume`, storage and reconcile previews, `power status`,
+  config, doctor, repair, and uninstall. Then it invokes the core.
 - **`bin/detach-core`** owns the provider-neutral session lifecycle, inline
   provider adaptations, checkpoint/recovery policy, tmux status, and internal
   self-reinvocation commands. It rejects direct invocation unless the frontend

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -133,7 +133,8 @@ refs and removes the matching temporary ref. It then reuses the
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
 the signed candidate, runs the real power smoke, measures a supervised
 closed-lid probe, publishes, and independently downloads and hashes every
-remote asset. Its private resume state lives under ignored `app/build/`.
+remote asset. Before local installation, it stops for the clean-install
+checklist below. Its private resume state lives under ignored `app/build/`.
 Set `DETACH_RELEASE_IGNORE_TIMING=1` only when the owner explicitly accepts
 busy-machine timing for that single release; the script requires the same exact
 release-target confirmation before it omits reference-machine timing checks.
@@ -141,3 +142,30 @@ Interrupted draft uploads may resume only after every existing asset digest is
 matched; an unexpected or changed asset fails closed. Do not run the two
 low-level scripts manually during a normal release. Do not run, tag, notarize,
 upload, or publish as part of ordinary implementation or verification.
+
+## Clean installation and system UI release checklist
+
+Run this checklist once for each signed release candidate. Automated tests
+cover Repair, keep/purge Uninstall, reinstall, failed updates, CLI
+synchronization, and helper replacement. This checklist covers only Finder and
+real macOS approval UI.
+
+1. Start a clean macOS 26 or later Apple Silicon account or VM in English.
+   Open the signed DMG. Confirm that Detach blocks setup from the DMG and tells
+   you to move the app. Use Finder to copy Detach to `/Applications`.
+2. Complete onboarding. Approve the background item and power helper. Allow
+   notifications. Confirm that Detach detects an authenticated provider. Start
+   the first managed session. Close the terminal and Detach, then reopen Detach
+   and confirm that the session is still live.
+3. In a second clean user account, select Russian. Deny notification access.
+   Confirm that the retry action opens System Settings. Confirm that the
+   background-item approval text and action are in Russian.
+4. Record the candidate tag and the result in private release notes. Do not run
+   the signed power smoke or closed-lid test as part of this checklist. Those
+   tests are separate release gates.
+
+After the checklist passes, resume the workflow with the exact release target:
+
+```bash
+DETACH_CONFIRM_INSTALL_MATRIX=owner/repository@vX.Y.Z scripts/release-version X.Y.Z
+```

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -670,6 +670,16 @@ build_release_artifacts() {
   has_stage artifacts || record_stage artifacts
 }
 
+confirm_install_update_matrix() {
+  has_stage install-matrix && return
+  release_artifacts_valid || die 'release artifacts changed before install-matrix review'
+  printf '%s\n' \
+    'Complete the clean installation and update checklist in docs/testing.md with the signed Detach.dmg. Use a clean macOS account or VM. Do not reuse the signed power or lid tests as evidence.'
+  exact_confirmation DETACH_CONFIRM_INSTALL_MATRIX \
+    'clean installation and update matrix'
+  record_stage install-matrix
+}
+
 installed_candidate_valid() {
   [ -d "$INSTALLED_APP" ] && [ ! -L "$INSTALLED_APP" ] || return 1
   [ "$(file_line "$INSTALLED_APP/Contents/Resources/DetachCLI/VERSION" 2>/dev/null || true)" = "$VERSION" ] || return 1
@@ -911,6 +921,7 @@ run_locked() {
   prepare_release_commit
   push_release_source
   build_release_artifacts
+  confirm_install_update_matrix
   install_release_candidate
   run_power_smoke
   run_lid_test

--- a/tests/distribution.sh
+++ b/tests/distribution.sh
@@ -381,6 +381,14 @@ grep -Fx 'core target sentinel' "$core_symlink_target/sentinel" >/dev/null
 [ ! -e "$core_safe_locks" ]
 [ "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")" = "$old_target" ]
 
+# The same update succeeds after the managed session is gone. Activation uses
+# the complete new payload and leaves the prior immutable payload available.
+"$payload_guard/detach-install" install --source app \
+  --payload-dir "$payload_guard" --version-file "$payload_guard/VERSION"
+[ "$("$DETACH_INSTALL_BIN_DIR/detach" __version)" = 0.1.1 ]
+[ "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")" != "$old_target" ]
+[ -d "$(dirname "$old_target")" ]
+
 # An unmanaged session on the same default server does not block the upgrade.
 # The upgrade also removes the obsolete portable Amphetamine watchdog only
 # after proving no legacy managed session remains.
@@ -648,6 +656,9 @@ rm -f "$DETACH_CONFIG_ROOT/config"
 "$payload_v2/detach-install" install --source install.sh --payload-dir "$payload_v2" \
   --version-file "$payload_v2/VERSION"
 ! grep -F 'AMPHETAMINE=' "$DETACH_CONFIG_ROOT/config" >/dev/null
+grep -Fx sentinel "$DETACH_CODEX_STATE_ROOT/sessions/kept/value" >/dev/null
+[ "$("$DETACH_INSTALL_BIN_DIR/detach" __version)" = 0.2.0 ]
+[ -x "$DETACH_INSTALL_BIN_DIR/detach" ]
 mkdir -p "$HOME/.codex"
 printf '%s\n' provider-sentinel >"$HOME/.codex/must-survive"
 DETACH_CODEX_STATE_ROOT="$HOME/.local/state/../../.codex" \

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -369,6 +369,7 @@ SH
 run_workflow() {
   local fail_after="${1:-}" lid_confirmation="${2:-example/detach@$TARGET_TAG}"
   local release_confirmation="${3:-example/detach@$TARGET_TAG}" ignore_timing="${4:-0}"
+  local install_confirmation="${5:-example/detach@$TARGET_TAG}"
   (
     cd -P "$REPO"
     PATH="$BIN:/usr/bin:/bin" \
@@ -386,6 +387,7 @@ run_workflow() {
       DETACH_RELEASE_TEST_FAIL_AFTER="$fail_after" \
       DETACH_RELEASE_IGNORE_TIMING="$ignore_timing" \
       DETACH_CONFIRM_RELEASE="$release_confirmation" \
+      DETACH_CONFIRM_INSTALL_MATRIX="$install_confirmation" \
       DETACH_CONFIRM_LID_TEST="$lid_confirmation" \
       "$REPO/scripts/release-version" "$TARGET_VERSION"
   )
@@ -441,7 +443,7 @@ run_resume_case() {
 
   git -C "$REPO" push -q --force origin "$release_ci_source:refs/heads/main"
 
-  for stage in pushed artifacts installed power-smoke lid published verified; do
+  for stage in pushed artifacts install-matrix installed power-smoke lid published verified; do
     expect_failure "resume-$stage" "injected safe failure after $stage" \
       run_workflow "$stage"
   done
@@ -514,6 +516,15 @@ run_preflight_rejection_cases() {
 
 run_hardware_rejection_case() {
   setup_fixture hardware-gate
+  expect_failure install-matrix-gate \
+    "clean installation and update matrix confirmation must exactly equal example/detach@$TARGET_TAG" \
+    run_workflow '' "example/detach@$TARGET_TAG" \
+      "example/detach@$TARGET_TAG" 0 wrong-confirmation
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-artifacts" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-install-matrix" ]
+  ! grep -q '^power-smoke$' "$ACTION_LOG"
+  ! grep -q '^publish$' "$ACTION_LOG"
+
   expect_failure hardware-gate \
     "closed-lid hardware test confirmation must exactly equal example/detach@$TARGET_TAG" \
     run_workflow '' wrong-confirmation


### PR DESCRIPTION
## Summary
- classify Sparkle failures and show localized recovery paths
- prove live-session retry and keep-state reinstall behavior
- require a clean-account system UI checklist before hardware release gates
- synchronize README and durable specs with the failure contract

## Verification
- scripts/quality-gate: PASS, policy 11, fingerprint 0e096293d34737c6fd4f0079e562c5f9cac4f708d3b0b3c6f1977315f0b02978
- focused Sparkle and localization tests: 12 passed
- focused setup, helper, notification, and distribution client tests: 144 passed
- tests/distribution.sh: PASS
- tests/release-workflow.sh: PASS

The release-only clean-account checklist and signed power/lid gates were not run.