### PR TITLE
Restore zsh startup after terminal launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ detach claude --detach -- "run the test suite and fix failures"
 The app and CLI operate on the same sessions. Start in one and continue in the
 other.
 
-When the terminal uses zsh, Detach starts the temporary command before it loads
-the user's shell startup files. A startup prompt, such as an oh-my-zsh update,
-can pause the command but cannot consume its file path. Answer the prompt to
-continue.
+When the terminal uses zsh, Detach uses a private startup guard until the
+temporary command starts. A startup prompt, such as an oh-my-zsh update, cannot
+consume the command path. Detach then restores the user's shell startup files
+for the session and for new windows in the same terminal process.
 
 ## One command center for Codex and Claude Code
 

--- a/app/Sources/DetachKit/TerminalLauncher.swift
+++ b/app/Sources/DetachKit/TerminalLauncher.swift
@@ -107,7 +107,10 @@ public enum TerminalLauncher {
     }
 
     @MainActor
-    static func openConfiguration(commandURL: URL) -> NSWorkspace.OpenConfiguration {
+    static func openConfiguration(
+        commandURL: URL,
+        processEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> NSWorkspace.OpenConfiguration {
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.activates = true
         configuration.addsToRecentItems = false
@@ -118,10 +121,36 @@ public enum TerminalLauncher {
         // A fresh application instance is required because NSWorkspace only
         // applies launch environment variables to a new process.
         configuration.createsNewApplicationInstance = true
-        configuration.environment = [
+        var environment = [
             "ZDOTDIR": commandURL.deletingLastPathComponent().path
         ]
+        if let originalZDOTDIR = processEnvironment["ZDOTDIR"] {
+            environment["DETACH_TERMINAL_ORIGINAL_ZDOTDIR"] = originalZDOTDIR
+        }
+        configuration.environment = environment
         return configuration
+    }
+
+    static func startupFileContents() -> Data {
+        Data("""
+        # Detach suppresses startup prompts until Terminal runs run.command.
+        detach_outer_zdotdir=${ZDOTDIR:-}
+        if [[ -n "$detach_outer_zdotdir" && ! -e "$detach_outer_zdotdir/run.command" ]]; then
+            if [[ -n ${DETACH_TERMINAL_ORIGINAL_ZDOTDIR+x} ]]; then
+                export ZDOTDIR="$DETACH_TERMINAL_ORIGINAL_ZDOTDIR"
+            else
+                unset ZDOTDIR
+            fi
+            unset DETACH_TERMINAL_ORIGINAL_ZDOTDIR
+            detach_user_zdotdir=${ZDOTDIR:-${HOME:-/}}
+            if [[ "$detach_user_zdotdir" != "$detach_outer_zdotdir" && -r "$detach_user_zdotdir/.zshenv" ]]; then
+                source "$detach_user_zdotdir/.zshenv"
+            fi
+            unset detach_user_zdotdir
+        fi
+        unset detach_outer_zdotdir
+
+        """.utf8)
     }
 
     static func commandFileContents(command: String) throws -> Data {
@@ -135,8 +164,12 @@ public enum TerminalLauncher {
         builtin cd -q -- "${HOME:-/}" || builtin cd -q -- / || exit 125
         /bin/rm -f -- "$command_file" || exit 125
         [[ ! -e "$command_file" ]] || exit 125
-        /bin/rmdir -- "$command_dir" 2>/dev/null || true
-        unset command_file command_dir ZDOTDIR
+        if [[ -n ${DETACH_TERMINAL_ORIGINAL_ZDOTDIR+x} ]]; then
+            export ZDOTDIR="$DETACH_TERMINAL_ORIGINAL_ZDOTDIR"
+        else
+            unset ZDOTDIR
+        fi
+        unset command_file command_dir DETACH_TERMINAL_ORIGINAL_ZDOTDIR
         exec /bin/zsh -lic \(shellQuoted(command))
 
         """
@@ -154,13 +187,19 @@ public enum TerminalLauncher {
         let directory = temporaryDirectory
             .appendingPathComponent("Detach-\(UUID().uuidString)", isDirectory: true)
         let url = directory.appendingPathComponent("run.command")
+        let startupURL = directory.appendingPathComponent(".zshenv")
         do {
             try fileManager.createDirectory(
                 at: directory,
                 withIntermediateDirectories: false,
                 attributes: [.posixPermissions: NSNumber(value: Int16(0o700))])
+            try startupFileContents()
+                .write(to: startupURL, options: .withoutOverwriting)
             try commandFileContents(command: command)
                 .write(to: url, options: .withoutOverwriting)
+            try fileManager.setAttributes(
+                [.posixPermissions: NSNumber(value: Int16(0o600))],
+                ofItemAtPath: startupURL.path)
             try fileManager.setAttributes(
                 [.posixPermissions: NSNumber(value: Int16(0o700))],
                 ofItemAtPath: url.path)

--- a/app/Tests/DetachKitTests/TerminalLauncherTests.swift
+++ b/app/Tests/DetachKitTests/TerminalLauncherTests.swift
@@ -23,7 +23,10 @@ final class TerminalLauncherTests: XCTestCase {
             temporaryDirectory: temporaryDirectory,
             fileManager: .default)
         let contents = try String(contentsOf: url, encoding: .utf8)
+        let startupURL = url.deletingLastPathComponent().appendingPathComponent(".zshenv")
+        let startupContents = try String(contentsOf: startupURL, encoding: .utf8)
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let startupAttributes = try FileManager.default.attributesOfItem(atPath: startupURL.path)
         let directoryAttributes = try FileManager.default.attributesOfItem(
             atPath: url.deletingLastPathComponent().path)
 
@@ -31,6 +34,9 @@ final class TerminalLauncherTests: XCTestCase {
         XCTAssertEqual(url.lastPathComponent, "run.command")
         XCTAssertEqual(url.pathExtension, "command")
         XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, NSNumber(value: 0o700))
+        XCTAssertEqual(
+            startupAttributes[.posixPermissions] as? NSNumber,
+            NSNumber(value: 0o600))
         XCTAssertEqual(
             directoryAttributes[.posixPermissions] as? NSNumber,
             NSNumber(value: 0o700))
@@ -42,9 +48,11 @@ final class TerminalLauncherTests: XCTestCase {
             try XCTUnwrap(contents.range(of: "/bin/rm -f -- \"$command_file\" || exit 125")?.lowerBound),
             try XCTUnwrap(contents.range(of: "exec /bin/zsh -lic")?.lowerBound))
         XCTAssertTrue(contents.contains("[[ ! -e \"$command_file\" ]] || exit 125"))
-        XCTAssertTrue(contents.contains("/bin/rmdir -- \"$command_dir\""))
-        XCTAssertTrue(contents.contains("unset command_file command_dir ZDOTDIR"))
+        XCTAssertTrue(contents.contains("DETACH_TERMINAL_ORIGINAL_ZDOTDIR"))
+        XCTAssertFalse(contents.contains("/bin/rmdir -- \"$command_dir\""))
         XCTAssertTrue(contents.contains("exec /bin/zsh -lic \(shellQuoted(command))"))
+        XCTAssertTrue(startupContents.contains("! -e \"$detach_outer_zdotdir/run.command\""))
+        XCTAssertTrue(startupContents.contains("source \"$detach_user_zdotdir/.zshenv\""))
     }
 
     @MainActor
@@ -53,12 +61,17 @@ final class TerminalLauncherTests: XCTestCase {
             command: "exec /usr/bin/true",
             temporaryDirectory: temporaryDirectory,
             fileManager: .default)
-        let configuration = TerminalLauncher.openConfiguration(commandURL: url)
+        let configuration = TerminalLauncher.openConfiguration(
+            commandURL: url,
+            processEnvironment: ["ZDOTDIR": "/Users/test/custom-zdotdir"])
 
         XCTAssertTrue(configuration.createsNewApplicationInstance)
         XCTAssertEqual(
             configuration.environment["ZDOTDIR"],
             url.deletingLastPathComponent().path)
+        XCTAssertEqual(
+            configuration.environment["DETACH_TERMINAL_ORIGINAL_ZDOTDIR"],
+            "/Users/test/custom-zdotdir")
     }
 
     func testFailureReasonRequiresSelectionOnlyForMissingTerminal() {
@@ -118,11 +131,9 @@ final class TerminalLauncherTests: XCTestCase {
             }
     }
 
-    func testCommandFileLeavesItsDirectoryBeforeDeletingIt() throws {
+    func testCommandFileRemovesPayloadAndKeepsStartupGuard() throws {
         let safeHome = temporaryDirectory.appendingPathComponent("home", isDirectory: true)
-        let zdotdir = temporaryDirectory.appendingPathComponent("zdotdir", isDirectory: true)
         try FileManager.default.createDirectory(at: safeHome, withIntermediateDirectories: false)
-        try FileManager.default.createDirectory(at: zdotdir, withIntermediateDirectories: false)
         let url = try TerminalLauncher.writeCommandFile(
             command: "exec /bin/pwd",
             temporaryDirectory: temporaryDirectory,
@@ -138,7 +149,8 @@ final class TerminalLauncherTests: XCTestCase {
         process.standardError = errors
         var environment = ProcessInfo.processInfo.environment
         environment["HOME"] = safeHome.path
-        environment["ZDOTDIR"] = zdotdir.path
+        environment["ZDOTDIR"] = commandDirectory.path
+        environment.removeValue(forKey: "DETACH_TERMINAL_ORIGINAL_ZDOTDIR")
         process.environment = environment
 
         try process.run()
@@ -149,7 +161,41 @@ final class TerminalLauncherTests: XCTestCase {
         XCTAssertEqual(process.terminationStatus, 0, stderr)
         XCTAssertEqual(stdout.trimmingCharacters(in: .whitespacesAndNewlines), safeHome.path)
         XCTAssertFalse(stderr.contains("getcwd"), stderr)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: commandDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: commandDirectory.appendingPathComponent(".zshenv").path))
+    }
+
+    func testStartupGuardRestoresUserStartupFilesInLaterShells() throws {
+        let safeHome = temporaryDirectory.appendingPathComponent("later-home", isDirectory: true)
+        try FileManager.default.createDirectory(at: safeHome, withIntermediateDirectories: false)
+        for (name, marker) in [
+            (".zshenv", "user-zshenv"),
+            (".zprofile", "user-zprofile"),
+            (".zshrc", "user-zshrc"),
+            (".zlogin", "user-zlogin")
+        ] {
+            try Data("print -r -- \(marker)\n".utf8).write(
+                to: safeHome.appendingPathComponent(name),
+                options: .withoutOverwriting)
+        }
+        let commandURL = try TerminalLauncher.writeCommandFile(
+            command: "exec /usr/bin/true",
+            temporaryDirectory: temporaryDirectory,
+            fileManager: .default)
+        let commandDirectory = commandURL.deletingLastPathComponent()
+
+        let initial = try runLoginZsh(home: safeHome, zdotdir: commandDirectory)
+        XCTAssertEqual(initial.status, 0, initial.stderr)
+        XCTAssertFalse(initial.stdout.contains("user-zsh"), initial.stdout)
+
+        try FileManager.default.removeItem(at: commandURL)
+        let later = try runLoginZsh(home: safeHome, zdotdir: commandDirectory)
+        XCTAssertEqual(later.status, 0, later.stderr)
+        XCTAssertTrue(later.stdout.contains("user-zshenv"), later.stdout)
+        XCTAssertTrue(later.stdout.contains("user-zprofile"), later.stdout)
+        XCTAssertTrue(later.stdout.contains("user-zshrc"), later.stdout)
+        XCTAssertTrue(later.stdout.contains("user-zlogin"), later.stdout)
     }
 
     @MainActor
@@ -174,6 +220,31 @@ final class TerminalLauncherTests: XCTestCase {
         XCTAssertNil(failure)
         XCTAssertEqual(openedApplicationURL, terminal.applicationURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: commandURL?.path ?? ""))
+    }
+
+    private func runLoginZsh(home: URL, zdotdir: URL) throws -> (
+        status: Int32,
+        stdout: String,
+        stderr: String
+    ) {
+        let output = Pipe()
+        let errors = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lic", "exec /usr/bin/true"]
+        process.standardOutput = output
+        process.standardError = errors
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = home.path
+        environment["ZDOTDIR"] = zdotdir.path
+        environment.removeValue(forKey: "DETACH_TERMINAL_ORIGINAL_ZDOTDIR")
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+        return (
+            process.terminationStatus,
+            String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            String(decoding: errors.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self))
     }
 
     @MainActor

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -155,16 +155,16 @@ Automation entitlement.
 
 Distribution bootstrap runs only from `/Applications`, never a DMG or App
 Translocation path. Terminal actions use `NSWorkspace`, not Apple Events, to
-open a private self-deleting `.command` file in a new terminal process. They set
-its directory as outer `ZDOTDIR`; the file clears it before user zsh startup so
-a prompt cannot consume its path. Open, Resume, and Recover use the selected
-terminal bundle identifier, with Terminal as fallback. The new-session sheet
-accepts an optional display name of at most 100 UTF-8 bytes. It rejects control
-characters, blocks invalid launches, explains the limit inline, and passes the
-label as one shell-quoted `--name` argument. The app uses typed `display_name`
-as the session title, with the project/internal name fallback for old records.
-Notifications are opt-in. One app poller provides baseline and transition
-deduplication.
+open a private self-deleting `.command` file in a new terminal process. A
+private `.zshenv` guard is outer `ZDOTDIR`. It blocks startup prompts until
+payload removal. It then restores the original `ZDOTDIR` for the session and
+later shells. No shell may inherit an unusable temporary startup directory.
+Open, Resume, and Recover use the selected terminal, with Terminal as fallback.
+The new-session sheet accepts an optional UTF-8 name up to 100 bytes. It rejects
+control characters, explains invalid input, blocks launch, and passes one
+shell-quoted `--name` argument. The app uses `display_name` as the title, with
+the project/internal name fallback for old records.
+Notifications are opt-in. One app poller deduplicates baseline and transitions.
 
 Sparkle 2 is pinned in `Package.resolved`, embedded with its symlink layout
 intact, and signed inside-out before the outer app. Ad-hoc development builds


### PR DESCRIPTION
## Summary
- keep the private startup guard after the command payload is removed
- restore the original ZDOTDIR and all user zsh startup files in later windows
- add a regression test for the first and later login shells

## Verification
- swift test --filter TerminalLauncherTests
- scripts/quality-gate (PASS policy 12)