### PR TITLE
Scope release resume credentials to remaining work

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -54,6 +54,9 @@ change real power state, upload assets, or claim publication.
   gate and workflow evidence.
 - Resume state is private under `app/build/`. Resume is allowed only when
   source, durable stage evidence, and existing asset digests still match.
+- A resume after the artifact stage requires only credentials for the remaining
+  publication work. If artifact validation requires a rebuild, the workflow
+  requires the Developer ID, notarization, and Sparkle credentials again.
 - After the atomic main/tag push, a paused release can resume from a newer
   synchronized `main` only when the release commit remains an ancestor and all
   later paths are release tooling, release tests, or release documentation.

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -15,6 +15,7 @@ LOCKED=0
 LID_WRAPPER_PID=""
 INSTALL_TEMP=""
 INSTALL_BACKUP=""
+ARTIFACT_CREDENTIALS_VERIFIED=0
 
 die() {
   printf 'release-version: %s\n' "$*" >&2
@@ -378,7 +379,12 @@ release_api_status() {
   esac
 }
 
-verify_credentials() {
+verify_github_credentials() {
+  command -v gh >/dev/null 2>&1 || die 'GitHub CLI (gh) is required'
+  gh auth status >/dev/null
+}
+
+verify_artifact_credentials() {
   local identity="${DETACH_CODESIGN_IDENTITY:-}"
   local notary_profile="${DETACH_NOTARY_PROFILE:-}"
   local public_key="${DETACH_SPARKLE_PUBLIC_ED_KEY:-}"
@@ -386,12 +392,12 @@ verify_credentials() {
   local key_account="${DETACH_SPARKLE_KEY_ACCOUNT:-dev.tsarev.detach}"
   local sparkle_tools signing_key identities key_mode key_mode_value
 
+  [ "$ARTIFACT_CREDENTIALS_VERIFIED" = 0 ] || return 0
+
   case "$identity" in 'Developer ID Application: '*) ;; *) die 'a Developer ID Application identity is required' ;; esac
   [ -n "$notary_profile" ] || die 'DETACH_NOTARY_PROFILE is required'
   [[ "$public_key" =~ ^[A-Za-z0-9+/]{43}=$ ]] || \
     die 'DETACH_SPARKLE_PUBLIC_ED_KEY must be a base64 Ed25519 public key'
-  command -v gh >/dev/null 2>&1 || die 'GitHub CLI (gh) is required'
-  gh auth status >/dev/null
   identities="$(security find-identity -v -p codesigning)"
   grep -F "\"$identity\"" <<<"$identities" >/dev/null || \
     die 'configured Developer ID signing identity is not installed or valid'
@@ -418,6 +424,12 @@ verify_credentials() {
   fi
   [ "$signing_key" = "$public_key" ] || \
     die 'configured Sparkle public key does not match the signing key'
+  ARTIFACT_CREDENTIALS_VERIFIED=1
+}
+
+verify_credentials() {
+  verify_github_credentials
+  verify_artifact_credentials
 }
 
 download_latest_manifest() {
@@ -751,6 +763,7 @@ release_artifacts_valid() {
 
 build_release_artifacts() {
   if ! release_artifacts_valid; then
+    verify_artifact_credentials
     note "building, signing and notarizing Detach $VERSION (build $BUILD)"
     DETACH_VERSION="$VERSION" \
       DETACH_BUILD_VERSION="$BUILD" \
@@ -1012,7 +1025,11 @@ run_locked() {
       note "Detach $VERSION is published, verified and GitHub Latest"
       return
     fi
-    verify_credentials
+    if has_stage artifacts; then
+      verify_github_credentials
+    else
+      verify_credentials
+    fi
   else
     initialize_workflow
   fi

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -267,7 +267,13 @@ SH
 #!/bin/bash
 set -eu
 case " $* " in
-  *' notarytool history '*) printf '%s\n' '{}' ;;
+  *' notarytool history '*)
+    [ "${FAKE_NOTARY_UNAVAILABLE:-0}" != 1 ] || {
+      printf '%s\n' 'fake notary credential unavailable' >&2
+      exit 69
+    }
+    printf '%s\n' '{}'
+    ;;
   *) exit 64 ;;
 esac
 SH
@@ -450,6 +456,7 @@ run_resume_case() {
     expect_failure "resume-$stage" "injected safe failure after $stage" \
       run_workflow "$stage"
   done
+  export FAKE_NOTARY_UNAVAILABLE=1
   mkdir -p "$REPO/docs"
   printf '%s\n' 'release tooling follow-up' >"$REPO/docs/testing.md"
   git -C "$REPO" add docs/testing.md
@@ -460,6 +467,7 @@ run_resume_case() {
       run_workflow "$stage"
   done
   run_workflow
+  unset FAKE_NOTARY_UNAVAILABLE
   [ "$(<"$REPO/VERSION")" = "$TARGET_VERSION" ]
   [ "$(<"$REPO/BUILD")" = 14 ]
   [ "$(git -C "$REPO" log --format=%s | grep -c "^Prepare $TARGET_VERSION release$")" = 1 ]
@@ -474,6 +482,18 @@ run_resume_case() {
     "$REPO/app/build/release-workflow/$TARGET_VERSION/release-impact.tsv" >/dev/null
   grep -F $'lid_test_required\tfalse' \
     "$REPO/app/build/release-workflow/$TARGET_VERSION/release-impact.tsv" >/dev/null
+}
+
+run_invalid_resume_artifact_credentials_case() {
+  setup_fixture invalid-resume-artifact-credentials
+  expect_failure invalid-resume-artifact-preparation \
+    'injected safe failure after artifacts' run_workflow artifacts
+  printf '%s\n' 'changed after notarization' >"$REPO/app/build/Detach.dmg"
+  export FAKE_NOTARY_UNAVAILABLE=1
+  expect_failure invalid-resume-artifact-credentials \
+    'fake notary credential unavailable' run_workflow
+  unset FAKE_NOTARY_UNAVAILABLE
+  [ ! -f "$RELEASE_EXISTS" ]
 }
 
 run_timing_override_cases() {
@@ -586,7 +606,8 @@ for release_case in \
   run_preflight_rejection_cases \
   run_hardware_rejection_case \
   run_remote_hash_case \
-  run_post_push_main_rejection_case; do
+  run_post_push_main_rejection_case \
+  run_invalid_resume_artifact_credentials_case; do
   "$release_case" &
   release_case_pids+=("$!")
   release_case_names+=("$release_case")


### PR DESCRIPTION
A release resumed after the immutable artifact stage now requires only credentials needed for publication. If artifact validation fails and a rebuild is needed, Developer ID, notarization, and Sparkle credentials are required again.\n\nRegression coverage proves both the valid-artifact resume and fail-closed rebuild paths.\n\nVerification: scripts/quality-gate PASS (policy 12, fingerprint ce479b599db30bacfac22f313c4b5e03c627a451a2b16ee10f07344f471a16b2).