### PR TITLE
Keep dashboard stable during deferred updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,8 +537,11 @@ an update fails, the active CLI does not change. Move Detach to `/Applications`
 before you try an update. For a download failure, check the network connection
 and try again. For an archive, signature, or installation failure, download
 the latest DMG. If the CLI does not match the app, open Detach settings, select
-System, and run Repair. A live managed session can block the CLI change. End
-the session and try the update again.
+System, and run Repair. A normal app update does not interrupt live sessions.
+If active sessions hold power leases, Detach keeps the current helper and the
+session dashboard. It retries the helper update after the sessions finish and
+the app becomes active again. Repairing a damaged active payload can still
+require you to end the sessions that use it.
 
 From a terminal:
 

--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -18,6 +18,7 @@ final class InstallationStore {
     enum Phase: Equatable {
         case idle
         case syncing
+        case updateDeferred
         case actionRequired
         case ready
         case failed(String)
@@ -138,16 +139,12 @@ final class InstallationStore {
     /// The assistant card derived from current state; `.mainApp` means the
     /// dashboard is shown instead of onboarding.
     var onboardingStep: OnboardingStep {
-        // A returning user must never see a transient setup card while the
-        // app bootstraps or refreshes on activation. Keep the dashboard
-        // mounted until a completed check publishes a real actionable state.
-        if onboardingEverCompleted,
-           phase == .idle || phase == .syncing || phase == .ready {
-            return .mainApp
-        }
         var failureMessage: String?
         if case .failed(let message) = phase { failureMessage = message }
-        return SetupGuidance.step(for: OnboardingStepInput(
+        return Self.onboardingStep(
+            phase: phase,
+            onboardingEverCompleted: onboardingEverCompleted,
+            input: OnboardingStepInput(
             isStableApplicationLocation: isStableApplicationLocation,
             // `.idle` precedes the automatic bootstrap; both present as the
             // hands-off setting-up card.
@@ -159,6 +156,26 @@ final class InstallationStore {
             powerReadinessConfirmed: powerHelperReadinessConfirmed,
             providerInstalled: providerCheckPassed,
             onboardingEverCompleted: onboardingEverCompleted))
+    }
+
+    static func onboardingStep(
+        phase: Phase,
+        onboardingEverCompleted: Bool,
+        input: OnboardingStepInput
+    ) -> OnboardingStep {
+        // A returning user must never see a transient setup card while the
+        // app bootstraps, refreshes, or waits for active power leases to end.
+        // Keep the dashboard mounted until a completed check publishes a real
+        // actionable state.
+        if onboardingEverCompleted {
+            switch phase {
+            case .idle, .syncing, .updateDeferred, .ready:
+                return .mainApp
+            case .actionRequired, .failed:
+                break
+            }
+        }
+        return SetupGuidance.step(for: input)
     }
 
     func bootstrap() async {
@@ -399,12 +416,18 @@ final class InstallationStore {
             await bootstrap()
             return
         }
+        if phase == .updateDeferred && !distributionMatchesBundle {
+            await synchronize(repair: false)
+            return
+        }
         let wasReady = phase == .ready
         if !wasReady { phase = .syncing }
         powerHelperStatus = powerHelper.status
+        var powerHelperUpdateDeferred = false
         if distributionMatchesBundle {
             do {
-                try await powerHelper.reconcileAfterAppUpdate()
+                powerHelperUpdateDeferred = try await powerHelper
+                    .reconcileAfterAppUpdate() == .deferredForActiveLeases
                 powerHelperError = nil
             } catch {
                 powerHelperError = error.localizedDescription
@@ -440,7 +463,10 @@ final class InstallationStore {
             return
         }
         if report != nil {
-            await refreshDoctor()
+            await refreshDoctor(
+                powerHelperUpdateDeferred: powerHelperUpdateDeferred)
+        } else if powerHelperUpdateDeferred && onboardingEverCompleted {
+            phase = .updateDeferred
         } else {
             updatePhase()
         }
@@ -527,15 +553,18 @@ final class InstallationStore {
             }
             distributionMatchesBundle = true
         } catch {
-            phase = .failed(error.localizedDescription)
+            phase = !repair && onboardingEverCompleted
+                ? .updateDeferred : .failed(error.localizedDescription)
             return
         }
 
         // The privileged daemon owns only the narrow closed-lid setting. Its
         // renewable leases and timer remain effective when Detach.app closes.
         powerHelperError = nil
+        var powerHelperUpdateDeferred = false
         do {
-            try await powerHelper.reconcileAfterAppUpdate()
+            powerHelperUpdateDeferred = try await powerHelper
+                .reconcileAfterAppUpdate() == .deferredForActiveLeases
         } catch {
             powerHelperError = error.localizedDescription
         }
@@ -566,7 +595,8 @@ final class InstallationStore {
         do {
             report = try await client.doctor()
         } catch {
-            phase = .failed(error.localizedDescription)
+            phase = powerHelperUpdateDeferred && onboardingEverCompleted
+                ? .updateDeferred : .failed(error.localizedDescription)
             return
         }
         powerHelperReadinessConfirmed = Self.powerHelperReadiness(
@@ -574,10 +604,16 @@ final class InstallationStore {
             powerHelperStatus: powerHelperStatus,
             powerHelperError: powerHelperError,
             report: report)
-        updatePhase()
+        if powerHelperUpdateDeferred && onboardingEverCompleted {
+            phase = .updateDeferred
+        } else {
+            updatePhase()
+        }
     }
 
-    private func refreshDoctor() async {
+    private func refreshDoctor(
+        powerHelperUpdateDeferred: Bool = false
+    ) async {
         guard let payloadDirectory else { phase = .ready; return }
         let client = DistributionClient(
             installer: ProcessDetachCLI(executable: payloadDirectory.appendingPathComponent("detach-install")),
@@ -603,9 +639,14 @@ final class InstallationStore {
                 powerHelperStatus: powerHelperStatus,
                 powerHelperError: powerHelperError,
                 report: report)
-            updatePhase()
+            if powerHelperUpdateDeferred && onboardingEverCompleted {
+                phase = .updateDeferred
+            } else {
+                updatePhase()
+            }
         } catch {
-            phase = .failed(error.localizedDescription)
+            phase = powerHelperUpdateDeferred && onboardingEverCompleted
+                ? .updateDeferred : .failed(error.localizedDescription)
         }
     }
 

--- a/app/Sources/DetachApp/PowerHelperService.swift
+++ b/app/Sources/DetachApp/PowerHelperService.swift
@@ -19,6 +19,11 @@ enum PowerHelperUnregistrationPreparation: Equatable {
     case activeLeases
 }
 
+enum PowerHelperReconciliationOutcome: Equatable {
+    case complete
+    case deferredForActiveLeases
+}
+
 @MainActor
 protocol PowerHelperLifecycleRunning: AnyObject {
     func prepareForUnregistration() async throws
@@ -264,22 +269,27 @@ final class PowerHelperService {
 
     var status: PowerHelperRegistrationStatus { backend.status }
 
-    func reconcileAfterAppUpdate() async throws {
+    @discardableResult
+    func reconcileAfterAppUpdate() async throws
+        -> PowerHelperReconciliationOutcome
+    {
         guard let digest = digestProvider() else {
             throw PowerHelperServiceError.bundledDefinitionMissing
         }
+        var outcome = PowerHelperReconciliationOutcome.complete
         try await performExclusiveOperation {
-            try await drive(to: .install(digest))
+            outcome = try await drive(to: .install(digest))
         }
+        return outcome
     }
 
     func enable() async throws {
-        try await reconcileAfterAppUpdate()
+        _ = try await reconcileAfterAppUpdate()
     }
 
     func disable() async throws {
         try await performExclusiveOperation {
-            try await drive(to: .remove)
+            _ = try await drive(to: .remove)
         }
     }
 
@@ -317,14 +327,16 @@ final class PowerHelperService {
         try await operation()
     }
 
-    private func drive(to desired: DesiredGoal) async throws {
+    private func drive(to desired: DesiredGoal) async throws
+        -> PowerHelperReconciliationOutcome
+    {
         var transaction = try loadOrMigrateTransaction(desired: desired)
         if transaction == nil {
             transaction = try bootstrapTransaction(for: desired)
-            if transaction == nil { return }
+            if transaction == nil { return .complete }
         }
 
-        guard var transaction else { return }
+        guard var transaction else { return .complete }
         transaction = try align(transaction, with: desired)
 
         // Every iteration either returns, crosses one externally observable
@@ -344,7 +356,7 @@ final class PowerHelperService {
                             throw PowerHelperServiceError
                                 .activeLeasesPreventUnregistration
                         }
-                        return
+                        return .deferredForActiveLeases
                     }
                     guard try lifetimeBarrierStatus() == .busy else {
                         // A helper from this build holds the lifetime lock
@@ -433,7 +445,7 @@ final class PowerHelperService {
                     // Keep `.removed`: a later reinstall must register a helper
                     // and receive a fresh XPC reply before reopening the root
                     // gate persisted by the removed generation.
-                    return
+                    return .complete
                 }
                 defaults.set(true, forKey: pendingDigestKey)
                 transaction.phase = .registering
@@ -456,10 +468,10 @@ final class PowerHelperService {
                     rememberDefinition(digest)
                     try handoffStore.clear()
                     clearLegacyHandoffMarkers()
-                    return
+                    return .complete
                 case .requiresApproval:
                     defaults.set(true, forKey: pendingDigestKey)
-                    return
+                    return .complete
                 case .notRegistered, .unavailable:
                     defaults.set(true, forKey: pendingDigestKey)
                     try await registerWithRetry()
@@ -467,7 +479,7 @@ final class PowerHelperService {
                     case .enabled:
                         continue
                     case .requiresApproval:
-                        return
+                        return .complete
                     case .notRegistered, .unavailable:
                         throw PowerHelperServiceError
                             .registrationDidNotComplete

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -124,6 +124,27 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertEqual(phase, .actionRequired)
     }
 
+    func testDeferredPowerHelperUpdateKeepsCompletedOnboardingOnDashboard() {
+        let fixture = makeCompletedOnboardingStore()
+        defer { fixture.cleanup() }
+
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .updateDeferred,
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: true,
+                    isBusy: false,
+                    failureMessage: nil,
+                    distributionMatchesBundle: true,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: false,
+                    providerInstalled: true,
+                    onboardingEverCompleted: true)),
+            .mainApp)
+    }
+
     func testHealthyReadinessInputsStillProduceReadyPhase() {
         let phase = InstallationStore.phaseForReadiness(
             isStableApplicationLocation: true,

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -474,16 +474,21 @@ final class PowerHelperServiceTests: XCTestCase {
     }
 
     func testChangedDefinitionDefersWhileSessionsHoldPowerLeases() async throws {
-        let backend = FakePowerHelperBackend(status: .enabled, registrations: [])
+        let backend = FakePowerHelperBackend(
+            status: .enabled, registrations: [.success(.enabled)])
         let lifecycle = FakePowerHelperLifecycle(
-            preparations: [.success(.activeLeases)])
+            preparations: [
+                .success(.activeLeases),
+                .success(.prepared),
+            ])
         let fixture = makeFixture(backend: backend, lifecycle: lifecycle)
         defer { fixture.cleanup() }
         fixture.defaults.set(
             "digest-previous", forKey: "powerHelperDefinitionDigest")
 
-        try await fixture.service.reconcileAfterAppUpdate()
+        let outcome = try await fixture.service.reconcileAfterAppUpdate()
 
+        XCTAssertEqual(outcome, .deferredForActiveLeases)
         XCTAssertEqual(lifecycle.prepareCalls, 1)
         XCTAssertEqual(backend.unregisterCalls, 0)
         XCTAssertEqual(backend.registerCalls, 0)
@@ -495,6 +500,18 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertFalse(fixture.defaults.bool(
             forKey: "powerHelperUnregistrationPending"))
         XCTAssertEqual(fixture.service.status, .enabled)
+
+        let retryOutcome = try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(retryOutcome, .complete)
+        XCTAssertEqual(lifecycle.prepareCalls, 2)
+        XCTAssertEqual(backend.unregisterCalls, 1)
+        XCTAssertEqual(backend.registerCalls, 1)
+        XCTAssertEqual(
+            fixture.defaults.string(forKey: "powerHelperDefinitionDigest"),
+            "digest-current")
+        XCTAssertFalse(fixture.defaults.bool(
+            forKey: "powerHelperDefinitionReconcilePending"))
     }
 
     func testFailedUnregisterKeepsRootGateClosedAndSubmittedPhase() async {
@@ -583,7 +600,7 @@ final class PowerHelperServiceTests: XCTestCase {
             .unregisterSubmitted)
 
         backend.completeSuspendedUnregister()
-        try await reconciliation.value
+        _ = try await reconciliation.value
 
         XCTAssertEqual(backend.registerCalls, 1)
         XCTAssertEqual(fixture.lifecycle.cancelCalls, 1)
@@ -1050,7 +1067,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertEqual(secondBackend.registerCalls, 0)
 
         firstBackend.completeSuspendedUnregister()
-        try await firstReconciliation.value
+        _ = try await firstReconciliation.value
     }
 
     func testDifferentUserWithoutJournalReplaysInterruptedSystemUnregister() async throws {
@@ -1174,7 +1191,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertEqual(foreignUser.lifecycle.cancelCalls, 0)
 
         backend.completeSuspendedUnregister()
-        try await recovery.value
+        _ = try await recovery.value
         XCTAssertEqual(backend.registerCalls, 1)
         XCTAssertEqual(foreignUser.lifecycle.cancelCalls, 1)
     }

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -27,18 +27,18 @@ dashboard action remains disabled until then, and after a long wait it offers
 an explicit monitor retry instead of a bypass. Completion is guarded again in
 the store and is recorded only by that explicit action, exactly once.
 
-After onboarding has ever completed, `.idle`, `.syncing`, and `.ready` all
-present `.mainApp`. This is a first-frame invariant: cold-launch bootstrap and
-scene-activation refresh must keep the existing dashboard mounted and must not
-flash onboarding. Only a completed `.actionRequired` or `.failed` result may
-surface setup again. A missing provider also shows the dashboard, not
-onboarding. Provider installation is offered only as the official command,
+After onboarding completes, `.idle`, `.syncing`, `.updateDeferred`, and
+`.ready` present `.mainApp`. Bootstrap, refresh, and an update held by active
+leases keep the dashboard mounted. Only a completed `.actionRequired` or
+`.failed` result can show setup again. A missing provider also shows the
+dashboard. Provider installation uses the official command,
 launched visibly in the user's own terminal through the private `.command`
 mechanism; never claim a guided install failed (there is no outcome channel),
 only that the CLI is not detected yet. When helper/plist bytes change after an
 app update, unregister, await completion, then use the bounded retry for the
 transient SMAppService Code=1 race. Do not replace a helper with active leases:
-defer the update.
+defer the update. Report a normal reconciliation outcome and retry on a later
+app activation.
 
 Every readiness build carries one unique `detach-app-build:<UUID>` value both
 in the main executable's `__TEXT,__detach_build` section and in the signed
@@ -182,4 +182,5 @@ validation, and installation errors provide the manual DMG path and the
 Settings > System Repair path. These errors state that the active CLI did not
 change. If app
 replacement completes but CLI or helper synchronization fails, the prior CLI
-stays active and Repair remains available.
+stays active and Repair remains available. Background synchronization keeps
+the dashboard. A later activation retries it.


### PR DESCRIPTION
## Summary
- report active power leases as a typed helper-update deferral
- keep returning users on the session dashboard while background synchronization waits
- retry deferred helper and CLI synchronization on a later activation

## Evidence
- focused Swift suites: 70 tests passed
- impact-selected quality gate policy 12: PASS
- selected stages: static, swift, quality-contracts, app, ui-e2e, release-budget

## Hardware impact
No power or clamshell implementation changed. Existing active-lease replacement barriers remain fail-closed, so the impact gate did not select real clamshell hardware verification.