### PR TITLE
Publish tagged release from tooling descendant

### DIFF
--- a/app/scripts/publish-release.sh
+++ b/app/scripts/publish-release.sh
@@ -19,6 +19,7 @@ FEED_URL="${DETACH_SPARKLE_FEED_URL:-https://github.com/$REPOSITORY/releases/lat
 RELEASE_TARGET="${DETACH_GITHUB_RELEASE_TARGET:-}"
 SEPARATE_RELEASE_REPOSITORY="${DETACH_SEPARATE_RELEASE_REPOSITORY:-0}"
 PUBLISH_CONFIRMATION="${DETACH_CONFIRM_PUBLISH:-}"
+ORCHESTRATED_COMMIT="${DETACH_RELEASE_EXPECTED_COMMIT:-}"
 RESUME_DRAFT="${DETACH_RESUME_DRAFT:-0}"
 RESUME_PUBLISHED="${DETACH_RESUME_PUBLISHED:-0}"
 APPCAST_VERIFIER="$APP_ROOT/scripts/verify-appcast.sh"
@@ -280,11 +281,29 @@ GIT_COMMIT="$(manifest_value git_commit)"
   printf 'Release manifest contains an invalid git commit\n' >&2
   exit 1
 }
-[ "$(git -C "$REPO_ROOT" rev-parse --verify HEAD)" = "$GIT_COMMIT" ] && \
-  [ "$(git -C "$REPO_ROOT" rev-list -n 1 "$TAG" 2>/dev/null || true)" = "$GIT_COMMIT" ] || {
-    printf 'Current HEAD/tag do not match the built release manifest\n' >&2
+[ "$(git -C "$REPO_ROOT" rev-list -n 1 "$TAG" 2>/dev/null || true)" = "$GIT_COMMIT" ] || {
+  printf 'Current tag does not match the built release manifest\n' >&2
+  exit 1
+}
+if [ -n "$ORCHESTRATED_COMMIT" ]; then
+  [[ "$ORCHESTRATED_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+    printf 'DETACH_RELEASE_EXPECTED_COMMIT must be a full Git commit\n' >&2
     exit 1
   }
+  [ "$ORCHESTRATED_COMMIT" = "$GIT_COMMIT" ] || {
+    printf 'Orchestrated commit does not match the built release manifest\n' >&2
+    exit 1
+  }
+  git -C "$REPO_ROOT" merge-base --is-ancestor "$GIT_COMMIT" HEAD || {
+    printf 'Current HEAD does not contain the built release commit\n' >&2
+    exit 1
+  }
+else
+  [ "$(git -C "$REPO_ROOT" rev-parse --verify HEAD)" = "$GIT_COMMIT" ] || {
+    printf 'Current HEAD does not match the built release manifest\n' >&2
+    exit 1
+  }
+fi
 
 for update_checksum in \
   "$UPDATE_ZIP.sha256" \

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -63,6 +63,9 @@ change real power state, upload assets, or claim publication.
   synchronized `main` only when the release commit remains an ancestor and all
   later paths are release tooling, release tests, or release documentation.
   The annotated tag and artifact manifest stay bound to the release commit.
+- The release orchestrator gives the lower-level publisher the exact manifest
+  commit. The publisher requires the tag to match it and the current `HEAD` to
+  contain it. The orchestrator separately rejects non-tooling descendants.
 - Sparkle remains pinned and signed inside-out. Production builds never carry
   the development library-validation exception. Appcasts contain exactly one
   arm64 hardware requirement.

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -340,8 +340,9 @@ remote_ref_commit() {
 release_tooling_path_allowed() {
   case "$1" in
     scripts/release-version|scripts/release-impact|scripts/quality-gate|\
+    app/scripts/publish-release.sh|\
     tests/quality-gate.sh|tests/release-impact.sh|tests/release-workflow.sh|\
-    tests/shell-safety.sh|tests/shell-safety-contract.sh|\
+    tests/publish-preflight.sh|tests/shell-safety.sh|tests/shell-safety-contract.sh|\
     docs/quality-gates.md|docs/specs/release.md|docs/testing.md)
       return 0
       ;;
@@ -989,6 +990,7 @@ publish_release() {
       DETACH_RELEASE_TAG="$TAG" \
       DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
       DETACH_CONFIRM_PUBLISH="$REPOSITORY@$TAG" \
+      DETACH_RELEASE_EXPECTED_COMMIT="$RELEASE_COMMIT" \
       DETACH_RESUME_DRAFT=1 \
       DETACH_RESUME_PUBLISHED=1 \
       "$APP_ROOT/scripts/publish-release.sh"

--- a/tests/publish-preflight.sh
+++ b/tests/publish-preflight.sh
@@ -377,6 +377,54 @@ grep -F 'hdiutil|attach -readonly -nobrowse -owners on -mountpoint ' \
 grep -F 'spctl|--assess --type open --context context:primary-signature --verbose=2' \
   "$TMP_ROOT/validation.log" >/dev/null
 
+# The release orchestrator can continue from a clean tooling descendant while
+# the tag and manifest stay bound to the built release commit. Direct use keeps
+# the stricter HEAD equality check.
+printf '%s\n' 'release tooling follow-up' >>"$TEST_REPO/README.md"
+git -C "$TEST_REPO" add README.md
+git -C "$TEST_REPO" commit -qm 'release tooling follow-up'
+rm -f "$GH_LOG"
+if PATH="$FAKE_BIN:/usr/bin:/bin" \
+    FAKE_GH_LOG="$GH_LOG" \
+    FAKE_VALIDATION_LOG="$TMP_ROOT/validation.log" \
+    DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
+    DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
+    "$TEST_APP/scripts/publish-release.sh" \
+    >"$TMP_ROOT/descendant-direct.stdout" \
+    2>"$TMP_ROOT/descendant-direct.stderr"; then
+  printf 'direct publish unexpectedly accepted a descendant HEAD\n' >&2
+  exit 1
+fi
+grep -F 'Current HEAD does not match the built release manifest' \
+  "$TMP_ROOT/descendant-direct.stderr" >/dev/null
+[ ! -e "$GH_LOG" ] || {
+  printf 'direct descendant rejection contacted GitHub\n' >&2
+  exit 1
+}
+
+: >"$TMP_ROOT/validation.log"
+PUBLISH_EXIT=0
+if PATH="$FAKE_BIN:/usr/bin:/bin" \
+    FAKE_GH_LOG="$GH_LOG" \
+    FAKE_VALIDATION_LOG="$TMP_ROOT/validation.log" \
+    DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
+    DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
+    DETACH_RELEASE_EXPECTED_COMMIT="$GIT_COMMIT" \
+    "$TEST_APP/scripts/publish-release.sh" \
+    >"$TMP_ROOT/descendant-orchestrated.stdout" \
+    2>"$TMP_ROOT/descendant-orchestrated.stderr"; then
+  printf 'orchestrated descendant unexpectedly passed fake gh\n' >&2
+  exit 1
+else
+  PUBLISH_EXIT=$?
+fi
+[ "$PUBLISH_EXIT" = 97 ] || {
+  printf 'orchestrated descendant did not reach gh (exit %s)\n' \
+    "$PUBLISH_EXIT" >&2
+  exit 1
+}
+grep -Fx 'auth status' "$GH_LOG" >/dev/null
+
 # A safe retry may encounter a draft created by a previous interrupted upload.
 # It must validate every existing digest, upload only missing allowlisted files,
 # and then publish the same draft instead of creating or replacing a release.
@@ -450,6 +498,7 @@ PATH="$FAKE_BIN:/usr/bin:/bin" \
   FAKE_DRAFT_PUBLISHED="$TMP_ROOT/draft-published" \
   DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
   DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
+  DETACH_RELEASE_EXPECTED_COMMIT="$GIT_COMMIT" \
   DETACH_RESUME_DRAFT=1 \
   "$TEST_APP/scripts/publish-release.sh" \
   >"$TMP_ROOT/resume-draft.stdout" 2>"$TMP_ROOT/resume-draft.stderr"
@@ -470,6 +519,7 @@ PATH="$FAKE_BIN:/usr/bin:/bin" \
   FAKE_DRAFT_PUBLISHED="$TMP_ROOT/draft-published" \
   DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
   DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
+  DETACH_RELEASE_EXPECTED_COMMIT="$GIT_COMMIT" \
   DETACH_RESUME_PUBLISHED=1 \
   "$TEST_APP/scripts/publish-release.sh" \
   >"$TMP_ROOT/resume-published.stdout" 2>"$TMP_ROOT/resume-published.stderr"

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -179,6 +179,9 @@ SH
 set -euo pipefail
 root="$(cd -P "$(dirname "$0")/../.." && pwd)"
 version="${DETACH_VERSION:?}"
+manifest="$root/app/build/update-assets/release-manifest.json"
+[ "${DETACH_RELEASE_EXPECTED_COMMIT:-}" = \
+  "$(plutil -extract git_commit raw -o - "$manifest")" ]
 mkdir -p "${FAKE_REMOTE_ASSETS:?}"
 cp "$root/app/build/Detach.dmg" "$root/app/build/Detach.dmg.sha256" \
   "$root/app/build/update-assets/Detach-$version.zip" \


### PR DESCRIPTION
The orchestrator now gives the lower-level publisher the exact manifest commit when a paused release resumes from an allowlisted tooling-only main descendant. The publisher still requires the tag to match that commit and HEAD to contain it; direct use keeps strict HEAD equality.\n\nVerification: scripts/quality-gate PASS (policy 12, fingerprint 6debbb6534d795015ab7cf807b8900071d580dcb752bf049d5ac3c27ed77f833).