### PR TITLE
Keep notary preflight on a private PTY

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -38,6 +38,9 @@ change real power state, upload assets, or claim publication.
   power, helper, watchdog, lease, assertion, or lid-probe impact. An unknown
   product path selects both manual gates. Test-only, documentation-only, and
   known unrelated product paths do not select them.
+- Notary credential preflight gives `notarytool` a private PTY and captures its
+  output in private workflow evidence. This supports protected Keychain
+  profiles without exposing submission history in the release log.
 - The path classifier is the fail-safe default. An explicit private semantic
   review can omit a false-positive manual gate only when it is permission-safe,
   ignored by Git, bound to the exact base and head commits, and gives a reason

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -401,6 +401,29 @@ verify_github_credentials() {
   gh auth status >/dev/null
 }
 
+verify_notary_profile() {
+  local profile="$1" output="$STATE_DIR/notary-preflight.json"
+
+  [ -x /usr/bin/expect ] || die 'system expect tool is required for notary preflight'
+  if ! DETACH_NOTARY_PREFLIGHT_PROFILE="$profile" \
+       DETACH_NOTARY_PREFLIGHT_OUTPUT="$output" \
+       /usr/bin/expect <<'EXPECT'
+log_user 0
+log_file -noappend $env(DETACH_NOTARY_PREFLIGHT_OUTPUT)
+spawn xcrun notarytool history \
+  --keychain-profile $env(DETACH_NOTARY_PREFLIGHT_PROFILE) \
+  --output-format json --no-progress
+expect eof
+set result [wait]
+exit [lindex $result 3]
+EXPECT
+  then
+    chmod 0600 "$output" 2>/dev/null || true
+    die "notary credential preflight failed; see private evidence: $output"
+  fi
+  chmod 0600 "$output"
+}
+
 verify_artifact_credentials() {
   local identity="${DETACH_CODESIGN_IDENTITY:-}"
   local notary_profile="${DETACH_NOTARY_PROFILE:-}"
@@ -418,9 +441,7 @@ verify_artifact_credentials() {
   identities="$(security find-identity -v -p codesigning)"
   grep -F "\"$identity\"" <<<"$identities" >/dev/null || \
     die 'configured Developer ID signing identity is not installed or valid'
-  xcrun notarytool history --keychain-profile "$notary_profile" \
-    --output-format json >"$STATE_DIR/notary-preflight.json"
-  chmod 0600 "$STATE_DIR/notary-preflight.json"
+  verify_notary_profile "$notary_profile"
 
   sparkle_tools="$APP_ROOT/.build/artifacts/sparkle/Sparkle/bin"
   if [ -n "$key_file" ]; then

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -274,6 +274,10 @@ SH
 set -eu
 case " $* " in
   *' notarytool history '*)
+    [ -t 1 ] || {
+      printf '%s\n' 'fake notary credential lookup requires a PTY' >&2
+      exit 68
+    }
     [ "${FAKE_NOTARY_UNAVAILABLE:-0}" != 1 ] || {
       printf '%s\n' 'fake notary credential unavailable' >&2
       exit 69
@@ -522,7 +526,7 @@ run_invalid_resume_artifact_credentials_case() {
   printf '%s\n' 'changed after notarization' >"$REPO/app/build/Detach.dmg"
   export FAKE_NOTARY_UNAVAILABLE=1
   expect_failure invalid-resume-artifact-credentials \
-    'fake notary credential unavailable' run_workflow
+    'notary credential preflight failed' run_workflow
   unset FAKE_NOTARY_UNAVAILABLE
   [ ! -f "$RELEASE_EXISTS" ]
 }


### PR DESCRIPTION
## Summary
- run notary credential validation in a private PTY
- capture submission history only in private release evidence
- fail closed with a stable diagnostic and test the TTY contract

## Verification
- tests/release-workflow.sh
- scripts/quality-gate (PASS policy 12)