### PR TITLE
Fix terminal launch through zsh startup prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ detach claude --detach -- "run the test suite and fix failures"
 The app and CLI operate on the same sessions. Start in one and continue in the
 other.
 
-When a terminal shell pauses at a startup prompt, such as an oh-my-zsh update,
-the app-launched command stays queued until that prompt is answered.
+When the terminal uses zsh, Detach starts the temporary command before it loads
+the user's shell startup files. A startup prompt, such as an oh-my-zsh update,
+can pause the command but cannot consume its file path. Answer the prompt to
+continue.
 
 ## One command center for Codex and Claude Code
 

--- a/app/Sources/DetachKit/TerminalLauncher.swift
+++ b/app/Sources/DetachKit/TerminalLauncher.swift
@@ -92,9 +92,7 @@ public enum TerminalLauncher {
     ) async throws {
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Void, Error>) in
-            let configuration = NSWorkspace.OpenConfiguration()
-            configuration.activates = true
-            configuration.addsToRecentItems = false
+            let configuration = openConfiguration(commandURL: commandURL)
             NSWorkspace.shared.open(
                 [commandURL],
                 withApplicationAt: applicationURL,
@@ -106,6 +104,24 @@ public enum TerminalLauncher {
                     }
                 }
         }
+    }
+
+    @MainActor
+    static func openConfiguration(commandURL: URL) -> NSWorkspace.OpenConfiguration {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        configuration.addsToRecentItems = false
+
+        // Terminal runs a .command document by typing its path into a new
+        // interactive shell. A startup hook that reads one key, such as the
+        // oh-my-zsh update prompt, can otherwise consume the leading slash.
+        // A fresh application instance is required because NSWorkspace only
+        // applies launch environment variables to a new process.
+        configuration.createsNewApplicationInstance = true
+        configuration.environment = [
+            "ZDOTDIR": commandURL.deletingLastPathComponent().path
+        ]
+        return configuration
     }
 
     static func commandFileContents(command: String) throws -> Data {
@@ -120,7 +136,7 @@ public enum TerminalLauncher {
         /bin/rm -f -- "$command_file" || exit 125
         [[ ! -e "$command_file" ]] || exit 125
         /bin/rmdir -- "$command_dir" 2>/dev/null || true
-        unset command_file command_dir
+        unset command_file command_dir ZDOTDIR
         exec /bin/zsh -lic \(shellQuoted(command))
 
         """

--- a/app/Tests/DetachKitTests/TerminalLauncherTests.swift
+++ b/app/Tests/DetachKitTests/TerminalLauncherTests.swift
@@ -43,7 +43,22 @@ final class TerminalLauncherTests: XCTestCase {
             try XCTUnwrap(contents.range(of: "exec /bin/zsh -lic")?.lowerBound))
         XCTAssertTrue(contents.contains("[[ ! -e \"$command_file\" ]] || exit 125"))
         XCTAssertTrue(contents.contains("/bin/rmdir -- \"$command_dir\""))
+        XCTAssertTrue(contents.contains("unset command_file command_dir ZDOTDIR"))
         XCTAssertTrue(contents.contains("exec /bin/zsh -lic \(shellQuoted(command))"))
+    }
+
+    @MainActor
+    func testLaunchUsesPrivateOuterZshStartupDirectory() throws {
+        let url = try TerminalLauncher.writeCommandFile(
+            command: "exec /usr/bin/true",
+            temporaryDirectory: temporaryDirectory,
+            fileManager: .default)
+        let configuration = TerminalLauncher.openConfiguration(commandURL: url)
+
+        XCTAssertTrue(configuration.createsNewApplicationInstance)
+        XCTAssertEqual(
+            configuration.environment["ZDOTDIR"],
+            url.deletingLastPathComponent().path)
     }
 
     func testFailureReasonRequiresSelectionOnlyForMissingTerminal() {

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -153,19 +153,18 @@ daemon is a distinct demand-launched LaunchDaemon. Neither plist may contain a
 user-specific path. Native power protection requires no Apple Events or
 Automation entitlement.
 
-Distribution bootstrap is allowed only from `/Applications`, not a DMG or App
-Translocation path. Terminal actions use a private self-deleting `.command`
-file and `NSWorkspace`; they do not use Apple Events. Session Open, Resume, and
-Recover actions name the application resolved from the currently selected
-terminal bundle identifier, with Terminal as the fallback when the selected
-application cannot be resolved. Before opening a new session, the new-session
-sheet accepts an optional human-readable display name of up to
-100 UTF-8 bytes, rejects control characters, blocks invalid launches, and
-explains the constraint inline. It passes the label as one shell-quoted
-`--name` argument. The app renders typed `display_name` as the primary session
-title while retaining the project/internal-name fallback for older records.
-Notifications are opt-in and driven by one app-level poller with baseline and
-transition deduplication.
+Distribution bootstrap runs only from `/Applications`, never a DMG or App
+Translocation path. Terminal actions use `NSWorkspace`, not Apple Events, to
+open a private self-deleting `.command` file in a new terminal process. They set
+its directory as outer `ZDOTDIR`; the file clears it before user zsh startup so
+a prompt cannot consume its path. Open, Resume, and Recover use the selected
+terminal bundle identifier, with Terminal as fallback. The new-session sheet
+accepts an optional display name of at most 100 UTF-8 bytes. It rejects control
+characters, blocks invalid launches, explains the limit inline, and passes the
+label as one shell-quoted `--name` argument. The app uses typed `display_name`
+as the session title, with the project/internal name fallback for old records.
+Notifications are opt-in. One app poller provides baseline and transition
+deduplication.
 
 Sparkle 2 is pinned in `Package.resolved`, embedded with its symlink layout
 intact, and signed inside-out before the outer app. Ad-hoc development builds


### PR DESCRIPTION
Summary:
- launch each terminal action in a fresh process with a private outer ZDOTDIR
- restore the user's zsh startup files only after the command file starts
- document and test the startup-prompt invariant

Evidence:
- TerminalLauncherTests: 9 passed
- scripts/quality-gate: PASS (static, swift, quality-contracts, app, ui-e2e, release-budget)
- reproduced the failure with oh-my-zsh and restored the affected session successfully