### PR TITLE
Select manual release gates by impact

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,7 +1,7 @@
 # Quality gates
 
 `scripts/quality-gate` is the tracked readiness contract for local agents, CI,
-and releases. Policy version 11 derives
+and releases. Policy version 12 derives
 the mandatory set from the Git diff, and selects the full repository gate for
 unknown paths or changes to this policy itself. Its resource-aware scheduler
 runs isolated work concurrently without allowing two SwiftPM operations to
@@ -54,9 +54,9 @@ share the same build directory.
 The stages are `static`, the gate orchestrator's own contract tests, `swift`,
 `quality-contracts`, development app build/verification, packaged-app
 `ui-e2e`, Codex and Claude integrations, distribution, bundled runtime,
-release and publish preflights, the hermetic release-workflow test, and the
-zero-work `release-budget` postflight. Every executable stage has a bounded
-timeout.
+release and publish preflights, the hermetic release-impact and
+release-workflow tests, and the zero-work `release-budget` postflight. Every
+executable stage has a bounded timeout.
 Logs, a versioned TSV summary, a provenance manifest, a safe execution-context
 record, a digest inventory of bounded fake-test diagnostics, and JUnit XML are
 written privately under `app/build/quality-gates/`. The schema-3 manifest binds
@@ -85,9 +85,20 @@ freshly bundled tmux and `detach-state`; none of these stages invokes SwiftPM.
 The gate therefore does not depend on writable user caches, ambient tmux,
 provider session state, or the installed Detach app.
 
-There are no quarantined tests in policy version 11. A future quarantine must be
+There are no quarantined tests in policy version 12. A future quarantine must be
 tracked here with an owner, expiry, and reason, and may not remove a release
 contract check.
+
+## Policy version 12: impact-selected manual release gates
+
+Policy 12 retains policy 11's functional stages, coverage floors, timing
+ceilings, and deterministic scheduling. It adds a fail-closed release impact
+classifier. The classifier selects the clean-account/system UI matrix only for
+related product changes. It selects the supervised closed-lid test only for
+related power changes. Unknown product paths select both manual gates. The
+`release-workflow` stage runs the classifier contract before the release
+orchestrator contract. This invalidates older resume evidence when the release
+gate selection changes.
 
 ## Policy version 11: deterministic reference-machine scheduling
 

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -13,7 +13,8 @@ change real power state, upload assets, or claim publication.
 - Release starts from clean, synchronized `main`. The tracked `BUILD`
   must match the latest published manifest; `VERSION` and `BUILD`
   change together in one release commit.
-- After exact owner confirmation, push the release commit to its unique
+- Invoking `scripts/release-version X.Y.Z` authorizes its automated commit,
+  tag, and publication steps. Push the release commit first to its unique
   `detach-release/vX.Y.Z` ref. The commit must pass the official GitHub Actions
   `quality-gates` job. Then make sure that remote `main` did not change.
   Atomically push the approved commit and annotated tag. Verify both refs and
@@ -27,19 +28,23 @@ change real power state, upload assets, or claim publication.
 - The immutable payload order is `detach`, `detach-core`,
   `detach-install`, `detach-state`, `detach-power`, `tmux`.
   Installation activates a content-addressed version atomically.
-- Developer ID signing, notarization, real signed power smoke, and supervised
-  closed-lid testing are mandatory release gates and are never inferred from
-  unit tests. The protected lid probe must emit its first liveness sample within
-  a bounded ten-second launch window before owner confirmation is accepted.
-- Automated release tests cover failed install and update paths. After the
-  signed artifacts exist, the owner must complete the short clean-account or VM
-  checklist in `docs/testing.md`. The workflow requires exact
-  `owner/repository@tag` confirmation before it installs the local candidate or
-  starts the signed power and lid gates. This checklist does not repeat those
-  hardware gates.
-- Publication requires exact `owner/repository@tag` confirmation. After
-  upload, every remote asset is downloaded and its digest independently
-  matched. Missing, extra, changed, or mismatched assets fail closed.
+- Developer ID signing, notarization, and the real signed power smoke are
+  mandatory for every release. `scripts/release-impact` compares the last
+  published tag with the release source. It selects the clean-account/system UI
+  matrix only for install, onboarding, approval, update, entitlement, or
+  localization impact. It selects supervised closed-lid testing only for
+  power, helper, watchdog, lease, assertion, or lid-probe impact. An unknown
+  product path selects both manual gates. Test-only, documentation-only, and
+  known unrelated product paths do not select them.
+- A selected closed-lid probe must emit its first liveness sample within a
+  bounded ten-second launch window before owner confirmation is accepted.
+  Automated release tests cover failed install and update paths. A selected
+  clean-account/system UI matrix uses the short checklist in `docs/testing.md`
+  and does not repeat the signed power or lid gates.
+- The release entry point supplies the low-level publication confirmation after
+  all selected gates pass. After upload, every remote asset is downloaded and
+  its digest is independently matched. Missing, extra, changed, or mismatched
+  assets fail closed.
 - Reference-machine timing budgets are mandatory by default. When the release
   Mac is intentionally busy, the owner may set
   `DETACH_RELEASE_IGNORE_TIMING=1` for one `release-version` invocation and
@@ -49,6 +54,10 @@ change real power state, upload assets, or claim publication.
   gate and workflow evidence.
 - Resume state is private under `app/build/`. Resume is allowed only when
   source, durable stage evidence, and existing asset digests still match.
+- After the atomic main/tag push, a paused release can resume from a newer
+  synchronized `main` only when the release commit remains an ancestor and all
+  later paths are release tooling, release tests, or release documentation.
+  The annotated tag and artifact manifest stay bound to the release commit.
 - Sparkle remains pinned and signed inside-out. Production builds never carry
   the development library-validation exception. Appcasts contain exactly one
   arm64 hardware requirement.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -123,18 +123,22 @@ specs, and the documentation workflow. It does not replace the selected gate.
 requires a clean synchronized `main`, reads literal release settings from the
 ignored owner-only `.env.release`, runs the complete suite before changing Git,
 requires the tracked root `BUILD` to match the latest published manifest,
-increments it together with `VERSION` in one release commit, creates one
-annotated tag, and requires an exact
-`owner/repository@tag` confirmation before pushing the commit to a unique
+increments it together with `VERSION` in one release commit, and creates one
+annotated tag. The invocation authorizes its automated commit, tag, and
+publication steps. It pushes the commit first to a unique
 `detach-release/vX.Y.Z` ref. The exact commit must pass the official GitHub
 Actions `quality-gates` job. The workflow makes sure that remote `main` did not
-change. Then it atomically pushes the approved commit and tag. It verifies both
-refs and removes the matching temporary ref. It then reuses the
+change. Then it atomically pushes the approved commit and tag, verifies both
+refs, and removes the matching temporary ref. It then reuses the
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
-the signed candidate, runs the real power smoke, measures a supervised
-closed-lid probe, publishes, and independently downloads and hashes every
-remote asset. Before local installation, it stops for the clean-install
-checklist below. Its private resume state lives under ignored `app/build/`.
+the signed candidate, runs the real power smoke, publishes, and independently
+downloads and hashes every remote asset. `scripts/release-impact` compares the
+last published tag with the release source. It selects the clean-account/system
+UI matrix only for install, onboarding, approval, update, entitlement, or
+localization impact. It selects the supervised closed-lid probe only for power,
+helper, watchdog, lease, assertion, or lid-probe impact. Unknown product paths
+select both manual gates. Its private resume state and impact evidence live
+under ignored `app/build/`.
 Set `DETACH_RELEASE_IGNORE_TIMING=1` only when the owner explicitly accepts
 busy-machine timing for that single release; the script requires the same exact
 release-target confirmation before it omits reference-machine timing checks.
@@ -145,10 +149,10 @@ upload, or publish as part of ordinary implementation or verification.
 
 ## Clean installation and system UI release checklist
 
-Run this checklist once for each signed release candidate. Automated tests
-cover Repair, keep/purge Uninstall, reinstall, failed updates, CLI
-synchronization, and helper replacement. This checklist covers only Finder and
-real macOS approval UI.
+Run this checklist only when `scripts/release-impact` selects the system UI
+matrix for the signed candidate. Automated tests cover Repair, keep/purge
+Uninstall, reinstall, failed updates, CLI synchronization, and helper
+replacement. This checklist covers only Finder and real macOS approval UI.
 
 1. Start a clean macOS 26 or later Apple Silicon account or VM in English.
    Open the signed DMG. Confirm that Detach blocks setup from the DMG and tells

--- a/scripts/quality-gate
+++ b/scripts/quality-gate
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
-POLICY_VERSION=11
+POLICY_VERSION=12
 MODE=change
 BASE_REF=""
 PLAN_ONLY=0
@@ -252,7 +252,7 @@ select_for_path() {
     scripts/build-tmux.sh)
       add_stage app; add_stage codex; add_stage claude; add_stage tmux-runtime; add_stage release-budget
       ;;
-    app/scripts/release.sh|app/scripts/publish-release.sh|app/scripts/make-dmg.sh|app/scripts/verify-appcast.sh|scripts/release-version|scripts/release-lid-probe|VERSION|BUILD)
+    app/scripts/release.sh|app/scripts/publish-release.sh|app/scripts/make-dmg.sh|app/scripts/verify-appcast.sh|scripts/release-version|scripts/release-impact|scripts/release-lid-probe|VERSION|BUILD)
       add_stage app; add_stage release-preflight; add_stage publish-preflight; add_stage release-workflow; add_stage release-budget
       ;;
     app/scripts/*)
@@ -279,7 +279,7 @@ select_for_path() {
     tests/publish-preflight.sh)
       add_stage publish-preflight; add_stage release-budget
       ;;
-    tests/release-workflow.sh)
+    tests/release-impact.sh|tests/release-workflow.sh)
       add_stage release-workflow; add_stage release-budget
       ;;
     .gitignore|.gitattributes)
@@ -777,7 +777,7 @@ run_static() {
   while IFS= read -r -d '' file; do
     [ -f "$ROOT/$file" ] || continue
     case "$file" in
-      *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/release-version|scripts/release-lid-probe)
+      *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/release-version|scripts/release-impact|scripts/release-lid-probe)
         /bin/bash -n "$ROOT/$file"
         ;;
     esac
@@ -923,7 +923,10 @@ run_stage_command() {
     tmux-runtime) "$ROOT/tests/tmux-runtime.sh" ;;
     release-preflight) "$ROOT/tests/release-preflight.sh" ;;
     publish-preflight) "$ROOT/tests/publish-preflight.sh" ;;
-    release-workflow) "$ROOT/tests/release-workflow.sh" ;;
+    release-workflow)
+      "$ROOT/tests/release-impact.sh"
+      "$ROOT/tests/release-workflow.sh"
+      ;;
   esac
 }
 

--- a/scripts/release-impact
+++ b/scripts/release-impact
@@ -1,0 +1,202 @@
+#!/bin/bash
+
+set -euo pipefail
+set +x
+export LC_ALL=C
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+
+die() {
+  printf 'release-impact: %s\n' "$*" >&2
+  exit 1
+}
+
+[ "$#" -eq 2 ] || die 'usage: scripts/release-impact BASE HEAD'
+BASE="$1"
+HEAD="$2"
+BASE_COMMIT="$(git -C "$ROOT" rev-parse --verify "$BASE^{commit}" 2>/dev/null)" || \
+  die "base is not a commit: $BASE"
+HEAD_COMMIT="$(git -C "$ROOT" rev-parse --verify "$HEAD^{commit}" 2>/dev/null)" || \
+  die "head is not a commit: $HEAD"
+git -C "$ROOT" merge-base --is-ancestor "$BASE_COMMIT" "$HEAD_COMMIT" || \
+  die 'base must be an ancestor of head'
+
+INSTALL_MATRIX_REQUIRED=false
+LID_TEST_REQUIRED=false
+UNKNOWN_IMPACT=false
+INSTALL_REASONS=()
+LID_REASONS=()
+UNKNOWN_REASONS=()
+
+add_unique() {
+  local array_name="$1" value="$2" existing
+  case "$array_name" in
+    INSTALL_REASONS)
+      for existing in "${INSTALL_REASONS[@]-}"; do
+        [ "$existing" != "$value" ] || return 0
+      done
+      INSTALL_REASONS+=( "$value" )
+      ;;
+    LID_REASONS)
+      for existing in "${LID_REASONS[@]-}"; do
+        [ "$existing" != "$value" ] || return 0
+      done
+      LID_REASONS+=( "$value" )
+      ;;
+    UNKNOWN_REASONS)
+      for existing in "${UNKNOWN_REASONS[@]-}"; do
+        [ "$existing" != "$value" ] || return 0
+      done
+      UNKNOWN_REASONS+=( "$value" )
+      ;;
+    *) die "unknown reason collection: $array_name" ;;
+  esac
+}
+
+require_install_matrix() {
+  INSTALL_MATRIX_REQUIRED=true
+  add_unique INSTALL_REASONS "$1"
+}
+
+require_lid_test() {
+  LID_TEST_REQUIRED=true
+  add_unique LID_REASONS "$1"
+}
+
+require_both_unknown() {
+  UNKNOWN_IMPACT=true
+  add_unique UNKNOWN_REASONS "$1"
+  require_install_matrix "$1"
+  require_lid_test "$1"
+}
+
+classify_path() {
+  local path="$1"
+  case "$path" in
+    README.md|AGENTS.md|CLAUDE.md|VERSION|BUILD|.gitignore|.gitattributes|\
+    .github/*|docs/*|app/Tests/*|tests/*)
+      ;;
+
+    app/Sources/DetachPower/*|app/Sources/DetachPowerHelper/*|\
+    app/Sources/DetachWatchdog/*|app/Sources/DetachKit/ClamshellLockRunner.swift|\
+    app/Sources/DetachKit/BoundedProcessRunner.swift|\
+    app/Sources/DetachKit/DetachPower*.swift|app/Sources/DetachKit/Power*.swift|\
+    app/Sources/DetachApp/InstallationStore.swift|\
+    app/Sources/DetachApp/PowerHelper*.swift|app/Sources/DetachApp/Watchdog*.swift)
+      require_install_matrix "$path"
+      require_lid_test "$path"
+      ;;
+
+    bin/detach|bin/detach-core)
+      require_lid_test "$path"
+      ;;
+
+    app/Sources/DetachApp/DetachApp.swift|\
+    app/Sources/DetachApp/Onboarding*.swift|\
+    app/Sources/DetachApp/RootView.swift|\
+    app/Sources/DetachApp/SetupGuidance.swift|\
+    app/Sources/DetachApp/Settings*.swift|\
+    app/Sources/DetachApp/UpdaterService.swift|\
+    app/Sources/DetachKit/DetachCLI.swift|\
+    app/Sources/DetachKit/DoctorReport.swift|\
+    app/Sources/DetachKit/Localization.swift|\
+    app/Sources/DetachKit/UpdateConfiguration.swift)
+      require_install_matrix "$path"
+      ;;
+
+    app/Sources/DetachApp/EmptySessionsView.swift|\
+    app/Sources/DetachApp/LogTextView.swift|\
+    app/Sources/DetachApp/MenuBar*.swift|\
+    app/Sources/DetachApp/NewSessionSheet.swift|\
+    app/Sources/DetachApp/Session*.swift|\
+    app/Sources/DetachApp/SidebarView.swift|\
+    app/Sources/DetachApp/TextSize.swift|\
+    app/Sources/DetachApp/Theme.swift|\
+    app/Sources/DetachApp/TipsBar.swift|\
+    app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift|\
+    app/Sources/DetachApp/UIE2E*.swift|\
+    app/Sources/DetachKit/ANSIText.swift|\
+    app/Sources/DetachKit/DetachState*.swift|\
+    app/Sources/DetachKit/LogPoller.swift|\
+    app/Sources/DetachKit/Session*.swift|\
+    app/Sources/DetachKit/Storage*.swift|\
+    app/Sources/DetachKit/Terminal*.swift|\
+    app/Sources/DetachKit/Tip.swift|\
+    app/Sources/DetachKit/Tmux*.swift|\
+    app/Sources/DetachState/main.swift|scripts/build-tmux.sh)
+      ;;
+
+    app/Sources/DetachKit/*|app/Sources/*)
+      require_both_unknown "$path"
+      ;;
+
+    app/Resources/en.lproj/*|app/Resources/ru.lproj/*|\
+    app/Resources/Info.plist|app/Resources/Detach.entitlements|\
+    app/Resources/DetachDevelopment.entitlements)
+      require_install_matrix "$path"
+      ;;
+
+    app/Resources/DetachWatchdog*|app/Resources/dev.tsarev.detach.power-*)
+      require_install_matrix "$path"
+      require_lid_test "$path"
+      ;;
+
+    app/Resources/Detach.icns|app/Resources/ThirdParty/*)
+      ;;
+
+    app/Resources/*|app/Package.swift|app/Package.resolved|\
+    app/scripts/make-app.sh|app/scripts/release.sh|app/scripts/bundle-modes.sh)
+      require_both_unknown "$path"
+      ;;
+
+    install.sh|scripts/install.sh)
+      require_install_matrix "$path"
+      ;;
+
+    scripts/release-lid-probe)
+      require_lid_test "$path"
+      ;;
+
+    app/scripts/make-dmg.sh)
+      require_install_matrix "$path"
+      ;;
+
+    scripts/release-version|scripts/release-impact|scripts/quality-gate|\
+    scripts/quality-history|scripts/test|\
+    app/scripts/make-icon.sh|\
+    app/scripts/publish-release.sh|app/scripts/render-icon.swift|\
+    app/scripts/sparkle-public-key.sh|app/scripts/verify-app.sh|\
+    app/scripts/verify-appcast.sh)
+      ;;
+
+    *)
+      require_both_unknown "$path"
+      ;;
+  esac
+}
+
+while IFS= read -r -d '' status && IFS= read -r -d '' path; do
+  classify_path "$path"
+  case "$status" in
+    R*|C*)
+      IFS= read -r -d '' path || die 'malformed rename/copy entry from Git'
+      classify_path "$path"
+      ;;
+  esac
+done < <(git -C "$ROOT" diff --name-status -z --find-renames "$BASE_COMMIT" "$HEAD_COMMIT")
+
+printf 'schema\t1\n'
+printf 'base_commit\t%s\n' "$BASE_COMMIT"
+printf 'head_commit\t%s\n' "$HEAD_COMMIT"
+printf 'install_matrix_required\t%s\n' "$INSTALL_MATRIX_REQUIRED"
+printf 'lid_test_required\t%s\n' "$LID_TEST_REQUIRED"
+printf 'unknown_impact\t%s\n' "$UNKNOWN_IMPACT"
+for path in "${INSTALL_REASONS[@]-}"; do
+  [ -z "$path" ] || printf 'install_matrix_reason\t%s\n' "$path"
+done
+for path in "${LID_REASONS[@]-}"; do
+  [ -z "$path" ] || printf 'lid_test_reason\t%s\n' "$path"
+done
+for path in "${UNKNOWN_REASONS[@]-}"; do
+  [ -z "$path" ] || printf 'unknown_reason\t%s\n' "$path"
+done

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -8,6 +8,7 @@ export LC_ALL=C
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 APP_ROOT="$ROOT/app"
 ENV_FILE="$ROOT/.env.release"
+IMPACT_SCRIPT="$ROOT/scripts/release-impact"
 TEST_MODE="${DETACH_RELEASE_TEST_MODE:-0}"
 IGNORE_TIMING="${DETACH_RELEASE_IGNORE_TIMING:-0}"
 LOCKED=0
@@ -203,6 +204,7 @@ validate_configuration() {
     APPLICATIONS_DIR="${DETACH_RELEASE_TEST_APPLICATIONS_DIR:-$APPLICATIONS_DIR}"
   fi
   [[ "$APPLICATIONS_DIR" = /* ]] || die 'release candidate application directory must be absolute'
+  [ -x "$IMPACT_SCRIPT" ] || die 'release impact classifier is unavailable'
   INSTALLED_APP="$APPLICATIONS_DIR/Detach.app"
   STATE_DIR="$APP_ROOT/build/release-workflow/$VERSION"
   mkdir -p "$STATE_DIR"
@@ -225,6 +227,46 @@ read_state_value() {
   [ -f "$STATE_DIR/$name" ] && [ ! -L "$STATE_DIR/$name" ] || return 1
   IFS= read -r value <"$STATE_DIR/$name" || [ -n "$value" ]
   printf '%s\n' "$value"
+}
+
+impact_value() {
+  local file="$1" key="$2" count value
+  count="$(awk -F '\t' -v wanted="$key" '$1 == wanted {count++} END {print count+0}' "$file")"
+  [ "$count" -eq 1 ] || die "release impact has missing or duplicate key: $key"
+  value="$(awk -F '\t' -v wanted="$key" '$1 == wanted {print substr($0, index($0, "\t") + 1); exit}' "$file")"
+  printf '%s\n' "$value"
+}
+
+resolve_release_impact() {
+  local previous_version impact="$STATE_DIR/release-impact.tsv"
+  local temporary="$STATE_DIR/.release-impact.$$"
+  local schema base_commit head_commit unknown
+
+  previous_version="$(read_state_value previous-version)" || \
+    die 'release workflow state has no previous version'
+  "$IMPACT_SCRIPT" "refs/tags/v$previous_version" "$SOURCE_COMMIT" >"$temporary"
+  chmod 0600 "$temporary"
+  schema="$(impact_value "$temporary" schema)"
+  base_commit="$(impact_value "$temporary" base_commit)"
+  head_commit="$(impact_value "$temporary" head_commit)"
+  INSTALL_MATRIX_REQUIRED="$(impact_value "$temporary" install_matrix_required)"
+  LID_TEST_REQUIRED="$(impact_value "$temporary" lid_test_required)"
+  unknown="$(impact_value "$temporary" unknown_impact)"
+  [ "$schema" = 1 ] || die 'release impact schema is unsupported'
+  [[ "$base_commit" =~ ^[0-9a-f]{40}$ ]] || die 'release impact base commit is invalid'
+  [ "$head_commit" = "$SOURCE_COMMIT" ] || die 'release impact head commit does not match source'
+  case "$INSTALL_MATRIX_REQUIRED:$LID_TEST_REQUIRED:$unknown" in
+    true:true:true|true:true:false|true:false:false|false:true:false|false:false:false) ;;
+    *) die 'release impact booleans are invalid or fail-open' ;;
+  esac
+  if [ -f "$impact" ]; then
+    cmp -s "$impact" "$temporary" || \
+      die 'release impact selection changed since preflight'
+    rm -f "$temporary"
+  else
+    mv -f "$temporary" "$impact"
+  fi
+  note "manual release gates: install-matrix=$INSTALL_MATRIX_REQUIRED lid=$LID_TEST_REQUIRED"
 }
 
 has_stage() {
@@ -276,6 +318,52 @@ remote_ref_commit() {
     commit="$(printf '%s\n' "$output" | awk -v exact="$ref" '$2 == exact {print $1; exit}')"
   fi
   printf '%s\n' "$commit"
+}
+
+release_tooling_path_allowed() {
+  case "$1" in
+    scripts/release-version|scripts/release-impact|scripts/quality-gate|\
+    tests/quality-gate.sh|tests/release-impact.sh|tests/release-workflow.sh|\
+    tests/shell-safety.sh|tests/shell-safety-contract.sh|\
+    docs/quality-gates.md|docs/specs/release.md|docs/testing.md)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+release_tooling_descendant_valid() {
+  local descendant="$1" path
+  git -C "$ROOT" merge-base --is-ancestor "$RELEASE_COMMIT" "$descendant" || return 1
+  while IFS= read -r -d '' path; do
+    release_tooling_path_allowed "$path" || return 1
+  done < <(git -C "$ROOT" diff --name-only -z "$RELEASE_COMMIT" "$descendant")
+}
+
+verify_release_remote_refs() {
+  local remote_main remote_tag
+  remote_main="$(remote_ref_commit refs/heads/main)"
+  remote_tag="$(remote_ref_commit "refs/tags/$TAG")"
+  [ "$remote_tag" = "$RELEASE_COMMIT" ] || \
+    die 'remote release tag does not match the release commit'
+  if [ "$remote_main" != "$RELEASE_COMMIT" ]; then
+    release_tooling_descendant_valid "$remote_main" || \
+      die 'remote main advanced after the release with non-tooling changes'
+  fi
+}
+
+verify_resumable_release_head() {
+  local head remote_main
+  head="$(git -C "$ROOT" rev-parse --verify HEAD)"
+  [ "$head" != "$RELEASE_COMMIT" ] || return 0
+  has_stage pushed || die 'HEAD is no longer the unpushed release commit'
+  remote_main="$(git -C "$ROOT" rev-parse --verify refs/remotes/origin/main)"
+  [ "$head" = "$remote_main" ] || \
+    die 'resumed release tooling must use synchronized main'
+  release_tooling_descendant_valid "$head" || \
+    die 'main advanced after the release with non-tooling changes'
 }
 
 release_api_status() {
@@ -436,6 +524,7 @@ initialize_workflow() {
 
 load_workflow() {
   local saved_version saved_repository saved_tag saved_timing_budget
+  fetch_origin
   saved_version="$(read_state_value version)" || die 'incomplete release workflow state (version)'
   saved_repository="$(read_state_value repository)" || die 'incomplete release workflow state (repository)'
   saved_tag="$(read_state_value tag)" || die 'incomplete release workflow state (tag)'
@@ -505,8 +594,7 @@ prepare_release_commit() {
     write_state_value release-commit "$RELEASE_COMMIT"
   fi
 
-  [ "$(git -C "$ROOT" rev-parse --verify HEAD)" = "$RELEASE_COMMIT" ] || \
-    die 'release commit is no longer HEAD'
+  verify_resumable_release_head
   [ "$(git -C "$ROOT" rev-parse "$RELEASE_COMMIT^")" = "$SOURCE_COMMIT" ] || \
     die 'release commit does not directly follow the tested source'
   [ "$(<"$ROOT/VERSION")" = "$VERSION" ] || die 'VERSION does not match the release target'
@@ -605,6 +693,11 @@ remove_release_ci_branch() {
 
 push_release_source() {
   local remote_main remote_tag
+  if has_stage pushed; then
+    verify_release_remote_refs
+    remove_release_ci_branch
+    return
+  fi
   remote_main="$(remote_ref_commit refs/heads/main)"
   remote_tag="$(remote_ref_commit "refs/tags/$TAG")"
   if [ "$remote_main" = "$RELEASE_COMMIT" ] && [ "$remote_tag" = "$RELEASE_COMMIT" ]; then
@@ -614,8 +707,7 @@ push_release_source() {
   fi
   [ "$remote_main" = "$SOURCE_COMMIT" ] || die 'remote main changed before release push'
   [ -z "$remote_tag" ] || die 'remote release tag appeared with an unexpected state'
-  exact_confirmation DETACH_CONFIRM_RELEASE \
-    "Release commit and annotated tag are ready; the next step validates the commit in GitHub Actions, pushes it, and later publishes $REPOSITORY@$TAG."
+  note "release invocation authorized CI validation and atomic publication of $REPOSITORY@$TAG"
   approve_release_source
   remote_main="$(remote_ref_commit refs/heads/main)"
   remote_tag="$(remote_ref_commit "refs/tags/$TAG")"
@@ -673,6 +765,11 @@ build_release_artifacts() {
 confirm_install_update_matrix() {
   has_stage install-matrix && return
   release_artifacts_valid || die 'release artifacts changed before install-matrix review'
+  if [ "$INSTALL_MATRIX_REQUIRED" = false ]; then
+    note 'skipping clean installation and system UI matrix: release impact does not select it'
+    record_stage install-matrix
+    return
+  fi
   printf '%s\n' \
     'Complete the clean installation and update checklist in docs/testing.md with the signed Detach.dmg. Use a clean macOS account or VM. Do not reuse the signed power or lid tests as evidence.'
   exact_confirmation DETACH_CONFIRM_INSTALL_MATRIX \
@@ -773,6 +870,11 @@ run_lid_test() {
   local attempts=0 started finished elapsed minimum maximum_gap
 
   has_stage lid && return
+  if [ "$LID_TEST_REQUIRED" = false ]; then
+    note 'skipping closed-lid hardware test: release impact does not select it'
+    record_stage lid
+    return
+  fi
   [ -x "$power" ] || die 'installed release candidate has no signed power client'
   rm -f "$ready" "$ticks"
   "$power" run --session "$session" --run-token "$token" --ready-file "$ready" -- \
@@ -820,9 +922,7 @@ run_publish_preflight() {
   git -C "$ROOT" diff --check
   verify_clean_worktree
   release_artifacts_valid || die 'release artifacts changed before publication'
-  [ "$(remote_ref_commit refs/heads/main)" = "$RELEASE_COMMIT" ] && \
-    [ "$(remote_ref_commit "refs/tags/$TAG")" = "$RELEASE_COMMIT" ] || \
-    die 'remote main/tag changed before publication'
+  verify_release_remote_refs
 }
 
 publish_release() {
@@ -856,9 +956,7 @@ verify_published_release() {
   mkdir -m 0700 "$remote_root"
   latest_tag="$(gh release view --repo "$REPOSITORY" --json tagName --jq .tagName)"
   [ "$latest_tag" = "$TAG" ] || die 'published release is not GitHub Latest'
-  [ "$(remote_ref_commit refs/heads/main)" = "$RELEASE_COMMIT" ] && \
-    [ "$(remote_ref_commit "refs/tags/$TAG")" = "$RELEASE_COMMIT" ] || \
-    die 'published remote main/tag do not match the release commit'
+  verify_release_remote_refs
 
   assets=(
     "$APP_ROOT/build/Detach.dmg"
@@ -918,6 +1016,7 @@ run_locked() {
   else
     initialize_workflow
   fi
+  resolve_release_impact
   prepare_release_commit
   push_release_source
   build_release_artifacts

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -149,8 +149,13 @@ printf '%s\n' '#!/bin/bash' >"$REPO/bin/detach"
 plan="$(gate --plan)"
 [[ "$plan" = *'stages=static,app,ui-e2e,codex,claude,distribution,tmux-runtime,release-budget' ]]
 
-setup_fixture release-impact
+setup_fixture release-files
 printf '%s\n' 999 >"$REPO/BUILD"
+plan="$(gate --plan)"
+[[ "$plan" = *'stages=static,app,ui-e2e,release-preflight,publish-preflight,release-workflow,release-budget' ]]
+
+setup_fixture release-impact
+printf '%s\n' '#!/bin/bash' >"$REPO/scripts/release-impact"
 plan="$(gate --plan)"
 [[ "$plan" = *'stages=static,app,ui-e2e,release-preflight,publish-preflight,release-workflow,release-budget' ]]
 
@@ -204,7 +209,7 @@ mkdir -p "$REPO/app/Sources/DetachKit"
 printf '%s\n' 'struct OddName {}' >"$REPO/app/Sources/DetachKit/line
 break.swift"
 plan="$(gate --plan --format json)"
-[[ "$plan" = '{"policy":11,"mode":"change","source_commit":"'* ]]
+[[ "$plan" = '{"policy":12,"mode":"change","source_commit":"'* ]]
 [[ "$plan" = *'"base_commit":"","input_fingerprint":"'* ]]
 [[ "$plan" = *'"stages":["static","swift","quality-contracts","app","ui-e2e","release-budget"]}' ]]
 

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -euo pipefail
+set +x
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-release-impact.XXXXXX")"
+REPO="$TMP_ROOT/repo"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+mkdir -p "$REPO/scripts"
+cp "$ROOT/scripts/release-impact" "$REPO/scripts/release-impact"
+chmod 0755 "$REPO/scripts/release-impact"
+git -C "$REPO" init -q
+git -C "$REPO" checkout -qb main
+git -C "$REPO" config user.name 'Detach Tests'
+git -C "$REPO" config user.email 'detach-tests@example.invalid'
+printf '%s\n' baseline >"$REPO/README.md"
+git -C "$REPO" add README.md scripts/release-impact
+git -C "$REPO" commit -qm baseline
+
+commit_path() {
+  local path="$1" value="$2"
+  mkdir -p "$(dirname "$REPO/$path")"
+  printf '%s\n' "$value" >"$REPO/$path"
+  git -C "$REPO" add "$path"
+  git -C "$REPO" commit -qm "$value"
+  git -C "$REPO" rev-parse HEAD
+}
+
+assert_value() {
+  local output="$1" key="$2" expected="$3" actual count
+  count="$(awk -F '\t' -v wanted="$key" '$1 == wanted {count++} END {print count+0}' "$output")"
+  [ "$count" -eq 1 ] || {
+    printf 'release impact key count mismatch: %s (%s)\n' "$key" "$count" >&2
+    exit 1
+  }
+  actual="$(awk -F '\t' -v wanted="$key" '$1 == wanted {print $2; exit}' "$output")"
+  [ "$actual" = "$expected" ] || {
+    printf 'release impact mismatch: %s=%s, expected %s\n' "$key" "$actual" "$expected" >&2
+    exit 1
+  }
+}
+
+BASE="$(git -C "$REPO" rev-parse HEAD)"
+SAFE_HEAD="$(commit_path app/Sources/DetachKit/TerminalLauncher.swift terminal)"
+"$REPO/scripts/release-impact" "$BASE" "$SAFE_HEAD" >"$TMP_ROOT/safe.tsv"
+assert_value "$TMP_ROOT/safe.tsv" install_matrix_required false
+assert_value "$TMP_ROOT/safe.tsv" lid_test_required false
+assert_value "$TMP_ROOT/safe.tsv" unknown_impact false
+
+MATRIX_HEAD="$(commit_path app/Sources/DetachApp/OnboardingView.swift onboarding)"
+"$REPO/scripts/release-impact" "$SAFE_HEAD" "$MATRIX_HEAD" >"$TMP_ROOT/matrix.tsv"
+assert_value "$TMP_ROOT/matrix.tsv" install_matrix_required true
+assert_value "$TMP_ROOT/matrix.tsv" lid_test_required false
+assert_value "$TMP_ROOT/matrix.tsv" unknown_impact false
+grep -F $'install_matrix_reason\tapp/Sources/DetachApp/OnboardingView.swift' \
+  "$TMP_ROOT/matrix.tsv" >/dev/null
+
+DMG_HEAD="$(commit_path app/scripts/make-dmg.sh dmg)"
+"$REPO/scripts/release-impact" "$MATRIX_HEAD" "$DMG_HEAD" >"$TMP_ROOT/dmg.tsv"
+assert_value "$TMP_ROOT/dmg.tsv" install_matrix_required true
+assert_value "$TMP_ROOT/dmg.tsv" lid_test_required false
+assert_value "$TMP_ROOT/dmg.tsv" unknown_impact false
+
+CORE_HEAD="$(commit_path bin/detach-core core)"
+"$REPO/scripts/release-impact" "$DMG_HEAD" "$CORE_HEAD" >"$TMP_ROOT/core.tsv"
+assert_value "$TMP_ROOT/core.tsv" install_matrix_required false
+assert_value "$TMP_ROOT/core.tsv" lid_test_required true
+assert_value "$TMP_ROOT/core.tsv" unknown_impact false
+
+SHARED_POWER_HEAD="$(commit_path app/Sources/DetachKit/BoundedProcessRunner.swift runner)"
+"$REPO/scripts/release-impact" "$CORE_HEAD" "$SHARED_POWER_HEAD" \
+  >"$TMP_ROOT/shared-power.tsv"
+assert_value "$TMP_ROOT/shared-power.tsv" install_matrix_required true
+assert_value "$TMP_ROOT/shared-power.tsv" lid_test_required true
+assert_value "$TMP_ROOT/shared-power.tsv" unknown_impact false
+
+POWER_HEAD="$(commit_path app/Sources/DetachPower/main.swift power)"
+"$REPO/scripts/release-impact" "$SHARED_POWER_HEAD" "$POWER_HEAD" \
+  >"$TMP_ROOT/power.tsv"
+assert_value "$TMP_ROOT/power.tsv" install_matrix_required true
+assert_value "$TMP_ROOT/power.tsv" lid_test_required true
+assert_value "$TMP_ROOT/power.tsv" unknown_impact false
+
+UNKNOWN_HEAD="$(commit_path product/new-runtime future)"
+"$REPO/scripts/release-impact" "$POWER_HEAD" "$UNKNOWN_HEAD" >"$TMP_ROOT/unknown.tsv"
+assert_value "$TMP_ROOT/unknown.tsv" install_matrix_required true
+assert_value "$TMP_ROOT/unknown.tsv" lid_test_required true
+assert_value "$TMP_ROOT/unknown.tsv" unknown_impact true
+grep -F $'unknown_reason\tproduct/new-runtime' "$TMP_ROOT/unknown.tsv" >/dev/null
+
+NEW_APP_HEAD="$(commit_path app/Sources/DetachApp/FutureFlow.swift future-app)"
+"$REPO/scripts/release-impact" "$UNKNOWN_HEAD" "$NEW_APP_HEAD" \
+  >"$TMP_ROOT/new-app.tsv"
+assert_value "$TMP_ROOT/new-app.tsv" install_matrix_required true
+assert_value "$TMP_ROOT/new-app.tsv" lid_test_required true
+assert_value "$TMP_ROOT/new-app.tsv" unknown_impact true
+grep -F $'unknown_reason\tapp/Sources/DetachApp/FutureFlow.swift' \
+  "$TMP_ROOT/new-app.tsv" >/dev/null
+
+git -C "$REPO" checkout -qb unrelated "$BASE"
+UNRELATED_HEAD="$(commit_path docs/note.md unrelated)"
+if "$REPO/scripts/release-impact" "$NEW_APP_HEAD" "$UNRELATED_HEAD" \
+    >"$TMP_ROOT/non-ancestor.out" 2>"$TMP_ROOT/non-ancestor.err"; then
+  printf 'release impact accepted a non-ancestor base\n' >&2
+  exit 1
+fi
+grep -F 'base must be an ancestor of head' "$TMP_ROOT/non-ancestor.err" >/dev/null
+
+printf 'Release impact tests passed\n'

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -41,6 +41,7 @@ setup_fixture() {
     "$REMOTE_ASSETS"
 
   install -m 0755 "$ROOT/scripts/release-version" "$REPO/scripts/release-version"
+  install -m 0755 "$ROOT/scripts/release-impact" "$REPO/scripts/release-impact"
   install -m 0755 "$ROOT/scripts/release-lid-probe" "$REPO/scripts/release-lid-probe"
   install -m 0755 "$ROOT/scripts/quality-gate" "$REPO/scripts/quality-gate"
   install -m 0755 "$ROOT/app/scripts/verify-appcast.sh" \
@@ -361,14 +362,16 @@ SH
   git -C "$REPO" config user.email 'detach-tests@example.invalid'
   git -C "$REPO" add .
   git -C "$REPO" commit -qm 'release workflow fixture'
+  git -C "$REPO" tag -a v1.2.3 -m 'published fixture'
   git init -q --bare "$ORIGIN"
   git -C "$REPO" remote add origin "$ORIGIN"
   git -C "$REPO" push -q -u origin main
+  git -C "$REPO" push -q origin v1.2.3
 }
 
 run_workflow() {
   local fail_after="${1:-}" lid_confirmation="${2:-example/detach@$TARGET_TAG}"
-  local release_confirmation="${3:-example/detach@$TARGET_TAG}" ignore_timing="${4:-0}"
+  local release_confirmation="${3:-}" ignore_timing="${4:-0}"
   local install_confirmation="${5:-example/detach@$TARGET_TAG}"
   (
     cd -P "$REPO"
@@ -443,7 +446,16 @@ run_resume_case() {
 
   git -C "$REPO" push -q --force origin "$release_ci_source:refs/heads/main"
 
-  for stage in pushed artifacts install-matrix installed power-smoke lid published verified; do
+  for stage in pushed artifacts; do
+    expect_failure "resume-$stage" "injected safe failure after $stage" \
+      run_workflow "$stage"
+  done
+  mkdir -p "$REPO/docs"
+  printf '%s\n' 'release tooling follow-up' >"$REPO/docs/testing.md"
+  git -C "$REPO" add docs/testing.md
+  git -C "$REPO" commit -qm 'adjust release tooling guidance'
+  git -C "$REPO" push -q origin main
+  for stage in install-matrix installed power-smoke lid published verified; do
     expect_failure "resume-$stage" "injected safe failure after $stage" \
       run_workflow "$stage"
   done
@@ -458,6 +470,10 @@ run_resume_case() {
   [ "$(grep -c '^release-preflight.sh$' "$ACTION_LOG")" = 2 ]
   [ "$(grep -c '^publish-preflight.sh$' "$ACTION_LOG")" = 2 ]
   [ -z "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
+  grep -F $'install_matrix_required\tfalse' \
+    "$REPO/app/build/release-workflow/$TARGET_VERSION/release-impact.tsv" >/dev/null
+  grep -F $'lid_test_required\tfalse' \
+    "$REPO/app/build/release-workflow/$TARGET_VERSION/release-impact.tsv" >/dev/null
 }
 
 run_timing_override_cases() {
@@ -516,6 +532,11 @@ run_preflight_rejection_cases() {
 
 run_hardware_rejection_case() {
   setup_fixture hardware-gate
+  mkdir -p "$REPO/app/Sources/DetachPower"
+  printf '%s\n' 'power impact' >"$REPO/app/Sources/DetachPower/main.swift"
+  git -C "$REPO" add app/Sources/DetachPower/main.swift
+  git -C "$REPO" commit -qm 'change power runtime'
+  git -C "$REPO" push -q origin main
   expect_failure install-matrix-gate \
     "clean installation and update matrix confirmation must exactly equal example/detach@$TARGET_TAG" \
     run_workflow '' "example/detach@$TARGET_TAG" \
@@ -541,6 +562,20 @@ run_remote_hash_case() {
   [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
 }
 
+run_post_push_main_rejection_case() {
+  setup_fixture post-push-main
+  expect_failure post-push-artifacts 'injected safe failure after artifacts' \
+    run_workflow artifacts
+  mkdir -p "$REPO/app/Sources/DetachKit"
+  printf '%s\n' 'product change' >"$REPO/app/Sources/DetachKit/TerminalLauncher.swift"
+  git -C "$REPO" add app/Sources/DetachKit/TerminalLauncher.swift
+  git -C "$REPO" commit -qm 'advance product source after tag'
+  git -C "$REPO" push -q origin main
+  expect_failure post-push-main \
+    'main advanced after the release with non-tooling changes' run_workflow
+  [ ! -f "$RELEASE_EXISTS" ]
+}
+
 # Each lane owns a separate repository below TMP_ROOT. Run the lanes together.
 # This keeps independent Git and fake-publication work out of the critical path.
 release_case_pids=()
@@ -550,7 +585,8 @@ for release_case in \
   run_timing_override_cases \
   run_preflight_rejection_cases \
   run_hardware_rejection_case \
-  run_remote_hash_case; do
+  run_remote_hash_case \
+  run_post_push_main_rejection_case; do
   "$release_case" &
   release_case_pids+=("$!")
   release_case_names+=("$release_case")

--- a/tests/shell-safety.sh
+++ b/tests/shell-safety.sh
@@ -16,7 +16,7 @@ failures=0
 while IFS= read -r -d '' file; do
   case "$file" in
     tests/shell-safety-contract.sh) continue ;;
-    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/release-version|scripts/release-lid-probe) ;;
+    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
     *) continue ;;
   esac
   [ -f "$ROOT/$file" ] || continue


### PR DESCRIPTION
Release invocation now authorizes automated commit, tag, and publication. A fail-closed diff classifier selects the clean-account matrix and supervised lid test only for relevant product changes; unknown product paths select both. The release workflow can safely resume from a tooling-only main descendant after the release tag.\n\nVerification: scripts/quality-gate PASS (policy 12, fingerprint 6dc1be1f6d65637bb53285506d2a7c750f491c8d625fc970dc6124f39df79e9e).