### PR TITLE
Bind semantic release impact reviews

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -38,6 +38,11 @@ change real power state, upload assets, or claim publication.
   power, helper, watchdog, lease, assertion, or lid-probe impact. An unknown
   product path selects both manual gates. Test-only, documentation-only, and
   known unrelated product paths do not select them.
+- The path classifier is the fail-safe default. An explicit private semantic
+  review can omit a false-positive manual gate only when it is permission-safe,
+  ignored by Git, bound to the exact base and head commits, and gives a reason
+  for each decision. It cannot narrow unknown-path impact or omit automated
+  tests, signing, notarization, the signed power smoke, or artifact checks.
 - A selected closed-lid probe must emit its first liveness sample within a
   bounded ten-second launch window before owner confirmation is accepted.
   Automated release tests cover failed install and update paths. A selected

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -139,6 +139,11 @@ localization impact. It selects the supervised closed-lid probe only for power,
 helper, watchdog, lease, assertion, or lid-probe impact. Unknown product paths
 select both manual gates. Its private resume state and impact evidence live
 under ignored `app/build/`.
+The path result is fail-safe. For a false positive, a release operator can
+supply `DETACH_RELEASE_IMPACT_REVIEW` with an absolute path directly under
+ignored `app/build/release-impact-reviews/`. The `0600` TSV file must bind the
+exact base and head commits, set both manual-gate decisions, and give a reason
+for each. It cannot narrow unknown-path impact or an automated release gate.
 Set `DETACH_RELEASE_IGNORE_TIMING=1` only when the owner explicitly accepts
 busy-machine timing for that single release; the script requires the same exact
 release-target confirmation before it omits reference-machine timing checks.

--- a/scripts/release-impact
+++ b/scripts/release-impact
@@ -27,6 +27,9 @@ UNKNOWN_IMPACT=false
 INSTALL_REASONS=()
 LID_REASONS=()
 UNKNOWN_REASONS=()
+SEMANTIC_REVIEW_APPLIED=false
+INSTALL_REVIEW_REASON=""
+LID_REVIEW_REASON=""
 
 add_unique() {
   local array_name="$1" value="$2" existing
@@ -68,6 +71,74 @@ require_both_unknown() {
   add_unique UNKNOWN_REASONS "$1"
   require_install_matrix "$1"
   require_lid_test "$1"
+}
+
+review_value() {
+  local file="$1" key="$2" count value
+  count="$(awk -F '\t' -v wanted="$key" '$1 == wanted {count++} END {print count+0}' "$file")"
+  [ "$count" -eq 1 ] || die "impact review has missing or duplicate key: $key"
+  value="$(awk -F '\t' -v wanted="$key" '$1 == wanted {print $2; exit}' "$file")"
+  printf '%s\n' "$value"
+}
+
+apply_semantic_review() {
+  local review="${DETACH_RELEASE_IMPACT_REVIEW:-}" review_root review_parent
+  local relative mode mode_value schema reviewed_base reviewed_head
+  local reviewed_install reviewed_lid key
+
+  [ -n "$review" ] || return 0
+  case "$review" in /*) ;; *) die 'impact review path must be absolute' ;; esac
+  [ -f "$review" ] && [ ! -L "$review" ] || \
+    die 'impact review must be a regular, non-symlink file'
+  review_root="$ROOT/app/build/release-impact-reviews"
+  [ -d "$review_root" ] && [ ! -L "$review_root" ] || \
+    die 'impact review root is unavailable or unsafe'
+  review_root="$(cd -P "$review_root" && pwd)"
+  review_parent="$(cd -P "$(dirname "$review")" && pwd)"
+  [ "$review_parent" = "$review_root" ] || \
+    die 'impact review must be directly under app/build/release-impact-reviews'
+  relative="${review#"$ROOT"/}"
+  git -C "$ROOT" check-ignore -q -- "$relative" || \
+    die 'impact review must remain ignored by Git'
+  if git -C "$ROOT" ls-files --error-unmatch -- "$relative" >/dev/null 2>&1; then
+    die 'impact review must never be tracked'
+  fi
+  mode="$(stat -f '%Lp' "$review")"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || die 'cannot validate impact review permissions'
+  mode_value=$((8#$mode))
+  [ $((mode_value & 077)) -eq 0 ] || \
+    die 'impact review must not be accessible by group/other'
+  awk -F '\t' '
+    NF != 2 {exit 1}
+    $1 !~ /^(schema|base_commit|head_commit|install_matrix_required|install_matrix_rationale|lid_test_required|lid_test_rationale)$/ {exit 1}
+  ' "$review" || die 'impact review has malformed or unsupported fields'
+  for key in schema base_commit head_commit install_matrix_required \
+      install_matrix_rationale lid_test_required lid_test_rationale; do
+    review_value "$review" "$key" >/dev/null
+  done
+  schema="$(review_value "$review" schema)"
+  reviewed_base="$(review_value "$review" base_commit)"
+  reviewed_head="$(review_value "$review" head_commit)"
+  reviewed_install="$(review_value "$review" install_matrix_required)"
+  INSTALL_REVIEW_REASON="$(review_value "$review" install_matrix_rationale)"
+  reviewed_lid="$(review_value "$review" lid_test_required)"
+  LID_REVIEW_REASON="$(review_value "$review" lid_test_rationale)"
+  [ "$schema" = 1 ] || die 'impact review schema is unsupported'
+  [ "$reviewed_base" = "$BASE_COMMIT" ] && [ "$reviewed_head" = "$HEAD_COMMIT" ] || \
+    die 'impact review does not match the exact release source range'
+  case "$reviewed_install:$reviewed_lid" in
+    true:true|true:false|false:true|false:false) ;;
+    *) die 'impact review gate values must be true or false' ;;
+  esac
+  [ "${#INSTALL_REVIEW_REASON}" -ge 20 ] && [ "${#LID_REVIEW_REASON}" -ge 20 ] || \
+    die 'impact review rationales must each contain at least 20 characters'
+  if [ "$UNKNOWN_IMPACT" = true ] && \
+     { [ "$reviewed_install" = false ] || [ "$reviewed_lid" = false ]; }; then
+    die 'impact review cannot omit a gate selected by an unknown product path'
+  fi
+  INSTALL_MATRIX_REQUIRED="$reviewed_install"
+  LID_TEST_REQUIRED="$reviewed_lid"
+  SEMANTIC_REVIEW_APPLIED=true
 }
 
 classify_path() {
@@ -185,12 +256,19 @@ while IFS= read -r -d '' status && IFS= read -r -d '' path; do
   esac
 done < <(git -C "$ROOT" diff --name-status -z --find-renames "$BASE_COMMIT" "$HEAD_COMMIT")
 
+apply_semantic_review
+
 printf 'schema\t1\n'
 printf 'base_commit\t%s\n' "$BASE_COMMIT"
 printf 'head_commit\t%s\n' "$HEAD_COMMIT"
 printf 'install_matrix_required\t%s\n' "$INSTALL_MATRIX_REQUIRED"
 printf 'lid_test_required\t%s\n' "$LID_TEST_REQUIRED"
 printf 'unknown_impact\t%s\n' "$UNKNOWN_IMPACT"
+printf 'semantic_review_applied\t%s\n' "$SEMANTIC_REVIEW_APPLIED"
+[ "$SEMANTIC_REVIEW_APPLIED" = false ] || {
+  printf 'install_matrix_review_reason\t%s\n' "$INSTALL_REVIEW_REASON"
+  printf 'lid_test_review_reason\t%s\n' "$LID_REVIEW_REASON"
+}
 for path in "${INSTALL_REASONS[@]-}"; do
   [ -z "$path" ] || printf 'install_matrix_reason\t%s\n' "$path"
 done

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -16,7 +16,8 @@ git -C "$REPO" checkout -qb main
 git -C "$REPO" config user.name 'Detach Tests'
 git -C "$REPO" config user.email 'detach-tests@example.invalid'
 printf '%s\n' baseline >"$REPO/README.md"
-git -C "$REPO" add README.md scripts/release-impact
+printf '%s\n' 'app/build/' >"$REPO/.gitignore"
+git -C "$REPO" add .gitignore README.md scripts/release-impact
 git -C "$REPO" commit -qm baseline
 
 commit_path() {
@@ -76,6 +77,51 @@ assert_value "$TMP_ROOT/shared-power.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/shared-power.tsv" lid_test_required true
 assert_value "$TMP_ROOT/shared-power.tsv" unknown_impact false
 
+REVIEW_ROOT="$REPO/app/build/release-impact-reviews"
+REVIEW="$REVIEW_ROOT/current.tsv"
+mkdir -m 0700 -p "$REVIEW_ROOT"
+cat >"$REVIEW" <<EOF
+schema	1
+base_commit	$CORE_HEAD
+head_commit	$SHARED_POWER_HEAD
+install_matrix_required	false
+install_matrix_rationale	Automated coverage proves this change does not alter clean-account system UI.
+lid_test_required	false
+lid_test_rationale	No assertion, lease, helper daemon, or closed-lid runtime behavior changed.
+EOF
+chmod 0600 "$REVIEW"
+DETACH_RELEASE_IMPACT_REVIEW="$REVIEW" \
+  "$REPO/scripts/release-impact" "$CORE_HEAD" "$SHARED_POWER_HEAD" \
+  >"$TMP_ROOT/reviewed.tsv"
+assert_value "$TMP_ROOT/reviewed.tsv" install_matrix_required false
+assert_value "$TMP_ROOT/reviewed.tsv" lid_test_required false
+assert_value "$TMP_ROOT/reviewed.tsv" unknown_impact false
+assert_value "$TMP_ROOT/reviewed.tsv" semantic_review_applied true
+grep -F $'install_matrix_review_reason\tAutomated coverage proves' \
+  "$TMP_ROOT/reviewed.tsv" >/dev/null
+grep -F $'lid_test_review_reason\tNo assertion, lease' \
+  "$TMP_ROOT/reviewed.tsv" >/dev/null
+
+chmod 0644 "$REVIEW"
+if DETACH_RELEASE_IMPACT_REVIEW="$REVIEW" \
+    "$REPO/scripts/release-impact" "$CORE_HEAD" "$SHARED_POWER_HEAD" \
+    >"$TMP_ROOT/review-mode.out" 2>"$TMP_ROOT/review-mode.err"; then
+  printf 'release impact accepted a public impact review\n' >&2
+  exit 1
+fi
+grep -F 'must not be accessible by group/other' \
+  "$TMP_ROOT/review-mode.err" >/dev/null
+chmod 0600 "$REVIEW"
+
+if DETACH_RELEASE_IMPACT_REVIEW="$REVIEW" \
+    "$REPO/scripts/release-impact" "$BASE" "$SHARED_POWER_HEAD" \
+    >"$TMP_ROOT/review-range.out" 2>"$TMP_ROOT/review-range.err"; then
+  printf 'release impact accepted a stale impact review\n' >&2
+  exit 1
+fi
+grep -F 'does not match the exact release source range' \
+  "$TMP_ROOT/review-range.err" >/dev/null
+
 POWER_HEAD="$(commit_path app/Sources/DetachPower/main.swift power)"
 "$REPO/scripts/release-impact" "$SHARED_POWER_HEAD" "$POWER_HEAD" \
   >"$TMP_ROOT/power.tsv"
@@ -89,6 +135,25 @@ assert_value "$TMP_ROOT/unknown.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/unknown.tsv" lid_test_required true
 assert_value "$TMP_ROOT/unknown.tsv" unknown_impact true
 grep -F $'unknown_reason\tproduct/new-runtime' "$TMP_ROOT/unknown.tsv" >/dev/null
+
+cat >"$REVIEW" <<EOF
+schema	1
+base_commit	$POWER_HEAD
+head_commit	$UNKNOWN_HEAD
+install_matrix_required	false
+install_matrix_rationale	A semantic review cannot narrow an unknown product path impact selection.
+lid_test_required	false
+lid_test_rationale	A semantic review cannot narrow an unknown product path impact selection.
+EOF
+chmod 0600 "$REVIEW"
+if DETACH_RELEASE_IMPACT_REVIEW="$REVIEW" \
+    "$REPO/scripts/release-impact" "$POWER_HEAD" "$UNKNOWN_HEAD" \
+    >"$TMP_ROOT/review-unknown.out" 2>"$TMP_ROOT/review-unknown.err"; then
+  printf 'release impact review omitted gates for an unknown product path\n' >&2
+  exit 1
+fi
+grep -F 'cannot omit a gate selected by an unknown product path' \
+  "$TMP_ROOT/review-unknown.err" >/dev/null
 
 NEW_APP_HEAD="$(commit_path app/Sources/DetachApp/FutureFlow.swift future-app)"
 "$REPO/scripts/release-impact" "$UNKNOWN_HEAD" "$NEW_APP_HEAD" \


### PR DESCRIPTION
## Summary
- keep path-based manual-gate selection as the fail-safe default
- allow an explicitly supplied private semantic review bound to the exact base/head commits
- reject tracked, symlinked, permission-unsafe, stale, malformed, and unknown-path narrowing reviews
- preserve every automated, signing, notarization, signed-power, and artifact gate

## Evidence
- release-impact hermetic tests: PASS
- impact-selected quality gate policy 12: PASS
- selected stages: static, app, ui-e2e, release-preflight, publish-preflight, release-workflow, release-budget