### PR TITLE
Ignore local presentation sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 /docs/superpowers/
 /docs/work/
 
+# Local presentation sources are internal working material. They are not
+# repository inputs and must not affect impact analysis or quality gates.
+/presentations/
+
 # Local credentials and release overrides must stay outside Git. Public
 # examples can be explicitly re-included as *.example files when needed.
 .env

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -25,6 +25,8 @@ against the same deterministic quality gate.
 - Durable specs describe current contracts. Ignored `docs/work/` contains
   temporary executable plans. Imports are not used for detailed specs because
   Claude expands imports eagerly.
+- Ignored `presentations/` contains internal presentation sources. Git and the
+  quality gate do not treat these files as repository inputs.
 - Fast diagnostics close the edit loop; `scripts/quality-gate` remains the
   sole readiness entry point. A focused command or diagnostic stage is never
   presented as final evidence.

--- a/tests/docs-contract.sh
+++ b/tests/docs-contract.sh
@@ -67,5 +67,7 @@ done
 
 git -C "$ROOT" check-ignore -q docs/work/example.md ||
   fail 'temporary ExecPlans must remain ignored'
+git -C "$ROOT" check-ignore -q presentations/internal.html ||
+  fail 'internal presentation sources must remain ignored'
 
 printf 'Documentation and context contracts passed\n'

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -34,7 +34,7 @@ prepare_template() {
   printf '#!/bin/bash\nexit 0\n' >"$TEMPLATE_REPO/tests/test-suite-contract.sh"
   chmod 0755 "$TEMPLATE_REPO/tests/test-suite-contract.sh"
   printf '%s\n' baseline >"$TEMPLATE_REPO/README.md"
-  printf '%s\n' actions.log results '*.out' >"$TEMPLATE_REPO/.gitignore"
+  printf '%s\n' actions.log results '*.out' /presentations/ >"$TEMPLATE_REPO/.gitignore"
   for stage in static gate-contract swift quality-contracts app ui-e2e codex claude distribution tmux-runtime release-preflight publish-preflight release-workflow; do
     printf '#!/bin/bash\nset -eu\n[ -z "${DETACH_RELEASE_TIMING_OVERRIDE:-}" ] || { printf "release timing override leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_CONFIRM_RELEASE:-}" ] || { printf "release confirmation leaked into stage\\n" >&2; exit 1; }\n[ "${CLANG_MODULE_CACHE_PATH:-}" = "${GATE_EXPECTED_MODULE_CACHE:?}" ] || { printf "unexpected Clang module cache: %%s\\n" "${CLANG_MODULE_CACHE_PATH:-missing}" >&2; exit 1; }\n[ "${SWIFTPM_MODULECACHE_OVERRIDE:-}" = "$GATE_EXPECTED_MODULE_CACHE" ] || { printf "unexpected SwiftPM module cache: %%s\\n" "${SWIFTPM_MODULECACHE_OVERRIDE:-missing}" >&2; exit 1; }\nprintf "%%s\\n" "%s" >>"${GATE_ACTION_LOG:?}"\nsleep "${STAGE_SLEEP:-0}"\ncase " ${FAIL_STAGES:-} " in *" %s "*) exit 23 ;; esac\n' "$stage" "$stage" \
       >"$TEMPLATE_REPO/tests/quality-gate-fixtures/$stage"
@@ -118,6 +118,14 @@ setup_fixture docs-contract
 printf '%s\n' '# changed contract' >"$REPO/tests/docs-contract.sh"
 plan="$(gate --plan)"
 [[ "$plan" = *'stages=static' ]]
+
+setup_fixture ignored-presentations
+clean_plan="$(gate --plan)"
+mkdir -p "$REPO/presentations"
+printf '%s\n' '<html>internal</html>' >"$REPO/presentations/internal.html"
+ignored_plan="$(gate --plan)"
+[ "$ignored_plan" = "$clean_plan" ]
+[ -z "$(git -C "$REPO" ls-files --others --exclude-standard presentations)" ]
 
 setup_fixture swift
 mkdir -p "$REPO/app/Sources/DetachKit"


### PR DESCRIPTION
Summary:
- ignore internal presentations sources through standard Git ignore semantics
- document the repository-input invariant
- prove ignored presentation changes do not alter the quality plan or fingerprint

Verification:
- tests/docs-contract.sh
- DETACH_QUALITY_GATE_CONTRACT_SHARD=selection tests/quality-gate.sh
- scripts/quality-gate: PASS, policy 12, fingerprint 83055c81bd1f2c6f13f89bda3cbe7ff50acfe23b41db798be3661457cc814a90

The presentation files themselves are not included.