### PR TITLE
Install release candidate from signed DMG

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -28,6 +28,8 @@ change real power state, upload assets, or claim publication.
 - The immutable payload order is `detach`, `detach-core`,
   `detach-install`, `detach-state`, `detach-power`, `tmux`.
   Installation activates a content-addressed version atomically.
+- The locally installed release candidate is copied from the validated signed
+  DMG. The workflow never installs a mutable intermediate app build.
 - Developer ID signing, notarization, and the real signed power smoke are
   mandatory for every release. `scripts/release-impact` compares the last
   published tag with the release source. It selects the clean-account/system UI

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -16,6 +16,9 @@ LID_WRAPPER_PID=""
 INSTALL_TEMP=""
 INSTALL_BACKUP=""
 ARTIFACT_CREDENTIALS_VERIFIED=0
+INSTALL_DMG_ROOT=""
+INSTALL_DMG_MOUNT=""
+INSTALL_DMG_ATTACHED=0
 
 die() {
   printf 'release-version: %s\n' "$*" >&2
@@ -26,7 +29,20 @@ note() {
   printf '==> %s\n' "$*"
 }
 
+cleanup_install_dmg() {
+  if [ "$INSTALL_DMG_ATTACHED" = 1 ] && [ -n "$INSTALL_DMG_MOUNT" ]; then
+    hdiutil detach "$INSTALL_DMG_MOUNT" >/dev/null 2>&1 || true
+  fi
+  INSTALL_DMG_ATTACHED=0
+  if [ -n "$INSTALL_DMG_ROOT" ]; then
+    rm -rf "$INSTALL_DMG_ROOT"
+  fi
+  INSTALL_DMG_ROOT=""
+  INSTALL_DMG_MOUNT=""
+}
+
 cleanup() {
+  cleanup_install_dmg
   if [ -n "$LID_WRAPPER_PID" ]; then
     kill -TERM "$LID_WRAPPER_PID" >/dev/null 2>&1 || true
     wait "$LID_WRAPPER_PID" >/dev/null 2>&1 || true
@@ -810,8 +826,35 @@ remove_install_scratch() {
   esac
 }
 
+copy_release_candidate_from_dmg() {
+  local destination="$1" dmg="$APP_ROOT/build/Detach.dmg" source_app
+
+  [ -f "$dmg" ] && [ ! -L "$dmg" ] || die 'release DMG is unavailable for installation'
+  INSTALL_DMG_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-release-install.XXXXXX")"
+  INSTALL_DMG_MOUNT="$INSTALL_DMG_ROOT/mount"
+  mkdir -m 0755 "$INSTALL_DMG_MOUNT"
+  if ! hdiutil attach -readonly -nobrowse -owners on \
+      -mountpoint "$INSTALL_DMG_MOUNT" "$dmg" \
+      >"$INSTALL_DMG_ROOT/attach.txt"; then
+    die 'could not mount the signed release DMG'
+  fi
+  INSTALL_DMG_ATTACHED=1
+  source_app="$INSTALL_DMG_MOUNT/Detach.app"
+  [ -d "$source_app" ] && [ ! -L "$source_app" ] || \
+    die 'signed release DMG has no real Detach.app'
+  DETACH_APP_PATH="$source_app" DETACH_VERSION="$VERSION" \
+    DETACH_REQUIRE_SPARKLE_CONFIG=1 DETACH_VERIFY_PRODUCTION=1 \
+    "$APP_ROOT/scripts/verify-app.sh" >/dev/null
+  ditto "$source_app" "$destination"
+  hdiutil detach "$INSTALL_DMG_MOUNT" >/dev/null || \
+    die 'could not detach the signed release DMG'
+  INSTALL_DMG_ATTACHED=0
+  rm -rf "$INSTALL_DMG_ROOT"
+  INSTALL_DMG_ROOT=""
+  INSTALL_DMG_MOUNT=""
+}
+
 install_release_candidate() {
-  local source_app="$APP_ROOT/build/Detach.app"
   local candidate="$APPLICATIONS_DIR/.Detach.release-$VERSION.app"
   local backup="$APPLICATIONS_DIR/.Detach.backup-$VERSION.app"
 
@@ -838,7 +881,7 @@ install_release_candidate() {
   fi
   [ ! -e "$candidate" ] || remove_install_scratch "$candidate"
   INSTALL_TEMP="$candidate"
-  ditto "$source_app" "$candidate"
+  copy_release_candidate_from_dmg "$candidate"
   [ -d "$candidate" ] && [ ! -L "$candidate" ] || die 'candidate copy is invalid'
   DETACH_APP_PATH="$candidate" DETACH_VERSION="$VERSION" \
     DETACH_REQUIRE_SPARKLE_CONFIG=1 DETACH_VERIFY_PRODUCTION=1 \

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -141,6 +141,9 @@ done
 exec "$@"
 POWER
 chmod 0755 "$app/Contents/MacOS/detach-power"
+rm -rf "$root/app/build/fake-dmg"
+mkdir -p "$root/app/build/fake-dmg"
+cp -R "$app" "$root/app/build/fake-dmg/Detach.app"
 printf '%s\n' 'signed dmg fixture' >"$root/app/build/Detach.dmg"
 printf '%s\n' 'signed update fixture' >"$assets/Detach-$version.zip"
 cat >"$assets/appcast.xml" <<XML
@@ -277,6 +280,28 @@ case " $* " in
   *) exit 64 ;;
 esac
 SH
+  write_executable "$BIN/hdiutil" <<'SH'
+#!/bin/bash
+set -eu
+case "${1:-}" in
+  attach)
+    mount=""
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -mountpoint) mount="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [ -n "$mount" ]
+    cp -R "${FAKE_DMG_APP:?}" "$mount/Detach.app"
+    ;;
+  detach)
+    rm -rf "${2:?}/Detach.app"
+    ;;
+  *) exit 64 ;;
+esac
+SH
   write_executable "$BIN/gh" <<'SH'
 #!/bin/bash
 set -eu
@@ -389,6 +414,7 @@ run_workflow() {
       FAKE_RELEASE_EXISTS="$RELEASE_EXISTS" \
       FAKE_PUBLISHED_MANIFEST="$PUBLISHED_MANIFEST" \
       FAKE_TARGET_TAG="$TARGET_TAG" \
+      FAKE_DMG_APP="$REPO/app/build/fake-dmg/Detach.app" \
       DETACH_RELEASE_TEST_MODE=1 \
       DETACH_QUALITY_GATE_TEST_MODE=1 \
       DETACH_RELEASE_TEST_APPLICATIONS_DIR="$APPS" \
@@ -456,6 +482,8 @@ run_resume_case() {
     expect_failure "resume-$stage" "injected safe failure after $stage" \
       run_workflow "$stage"
   done
+  printf '%s\n' development \
+    >"$REPO/app/build/Detach.app/Contents/Resources/DetachCLI/VERSION"
   export FAKE_NOTARY_UNAVAILABLE=1
   mkdir -p "$REPO/docs"
   printf '%s\n' 'release tooling follow-up' >"$REPO/docs/testing.md"


### PR DESCRIPTION
The release orchestrator now mounts the validated signed DMG read-only and copies its production Detach.app into the local candidate. It no longer trusts the mutable intermediate app build, which normal quality gates can replace.\n\nThe hermetic resume test overwrites the intermediate app after artifacts and proves installation still uses the DMG copy.\n\nVerification: scripts/quality-gate PASS (policy 12, fingerprint 80332057cd55ada58242cc9857275efb2733ceb8e19d66937b9613a461ba270d).