### PR TITLE
Release power protection while sessions wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ records, not guesses based on terminal text. Mid-turn permission prompts are
 not currently part of that signal.
 
 The optional menu bar companion shows whether the Mac can sleep, how fresh the
-background health report is, how many protected sessions are live, and which
+background health report is, how many sessions hold protection, and which
 sessions are waiting for an answer. While sessions are active, the dot in the
 menu bar glyph turns green; it turns orange when at least one session is
 waiting for your reply. Closing the main window keeps the menu bar and
@@ -170,9 +170,9 @@ run (for example with `/clear`), Detach follows the provider to that new
 conversation, so status and later checkpoints track the conversation you are
 actually in.
 
-The app window is not the runtime. A session, its power lease, and its
-checkpoint loop continue independently; the dashboard catches up when it is
-opened again.
+The app window is not the runtime. A session and its checkpoint loop continue
+independently. Its power protection follows whether the agent is working or
+waiting; the dashboard catches up when it is opened again.
 
 ## Health that distinguishes slow from broken
 
@@ -299,10 +299,16 @@ Deleting Detach state does not delete provider transcripts or conversations.
 
 ## Close the lid without abandoning the run
 
-Keep-awake protection starts automatically for each managed session. An
+Keep-awake protection starts automatically when a managed session starts. An
 unprivileged wrapper holds the normal IOKit idle-sleep assertion while a
 narrowly scoped signed helper manages closed-lid protection. The provider is
 started only after both protections are confirmed.
+
+When an agent finishes a turn and waits for your reply, that session releases
+both Detach protection layers. Its provider, tmux session, and checkpoints stay
+available. A new turn reacquires both layers. The Mac can sleep only when every
+live session is waiting. If at least one agent is working, that session keeps
+the Mac awake. Missing or invalid lifecycle state keeps protection active.
 
 The app, menu bar, CLI, and tmux status bar expose the same text-first state:
 **Mac stays awake**, **Mac can sleep**, **Low battery**, **Mac can sleep:
@@ -334,11 +340,11 @@ one warning per hot interval when session notifications are enabled.
 <details>
 <summary><strong>How the power safety boundary works</strong></summary>
 
-Each live session has a renewable root-helper lease. The runtime renews it
-every 30 seconds; a lease expires after 120 seconds without a heartbeat. The
-last live lease restores normal closed-lid sleep. An orderly stop releases the
-lease immediately, while the TTL bounds stale protection after an uncatchable
-crash or `SIGKILL`.
+Each working session has a renewable root-helper lease. The wrapper renews it
+every 30 seconds; a lease expires after 120 seconds without a heartbeat. A
+waiting session releases its lease immediately. The last working lease restores
+normal closed-lid sleep. An orderly stop also releases the lease immediately,
+while the TTL bounds stale protection after an uncatchable crash or `SIGKILL`.
 
 Ownership is persisted before power changes. If closed-lid protection was
 already active, Detach borrows it and never disables it. If Detach enabled the
@@ -538,9 +544,9 @@ before you try an update. For a download failure, check the network connection
 and try again. For an archive, signature, or installation failure, download
 the latest DMG. If the CLI does not match the app, open Detach settings, select
 System, and run Repair. A normal app update does not interrupt live sessions.
-If active sessions hold power leases, Detach keeps the current helper and the
-session dashboard. It retries the helper update after the sessions finish and
-the app becomes active again. Repairing a damaged active payload can still
+If working sessions hold power leases, Detach keeps the current helper and the
+session dashboard. It retries the helper update after the leases are released
+and the app becomes active again. Repairing a damaged active payload can still
 require you to end the sessions that use it.
 
 From a terminal:

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -349,9 +349,10 @@
 "Use ＋ to start Codex or Claude in any project." = "Use ＋ to start Codex or Claude in any project.";
 
 /* Mac Power hero */
-"Held awake by active sessions: %d" = "Held awake by active sessions: %d";
+"Held awake by working sessions: %d" = "Held awake by working sessions: %d";
 "Sleep protection is active" = "Sleep protection is active";
 "No active agent sessions" = "No active agent sessions";
+"Sessions waiting for replies: %d" = "Sessions waiting for replies: %d";
 "Active sessions without sleep protection: %d" = "Active sessions without sleep protection: %d";
 "Protection released until power is connected" = "Protection released until power is connected";
 "Confirming sleep protection…" = "Confirming sleep protection…";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -349,9 +349,10 @@
 "Use ＋ to start Codex or Claude in any project." = "Нажмите ＋, чтобы запустить Codex или Claude в любом проекте.";
 
 /* Mac Power hero */
-"Held awake by active sessions: %d" = "Mac держат активные сессии: %d";
+"Held awake by working sessions: %d" = "Mac не спит из-за работающих сессий: %d";
 "Sleep protection is active" = "Защита от сна активна";
 "No active agent sessions" = "Нет активных сессий агентов";
+"Sessions waiting for replies: %d" = "Сессии ждут ответа: %d";
 "Active sessions without sleep protection: %d" = "Активные сессии без защиты от сна: %d";
 "Protection released until power is connected" = "Защита снята до подключения питания";
 "Confirming sleep protection…" = "Подтверждаем защиту от сна…";

--- a/app/Sources/DetachApp/MenuBarPresentation.swift
+++ b/app/Sources/DetachApp/MenuBarPresentation.swift
@@ -56,12 +56,14 @@ struct MenuBarPresentation: Equatable {
     ) {
         let state = heartbeat.effectivePowerState
         let running = allSessions.filter { $0.effectiveStatus == .running }
+        let working = running.filter { !$0.isWaitingForUser }
         power = MacPowerSettingsPresentation(
             state: state,
             helperStatus: helperStatus,
             watchdogStatus: watchdogStatus,
             distributionMatchesBundle: distributionMatchesBundle,
-            activeSessionCount: running.count)
+            activeSessionCount: running.count,
+            workingSessionCount: working.count)
         ageSeconds = heartbeat.healthy
             ? heartbeat.age(relativeTo: now).map { max(0, Int($0)) }
             : nil
@@ -84,7 +86,7 @@ struct MenuBarPresentation: Equatable {
             switch state {
             case .protected, .transitioning:
                 icon = .active(
-                    sessionCount: showsSessionCount ? running.count : nil)
+                    sessionCount: showsSessionCount ? working.count : nil)
             case .allowed:
                 icon = .canSleep
             case .lowBattery:
@@ -147,11 +149,13 @@ extension MacPowerSettingsPresentation.Reason {
     var localizedText: String {
         switch self {
         case let .activeSessions(count):
-            L10n.format("Held awake by active sessions: %d", count)
+            L10n.format("Held awake by working sessions: %d", count)
         case .protectionActive:
             L10n.string("Sleep protection is active")
         case .noActiveSessions:
             L10n.string("No active agent sessions")
+        case let .waitingSessions(count):
+            L10n.format("Sessions waiting for replies: %d", count)
         case let .sessionsNotHolding(count):
             L10n.format("Active sessions without sleep protection: %d", count)
         case .lowBattery:

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -19,6 +19,7 @@ struct MacPowerSettingsPresentation: Equatable {
         case activeSessions(Int)
         case protectionActive
         case noActiveSessions
+        case waitingSessions(Int)
         case sessionsNotHolding(Int)
         case lowBattery
         case temperature
@@ -36,7 +37,8 @@ struct MacPowerSettingsPresentation: Equatable {
         helperStatus: PowerHelperRegistrationStatus,
         watchdogStatus: WatchdogStatus,
         distributionMatchesBundle: Bool,
-        activeSessionCount: Int? = nil
+        activeSessionCount: Int? = nil,
+        workingSessionCount: Int? = nil
     ) {
         self.state = state
         if helperStatus == .requiresApproval {
@@ -54,8 +56,9 @@ struct MacPowerSettingsPresentation: Equatable {
         }
         switch state {
         case .protected:
-            if let activeSessionCount, activeSessionCount > 0 {
-                reason = .activeSessions(activeSessionCount)
+            let protectedCount = workingSessionCount ?? activeSessionCount
+            if let protectedCount, protectedCount > 0 {
+                reason = .activeSessions(protectedCount)
             } else {
                 reason = .protectionActive
             }
@@ -63,7 +66,11 @@ struct MacPowerSettingsPresentation: Equatable {
             // The heartbeat wins, but never claim "no sessions" while the
             // session poller can see running ones.
             if let activeSessionCount, activeSessionCount > 0 {
-                reason = .sessionsNotHolding(activeSessionCount)
+                if workingSessionCount == 0 {
+                    reason = .waitingSessions(activeSessionCount)
+                } else {
+                    reason = .sessionsNotHolding(activeSessionCount)
+                }
             } else {
                 reason = .noActiveSessions
             }
@@ -901,14 +908,16 @@ struct SettingsView: View {
     }
 
     private var macPowerPresentation: MacPowerSettingsPresentation {
-        MacPowerSettingsPresentation(
+        let running = sessionStore.sessions.filter {
+            $0.effectiveStatus == .running
+        }
+        return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,
-            activeSessionCount: sessionStore.sessions.filter {
-                $0.effectiveStatus == .running
-            }.count)
+            activeSessionCount: running.count,
+            workingSessionCount: running.filter { !$0.isWaitingForUser }.count)
     }
 
     private var macPowerHeroRow: some View {

--- a/app/Sources/DetachKit/DetachPowerCommand.swift
+++ b/app/Sources/DetachKit/DetachPowerCommand.swift
@@ -502,7 +502,10 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
     private var latch = PowerThermalSafetyLatch()
     private var lastState: PowerThermalState = .unknown
     private var leaseIdentity: PowerLeaseIdentity?
-    private var releaseFailure: Error?
+    private var leaseIsHeld = false
+    private var activityRequiresProtection = true
+    private var safetyReleaseFailure: Error?
+    private var transitionFailure: Error?
 
     init(
         helperClient: any PowerHelperClient,
@@ -527,11 +530,15 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         defer { lock.unlock() }
         lastState = state
         _ = latch.observe(state, now: now(), cooldown: cooldown)
-        if latch.isActive {
-            do {
-                try enforceReleaseLocked()
-            } catch {
-                if releaseFailure == nil { releaseFailure = error }
+        guard latch.isActive else { return }
+        do {
+            try reconcileLocked()
+            transitionFailure = nil
+        } catch {
+            if latch.isActive {
+                if safetyReleaseFailure == nil { safetyReleaseFailure = error }
+            } else {
+                transitionFailure = error
             }
         }
     }
@@ -540,11 +547,12 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         leaseIdentity = identity
+        leaseIsHeld = true
         if latch.isActive {
             do {
-                try enforceReleaseLocked()
+                try reconcileLocked()
             } catch {
-                if releaseFailure == nil { releaseFailure = error }
+                if safetyReleaseFailure == nil { safetyReleaseFailure = error }
             }
         }
     }
@@ -552,25 +560,129 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
     func detachLease() {
         lock.lock()
         leaseIdentity = nil
+        leaseIsHeld = false
         lock.unlock()
     }
 
-    func refresh() throws -> Bool {
+    func observeActivity(_ state: PowerRunActivityState) {
         lock.lock()
         defer { lock.unlock() }
-        if let releaseFailure { throw releaseFailure }
+        guard activityRequiresProtection != state.requiresProtection else {
+            return
+        }
+        activityRequiresProtection = state.requiresProtection
+        do {
+            try reconcileLocked()
+            transitionFailure = nil
+        } catch {
+            if latch.isActive {
+                if safetyReleaseFailure == nil { safetyReleaseFailure = error }
+            } else {
+                transitionFailure = error
+            }
+        }
+    }
+
+    func refresh() throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let safetyReleaseFailure { throw safetyReleaseFailure }
         _ = latch.observe(lastState, now: now(), cooldown: cooldown)
-        if latch.isActive { try enforceReleaseLocked() }
-        return latch.isActive
+        do {
+            try reconcileLocked()
+            transitionFailure = nil
+        } catch {
+            transitionFailure = error
+            throw error
+        }
     }
 
     func validateRelease() throws {
         lock.lock()
         defer { lock.unlock() }
-        if let releaseFailure { throw releaseFailure }
+        if let safetyReleaseFailure { throw safetyReleaseFailure }
+        if let transitionFailure { throw transitionFailure }
     }
 
-    private func enforceReleaseLocked() throws {
+    private func reconcileLocked() throws {
+        if !activityRequiresProtection {
+            try transitionToIdleLocked()
+        } else if latch.isActive {
+            try enforceSafetyReleaseLocked()
+        } else {
+            try transitionToProtectedLocked()
+        }
+    }
+
+    private func transitionToProtectedLocked() throws {
+        guard let leaseIdentity else { return }
+        if !assertionController.isActive {
+            let status = try helperClient.status()
+            if status.lowBattery || status.thermalSafetyActive {
+                if leaseIsHeld {
+                    _ = try helperClient.renewLease(
+                        leaseIdentity, assertionActive: false)
+                }
+                return
+            }
+            _ = try assertionController.acquire()
+        }
+        guard assertionController.isActive else {
+            throw DetachPowerCommandError.assertionUnavailable
+        }
+
+        let confirmed: Bool
+        do {
+            if leaseIsHeld {
+                confirmed = try helperClient.renewLease(
+                    leaseIdentity, assertionActive: true)
+            } else {
+                confirmed = try helperClient.acquireLease(
+                    leaseIdentity, assertionActive: true)
+            }
+        } catch {
+            // The helper may have committed before the transport failed. Keep
+            // cleanup conservative and stage a later idle release if needed.
+            leaseIsHeld = true
+            throw error
+        }
+        if confirmed {
+            leaseIsHeld = true
+            return
+        }
+
+        let status = try helperClient.status()
+        guard status.lowBattery || status.thermalSafetyActive else {
+            throw DetachPowerCommandError.helperLeaseUnavailable
+        }
+        _ = try assertionController.release()
+        if leaseIsHeld {
+            _ = try helperClient.renewLease(
+                leaseIdentity, assertionActive: false)
+        }
+    }
+
+    private func transitionToIdleLocked() throws {
+        guard let leaseIdentity else {
+            _ = try assertionController.release()
+            return
+        }
+        guard leaseIsHeld || assertionController.isActive else { return }
+
+        if leaseIsHeld {
+            // First persist that the local assertion is about to end. This
+            // makes every partial failure fail awake or report unavailable.
+            _ = try helperClient.renewLease(
+                leaseIdentity, assertionActive: false)
+        }
+        _ = try assertionController.release()
+        if leaseIsHeld {
+            try helperClient.releaseLease(leaseIdentity)
+            leaseIsHeld = false
+        }
+    }
+
+    private func enforceSafetyReleaseLocked() throws {
         var firstError: Error?
         if assertionController.isActive {
             do {
@@ -579,7 +691,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
                 firstError = error
             }
         }
-        if let leaseIdentity {
+        if let leaseIdentity, leaseIsHeld {
             do {
                 _ = try helperClient.renewLease(
                     leaseIdentity, assertionActive: false)
@@ -599,6 +711,7 @@ public struct DetachPowerCommand: Sendable {
     private let assertionController: any IdleSleepAssertionControlling
     private let childRunner: any ChildCommandRunning
     private let heartbeatRunner: any PowerHeartbeatRunning
+    private let activityWatcher: any PowerRunActivityWatching
     private let thermalWatcher: any PowerThermalStateWatching
     private let thermalNow: @Sendable () -> Date
     private let thermalCooldown: TimeInterval
@@ -610,6 +723,8 @@ public struct DetachPowerCommand: Sendable {
         assertionController: any IdleSleepAssertionControlling = PowerAssertionController(),
         childRunner: any ChildCommandRunning = ProcessChildCommandRunner(),
         heartbeatRunner: any PowerHeartbeatRunning = DispatchPowerHeartbeatRunner(),
+        activityWatcher: any PowerRunActivityWatching =
+            FilePowerRunActivityWatcher(),
         thermalWatcher: any PowerThermalStateWatching =
             ProcessInfoPowerThermalStateWatcher(),
         thermalNow: @escaping @Sendable () -> Date = { Date() },
@@ -621,6 +736,7 @@ public struct DetachPowerCommand: Sendable {
         self.assertionController = assertionController
         self.childRunner = childRunner
         self.heartbeatRunner = heartbeatRunner
+        self.activityWatcher = activityWatcher
         self.thermalWatcher = thermalWatcher
         self.thermalNow = thermalNow
         self.thermalCooldown = max(0, thermalCooldown)
@@ -643,7 +759,9 @@ public struct DetachPowerCommand: Sendable {
             return try executeRun(
                 identity: parsed.identity,
                 command: parsed.command,
-                readyFile: parsed.readyFile)
+                readyFile: parsed.readyFile,
+                activityFile: parsed.activityFile,
+                activitySourceFile: parsed.activitySourceFile)
         case "helper":
             guard let lifecycleClient = helperClient
                     as? any PowerHelperLifecycleClient else {
@@ -672,6 +790,8 @@ public struct DetachPowerCommand: Sendable {
                 "usage: detach-power status --json | detach-power run "
                     + "--session NAME --run-token TOKEN "
                     + "[--ready-file ABSOLUTE_PATH] [--pid-file ABSOLUTE_PATH] "
+                    + "[--activity-file ABSOLUTE_PATH] "
+                    + "[--activity-source-file ABSOLUTE_PATH] "
                     + "-- COMMAND [ARGS...] "
                     + "| detach-power helper "
                     + "prepare-unregistration|cancel-unregistration "
@@ -683,7 +803,9 @@ public struct DetachPowerCommand: Sendable {
     private func executeRun(
         identity: PowerLeaseIdentity,
         command: ChildCommand,
-        readyFile: String?
+        readyFile: String?,
+        activityFile: String?,
+        activitySourceFile: String?
     ) throws -> DetachPowerCommandResult {
         let thermalController = PowerRunThermalSafetyController(
             helperClient: helperClient,
@@ -701,6 +823,8 @@ public struct DetachPowerCommand: Sendable {
                         identity: identity,
                         command: command,
                         readyFile: readyFile,
+                        activityFile: activityFile,
+                        activitySourceFile: activitySourceFile,
                         thermalController: thermalController)
                 })
         } catch {
@@ -716,6 +840,8 @@ public struct DetachPowerCommand: Sendable {
         identity: PowerLeaseIdentity,
         command: ChildCommand,
         readyFile: String?,
+        activityFile: String?,
+        activitySourceFile: String?,
         thermalController: PowerRunThermalSafetyController
     ) throws -> ChildCommandResult {
         guard !thermalController.isActive else {
@@ -751,50 +877,26 @@ public struct DetachPowerCommand: Sendable {
         }
 
         let result = try clamshellLockRunner.run {
-            if let readyFile {
-                try readinessMarker.markReady(atPath: readyFile)
-            }
-            return try heartbeatRunner.run(
-                heartbeat: {
-                    try renewProtection(
-                        identity: identity,
-                        thermalController: thermalController)
+            try activityWatcher.run(
+                activityFile: activityFile,
+                activitySourceFile: activitySourceFile,
+                onStateChange: { state in
+                    thermalController.observeActivity(state)
                 },
                 operation: {
-                    try childRunner.run(command)
+                    if let readyFile {
+                        try readinessMarker.markReady(atPath: readyFile)
+                    }
+                    return try heartbeatRunner.run(
+                        heartbeat: {
+                            try thermalController.refresh()
+                        },
+                        operation: {
+                            try childRunner.run(command)
+                        })
                 })
         }
         return result
-    }
-
-    private func renewProtection(
-        identity: PowerLeaseIdentity,
-        thermalController: PowerRunThermalSafetyController
-    ) throws {
-        if try thermalController.refresh() { return }
-        if !assertionController.isActive {
-            let status = try helperClient.status()
-            if status.lowBattery || status.thermalSafetyActive {
-                _ = try helperClient.renewLease(
-                    identity, assertionActive: false)
-                return
-            }
-            _ = try assertionController.acquire()
-        }
-        guard assertionController.isActive else {
-            throw DetachPowerCommandError.assertionUnavailable
-        }
-        guard try helperClient.renewLease(
-            identity, assertionActive: true) else {
-            let status = try helperClient.status()
-            guard status.lowBattery || status.thermalSafetyActive else {
-                throw DetachPowerCommandError.helperLeaseUnavailable
-            }
-            _ = try assertionController.release()
-            _ = try helperClient.renewLease(
-                identity, assertionActive: false)
-            return
-        }
     }
 
     private func parseRunArguments(
@@ -802,12 +904,16 @@ public struct DetachPowerCommand: Sendable {
     ) throws -> (
         identity: PowerLeaseIdentity,
         command: ChildCommand,
-        readyFile: String?
+        readyFile: String?,
+        activityFile: String?,
+        activitySourceFile: String?
     ) {
         var sessionName: String?
         var runToken: String?
         var readyFile: String?
         var pidFile: String?
+        var activityFile: String?
+        var activitySourceFile: String?
         var index = 0
 
         while index < arguments.count {
@@ -829,7 +935,9 @@ public struct DetachPowerCommand: Sendable {
                         executable: executable,
                         arguments: Array(child.dropFirst()),
                         pidFile: pidFile),
-                    readyFile)
+                    readyFile,
+                    activityFile,
+                    activitySourceFile)
             }
 
             switch argument {
@@ -860,6 +968,22 @@ public struct DetachPowerCommand: Sendable {
                         "--pid-file requires one absolute path")
                 }
                 pidFile = arguments[index + 1]
+                index += 2
+            case "--activity-file":
+                guard activityFile == nil, index + 1 < arguments.count,
+                      arguments[index + 1].hasPrefix("/") else {
+                    throw DetachPowerCommandError.usage(
+                        "--activity-file requires one absolute path")
+                }
+                activityFile = arguments[index + 1]
+                index += 2
+            case "--activity-source-file":
+                guard activitySourceFile == nil, index + 1 < arguments.count,
+                      arguments[index + 1].hasPrefix("/") else {
+                    throw DetachPowerCommandError.usage(
+                        "--activity-source-file requires one absolute path")
+                }
+                activitySourceFile = arguments[index + 1]
                 index += 2
             default:
                 throw DetachPowerCommandError.usage("unknown run option: \(argument)")

--- a/app/Sources/DetachKit/PowerRunActivity.swift
+++ b/app/Sources/DetachKit/PowerRunActivity.swift
@@ -1,0 +1,233 @@
+import Darwin
+import Foundation
+
+/// Structured provider activity reduced by the runtime for power policy.
+/// Unknown input always maps to `working` so a damaged handoff fails awake.
+public enum PowerRunActivityState: String, Equatable, Sendable {
+    case working
+    case waiting
+
+    public var requiresProtection: Bool { self == .working }
+}
+
+public protocol PowerRunActivityReading: Sendable {
+    func state(atPath path: String) -> PowerRunActivityState
+}
+
+/// Reads one private, run-token-scoped activity handoff without following a
+/// symlink. Only the exact `waiting` record permits sleep.
+public struct FilePowerRunActivityReader: PowerRunActivityReading {
+    private static let recordByteCount = 8
+
+    public init() {}
+
+    public func state(atPath path: String) -> PowerRunActivityState {
+        guard let descriptor = Self.openValidated(
+            path: path,
+            flags: O_RDONLY | O_CLOEXEC)
+        else {
+            return .working
+        }
+        defer { Darwin.close(descriptor) }
+
+        var bytes = [UInt8](repeating: 0, count: Self.recordByteCount + 1)
+        let count = bytes.withUnsafeMutableBytes { buffer -> Int in
+            while true {
+                let result = Darwin.pread(
+                    descriptor,
+                    buffer.baseAddress,
+                    buffer.count,
+                    0)
+                if result < 0, errno == EINTR { continue }
+                return result
+            }
+        }
+        guard count == Self.recordByteCount else { return .working }
+        let record = String(decoding: bytes.prefix(count), as: UTF8.self)
+        return record == "waiting\n" ? .waiting : .working
+    }
+
+    static func openValidated(path: String, flags: Int32) -> Int32? {
+        let descriptor = Darwin.open(path, flags | O_NOFOLLOW)
+        guard descriptor >= 0 else { return nil }
+
+        var information = stat()
+        guard Darwin.fstat(descriptor, &information) == 0,
+              information.st_mode & S_IFMT == S_IFREG,
+              information.st_uid == Darwin.geteuid() else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+}
+
+/// Observes activity-file writes without polling. The provider operation keeps
+/// running if the watcher is unavailable, but the callback receives `working`
+/// so protection stays active.
+public protocol PowerRunActivityWatching: Sendable {
+    func run(
+        activityFile: String?,
+        activitySourceFile: String?,
+        onStateChange: @escaping @Sendable (PowerRunActivityState) -> Void,
+        operation: @escaping @Sendable () throws -> ChildCommandResult
+    ) throws -> ChildCommandResult
+}
+
+private struct PowerRunActivitySource {
+    let descriptor: Int32
+}
+
+/// Opens the transcript recorded by the runtime only when its inode, mtime,
+/// and size still match the snapshot that produced `waiting`.
+private struct FilePowerRunActivitySourceReader {
+    private static let maximumRecordByteCount = 16 * 1024
+
+    func openSource(atPath handoffPath: String) -> PowerRunActivitySource? {
+        guard let handoff = FilePowerRunActivityReader.openValidated(
+            path: handoffPath,
+            flags: O_RDONLY | O_CLOEXEC)
+        else {
+            return nil
+        }
+        defer { Darwin.close(handoff) }
+
+        var handoffInformation = stat()
+        guard Darwin.fstat(handoff, &handoffInformation) == 0,
+              handoffInformation.st_size > 0,
+              handoffInformation.st_size <= Self.maximumRecordByteCount else {
+            return nil
+        }
+        let expectedCount = Int(handoffInformation.st_size)
+        var bytes = [UInt8](repeating: 0, count: expectedCount)
+        let count = bytes.withUnsafeMutableBytes { buffer -> Int in
+            while true {
+                let result = Darwin.pread(
+                    handoff,
+                    buffer.baseAddress,
+                    buffer.count,
+                    0)
+                if result < 0, errno == EINTR { continue }
+                return result
+            }
+        }
+        guard count == expectedCount,
+              let separator = bytes.firstIndex(of: UInt8(ascii: "\n")) else {
+            return nil
+        }
+        let signature = String(decoding: bytes[..<separator], as: UTF8.self)
+        let path = String(decoding: bytes[bytes.index(after: separator)...], as: UTF8.self)
+        guard path.hasPrefix("/"), !path.isEmpty, !path.utf8.contains(0),
+              let descriptor = FilePowerRunActivityReader.openValidated(
+                path: path,
+                flags: O_EVTONLY | O_CLOEXEC) else {
+            return nil
+        }
+
+        var sourceInformation = stat()
+        guard Darwin.fstat(descriptor, &sourceInformation) == 0,
+              signature == Self.signature(for: sourceInformation) else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        return PowerRunActivitySource(descriptor: descriptor)
+    }
+
+    private static func signature(for information: stat) -> String {
+        "\(information.st_ino):\(information.st_mtimespec.tv_sec):\(information.st_size)"
+    }
+}
+
+private final class PowerRunActivitySourceWatchBox: @unchecked Sendable {
+    var source: (any DispatchSourceFileSystemObject)?
+    var waiting = false
+}
+
+public final class FilePowerRunActivityWatcher:
+    PowerRunActivityWatching, @unchecked Sendable
+{
+    private let reader: any PowerRunActivityReading
+    private let sourceReader = FilePowerRunActivitySourceReader()
+    private let queue: DispatchQueue
+
+    public init(
+        reader: any PowerRunActivityReading = FilePowerRunActivityReader(),
+        queue: DispatchQueue = DispatchQueue(
+            label: "dev.tsarev.detach.power-activity")
+    ) {
+        self.reader = reader
+        self.queue = queue
+    }
+
+    public func run(
+        activityFile: String?,
+        activitySourceFile: String?,
+        onStateChange: @escaping @Sendable (PowerRunActivityState) -> Void,
+        operation: @escaping @Sendable () throws -> ChildCommandResult
+    ) throws -> ChildCommandResult {
+        guard let activityFile, let activitySourceFile else {
+            return try operation()
+        }
+        guard let descriptor = FilePowerRunActivityReader.openValidated(
+                path: activityFile,
+                flags: O_EVTONLY | O_CLOEXEC) else {
+            onStateChange(.working)
+            return try operation()
+        }
+
+        let activityEvents = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .delete, .rename, .revoke],
+            queue: queue)
+        let sourceWatch = PowerRunActivitySourceWatchBox()
+        let eventQueue = queue
+        let applyActivity = { [reader, sourceReader] in
+            sourceWatch.source?.cancel()
+            sourceWatch.source = nil
+            sourceWatch.waiting = false
+
+            guard reader.state(atPath: activityFile) == .waiting,
+                  let source = sourceReader.openSource(
+                    atPath: activitySourceFile) else {
+                onStateChange(.working)
+                return
+            }
+            let sourceEvents = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: source.descriptor,
+                eventMask: [.write, .delete, .rename, .revoke],
+                queue: eventQueue)
+            sourceEvents.setEventHandler {
+                guard sourceWatch.waiting else { return }
+                sourceWatch.waiting = false
+                onStateChange(.working)
+                sourceWatch.source?.cancel()
+                sourceWatch.source = nil
+            }
+            sourceEvents.setCancelHandler {
+                Darwin.close(source.descriptor)
+            }
+            sourceWatch.source = sourceEvents
+            sourceWatch.waiting = true
+            sourceEvents.resume()
+            onStateChange(.waiting)
+        }
+        activityEvents.setEventHandler {
+            applyActivity()
+        }
+        activityEvents.setCancelHandler {
+            Darwin.close(descriptor)
+        }
+        applyActivity()
+        activityEvents.resume()
+
+        let result = Result { try operation() }
+        activityEvents.cancel()
+        eventQueue.sync {
+            sourceWatch.waiting = false
+            sourceWatch.source?.cancel()
+            sourceWatch.source = nil
+        }
+        queue.sync {}
+        return try result.get()
+    }
+}

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -89,6 +89,12 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
         XCTAssertEqual(
             presentation(state: .allowed, activeSessionCount: 0).reason,
             .noActiveSessions)
+        XCTAssertEqual(
+            presentation(
+                state: .allowed,
+                activeSessionCount: 2,
+                workingSessionCount: 0).reason,
+            .waitingSessions(2))
     }
 
     func testReasonsForRemainingStates() {
@@ -109,13 +115,15 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
         helper: PowerHelperRegistrationStatus = .enabled,
         watchdog: WatchdogStatus = .enabled,
         distributionMatchesBundle: Bool = true,
-        activeSessionCount: Int? = nil
+        activeSessionCount: Int? = nil,
+        workingSessionCount: Int? = nil
     ) -> MacPowerSettingsPresentation {
         MacPowerSettingsPresentation(
             state: state,
             helperStatus: helper,
             watchdogStatus: watchdog,
             distributionMatchesBundle: distributionMatchesBundle,
-            activeSessionCount: activeSessionCount)
+            activeSessionCount: activeSessionCount,
+            workingSessionCount: workingSessionCount)
     }
 }

--- a/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
@@ -139,7 +139,7 @@ final class MenuBarPresentationTests: XCTestCase {
 
         XCTAssertEqual(
             presentation.headerText,
-            "Mac stays awake · Held awake by active sessions: 2 · checked 30 s ago")
+            "Mac stays awake · Held awake by working sessions: 2 · checked 30 s ago")
     }
 
     func testHeaderTextOmitsFreshnessWhenHeartbeatIsStale() {
@@ -181,9 +181,10 @@ final class MenuBarPresentationTests: XCTestCase {
 
     func testEveryPowerReasonHasUserFacingMenuText() {
         let cases: [(MacPowerSettingsPresentation.Reason, String)] = [
-            (.activeSessions(3), "Held awake by active sessions: 3"),
+            (.activeSessions(3), "Held awake by working sessions: 3"),
             (.protectionActive, "Sleep protection is active"),
             (.noActiveSessions, "No active agent sessions"),
+            (.waitingSessions(4), "Sessions waiting for replies: 4"),
             (.sessionsNotHolding(2), "Active sessions without sleep protection: 2"),
             (.lowBattery, "Protection released until power is connected"),
             (.confirming, "Confirming sleep protection…"),
@@ -243,6 +244,21 @@ final class MenuBarPresentationTests: XCTestCase {
                 runningSession(id: "b", waiting: true),
             ])
 
+        XCTAssertEqual(presentation.sessionDot, .answerReady)
+        XCTAssertEqual(presentation.icon, .active(sessionCount: 1))
+        XCTAssertEqual(presentation.power.reason, .activeSessions(1))
+    }
+
+    func testAllWaitingSessionsExplainWhyTheMacCanSleep() {
+        let presentation = makePresentation(
+            powerState: "allowed",
+            sessions: [
+                runningSession(id: "a", waiting: true),
+                runningSession(id: "b", waiting: true),
+            ])
+
+        XCTAssertEqual(presentation.icon, .canSleep)
+        XCTAssertEqual(presentation.power.reason, .waitingSessions(2))
         XCTAssertEqual(presentation.sessionDot, .answerReady)
     }
 

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -232,6 +232,28 @@ final class DetachPowerCommandTests: XCTestCase {
         }
     }
 
+    private final class FakeActivityWatcher:
+        PowerRunActivityWatching, @unchecked Sendable
+    {
+        var states: [PowerRunActivityState]
+
+        init(states: [PowerRunActivityState] = []) {
+            self.states = states
+        }
+
+        func run(
+            activityFile: String?,
+            activitySourceFile: String?,
+            onStateChange: @escaping @Sendable (PowerRunActivityState) -> Void,
+            operation: @escaping @Sendable () throws -> ChildCommandResult
+        ) throws -> ChildCommandResult {
+            for state in states {
+                onStateChange(state)
+            }
+            return try operation()
+        }
+    }
+
     private final class FakeThermalWatcher:
         PowerThermalStateWatching, @unchecked Sendable
     {
@@ -273,7 +295,8 @@ final class DetachPowerCommandTests: XCTestCase {
     private func fixture(
         thermalWatcher: any PowerThermalStateWatching = FakeThermalWatcher(),
         thermalNow: @escaping @Sendable () -> Date = { Date() },
-        thermalCooldown: TimeInterval = PowerThermalSafetyLatch.defaultCooldown
+        thermalCooldown: TimeInterval = PowerThermalSafetyLatch.defaultCooldown,
+        activityWatcher: any PowerRunActivityWatching = FakeActivityWatcher()
     ) -> (
         DetachPowerCommand,
         EventLog,
@@ -293,6 +316,7 @@ final class DetachPowerCommandTests: XCTestCase {
                 assertionController: assertion,
                 childRunner: child,
                 heartbeatRunner: heartbeat,
+                activityWatcher: activityWatcher,
                 thermalWatcher: thermalWatcher,
                 thermalNow: thermalNow,
                 thermalCooldown: thermalCooldown),
@@ -399,6 +423,65 @@ final class DetachPowerCommandTests: XCTestCase {
             "helper.release",
             "assertion.release",
         ])
+    }
+
+    func testWaitingActivityReleasesBothProtectionsBeforeChildRuns() throws {
+        let watcher = FakeActivityWatcher(states: [.waiting])
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            activityWatcher: watcher)
+        heartbeat.heartbeatCount = 0
+        child.onRun = {
+            XCTAssertFalse(assertion.isActive)
+            XCTAssertEqual(helper.released.count, 1)
+        }
+
+        let result = try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--activity-file", "/fixture/activity",
+            "--activity-source-file", "/fixture/activity-source", "--",
+            "/fixture/provider",
+        ])
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(helper.renewed.map(\.1), [false])
+        XCTAssertEqual(helper.released.count, 2)
+        XCTAssertFalse(assertion.isActive)
+        XCTAssertEqual(events.values, [
+            "assertion.acquire",
+            "helper.acquire",
+            "helper.renew",
+            "assertion.release",
+            "helper.release",
+            "heartbeat.start",
+            "child.run",
+            "heartbeat.end",
+            "helper.release",
+            "assertion.release",
+        ])
+    }
+
+    func testWorkingActivityReacquiresAfterWaitingBeforeChildRuns() throws {
+        let watcher = FakeActivityWatcher(states: [.waiting, .working])
+        let (command, _, assertion, helper, child, heartbeat) = fixture(
+            activityWatcher: watcher)
+        heartbeat.heartbeatCount = 0
+        child.onRun = {
+            XCTAssertTrue(assertion.isActive)
+            XCTAssertEqual(helper.acquired.count, 2)
+            XCTAssertEqual(helper.released.count, 1)
+        }
+
+        _ = try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--activity-file", "/fixture/activity",
+            "--activity-source-file", "/fixture/activity-source", "--",
+            "/fixture/provider",
+        ])
+
+        XCTAssertEqual(helper.acquired.map(\.1), [true, true])
+        XCTAssertEqual(helper.renewed.map(\.1), [false])
+        XCTAssertEqual(helper.released.count, 2)
+        XCTAssertFalse(assertion.isActive)
     }
 
     func testAssertionFailureRefusesToAcquireLeaseOrLaunchChild() {
@@ -932,6 +1015,14 @@ final class DetachPowerCommandTests: XCTestCase {
              "--pid-file requires one absolute path"),
             (["run", "--pid-file", "/a", "--pid-file", "/b"],
              "--pid-file requires one absolute path"),
+            (["run", "--activity-file", "relative"],
+             "--activity-file requires one absolute path"),
+            (["run", "--activity-file", "/a", "--activity-file", "/b"],
+             "--activity-file requires one absolute path"),
+            (["run", "--activity-source-file", "relative"],
+             "--activity-source-file requires one absolute path"),
+            (["run", "--activity-source-file", "/a", "--activity-source-file", "/b"],
+             "--activity-source-file requires one absolute path"),
             (["run", "--mystery"], "unknown run option: --mystery"),
             (["run", "--session", "s", "--run-token", "t"],
              "run requires -- COMMAND [ARGS...]"),

--- a/app/Tests/DetachKitTests/PowerProtectionTests.swift
+++ b/app/Tests/DetachKitTests/PowerProtectionTests.swift
@@ -376,6 +376,47 @@ final class PowerProtectionTests: XCTestCase {
         XCTAssertFalse(coordinator.ownsClosedLidProtection)
     }
 
+    func testCoordinatorPermitsSleepOnlyAfterEveryWorkingSessionReleasesItsLease() {
+        let backend = FakeClosedLidBackend(enabled: false)
+        var coordinator = PowerProtectionCoordinator()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let leases = ["one", "two"].map {
+            PowerLease(
+                id: $0,
+                sessionName: "session-\($0)",
+                runToken: "run-\($0)",
+                renewedAt: now,
+                assertionActive: true)
+        }
+
+        let bothWorking = coordinator.reconcile(
+            leases: leases,
+            now: now,
+            timeout: 60,
+            lowBattery: false,
+            backend: backend)
+        let oneWorking = coordinator.reconcile(
+            leases: [leases[1]],
+            now: now,
+            timeout: 60,
+            lowBattery: false,
+            backend: backend)
+        let allWaiting = coordinator.reconcile(
+            leases: [],
+            now: now,
+            timeout: 60,
+            lowBattery: false,
+            backend: backend)
+
+        XCTAssertEqual(bothWorking.state, .protected)
+        XCTAssertEqual(bothWorking.leaseCount, 2)
+        XCTAssertEqual(oneWorking.state, .protected)
+        XCTAssertEqual(oneWorking.leaseCount, 1)
+        XCTAssertEqual(allWaiting.state, .allowed)
+        XCTAssertEqual(allWaiting.leaseCount, 0)
+        XCTAssertEqual(backend.writes, [true, false])
+    }
+
     func testCoordinatorBorrowsPreexistingProtectionWithoutDisablingIt() {
         let backend = FakeClosedLidBackend(enabled: true)
         var coordinator = PowerProtectionCoordinator()

--- a/app/Tests/DetachKitTests/PowerRunActivityTests.swift
+++ b/app/Tests/DetachKitTests/PowerRunActivityTests.swift
@@ -1,0 +1,138 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import DetachKit
+
+final class PowerRunActivityTests: XCTestCase {
+    private final class ObservationBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var waiting = false
+
+        func markWaiting() {
+            lock.lock()
+            waiting = true
+            lock.unlock()
+        }
+
+        func followsWaiting() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return waiting
+        }
+    }
+
+    func testReaderPermitsSleepOnlyForExactOwnedRegularWaitingRecord() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-activity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let activity = directory.appendingPathComponent("activity")
+        let symlink = directory.appendingPathComponent("activity-link")
+        let reader = FilePowerRunActivityReader()
+
+        XCTAssertEqual(reader.state(atPath: activity.path), .working)
+        try Data("waiting\n".utf8).write(to: activity)
+        XCTAssertEqual(reader.state(atPath: activity.path), .waiting)
+
+        for malformed in ["waiting", "waiting\nextra", "idle\n", "\n"] {
+            try Data(malformed.utf8).write(to: activity)
+            XCTAssertEqual(reader.state(atPath: activity.path), .working)
+        }
+
+        try Data("waiting\n".utf8).write(to: activity)
+        try FileManager.default.createSymbolicLink(
+            at: symlink,
+            withDestinationURL: activity)
+        XCTAssertEqual(reader.state(atPath: symlink.path), .working)
+    }
+
+    func testWatcherReacquiresOnTranscriptWriteWithoutActivityPolling() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-watch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let activity = directory.appendingPathComponent("activity")
+        let activitySource = directory.appendingPathComponent("activity-source")
+        let transcript = directory.appendingPathComponent("transcript.jsonl")
+        try Data("working\n".utf8).write(to: activity)
+        try Data("initial\n".utf8).write(to: transcript)
+        var information = stat()
+        XCTAssertEqual(Darwin.lstat(transcript.path, &information), 0)
+        let signature = "\(information.st_ino):\(information.st_mtimespec.tv_sec):\(information.st_size)"
+        try Data("\(signature)\n\(transcript.path)".utf8).write(
+            to: activitySource)
+        let observedWaiting = DispatchSemaphore(value: 0)
+        let observedWorking = DispatchSemaphore(value: 0)
+        let watcher = FilePowerRunActivityWatcher()
+        let observation = ObservationBox()
+
+        let result = try watcher.run(
+            activityFile: activity.path,
+            activitySourceFile: activitySource.path,
+            onStateChange: { state in
+                if state == .waiting {
+                    observation.markWaiting()
+                    observedWaiting.signal()
+                } else if observation.followsWaiting() {
+                    observedWorking.signal()
+                }
+            },
+            operation: {
+                let handle = try FileHandle(forWritingTo: activity)
+                try handle.truncate(atOffset: 0)
+                try handle.write(contentsOf: Data("waiting\n".utf8))
+                try handle.synchronize()
+                try handle.close()
+                XCTAssertEqual(
+                    observedWaiting.wait(timeout: .now() + 2),
+                    .success)
+                let transcriptHandle = try FileHandle(forWritingTo: transcript)
+                try transcriptHandle.seekToEnd()
+                try transcriptHandle.write(contentsOf: Data("next turn\n".utf8))
+                try transcriptHandle.synchronize()
+                try transcriptHandle.close()
+                XCTAssertEqual(
+                    observedWorking.wait(timeout: .now() + 2),
+                    .success)
+                return ChildCommandResult(exitCode: 17)
+            })
+
+        XCTAssertEqual(result.exitCode, 17)
+    }
+
+    func testWatcherRejectsWaitingWithMismatchedTranscriptSnapshot() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-source-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let activity = directory.appendingPathComponent("activity")
+        let activitySource = directory.appendingPathComponent("activity-source")
+        let transcript = directory.appendingPathComponent("transcript.jsonl")
+        try Data("waiting\n".utf8).write(to: activity)
+        try Data("initial\n".utf8).write(to: transcript)
+        try Data("0:0:0\n\(transcript.path)".utf8).write(to: activitySource)
+        let observedWorking = DispatchSemaphore(value: 0)
+        let watcher = FilePowerRunActivityWatcher()
+
+        let result = try watcher.run(
+            activityFile: activity.path,
+            activitySourceFile: activitySource.path,
+            onStateChange: { state in
+                if state == .working { observedWorking.signal() }
+            },
+            operation: {
+                XCTAssertEqual(
+                    observedWorking.wait(timeout: .now() + 2),
+                    .success)
+                return ChildCommandResult(exitCode: 23)
+            })
+
+        XCTAssertEqual(result.exitCode, 23)
+    }
+}

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -30,6 +30,7 @@ DEFAULT_CHECKPOINT_INTERVAL=300
 DEFAULT_HISTORY_LIMIT=50000
 DEFAULT_HEALTH_HEARTBEAT_INTERVAL=10
 DEFAULT_HEALTH_HEARTBEAT_STALE=45
+DEFAULT_IDLE_HEALTH_HEARTBEAT_INTERVAL=30
 
 error() {
   printf '%s: %s\n' "$PROGRAM" "$*" >&2
@@ -112,6 +113,7 @@ else
 fi
 HEALTH_HEARTBEAT_INTERVAL="${DETACH_HEALTH_HEARTBEAT_INTERVAL:-$DEFAULT_HEALTH_HEARTBEAT_INTERVAL}"
 HEALTH_HEARTBEAT_STALE="${DETACH_HEALTH_HEARTBEAT_STALE:-$DEFAULT_HEALTH_HEARTBEAT_STALE}"
+IDLE_HEALTH_HEARTBEAT_INTERVAL="${DETACH_IDLE_HEALTH_HEARTBEAT_INTERVAL:-$DEFAULT_IDLE_HEALTH_HEARTBEAT_INTERVAL}"
 TMUX_STYLE_ENABLED="${DETACH_TMUX_STYLE:-${CONFIG_TMUX_STYLE:-1}}"
 case "$TMUX_STYLE_ENABLED" in
   0|1) ;;
@@ -220,6 +222,13 @@ validate_runtime_config() {
   esac
   [ "$HEALTH_HEARTBEAT_STALE" -gt "$HEALTH_HEARTBEAT_INTERVAL" ] || \
     die "health heartbeat stale threshold must exceed its interval"
+  case "$IDLE_HEALTH_HEARTBEAT_INTERVAL" in
+    ''|*[!0-9]*) die "idle health heartbeat interval must be a positive integer" ;;
+  esac
+  [ "$IDLE_HEALTH_HEARTBEAT_INTERVAL" -ge "$HEALTH_HEARTBEAT_INTERVAL" ] || \
+    die "idle health heartbeat interval must not be shorter than the active interval"
+  [ "$HEALTH_HEARTBEAT_STALE" -gt "$IDLE_HEALTH_HEARTBEAT_INTERVAL" ] || \
+    die "health heartbeat stale threshold must exceed the idle interval"
 }
 
 managed_requirements_toml() {
@@ -3037,12 +3046,116 @@ power_refresh_session_status() {
   tmux_apply_session_style "$session" "$status"
 }
 
+write_power_activity_state() {
+  local activity_file="$1"
+  local state="$2"
+  local force="${3:-0}"
+  local current=""
+
+  case "$state" in working|waiting) ;; *) return 1 ;; esac
+  if [ -e "$activity_file" ]; then
+    [ -f "$activity_file" ] && [ ! -L "$activity_file" ] || return 1
+    IFS= read -r current <"$activity_file" || current=""
+    [ "$current" != "$state" ] || [ "$force" = "1" ] || return 0
+  fi
+  printf '%s\n' "$state" >"$activity_file"
+}
+
+write_power_activity_source() {
+  local source_file="$1"
+  local transcript="$2"
+  local signature="$3"
+
+  [ -f "$transcript" ] && [ ! -L "$transcript" ] || return 1
+  if [ -e "$source_file" ]; then
+    [ -f "$source_file" ] && [ ! -L "$source_file" ] || return 1
+  fi
+  printf '%s\n%s' "$signature" "$transcript" >"$source_file"
+}
+
+POWER_ACTIVITY_TRANSCRIPT=""
+POWER_ACTIVITY_TRANSCRIPT_SIGNATURE=""
+POWER_ACTIVITY_WAITING_SOURCE_TRANSCRIPT=""
+POWER_ACTIVITY_WAITING_SOURCE_SIGNATURE=""
+POWER_ACTIVITY_STATE="working"
+
+refresh_power_activity_state() {
+  local session="$1"
+  local activity_file="$2"
+  local source_file="$3"
+  local transcript=""
+  local transcript_signature=""
+  local verified_signature=""
+  local source_changed=0
+  local state="working"
+
+  transcript="$(read_meta_field "$session" transcript_path rollout_path 2>/dev/null || true)"
+  if [ -z "$transcript" ] || [ ! -f "$transcript" ] || [ -L "$transcript" ]; then
+    POWER_ACTIVITY_TRANSCRIPT=""
+    POWER_ACTIVITY_TRANSCRIPT_SIGNATURE=""
+    POWER_ACTIVITY_STATE="working"
+    write_power_activity_state "$activity_file" working
+    return
+  fi
+
+  transcript_signature="$(stat -f '%i:%m:%z' "$transcript" 2>/dev/null || true)"
+  if [ -z "$transcript_signature" ]; then
+    POWER_ACTIVITY_TRANSCRIPT=""
+    POWER_ACTIVITY_TRANSCRIPT_SIGNATURE=""
+    POWER_ACTIVITY_STATE="working"
+    write_power_activity_state "$activity_file" working
+    return
+  fi
+
+  if [ "$transcript" != "$POWER_ACTIVITY_TRANSCRIPT" ]; then
+    POWER_ACTIVITY_TRANSCRIPT="$transcript"
+    POWER_ACTIVITY_TRANSCRIPT_SIGNATURE="$transcript_signature"
+    if [ ! "$transcript" -nt "$activity_file" ]; then
+      POWER_ACTIVITY_STATE="working"
+      write_power_activity_state "$activity_file" working
+      return
+    fi
+  elif [ "$transcript_signature" = "$POWER_ACTIVITY_TRANSCRIPT_SIGNATURE" ]; then
+    return
+  else
+    POWER_ACTIVITY_TRANSCRIPT_SIGNATURE="$transcript_signature"
+  fi
+
+  transcript_model_context "$transcript"
+  verified_signature="$(stat -f '%i:%m:%z' "$transcript" 2>/dev/null || true)"
+  if [ -z "$verified_signature" ] || \
+     [ "$verified_signature" != "$transcript_signature" ]; then
+    POWER_ACTIVITY_TRANSCRIPT_SIGNATURE=""
+    POWER_ACTIVITY_STATE="working"
+    write_power_activity_state "$activity_file" working
+    return
+  fi
+  [ "$TRANSCRIPT_AGENT_TURN_STATE" != "waiting" ] || state="waiting"
+  if [ "$state" = "waiting" ]; then
+    if [ "$transcript" != "$POWER_ACTIVITY_WAITING_SOURCE_TRANSCRIPT" ] || \
+       [ "$verified_signature" != "$POWER_ACTIVITY_WAITING_SOURCE_SIGNATURE" ]; then
+      source_changed=1
+    fi
+    write_power_activity_source \
+      "$source_file" "$transcript" "$verified_signature" || state="working"
+    if [ "$state" = "waiting" ]; then
+      POWER_ACTIVITY_WAITING_SOURCE_TRANSCRIPT="$transcript"
+      POWER_ACTIVITY_WAITING_SOURCE_SIGNATURE="$verified_signature"
+    fi
+  fi
+  POWER_ACTIVITY_STATE="$state"
+  write_power_activity_state "$activity_file" "$state" "$source_changed"
+}
+
 runtime_status_loop() {
   local session="$1"
   local run_token="$2"
   local worker_pid="$3"
   local provider_pid_file="$4"
+  local activity_file="$5"
+  local activity_source_file="$6"
   local sleep_pid=""
+  local sleep_interval
 
   runtime_status_loop_cleanup() {
     if [ -n "$sleep_pid" ]; then
@@ -3056,8 +3169,14 @@ runtime_status_loop() {
         [ "$(tmux_option "$session" '@detach_run_token')" = "$run_token" ]; do
     runtime_heartbeat_once \
       "$session" "$run_token" "$worker_pid" "$provider_pid_file"
+    refresh_power_activity_state \
+      "$session" "$activity_file" "$activity_source_file" 2>/dev/null || \
+      write_power_activity_state "$activity_file" working 2>/dev/null || true
     power_refresh_session_status "$session" 2>/dev/null || true
-    sleep "$HEALTH_HEARTBEAT_INTERVAL" &
+    sleep_interval="$HEALTH_HEARTBEAT_INTERVAL"
+    [ "$POWER_ACTIVITY_STATE" != "waiting" ] || \
+      sleep_interval="$IDLE_HEALTH_HEARTBEAT_INTERVAL"
+    sleep "$sleep_interval" &
     sleep_pid=$!
     wait "$sleep_pid" || exit 0
     sleep_pid=""
@@ -3088,9 +3207,13 @@ worker_main() {
   local has_claude_permission=0
   local power_ready_file
   local provider_pid_file
+  local power_activity_file
+  local power_activity_source_file
 
   power_ready_file="$(session_dir "$session")/power-ready-$run_token"
   provider_pid_file="$(session_dir "$session")/provider-pid-$run_token"
+  power_activity_file="$(session_dir "$session")/power-activity-$run_token"
+  power_activity_source_file="$(session_dir "$session")/power-activity-source-$run_token"
 
   worker_cleanup() {
     local cleanup_status=$?
@@ -3107,7 +3230,8 @@ worker_main() {
       wait "$power_monitor_pid" 2>/dev/null || true
     fi
     checkpoint_once "$session" "$run_token" || true
-    rm -f "$provider_pid_file"
+    rm -f "$provider_pid_file" "$power_activity_file" \
+      "$power_activity_source_file"
 
     if [ "$exit_status" -eq 0 ]; then
       status_label="completed"
@@ -3211,17 +3335,25 @@ worker_main() {
 
   "$SELF" __checkpoint_loop "$session" "$run_token" "$$" &
   checkpoint_pid=$!
-  runtime_status_loop "$session" "$run_token" "$$" "$provider_pid_file" &
+  write_power_activity_state "$power_activity_file" working || \
+    die "could not initialize provider activity state"
+  runtime_status_loop \
+    "$session" "$run_token" "$$" "$provider_pid_file" "$power_activity_file" \
+    "$power_activity_source_file" &
   power_monitor_pid=$!
 
   set +e
   if [ "$PROVIDER" = "claude" ]; then
     "$POWER_BIN" run --session "$session" --run-token "$run_token" \
-      --ready-file "$power_ready_file" --pid-file "$provider_pid_file" -- \
+      --ready-file "$power_ready_file" --pid-file "$provider_pid_file" \
+      --activity-file "$power_activity_file" \
+      --activity-source-file "$power_activity_source_file" -- \
       "$agent_bin" "${claude_args[@]}"
   else
     "$POWER_BIN" run --session "$session" --run-token "$run_token" \
-      --ready-file "$power_ready_file" --pid-file "$provider_pid_file" -- \
+      --ready-file "$power_ready_file" --pid-file "$provider_pid_file" \
+      --activity-file "$power_activity_file" \
+      --activity-source-file "$power_activity_source_file" -- \
       "$agent_bin" "${codex_args[@]}"
   fi
   exit_status=$?
@@ -3251,6 +3383,7 @@ tmux_environment_args() {
               DETACH_CLAUDE_STATE_ROOT DETACH_CLAUDE_CHECKPOINT_INTERVAL \
               DETACH_CLAUDE_HISTORY_LIMIT DETACH_CLAUDE_SYNC DETACH_CLAUDE_BIN \
               DETACH_HEALTH_HEARTBEAT_INTERVAL DETACH_HEALTH_HEARTBEAT_STALE \
+              DETACH_IDLE_HEALTH_HEARTBEAT_INTERVAL \
               CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN; do
     value="${!name-}"
     [ -n "$value" ] || continue
@@ -3279,6 +3412,8 @@ start_tmux_session() {
   local default_base
   local power_ready_file
   local provider_pid_file
+  local power_activity_file
+  local power_activity_source_file
   local worker_pid
   local provider_pid
   local readiness_attempts=0
@@ -3287,6 +3422,8 @@ start_tmux_session() {
   run_token="$(new_run_token)"
   power_ready_file="$(session_dir "$session")/power-ready-$run_token"
   provider_pid_file="$(session_dir "$session")/provider-pid-$run_token"
+  power_activity_file="$(session_dir "$session")/power-activity-$run_token"
+  power_activity_source_file="$(session_dir "$session")/power-activity-source-$run_token"
   if [ "$PROVIDER" = "claude" ] && [ -z "$recovery_id" ]; then
     recovery_id="$(new_run_token)"
   fi
@@ -3307,7 +3444,8 @@ start_tmux_session() {
       [ "$created" -eq 0 ] || "${TMUX_CMD[@]}" kill-session -t "=$session" 2>/dev/null || true
       "$POWER_BIN" release --session "$session" --run-token "$run_token" \
         >/dev/null 2>&1 || true
-      rm -f "$power_ready_file" "$provider_pid_file" "$legacy_env_file"
+      rm -f "$power_ready_file" "$provider_pid_file" "$power_activity_file" \
+        "$power_activity_source_file" "$legacy_env_file"
       state_update_meta_for_run "$session" "$run_token" \
         --string status start_failed --string finished_at "$(now_iso)" || true
     fi
@@ -3330,7 +3468,8 @@ start_tmux_session() {
     die "could not initialize session metadata"
   snapshot_known_threads "$session" "$cwd" || die "could not snapshot existing $PROVIDER_LABEL sessions"
   write_resume_args "$session" "$@" || die "could not save $PROVIDER_LABEL resume options"
-  rm -f "$power_ready_file" "$provider_pid_file"
+  rm -f "$power_ready_file" "$provider_pid_file" "$power_activity_file" \
+    "$power_activity_source_file"
   session_color="$(read_meta_field "$session" session_color)"
   default_base="$(read_meta_field "$session" default_session_base 2>/dev/null || true)"
   [[ "$session_color" =~ ^#[0-9A-Fa-f]{6}$ ]] || \

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -70,11 +70,10 @@ a session waits for a reply (answer-ready outranks working; the badge states
 suppress the tint so a power warning stays visible). The image stays template
 while monochrome; only the tinted states draw with real color, using
 label/system colors resolved at composite time, and VoiceOver names the
-session state in words. The first menu
-line is `state · reason · freshness`, reusing the Mac Power presentation words.
-An allowed heartbeat with visible running sessions must say they are not
-holding sleep protection, never claim there are no sessions. Both glyph and
-words derive from the shared `checked_at`-based heartbeat reader and the
+session state in words. The first menu line is `state · reason · freshness`.
+Protected state counts working sessions. Allowed state names all-waiting or an
+unprotected working session and never claims no sessions. The glyph and words
+derive from the shared `checked_at`-based heartbeat reader and the
 app-level shared session poller — never `pmset` or root XPC from UI, and
 freshness comes from the document timestamp, not file mtime. One
 `detach list --json` poller serves the window, notifications, and the menu

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -5,11 +5,28 @@
 Power protection has two required layers and one observable combined state:
 
 1. `detach-power` is an unprivileged, signed wrapper. It holds the public IOKit
-   user-idle-system-sleep assertion, acquires a root-helper lease over XPC, runs
-   the provider with inherited cwd/environment/stdio, and returns its exit code.
+   user-idle-system-sleep assertion and a root-helper lease over XPC while its
+   provider is working. It runs the provider with inherited
+   cwd/environment/stdio and returns its exit code.
 2. `DetachPowerHelper` is a demand-launched root daemon registered from the app.
    It manages only the machine-wide closed-lid setting through absolute
    `/usr/bin/pmset` invocations and a renewable lease registry.
+
+The wrapper must acquire both layers before provider launch. It watches a
+private, run-token-scoped activity file. Before it accepts `waiting`, it also
+validates a recorded inode/mtime/size snapshot and starts an event watcher on the
+exact provider transcript. It then stages the helper lease as
+assertion-inactive, releases the IOKit assertion, and releases the helper lease.
+Any transcript change immediately means `working` and reacquires both layers;
+it does not wait for the idle runtime heartbeat. Missing, changed, or malformed
+handoff state stays `working`. Transition failures are surfaced and must not
+claim that sleep is safe. The provider continues while waiting.
+
+Each working session owns a separate helper lease. Outside the low-battery and
+thermal fail-safe states, the helper keeps the machine-wide closed-lid setting
+active while at least one working lease exists. Detach can permit normal sleep
+only after every live session is waiting or stopped. One waiting session must
+never release another working session's protection.
 
 The root helper installs a listener-level Foundation code-signing requirement
 before accepting XPC or reconciling power state. It accepts only valid code
@@ -39,10 +56,12 @@ reconciled, and implausibly future renewal timestamps expire rather than live
 forever. Do not manually change the same machine-wide boolean while Detach owns
 it.
 
-The client lease heartbeat remains every 30 seconds; the helper reconciles
-machine power state every 10 seconds. Leases expire after 120 seconds without
-renewal, with a maximum of 256. Transient renewal failures are retried; an
-active failure is surfaced rather than silently reporting protection. Read-only
+The client lease heartbeat remains every 30 seconds while protected; the helper
+reconciles machine power state every 10 seconds. Leases expire after 120 seconds
+without renewal, with a maximum of 256. The runtime health loop slows from ten
+to 30 seconds while waiting, below its 45-second stale limit. Transient renewal
+failures are retried; an active failure is surfaced rather than silently
+reporting protection. Read-only
 status returns a cached snapshot refreshed at startup, after mutations, and by
 the reconciler. It must never invoke `pmset` or wait behind the root mutation
 lock, so UI, watchdog, and tmux polling remain nonblocking.
@@ -54,7 +73,8 @@ reconciles the owned setting before returning failure. This prevents a timed-out
 caller from activating protection later. The outer XPC timeout remains 30
 seconds so rollback can finish. Root `pmset` invocations have bounded output and
 a two-second timeout. The readable tmux power label refreshes every ten seconds
-rather than spawning one root status request every two seconds per session.
+while working and every 30 seconds while waiting, rather than spawning one root
+status request every two seconds per session.
 
 The low-battery threshold is 10% while on battery power. The helper releases
 closed-lid protection it owns, the wrapper releases its IOKit assertion, and the

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -132,7 +132,9 @@ through:
 
 ```text
 detach-power run --session <name> --run-token <token>
-  --ready-file <absolute-path> --pid-file <absolute-path> -- <provider> ...
+  --ready-file <absolute-path> --pid-file <absolute-path>
+  --activity-file <absolute-path> --activity-source-file <absolute-path>
+  -- <provider> ...
 ```
 
 The power wrapper must confirm both protection layers and atomically mark the
@@ -183,13 +185,13 @@ the original copy tables immediately.
 `M-Enter`; off restores the original binding or plain Enter. It adds
 `*:extkeys` and `*:hyperlinks` once; OSC 8 links stay independent.
 
-`list --json` emits JSONL schema 1 and includes the optional `display_name`,
-`power_protection_state`, `agent_turn_state`, opaque `agent_turn_id`, runtime
-PIDs, health reason/actions, reconcile action, freshness, ownership proof, and
-cleanup eligibility. Keep the emitter and Swift `Session` decoder synchronized.
-Derive turn state from structured provider lifecycle records, never terminal
-text. Cleanup uses typed `cleanup_eligible`. List decodes metadata once and
-combines health assessment with public JSON emission in one typed call.
+`list --json` emits JSONL schema 1 with optional `display_name`, power and turn
+state, opaque turn ID, PIDs, health, reconcile, freshness, ownership,
+and cleanup fields. Keep the emitter and Swift `Session` decoder synchronized.
+Provider lifecycle records, never terminal text, supply turn state
+and the private run-token activity file defined in `power.md`.
+Cleanup uses typed `cleanup_eligible`. List decodes metadata once for health
+assessment and public JSON.
 
 ### Provider identity and checkpoints
 

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -159,6 +159,9 @@ export DETACH_TMUX_CONFIG="$TMP_ROOT/tmux.conf"
 export DETACH_CLAUDE_BIN="$ROOT/tests/fake-claude"
 export DETACH_CODEX_BIN="$ROOT/tests/fake-codex"
 export DETACH_CLAUDE_CHECKPOINT_INTERVAL=1
+export DETACH_HEALTH_HEARTBEAT_INTERVAL=1
+export DETACH_IDLE_HEALTH_HEARTBEAT_INTERVAL=2
+export DETACH_HEALTH_HEARTBEAT_STALE=4
 export DETACH_CLAUDE_SYNC=0
 export DETACH_LOCKS_ROOT="$TMP_ROOT/locks"
 export DETACH_INSTALL_STATE_ROOT="$TEST_INSTALL_STATE_ROOT"
@@ -197,6 +200,19 @@ wait_for_fake_claude_ready() {
     }
     sleep 0.05
   done
+}
+
+wait_for_file_text() {
+  local file="$1" text="$2" attempts=0
+  while [ "$attempts" -lt 100 ]; do
+    if [ -f "$file" ] && grep -Fx -- "$text" "$file" >/dev/null 2>&1; then
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  printf 'timed out waiting for %s in %s\n' "$text" "$file" >&2
+  return 1
 }
 
 bash -n "$SCRIPT"
@@ -406,6 +422,13 @@ printf '%s' "$json_line" | grep -F '"model":' | grep -F '"context_used_tokens":'
 assert_json_field agent_turn_state working
 assert_json_field agent_turn_id "$session_id"
 transcript="$("$STATE_HELPER" meta get "$meta" transcript_path)"
+power_activity="$DETACH_CLAUDE_STATE_ROOT/sessions/$session/power-activity-$("$STATE_HELPER" meta get "$meta" run_token)"
+power_activity_source="$DETACH_CLAUDE_STATE_ROOT/sessions/$session/power-activity-source-$("$STATE_HELPER" meta get "$meta" run_token)"
+wait_for_file_text "$power_activity" working
+grep -Fx -- '--activity-file' "$FAKE_POWER_ARGS_FILE" >/dev/null
+grep -Fx -- "$power_activity" "$FAKE_POWER_ARGS_FILE" >/dev/null
+grep -Fx -- '--activity-source-file' "$FAKE_POWER_ARGS_FILE" >/dev/null
+grep -Fx -- "$power_activity_source" "$FAKE_POWER_ARGS_FILE" >/dev/null
 printf '{"type":"user","isSidechain":false,"isMeta":false,"sessionId":"%s","message":{"role":"user","content":[{"type":"tool_result"}]},"uuid":"tool-result-event","timestamp":"2099-01-01T00:02:00.000Z"}\n' \
   "$session_id" >>"$transcript"
 printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1"},"uuid":"assistant-chunk-1","timestamp":"2099-01-01T00:03:00.000Z"}\n' \
@@ -423,6 +446,14 @@ json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin effective_status)" = "running" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "waiting" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "turn-duration-1" ]
+wait_for_file_text "$power_activity" waiting
+[ -s "$power_activity_source" ]
+printf '{"type":"user","isSidechain":false,"isMeta":false,"sessionId":"%s","message":{"role":"user","content":"continue"},"uuid":"turn-after-idle","timestamp":"2099-01-01T00:03:03.000Z"}\n' \
+  "$session_id" >>"$transcript"
+wait_for_file_text "$power_activity" working
+json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "working" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "turn-after-idle" ]
 [ -s "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" ]
 [ -d "$CLAUDE_CONFIG_DIR/projects/fake/$session_id/subagents" ]
 [ -d "$CLAUDE_CONFIG_DIR/projects/fake/$session_id/tool-results" ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -127,6 +127,44 @@ process_group_exists() {
   ps -axo pgid= | awk -v pgid="$1" '$1 == pgid { found = 1 } END { exit(found ? 0 : 1) }'
 }
 
+signal_process_group_members() {
+  local signal="$1"
+  local pgid="$2"
+  local excluded_pid="${3:-}"
+  local pid
+  while IFS= read -r pid; do
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    /bin/kill "-$signal" "$pid" 2>/dev/null || true
+  done < <(ps -axo pid=,pgid= | \
+    awk -v pgid="$pgid" -v excluded="$excluded_pid" \
+      '$2 == pgid && $1 != excluded { print $1 }')
+}
+
+wait_for_process_group_stopped() {
+  local pgid="$1"
+  local excluded_pid="$2"
+  local attempts=0
+  while [ "$attempts" -lt 50 ]; do
+    signal_process_group_members STOP "$pgid" "$excluded_pid"
+    if ps -axo pid=,pgid=,stat= | \
+      awk -v pgid="$pgid" -v excluded="$excluded_pid" '
+      $2 == pgid && $1 != excluded {
+        found = 1
+        if ($3 !~ /^[TZ]/) active = 1
+      }
+      END { exit(found && !active ? 0 : 1) }
+    '; then
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    sleep 0.05
+  done
+  printf 'timed out waiting for process group %s to stop\n' "$pgid" >&2
+  ps -axo pid=,ppid=,pgid=,stat=,command= | \
+    awk -v pgid="$pgid" '$3 == pgid { print }' >&2
+  return 1
+}
+
 wait_for_process_group_exit() {
   local pgid="$1"
   local attempts=0
@@ -286,6 +324,9 @@ export DETACH_TMUX_SOCKET_PATH="$SOCKET_PATH"
 export DETACH_TMUX_CONFIG="$TMP_ROOT/tmux.conf"
 export DETACH_CODEX_BIN="$ROOT/tests/fake-codex"
 export DETACH_CODEX_CHECKPOINT_INTERVAL=1
+export DETACH_HEALTH_HEARTBEAT_INTERVAL=1
+export DETACH_IDLE_HEALTH_HEARTBEAT_INTERVAL=2
+export DETACH_HEALTH_HEARTBEAT_STALE=4
 export DETACH_CODEX_SYNC=0
 export DETACH_CODEX_REQUIREMENTS_FILE="$TMP_ROOT/requirements.toml"
 export CODEX_HOME="$TMP_ROOT/codex-home"
@@ -308,6 +349,10 @@ printf '%s\n' \
   'bind-key -T copy-mode a send-keys -X cursor-left' \
   >"$DETACH_TMUX_CONFIG"
 printf '%s\n' 'allowed_approval_policies = ["untrusted", "on-request"]' >"$DETACH_CODEX_REQUIREMENTS_FILE"
+
+test_sqlite() {
+  sqlite3 -cmd '.timeout 5000' "$@"
+}
 
 bash -n "$SCRIPT"
 bash -n "$ROOT/bin/detach-core"
@@ -640,13 +685,32 @@ process_group_exists "$first_worker_pgid"
 # A stale observer or checkpoint must not call a live long provider turn hung.
 health_meta="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/meta.json"
 run_token="$("$STATE_HELPER" meta get "$health_meta" run_token)"
+if ! wait_for_process_group_stopped "$first_worker_pgid" "$first_worker_pid"; then
+  signal_process_group_members CONT "$first_worker_pgid" "$first_worker_pid"
+  exit 1
+fi
+stale_snapshot_status=0
 "$STATE_HELPER" meta patch "$health_meta" --run-token "$run_token" \
   --integer worker_heartbeat_epoch 1 \
-  --string worker_heartbeat_at '1970-01-01T00:00:01Z'
-tmux -L "$SOCKET" set-option -q -t "=$SESSION:" @detach_heartbeat_epoch 1
-health_json="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")"
-[ "$(printf '%s' "$health_json" | "$STATE_HELPER" meta get /dev/stdin effective_status)" = running ]
-[ "$(printf '%s' "$health_json" | "$STATE_HELPER" meta get /dev/stdin health_reason)" = heartbeat_stale ]
+  --string worker_heartbeat_at '1970-01-01T00:00:01Z' || stale_snapshot_status=$?
+if [ "$stale_snapshot_status" -eq 0 ]; then
+  tmux -L "$SOCKET" set-option -q -t "=$SESSION:" @detach_heartbeat_epoch 1 || \
+    stale_snapshot_status=$?
+fi
+if [ "$stale_snapshot_status" -eq 0 ]; then
+  health_json="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")" || \
+    stale_snapshot_status=$?
+fi
+if [ "$stale_snapshot_status" -eq 0 ]; then
+  stale_effective_status="$(printf '%s' "$health_json" | \
+    "$STATE_HELPER" meta get /dev/stdin effective_status)" || stale_snapshot_status=$?
+  stale_health_reason="$(printf '%s' "$health_json" | \
+    "$STATE_HELPER" meta get /dev/stdin health_reason)" || stale_snapshot_status=$?
+fi
+signal_process_group_members CONT "$first_worker_pgid" "$first_worker_pid"
+[ "$stale_snapshot_status" -eq 0 ]
+[ "$stale_effective_status" = running ]
+[ "$stale_health_reason" = heartbeat_stale ]
 
 # A mismatched run-token blocks cleanup and PID assumptions, but never makes
 # Detach signal or delete the still managed pane.
@@ -878,7 +942,7 @@ run_codex stop integration
 # Explicit resume follows Codex semantics and accepts the exact thread UUID.
 export FAKE_CODEX_INIT_DELAY=0
 export FAKE_CODEX_SLEEP=1
-expected_rollout="$(sqlite3 "$CODEX_HOME/state_5.sqlite" "SELECT rollout_path FROM threads WHERE id = '$expected_id';")"
+expected_rollout="$(test_sqlite "$CODEX_HOME/state_5.sqlite" "SELECT rollout_path FROM threads WHERE id = '$expected_id';")"
 cp -p "$expected_rollout" "$checkpoint/rollout.jsonl"
 printf '{damaged rollout\n' >"$expected_rollout"
 uppercase_id="$(printf '%s' "$expected_id" | tr '[:lower:]' '[:upper:]')"
@@ -935,12 +999,28 @@ printf '%s' "$json_line" | grep -F '"model":' | grep -F '"context_used_tokens":'
 turn_rollout="$("$STATE_HELPER" meta get "$meta" transcript_path)"
 turn_id="$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)"
 [ -n "$turn_id" ]
+power_activity="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/power-activity-$("$STATE_HELPER" meta get "$meta" run_token)"
+power_activity_source="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/power-activity-source-$("$STATE_HELPER" meta get "$meta" run_token)"
+wait_for_file_text "$power_activity" working
+grep -Fx -- '--activity-file' "$FAKE_POWER_ARGS_FILE" >/dev/null
+grep -Fx -- "$power_activity" "$FAKE_POWER_ARGS_FILE" >/dev/null
+grep -Fx -- '--activity-source-file' "$FAKE_POWER_ARGS_FILE" >/dev/null
+grep -Fx -- "$power_activity_source" "$FAKE_POWER_ARGS_FILE" >/dev/null
 printf '{"timestamp":"2099-01-01T00:10:00Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"%s"}}\n' \
   "$turn_id" >>"$turn_rollout"
 json_line="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin effective_status)" = "running" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "waiting" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "$turn_id" ]
+wait_for_file_text "$power_activity" waiting
+[ -s "$power_activity_source" ]
+printf '%s\n' \
+  '{"timestamp":"2099-01-01T00:10:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-after-idle"}}' \
+  >>"$turn_rollout"
+wait_for_file_text "$power_activity" working
+json_line="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "working" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "turn-after-idle" ]
 
 # Codex /clear opens a successor thread inside the same provider process.
 # Discovery must rebind identity, turn state, and checkpoints to the newest
@@ -962,7 +1042,7 @@ switch_thread() {
     "$switch_id" "$switch_project_dir" "$switch_run_token" >"$switch_rollout"
   printf '{"timestamp":"2099-01-01T00:20:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"%s"}}\n' \
     "$switch_turn" >>"$switch_rollout"
-  sqlite3 "$CODEX_HOME/state_5.sqlite" \
+  test_sqlite "$CODEX_HOME/state_5.sqlite" \
     "INSERT OR REPLACE INTO threads (id, rollout_path, created_at_ms, updated_at_ms, source, thread_source, cwd) \
      VALUES ('$switch_id', '${switch_rollout//\'/\'\'}', $switch_ms, $switch_ms, 'cli', '$switch_source', '${switch_project_dir//\'/\'\'}');"
 }
@@ -977,7 +1057,7 @@ wait_for_file_text "$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint.log" \
 [ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" = "$pre_switch_id" ]
 grep -F 'ambiguous Codex thread switch' \
   "$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint.log" >/dev/null
-sqlite3 "$CODEX_HOME/state_5.sqlite" "DELETE FROM threads WHERE id = '$switch_b';"
+test_sqlite "$CODEX_HOME/state_5.sqlite" "DELETE FROM threads WHERE id = '$switch_b';"
 rm -f "$CODEX_HOME/sessions/2099/01/01/rollout-test-$switch_b.jsonl"
 attempts=0
 while [ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" != "$switch_a" ] && \


### PR DESCRIPTION
## Summary

- release both Detach power layers when a structured provider lifecycle says the session is waiting
- reacquire immediately on the next transcript event and keep unknown state fail-awake
- keep global protection while any working session remains, and synchronize app wording and counts
- add Codex, Claude, Swift, and helper lease regression coverage

## Testing

- `scripts/quality-gate` — PASS (policy 12, fingerprint `51cb9d8817382168663503d33d2e98bfdabee0410d80474cfb16da8ce2585fe2`)
- focused Swift power/app selection — 103 tests passed
- `tests/docs-contract.sh`
- `git diff --check`

Real power, closed-lid hardware, signing, notarization, and release publication checks were not run; they remain release-only gates.