### PR TITLE
Build automation-first quality foundation

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -18,16 +18,16 @@ concurrency:
 jobs:
   quality-gates:
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 10
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Restore Swift and tmux caches
         id: swift-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             app/.build
@@ -35,17 +35,25 @@ jobs:
           restore-keys: |
             detach-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.resolved', 'scripts/build-tmux.sh') }}-
             detach-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-
-      - name: Run pull-request change gate
+      - name: Run authoritative pull-request gate
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: scripts/quality-gate --base "$BASE_SHA" --without-release-budget
-      - name: Run full repository gate
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+          DETACH_QUALITY_AUTHORITY: ci-merge
+        run: scripts/quality-gate --mode repository --base "$BASE_SHA" --keep-going --without-release-budget
+      - name: Run main repository gate
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        env:
+          DETACH_QUALITY_AUTHORITY: ci-main
+        run: scripts/quality-gate --mode repository --keep-going --without-release-budget
+      - name: Run release repository gate
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/detach-release/')
+        env:
+          DETACH_QUALITY_AUTHORITY: release
         run: scripts/quality-gate --mode repository --keep-going --without-release-budget
       - name: Save Swift and tmux caches
         if: always() && steps.swift-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             app/.build
@@ -74,9 +82,44 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
       - name: Upload gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quality-gate-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: app/build/quality-gates
           if-no-files-found: ignore
           retention-days: 14
+
+  quality-dashboard:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: quality-gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Download exact main quality evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: quality-gate-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: app/build/quality-gates
+      - name: Generate quality dashboard
+        run: >-
+          scripts/quality-dashboard generate
+          --result-root app/build/quality-gates
+          --output app/build/quality-dashboard
+          --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: app/build/quality-dashboard
+      - name: Deploy quality dashboard
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # Local presentation sources are internal working material. They are not
 # repository inputs and must not affect impact analysis or quality gates.
 /presentations/
+__pycache__/
+*.pyc
 
 # Local credentials and release overrides must stay outside Git. Public
 # examples can be explicitly re-included as *.example files when needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,15 @@ the providers separately.
    risky migration, or work with unresolved requirements, create an ignored
    ExecPlan under `docs/work/` from `docs/exec-plan-template.md` and keep it current.
 4. During implementation, run the narrow checks named by the selected specs.
-   Before reporting readiness, run `scripts/quality-gate` once. Use
-   `--resume latest` after a compatible interrupted or failed run.
+   Before handoff, inspect `scripts/quality-gate --plan --explain` and run the
+   focused local diagnostics once. Use `--resume latest` after a compatible
+   interrupted or failed run. Hosted pull-request CI is readiness authority.
 5. Review the final diff and evidence. Update the user contract or durable spec
    in the same change whenever behavior or an invariant changes.
 6. Unless the owner explicitly asks to keep work local, ordinary changes use a
    topic branch: stage only task-scoped files, inspect the staged public diff,
-   commit after readiness passes, push, and merge only through a PR whose
-   required `quality-gates` job passed. Verify final `main` upstream parity.
+   commit after local diagnostics pass, push, and merge only through a PR whose
+   required authoritative `quality-gates` job passed. Verify final `main` upstream parity.
    `scripts/release-version` is the sole direct-`main` path.
 
 `README.md` is the user-facing contract. `docs/specs/` contains durable
@@ -67,17 +68,17 @@ read every spec preemptively.
 
 ## Verification loop
 
-- `scripts/quality-gate --plan --explain`: inspect the mandatory readiness
-  stages selected from the actual diff.
-- `scripts/quality-gate`: authoritative impact-aware readiness gate.
-- `scripts/quality-gate --mode repository`: every automated repository
-  check; use for policy work and final broad audits.
+- `scripts/quality-gate --plan --explain`: inspect the local diagnostic stages
+  selected from the actual diff.
+- `scripts/quality-gate`: impact-aware local diagnostic.
+- `scripts/quality-gate --mode repository`: every automated repository check
+  as a local diagnostic. Hosted pull-request CI runs this mode as authority.
 - `--stage <name>` and direct test commands are diagnostic only, not readiness
   evidence.
 - Prefer one focused test while iterating. Do not repeatedly pay for the full
   suite when a narrower deterministic check can close the feedback loop.
 - Treat a local timing-budget failure as performance work: diagnose and reduce
-  the slow stage before rerunning readiness. Never rerun merely for warmer
+  the slow stage before rerunning it. Never rerun merely for warmer
   caches, timing variance, or a lucky result; rerun unchanged only after
   evidence identifies an unrelated external transient, and record its cause.
 - Never run real power tests, signing, notarization, tagging, upload, or
@@ -132,8 +133,8 @@ The repository, history, CI logs, releases, and artifacts are public.
 ## Definition of done
 
 A change is ready only when its observable behavior has regression evidence,
-the impact-selected quality gate prints PASS, affected user docs and durable
-specs agree with the code, and `git diff --check` is clean. Report manual
+the hosted pull-request repository gate prints authoritative PASS, affected
+user docs and durable specs agree with the code, and `git diff --check` is clean. Report manual
 release gates that were not run. Do not substitute a plausible implementation,
 a narrow test, or a green stale manifest for requirement-by-requirement
 evidence. Unless the owner requests a local-only handoff, deliver ready work as

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,9 +1,10 @@
 # Quality gates
 
-`scripts/quality-gate` is the tracked readiness contract for local agents, CI,
-and releases. Policy version 12 derives
-the mandatory set from the Git diff, and selects the full repository gate for
-unknown paths or changes to this policy itself. Its resource-aware scheduler
+`scripts/quality-gate` is the tracked quality contract for local agents, CI,
+and releases. Policy version 13 derives local diagnostics from one typed
+manifest and selects the full repository gate for unknown paths. Hosted pull-
+request CI runs every functional stage once and is the sole ordinary merge
+authority. The resource-aware scheduler
 runs isolated work concurrently without allowing two SwiftPM operations to
 share the same build directory.
 
@@ -13,7 +14,8 @@ share the same build directory.
 - `scripts/quality-gate --base <ref>` checks committed changes since a trusted
   merge base plus staged, unstaged, and untracked files.
 - `scripts/quality-gate --mode repository` runs every automated repository
-  check. CI uses this mode on `main`; pull requests use impact analysis.
+  check. Local use is diagnostic. Pull requests use this complete mode with
+  `ci-merge` authority.
 - `scripts/quality-gate --without-release-budget` disables the local
   reference-machine wall and per-stage timing checks. The `main` and pull
   request CI workflows use it because hosted-runner timing is not comparable
@@ -50,6 +52,10 @@ share the same build directory.
   downloaded evidence as run counts, failure counts, environment-failure
   counts, and p50/p95 wall and stage durations. It is observational and cannot
   produce readiness evidence.
+- `scripts/quality-dashboard generate` validates the latest schema-4 manifest
+  and summary digest, then writes deterministic static HTML and JSON under
+  `app/build/quality-dashboard/`. `scripts/quality-dashboard serve` binds only
+  loopback and stops after its bounded deadline.
 
 The stages are `static`, the gate orchestrator's own contract tests, `swift`,
 `quality-contracts`, development app build/verification, packaged-app
@@ -59,8 +65,8 @@ release-workflow tests, and the zero-work `release-budget` postflight. Every
 executable stage has a bounded timeout.
 Logs, a versioned TSV summary, a provenance manifest, a safe execution-context
 record, a digest inventory of bounded fake-test diagnostics, and JUnit XML are
-written privately under `app/build/quality-gates/`. The schema-3 manifest binds
-evidence to the policy, source commit, resolved base commit, selected stages,
+written privately under `app/build/quality-gates/`. The schema-4 manifest binds
+evidence to the policy, authority, source commit, resolved base commit, selected stages,
 input and plan fingerprints, timestamps, inherited timing, parent evidence,
 environment and artifact inventories, and SHA-256 digests of the summary and
 every stage log. Failure, environment failure, timeout, interruption, blocked
@@ -85,9 +91,33 @@ freshly bundled tmux and `detach-state`; none of these stages invokes SwiftPM.
 The gate therefore does not depend on writable user caches, ambient tmux,
 provider session state, or the installed Detach app.
 
-There are no quarantined tests in policy version 12. A future quarantine must be
+There are no quarantined tests in policy version 13. A future quarantine must be
 tracked here with an owner, expiry, and reason, and may not remove a release
 contract check.
+
+## Policy version 13: one policy and explicit authority
+
+Policy 13 keeps policy 12's functional checks and fail-closed manual release
+selection. It changes the quality control boundary:
+
+1. `quality/policy.tsv` owns stage order, timeouts, dependencies, path routing,
+   release impact, critical sources, requirements, and cycle deadlines.
+2. The stdlib-only Python policy engine validates every tracked path and fails
+   safe for an unknown added path. Production scripts contain no second path
+   classifier or critical-source list.
+3. Local change and repository runs record `local-diagnostic` authority and
+   print `DIAGNOSTIC PASS`. They cannot claim merge readiness.
+4. Pull-request CI runs repository mode on the exact change, records `ci-merge`
+   authority, and is the sole ordinary merge-readiness PASS.
+5. CI cancels superseded work and has a ten-minute workflow deadline. Every
+   stage also keeps its policy-owned timeout.
+6. Resume requires the same policy, input, commits, stage coverage, and
+   authority. Local evidence cannot satisfy CI.
+7. Every plan and manifest names affected product capabilities and user
+   journeys. The generated policy JSON rejects orphan paths, requirements,
+   journeys, and scenarios.
+8. A separate least-privilege job publishes the dashboard to GitHub Pages only
+   from a successful `main` run. It cannot publish local or pull-request data.
 
 ## Policy version 12: impact-selected manual release gates
 
@@ -375,7 +405,8 @@ evade the static gate merely because they are untracked.
 | CLI/session lifecycle | static, app, UI e2e, both isolated integrations, distribution, runtime, release budget |
 | Install/distribution | static, app, UI e2e, distribution, runtime, release budget |
 | Release/publication | static, app, UI e2e, release/publish preflights, release-workflow test, release budget |
-| Gate policy, CI, mixed unknown path | full repository gate |
+| Gate policy and CI | static policy and gate self-contracts locally; full repository gate in CI |
+| Mixed unknown path | full repository gate |
 
 Known mixed diffs take the union of their mandatory gates. Deletions use their
 old path; renames and copies conservatively use both paths. Dependencies are
@@ -385,15 +416,16 @@ bundled tmux). An unclassifiable path fails safe to the full set.
 ## Definition of Done
 
 An agent may report a change ready only when the changed behavior has a
-regression or contract test, the normal impact-selected gate has printed PASS,
-user-facing documentation is synchronized, and `git diff --check` is clean.
+regression or contract test, the hosted pull-request repository gate has
+printed authoritative PASS, user-facing documentation is synchronized, and
+`git diff --check` is clean.
 The report must name any manual release gate that was not run. A single test or
 `--stage` rerun is useful diagnosis but cannot replace the selected gate.
 
-CI and `scripts/release-version` invoke this same entry point. CI runs every
-selected functional stage and the static timing-policy ratchets, but enforces
+CI and `scripts/release-version` invoke this same entry point. Pull-request CI
+runs every functional stage and the static timing-policy ratchets once, but enforces
 neither reference-machine stage ceilings nor the `release-budget` wall ceiling;
-local and release readiness still require both. CI publishes its manifest,
+release readiness still requires both. Local timing is diagnostic. CI publishes its manifest,
 TSV, JUnit report, and logs for 14 days even when the gate passes, and also
 exposes the summary in the workflow UI. It does not copy a separate test matrix.
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -3,8 +3,8 @@
 ## Outcome
 
 Codex and Claude Code receive the same small durable instruction core, discover
-only task-relevant detailed specs, use focused tests while iterating, and finish
-against the same deterministic quality gate.
+only task-relevant detailed specs, and use focused tests while iterating.
+Hosted pull-request CI is the deterministic merge-readiness authority.
 
 ## Invariants
 
@@ -27,21 +27,26 @@ against the same deterministic quality gate.
   Claude expands imports eagerly.
 - Ignored `presentations/` contains internal presentation sources. Git and the
   quality gate do not treat these files as repository inputs.
-- Fast diagnostics close the edit loop; `scripts/quality-gate` remains the
-  sole readiness entry point. A focused command or diagnostic stage is never
-  presented as final evidence.
+- Fast local diagnostics close the edit loop. They never claim merge readiness.
+  Hosted pull-request CI runs the full repository gate on the exact change and
+  is the sole ordinary merge-readiness authority.
 - `scripts/test critical`, `unit`, `coverage`, `smoke`, and `full` are the
   stable human entry points for the high-risk logic loop, complete Swift loop,
-  measured coverage loop, freshly packaged product smoke, and exhaustive
-  repository readiness respectively. Each supports `--plan`; only `full` is
-  readiness evidence because it delegates to the repository quality gate.
+  measured coverage loop, freshly packaged product smoke, and exhaustive local
+  repository diagnostic respectively. Each supports `--plan`. No command in
+  this group is merge-readiness evidence.
 - Resume evidence retains stage timing and digest-bound logs, binds its parent,
-  and cannot turn a prior time-budget regression into readiness.
+  requires the same authority, and cannot turn a prior time-budget regression
+  into authoritative evidence.
 - A local timing-budget failure creates performance work. Warm-cache or
   variance reruns cannot turn it into readiness; an unchanged rerun is allowed
   only for an evidenced unrelated external transient whose cause is recorded.
-- Hosted CI runs every selected functional check and timing-policy ratchet but
-  does not enforce reference-machine wall or per-stage timing ceilings.
+- Pull-request CI runs every functional check once and the timing-policy
+  ratchets. It does not enforce reference-machine wall or per-stage timing
+  ceilings. The workflow has a ten-minute overall deadline.
+- A deterministic static dashboard reads only validated gate evidence. The
+  same artifact opens locally and deploys to GitHub Pages only after a green
+  `main` repository run. Its deploy job alone has Pages write permission.
 - The active GitHub ruleset for `main` has no bypass actors. It requires the
   GitHub Actions `quality-gates` job. An administrator cannot use an unchecked
   push as a substitute for CI. A release commit first gets the same check on
@@ -68,4 +73,5 @@ only for a rule needed on most tasks.
 ## Verification
 
 Run `tests/docs-contract.sh` and `tests/test-suite-contract.sh`, inspect the
-context map for the affected area, then run the impact-selected quality gate.
+context map for the affected area, and run the focused local diagnostics. The
+required pull-request job supplies final merge evidence.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,13 +16,14 @@
   packaged-app Accessibility flow, then verifies the bundled runtime. It needs
   a logged-in WindowServer session and an environment that permits the private
   app and tmux socket. Use `scripts/test --plan smoke` to inspect the steps.
-- `scripts/test full` — every automated repository check; it delegates exactly
-  to `scripts/quality-gate --mode repository` and is readiness evidence.
-  `critical` and `smoke` are focused diagnostics and never substitute for it.
+- `scripts/test full` — every automated repository check as a local diagnostic;
+  it delegates exactly to `scripts/quality-gate --mode repository`. It does not
+  claim merge readiness. Pull-request CI runs the same functional matrix once
+  on the exact change and is merge authority.
 
-- `scripts/quality-gate` — the policy-versioned, impact-aware readiness entry
-  point for agents. It selects mandatory checks from the diff and fails safe to
-  the repository gate for unknown impact. See `docs/quality-gates.md`.
+- `scripts/quality-gate` — the policy-versioned, impact-aware local diagnostic
+  entry point. It selects checks from the diff and fails safe to the repository
+  gate for unknown impact. See `docs/quality-gates.md`.
 - `scripts/quality-gate --plan --explain` explains impact selection;
   `--plan --format json` is the machine-readable equivalent. A failed or
   interrupted run may use `--resume <run-dir>` or `--resume latest` only while
@@ -32,11 +33,17 @@
 - `scripts/quality-history [RESULT_ROOT]` reports p50/p95 wall and stage timing,
   ordinary failures, and execution-environment failures across retained local
   or downloaded gate evidence. It is telemetry, not readiness evidence.
-- `scripts/quality-gate --mode repository` — every automated repository gate.
-  CI uses the same entry point with `--without-release-budget`, disabling local
+- `scripts/quality-dashboard generate` creates
+  `app/build/quality-dashboard/{index.html,data.json}` from the newest schema-4
+  evidence. `scripts/quality-dashboard serve --seconds 300` serves it only on
+  loopback and stops at the deadline. A green `main` workflow publishes the
+  same static files to `https://iltsarev.github.io/detach/`.
+- `scripts/quality-gate --mode repository` — every automated repository check.
+  Local use is diagnostic. Pull-request CI uses the same entry point once with
+  `ci-merge` authority and `--without-release-budget`, disabling local
   reference-machine wall and stage timing enforcement while retaining every
-  selected functional stage and the static budget ratchets. Direct local use is
-  not readiness evidence. A normal release enforces the budgets; only the
+  functional stage and the static budget ratchets. A normal release enforces
+  the budgets; only the
   owner-confirmed `DETACH_RELEASE_IGNORE_TIMING=1 scripts/release-version X.Y.Z`
   path may omit them for one intentionally busy-machine release, with the
   waiver recorded in private evidence. `--stage` is diagnostic only and is not
@@ -53,8 +60,7 @@
   applies stage budgets to ordinary local partial plans, exempts only the
   explicit GitHub-only budget-free plan, and raises the established UI floors.
   Policy 9 adds contract-locked `critical`, `unit`, `coverage`, `smoke`, and
-  `full` operator entry points while retaining the quality gate as the only
-  readiness authority. Policy 10 adds the exact-owner-confirmed busy-machine
+  `full` operator entry points. Policy 10 adds the exact-owner-confirmed busy-machine
   release timing waiver without removing any functional or hardware gate.
 
 - `DETACH_TEST_TMUX_BIN="$PWD/app/build/Detach.app/Contents/Resources/DetachCLI/tmux" tests/run.sh`

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -1,0 +1,1876 @@
+{
+  "capabilities": [
+    {
+      "id": "quality-system",
+      "journeys": [
+        "J-QUALITY-CHANGE"
+      ],
+      "requirements": [],
+      "spec": "docs/specs/documentation.md"
+    },
+    {
+      "id": "documentation",
+      "journeys": [
+        "J-DOCS-CONSISTENCY"
+      ],
+      "requirements": [],
+      "spec": "docs/specs/documentation.md"
+    },
+    {
+      "id": "session-lifecycle",
+      "journeys": [
+        "J-SESSION-CREATE",
+        "J-SESSION-PERSIST",
+        "J-SESSION-RECOVER",
+        "J-SESSION-STOP",
+        "J-SESSION-DELETE"
+      ],
+      "requirements": [
+        "QC-RUNTIME-STATE",
+        "QC-RUNTIME-OWNERSHIP",
+        "QC-RUNTIME-STORAGE",
+        "QC-RUNTIME-TRANSITION"
+      ],
+      "spec": "docs/specs/runtime.md"
+    },
+    {
+      "id": "power-protection",
+      "journeys": [
+        "J-POWER-ENABLE",
+        "J-POWER-LOW-BATTERY",
+        "J-POWER-HELPER-LEASE",
+        "J-POWER-CLOSED-LID"
+      ],
+      "requirements": [
+        "QC-POWER-ASSERTION",
+        "QC-POWER-AUTH",
+        "QC-POWER-LEASE",
+        "QC-POWER-XPC",
+        "QC-POWER-PROTECTION",
+        "QC-POWER-CLI",
+        "QC-POWER-PLATFORM"
+      ],
+      "spec": "docs/specs/power.md"
+    },
+    {
+      "id": "app-experience",
+      "journeys": [
+        "J-APP-DASHBOARD",
+        "J-APP-EMPTY",
+        "J-APP-FAILURE",
+        "J-APP-FOCUS"
+      ],
+      "requirements": [
+        "QC-HEALTH-FRESHNESS",
+        "QC-HEALTH-PRESENTATION",
+        "QC-APP-TIPS"
+      ],
+      "spec": "docs/specs/app.md"
+    },
+    {
+      "id": "onboarding",
+      "journeys": [
+        "J-ONBOARD-FIRST-RUN",
+        "J-ONBOARD-PROVIDER",
+        "J-ONBOARD-APPROVAL"
+      ],
+      "requirements": [
+        "QC-APP-ONBOARDING"
+      ],
+      "spec": "docs/specs/app.md"
+    },
+    {
+      "id": "settings",
+      "journeys": [
+        "J-SETTINGS-CHANGE"
+      ],
+      "requirements": [
+        "QC-APP-SETTINGS"
+      ],
+      "spec": "docs/specs/app.md"
+    },
+    {
+      "id": "update",
+      "journeys": [
+        "J-UPDATE-CHECK",
+        "J-UPDATE-APPLY"
+      ],
+      "requirements": [
+        "QC-APP-UPDATE"
+      ],
+      "spec": "docs/specs/app.md"
+    },
+    {
+      "id": "diagnostics",
+      "journeys": [
+        "J-DOCTOR-REPORT"
+      ],
+      "requirements": [
+        "QC-APP-DOCTOR"
+      ],
+      "spec": "docs/specs/app.md"
+    },
+    {
+      "id": "installation",
+      "journeys": [
+        "J-INSTALL-CLEAN",
+        "J-INSTALL-REPAIR",
+        "J-INSTALL-UNINSTALL"
+      ],
+      "requirements": [
+        "QC-RELEASE-INSTALL"
+      ],
+      "spec": "docs/specs/release.md"
+    },
+    {
+      "id": "publication",
+      "journeys": [
+        "J-PUBLISH-ARTIFACTS"
+      ],
+      "requirements": [
+        "QC-RELEASE-PUBLISH"
+      ],
+      "spec": "docs/specs/release.md"
+    }
+  ],
+  "critical_sources": [
+    {
+      "coverage_floor": 99.1,
+      "path": "app/Sources/DetachKit/SessionHealth.swift",
+      "requirement": "QC-HEALTH-FRESHNESS"
+    },
+    {
+      "coverage_floor": 99.03,
+      "path": "app/Sources/DetachKit/DetachState.swift",
+      "requirement": "QC-RUNTIME-STATE"
+    },
+    {
+      "coverage_floor": 96.7,
+      "path": "app/Sources/DetachKit/DetachStateCommand.swift",
+      "requirement": "QC-RUNTIME-STATE"
+    },
+    {
+      "coverage_floor": 95.28,
+      "path": "app/Sources/DetachKit/Storage.swift",
+      "requirement": "QC-RUNTIME-STORAGE"
+    },
+    {
+      "coverage_floor": 100.0,
+      "path": "app/Sources/DetachKit/StorageStore.swift",
+      "requirement": "QC-RUNTIME-STORAGE"
+    },
+    {
+      "coverage_floor": 100.0,
+      "path": "app/Sources/DetachKit/Tip.swift",
+      "requirement": "QC-APP-TIPS"
+    },
+    {
+      "coverage_floor": 95.21,
+      "path": "app/Sources/DetachKit/DetachPowerCommand.swift",
+      "requirement": "QC-POWER-CLI"
+    },
+    {
+      "coverage_floor": 100.0,
+      "path": "app/Sources/DetachKit/DetachPowerExecutable.swift",
+      "requirement": "QC-POWER-CLI"
+    },
+    {
+      "coverage_floor": 98.21,
+      "path": "app/Sources/DetachKit/PowerHelperLeaseService.swift",
+      "requirement": "QC-POWER-LEASE"
+    },
+    {
+      "coverage_floor": 82.23,
+      "path": "app/Sources/DetachKit/PowerHelperXPC.swift",
+      "requirement": "QC-POWER-XPC"
+    },
+    {
+      "coverage_floor": 84.54,
+      "path": "app/Sources/DetachKit/PowerHelperPlatform.swift",
+      "requirement": "QC-POWER-PLATFORM"
+    },
+    {
+      "coverage_floor": 98.11,
+      "path": "app/Sources/DetachKit/SessionStore.swift",
+      "requirement": "QC-RUNTIME-OWNERSHIP"
+    },
+    {
+      "coverage_floor": 100.0,
+      "path": "app/Sources/DetachKit/DoctorReport.swift",
+      "requirement": "QC-APP-DOCTOR"
+    }
+  ],
+  "dependencies": [
+    {
+      "dependent": "ui-e2e",
+      "prerequisite": "app"
+    }
+  ],
+  "journeys": [
+    {
+      "capability": "quality-system",
+      "id": "J-QUALITY-CHANGE",
+      "requirements": [],
+      "scenarios": [
+        "SC-POLICY-CONTRACT"
+      ],
+      "summary": "A policy change keeps local feedback focused and hosted evidence complete."
+    },
+    {
+      "capability": "documentation",
+      "id": "J-DOCS-CONSISTENCY",
+      "requirements": [],
+      "scenarios": [
+        "SC-DOCS-CONTRACT"
+      ],
+      "summary": "Documentation and executable contracts stay synchronized."
+    },
+    {
+      "capability": "session-lifecycle",
+      "id": "J-SESSION-CREATE",
+      "requirements": [
+        "QC-RUNTIME-STATE",
+        "QC-RUNTIME-OWNERSHIP"
+      ],
+      "scenarios": [
+        "SC-SESSION-CREATE-CODEX",
+        "SC-SESSION-CREATE-CLAUDE"
+      ],
+      "summary": "A user creates a managed provider session."
+    },
+    {
+      "capability": "session-lifecycle",
+      "id": "J-SESSION-PERSIST",
+      "requirements": [
+        "QC-RUNTIME-STATE",
+        "QC-RUNTIME-STORAGE"
+      ],
+      "scenarios": [
+        "SC-SESSION-PERSIST-CODEX",
+        "SC-SESSION-PERSIST-CLAUDE"
+      ],
+      "summary": "A live session remains available after the app exits."
+    },
+    {
+      "capability": "session-lifecycle",
+      "id": "J-SESSION-RECOVER",
+      "requirements": [
+        "QC-RUNTIME-OWNERSHIP",
+        "QC-RUNTIME-STORAGE",
+        "QC-RUNTIME-TRANSITION"
+      ],
+      "scenarios": [
+        "SC-SESSION-RECOVER-CODEX",
+        "SC-SESSION-RECOVER-CLAUDE"
+      ],
+      "summary": "A user recovers the exact owned session after interruption."
+    },
+    {
+      "capability": "session-lifecycle",
+      "id": "J-SESSION-STOP",
+      "requirements": [
+        "QC-RUNTIME-OWNERSHIP"
+      ],
+      "scenarios": [
+        "SC-SESSION-STOP-CODEX",
+        "SC-SESSION-STOP-CLAUDE"
+      ],
+      "summary": "A user stops only the selected owned session."
+    },
+    {
+      "capability": "session-lifecycle",
+      "id": "J-SESSION-DELETE",
+      "requirements": [
+        "QC-RUNTIME-OWNERSHIP",
+        "QC-RUNTIME-STORAGE"
+      ],
+      "scenarios": [
+        "SC-SESSION-DELETE-CODEX",
+        "SC-SESSION-DELETE-CLAUDE"
+      ],
+      "summary": "A user deletes one completed session without affecting another session."
+    },
+    {
+      "capability": "power-protection",
+      "id": "J-POWER-ENABLE",
+      "requirements": [
+        "QC-POWER-ASSERTION",
+        "QC-POWER-LEASE"
+      ],
+      "scenarios": [
+        "SC-POWER-UNIT"
+      ],
+      "summary": "A protected session acquires both required power protections."
+    },
+    {
+      "capability": "power-protection",
+      "id": "J-POWER-LOW-BATTERY",
+      "requirements": [
+        "QC-POWER-PROTECTION"
+      ],
+      "scenarios": [
+        "SC-POWER-LOW-BATTERY"
+      ],
+      "summary": "Low battery removes unsafe protection and reports the reason."
+    },
+    {
+      "capability": "power-protection",
+      "id": "J-POWER-HELPER-LEASE",
+      "requirements": [
+        "QC-POWER-AUTH",
+        "QC-POWER-LEASE",
+        "QC-POWER-XPC"
+      ],
+      "scenarios": [
+        "SC-POWER-HELPER"
+      ],
+      "summary": "The helper accepts only an authorized bounded lease."
+    },
+    {
+      "capability": "power-protection",
+      "id": "J-POWER-CLOSED-LID",
+      "requirements": [
+        "QC-POWER-PROTECTION"
+      ],
+      "scenarios": [
+        "SC-POWER-CLOSED-LID"
+      ],
+      "summary": "A protected session continues on supervised supported hardware with the lid closed."
+    },
+    {
+      "capability": "app-experience",
+      "id": "J-APP-DASHBOARD",
+      "requirements": [
+        "QC-HEALTH-FRESHNESS",
+        "QC-HEALTH-PRESENTATION"
+      ],
+      "scenarios": [
+        "SC-UI-DASHBOARD"
+      ],
+      "summary": "A user sees fresh typed session health on the dashboard."
+    },
+    {
+      "capability": "app-experience",
+      "id": "J-APP-EMPTY",
+      "requirements": [
+        "QC-HEALTH-PRESENTATION",
+        "QC-APP-TIPS"
+      ],
+      "scenarios": [
+        "SC-UI-EMPTY"
+      ],
+      "summary": "A user sees useful empty-state guidance."
+    },
+    {
+      "capability": "app-experience",
+      "id": "J-APP-FAILURE",
+      "requirements": [
+        "QC-HEALTH-PRESENTATION"
+      ],
+      "scenarios": [
+        "SC-UI-FAILURE"
+      ],
+      "summary": "A user sees an actionable failure without parsed terminal claims."
+    },
+    {
+      "capability": "app-experience",
+      "id": "J-APP-FOCUS",
+      "requirements": [
+        "QC-HEALTH-PRESENTATION"
+      ],
+      "scenarios": [
+        "SC-UI-FOCUS"
+      ],
+      "summary": "Background status checks do not steal keyboard focus."
+    },
+    {
+      "capability": "onboarding",
+      "id": "J-ONBOARD-FIRST-RUN",
+      "requirements": [
+        "QC-APP-ONBOARDING"
+      ],
+      "scenarios": [
+        "SC-UI-ONBOARD-FIRST-RUN"
+      ],
+      "summary": "A new user completes the first-run setup."
+    },
+    {
+      "capability": "onboarding",
+      "id": "J-ONBOARD-PROVIDER",
+      "requirements": [
+        "QC-APP-ONBOARDING"
+      ],
+      "scenarios": [
+        "SC-UI-ONBOARD-PROVIDER"
+      ],
+      "summary": "Onboarding detects an authenticated supported provider."
+    },
+    {
+      "capability": "onboarding",
+      "id": "J-ONBOARD-APPROVAL",
+      "requirements": [
+        "QC-APP-ONBOARDING"
+      ],
+      "scenarios": [
+        "SC-UI-ONBOARD-APPROVAL"
+      ],
+      "summary": "Onboarding explains and observes required macOS approvals."
+    },
+    {
+      "capability": "settings",
+      "id": "J-SETTINGS-CHANGE",
+      "requirements": [
+        "QC-APP-SETTINGS"
+      ],
+      "scenarios": [
+        "SC-UI-SETTINGS"
+      ],
+      "summary": "A user changes a setting and observes the persisted result."
+    },
+    {
+      "capability": "update",
+      "id": "J-UPDATE-CHECK",
+      "requirements": [
+        "QC-APP-UPDATE"
+      ],
+      "scenarios": [
+        "SC-UPDATE-CHECK"
+      ],
+      "summary": "A user receives a typed update state."
+    },
+    {
+      "capability": "update",
+      "id": "J-UPDATE-APPLY",
+      "requirements": [
+        "QC-APP-UPDATE"
+      ],
+      "scenarios": [
+        "SC-UPDATE-APPLY"
+      ],
+      "summary": "A valid update preserves the arm64 and signature contract."
+    },
+    {
+      "capability": "diagnostics",
+      "id": "J-DOCTOR-REPORT",
+      "requirements": [
+        "QC-APP-DOCTOR"
+      ],
+      "scenarios": [
+        "SC-DOCTOR-REPORT"
+      ],
+      "summary": "A user receives a typed actionable doctor report."
+    },
+    {
+      "capability": "installation",
+      "id": "J-INSTALL-CLEAN",
+      "requirements": [
+        "QC-RELEASE-INSTALL"
+      ],
+      "scenarios": [
+        "SC-INSTALL-CLEAN"
+      ],
+      "summary": "A user installs one immutable self-contained payload."
+    },
+    {
+      "capability": "installation",
+      "id": "J-INSTALL-REPAIR",
+      "requirements": [
+        "QC-RELEASE-INSTALL"
+      ],
+      "scenarios": [
+        "SC-INSTALL-REPAIR"
+      ],
+      "summary": "Repair restores the exact immutable payload."
+    },
+    {
+      "capability": "installation",
+      "id": "J-INSTALL-UNINSTALL",
+      "requirements": [
+        "QC-RELEASE-INSTALL"
+      ],
+      "scenarios": [
+        "SC-INSTALL-UNINSTALL"
+      ],
+      "summary": "Uninstall removes only Detach-owned data selected by the user."
+    },
+    {
+      "capability": "publication",
+      "id": "J-PUBLISH-ARTIFACTS",
+      "requirements": [
+        "QC-RELEASE-PUBLISH"
+      ],
+      "scenarios": [
+        "SC-PUBLISH-CONTRACT"
+      ],
+      "summary": "Publication exposes only verified allowlisted artifacts."
+    }
+  ],
+  "limits": {
+    "local_feedback_seconds": 120,
+    "max_repair_loops": 2,
+    "merge_wait_seconds": 300,
+    "pr_feedback_seconds": 600,
+    "review_seconds": 180
+  },
+  "policy": 13,
+  "release_domains": [
+    {
+      "gates": "-",
+      "id": "safe",
+      "unknown": false
+    },
+    {
+      "gates": "install",
+      "id": "install",
+      "unknown": false
+    },
+    {
+      "gates": "lid",
+      "id": "lid",
+      "unknown": false
+    },
+    {
+      "gates": "install,lid",
+      "id": "both",
+      "unknown": false
+    },
+    {
+      "gates": "install,lid",
+      "id": "unknown",
+      "unknown": true
+    }
+  ],
+  "requirements": [
+    {
+      "id": "QC-RUNTIME-STATE",
+      "spec": "docs/specs/runtime.md",
+      "summary": "Typed state is the only shared state mutation boundary."
+    },
+    {
+      "id": "QC-RUNTIME-OWNERSHIP",
+      "spec": "docs/specs/runtime.md",
+      "summary": "Session operations prove the exact run token and process ownership."
+    },
+    {
+      "id": "QC-RUNTIME-STORAGE",
+      "spec": "docs/specs/runtime.md",
+      "summary": "Restores validate path, symlink, identity, and JSONL data before replacement."
+    },
+    {
+      "id": "QC-POWER-ASSERTION",
+      "spec": "docs/specs/power.md",
+      "summary": "Power protection owns a user IOKit assertion."
+    },
+    {
+      "id": "QC-POWER-AUTH",
+      "spec": "docs/specs/power.md",
+      "summary": "Helper authorization binds audit token, console user, signing, and deadline."
+    },
+    {
+      "id": "QC-POWER-LEASE",
+      "spec": "docs/specs/power.md",
+      "summary": "The root helper lease is bounded and ownership safe."
+    },
+    {
+      "id": "QC-POWER-XPC",
+      "spec": "docs/specs/power.md",
+      "summary": "The helper accepts only the typed power protocol."
+    },
+    {
+      "id": "QC-POWER-PROTECTION",
+      "spec": "docs/specs/power.md",
+      "summary": "Low battery fails safe."
+    },
+    {
+      "id": "QC-POWER-CLI",
+      "spec": "docs/specs/power.md",
+      "summary": "The power command reports and enforces typed protection state."
+    },
+    {
+      "id": "QC-POWER-PLATFORM",
+      "spec": "docs/specs/power.md",
+      "summary": "Platform power operations preserve the helper safety boundary."
+    },
+    {
+      "id": "QC-HEALTH-FRESHNESS",
+      "spec": "docs/specs/app.md",
+      "summary": "Health claims use typed fresh state."
+    },
+    {
+      "id": "QC-HEALTH-PRESENTATION",
+      "spec": "docs/specs/app.md",
+      "summary": "The app presents typed health state without parsing terminal text."
+    },
+    {
+      "id": "QC-RUNTIME-TRANSITION",
+      "spec": "docs/specs/runtime.md",
+      "summary": "Session transitions preserve exact process identity."
+    },
+    {
+      "id": "QC-APP-TIPS",
+      "spec": "docs/specs/app.md",
+      "summary": "Session tips remain deterministic and user visible."
+    },
+    {
+      "id": "QC-APP-DOCTOR",
+      "spec": "docs/specs/app.md",
+      "summary": "Doctor output derives from typed runtime state."
+    },
+    {
+      "id": "QC-APP-ONBOARDING",
+      "spec": "docs/specs/app.md",
+      "summary": "Onboarding leads a new user through supported provider and approval setup."
+    },
+    {
+      "id": "QC-APP-SETTINGS",
+      "spec": "docs/specs/app.md",
+      "summary": "Settings changes persist and affect only their declared behavior."
+    },
+    {
+      "id": "QC-APP-UPDATE",
+      "spec": "docs/specs/app.md",
+      "summary": "Update state and application preserve the signed arm64 contract."
+    },
+    {
+      "id": "QC-RELEASE-INSTALL",
+      "spec": "docs/specs/release.md",
+      "summary": "Install, repair, and uninstall mutate only Detach-owned payloads and selected state."
+    },
+    {
+      "id": "QC-RELEASE-PUBLISH",
+      "spec": "docs/specs/release.md",
+      "summary": "Publication exposes only independently verified allowlisted artifacts."
+    }
+  ],
+  "routes": [
+    {
+      "pattern": "quality/*",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": ".github/workflows/quality-gates.yml",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "docs/quality-gates.md",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "docs/testing.md",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-gate",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-policy",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_policy.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-dashboard",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_dashboard.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-history",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/test",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tests/quality-*",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tests/release-budget*",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tests/shell-safety*",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tests/test-suite-contract.sh",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tests/docs-contract.sh",
+      "priority": 990,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
+      "pattern": "*.md",
+      "priority": 950,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
+      "pattern": "docs/assets/*",
+      "priority": 950,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
+      "pattern": "AGENTS.md",
+      "priority": 960,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
+      "pattern": "CLAUDE.md",
+      "priority": 960,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/DetachState*.swift",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "state-runtime"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Session*.swift",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "state-runtime"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Storage*.swift",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "state-runtime"
+    },
+    {
+      "pattern": "app/Sources/DetachState/*.swift",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "state-runtime"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/DetachPower*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Power*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/ClamshellLockRunner.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/BoundedProcessRunner.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachPower/*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachPowerHelper/*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachWatchdog/*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/InstallationStore.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/PowerHelper*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/Watchdog*.swift",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "power"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/DetachApp.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "onboarding-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/Onboarding*.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "onboarding-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/RootView.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "onboarding-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/SetupGuidance.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "onboarding-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/Settings*.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "settings-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/UpdaterService.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "update-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/DetachCLI.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "runtime-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/DoctorReport.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "diagnostics-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Localization.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "onboarding-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/UpdateConfiguration.swift",
+      "priority": 880,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "update-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/EmptySessionsView.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/LogTextView.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/MenuBar*.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/NewSessionSheet.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "session-ui-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/Session*.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "session-ui-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/SidebarView.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "session-ui-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/TextSize.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/Theme.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/TipsBar.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/UIE2E*.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachApp/*.swift",
+      "priority": 850,
+      "release_domain": "unknown",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/ANSIText.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/LogPoller.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Terminal*.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "runtime-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Tip.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/Tmux*.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "runtime-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/*.swift",
+      "priority": 840,
+      "release_domain": "unknown",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Sources/*",
+      "priority": 800,
+      "release_domain": "unknown",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-source"
+    },
+    {
+      "pattern": "app/Tests/*",
+      "priority": 800,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "swift-test"
+    },
+    {
+      "pattern": "app/Resources/en.lproj/*",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/ru.lproj/*",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/Info.plist",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/Detach.entitlements",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/DetachDevelopment.entitlements",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/DetachWatchdog*",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/dev.tsarev.detach.power-*",
+      "priority": 900,
+      "release_domain": "both",
+      "spec": "docs/specs/power.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/Detach.icns",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/ThirdParty/*",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Resources/*",
+      "priority": 800,
+      "release_domain": "unknown",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Package.swift",
+      "priority": 900,
+      "release_domain": "unknown",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "app/Package.resolved",
+      "priority": 900,
+      "release_domain": "unknown",
+      "spec": "docs/specs/app.md",
+      "test_domain": "package"
+    },
+    {
+      "pattern": "bin/detach",
+      "priority": 900,
+      "release_domain": "lid",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "cli"
+    },
+    {
+      "pattern": "bin/detach-core",
+      "priority": 900,
+      "release_domain": "lid",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "cli"
+    },
+    {
+      "pattern": "bin/*",
+      "priority": 800,
+      "release_domain": "unknown",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "cli"
+    },
+    {
+      "pattern": "install.sh",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "install"
+    },
+    {
+      "pattern": "scripts/install.sh",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "install"
+    },
+    {
+      "pattern": "scripts/build-tmux.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "tmux-build"
+    },
+    {
+      "pattern": "scripts/release-lid-probe",
+      "priority": 900,
+      "release_domain": "lid",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "app/scripts/make-dmg.sh",
+      "priority": 900,
+      "release_domain": "install",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "app/scripts/make-app.sh",
+      "priority": 900,
+      "release_domain": "unknown",
+      "spec": "docs/specs/release.md",
+      "test_domain": "app-script"
+    },
+    {
+      "pattern": "app/scripts/release.sh",
+      "priority": 900,
+      "release_domain": "unknown",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "app/scripts/bundle-modes.sh",
+      "priority": 900,
+      "release_domain": "unknown",
+      "spec": "docs/specs/release.md",
+      "test_domain": "app-script"
+    },
+    {
+      "pattern": "app/scripts/publish-release.sh",
+      "priority": 890,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "app/scripts/verify-appcast.sh",
+      "priority": 890,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "app/scripts/*",
+      "priority": 880,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "app-script"
+    },
+    {
+      "pattern": "scripts/release-version",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "scripts/release-impact",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "scripts/*",
+      "priority": 800,
+      "release_domain": "unknown",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "unknown"
+    },
+    {
+      "pattern": "tests/run.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "codex-test"
+    },
+    {
+      "pattern": "tests/fake-codex",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "codex-test"
+    },
+    {
+      "pattern": "tests/run-claude.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "claude-test"
+    },
+    {
+      "pattern": "tests/fake-claude",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "claude-test"
+    },
+    {
+      "pattern": "tests/distribution.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "distribution-test"
+    },
+    {
+      "pattern": "tests/tmux-runtime.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "runtime-test"
+    },
+    {
+      "pattern": "tests/power-smoke.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/power.md",
+      "test_domain": "runtime-test"
+    },
+    {
+      "pattern": "tests/ui-e2e.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "ui-test"
+    },
+    {
+      "pattern": "tests/ui-e2e-contract.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "ui-test"
+    },
+    {
+      "pattern": "tests/fake-ui-cli",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "ui-test"
+    },
+    {
+      "pattern": "tests/release-preflight.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-preflight-test"
+    },
+    {
+      "pattern": "tests/publish-preflight.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "publish-preflight-test"
+    },
+    {
+      "pattern": "tests/release-impact.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-workflow-test"
+    },
+    {
+      "pattern": "tests/release-workflow.sh",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-workflow-test"
+    },
+    {
+      "pattern": "tests/*",
+      "priority": 500,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "unknown"
+    },
+    {
+      "pattern": "VERSION",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "BUILD",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/release.md",
+      "test_domain": "release-tool"
+    },
+    {
+      "pattern": "README.md",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
+      "pattern": ".gitignore",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "metadata"
+    },
+    {
+      "pattern": ".gitattributes",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "metadata"
+    },
+    {
+      "pattern": ".github/*",
+      "priority": 800,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "unknown"
+    },
+    {
+      "pattern": "app/.gitignore",
+      "priority": 700,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "metadata"
+    },
+    {
+      "pattern": "*.sh",
+      "priority": 100,
+      "release_domain": "unknown",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "unknown"
+    }
+  ],
+  "scenarios": [
+    {
+      "command": "tests/quality-policy.sh",
+      "id": "SC-POLICY-CONTRACT",
+      "stage": "gate-contract",
+      "status": "automated"
+    },
+    {
+      "command": "tests/docs-contract.sh",
+      "id": "SC-DOCS-CONTRACT",
+      "stage": "static",
+      "status": "automated"
+    },
+    {
+      "command": "tests/run.sh",
+      "id": "SC-SESSION-CREATE-CODEX",
+      "stage": "codex",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run-claude.sh",
+      "id": "SC-SESSION-CREATE-CLAUDE",
+      "stage": "claude",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run.sh",
+      "id": "SC-SESSION-PERSIST-CODEX",
+      "stage": "codex",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run-claude.sh",
+      "id": "SC-SESSION-PERSIST-CLAUDE",
+      "stage": "claude",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run.sh",
+      "id": "SC-SESSION-RECOVER-CODEX",
+      "stage": "codex",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run-claude.sh",
+      "id": "SC-SESSION-RECOVER-CLAUDE",
+      "stage": "claude",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run.sh",
+      "id": "SC-SESSION-STOP-CODEX",
+      "stage": "codex",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run-claude.sh",
+      "id": "SC-SESSION-STOP-CLAUDE",
+      "stage": "claude",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run.sh",
+      "id": "SC-SESSION-DELETE-CODEX",
+      "stage": "codex",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/run-claude.sh",
+      "id": "SC-SESSION-DELETE-CLAUDE",
+      "stage": "claude",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "cd app && swift test --filter Power",
+      "id": "SC-POWER-UNIT",
+      "stage": "swift",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "cd app && swift test --filter PowerProtection",
+      "id": "SC-POWER-LOW-BATTERY",
+      "stage": "swift",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "cd app && swift test --filter PowerHelper",
+      "id": "SC-POWER-HELPER",
+      "stage": "swift",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "scripts/release-lid-probe",
+      "id": "SC-POWER-CLOSED-LID",
+      "stage": "release-budget",
+      "status": "manual-release"
+    },
+    {
+      "command": "tests/ui-e2e.sh",
+      "id": "SC-UI-DASHBOARD",
+      "stage": "ui-e2e",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/ui-e2e.sh",
+      "id": "SC-UI-EMPTY",
+      "stage": "ui-e2e",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "pending out-of-process UI journey",
+      "id": "SC-UI-FAILURE",
+      "stage": "ui-e2e",
+      "status": "planned"
+    },
+    {
+      "command": "tests/ui-e2e.sh",
+      "id": "SC-UI-FOCUS",
+      "stage": "ui-e2e",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "pending out-of-process UI journey",
+      "id": "SC-UI-ONBOARD-FIRST-RUN",
+      "stage": "ui-e2e",
+      "status": "planned"
+    },
+    {
+      "command": "pending out-of-process UI journey",
+      "id": "SC-UI-ONBOARD-PROVIDER",
+      "stage": "ui-e2e",
+      "status": "planned"
+    },
+    {
+      "command": "pending out-of-process UI journey",
+      "id": "SC-UI-ONBOARD-APPROVAL",
+      "stage": "ui-e2e",
+      "status": "planned"
+    },
+    {
+      "command": "pending out-of-process UI journey",
+      "id": "SC-UI-SETTINGS",
+      "stage": "ui-e2e",
+      "status": "planned"
+    },
+    {
+      "command": "tests/release-preflight.sh",
+      "id": "SC-UPDATE-CHECK",
+      "stage": "release-preflight",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/publish-preflight.sh",
+      "id": "SC-UPDATE-APPLY",
+      "stage": "publish-preflight",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/distribution.sh",
+      "id": "SC-DOCTOR-REPORT",
+      "stage": "distribution",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/distribution.sh",
+      "id": "SC-INSTALL-CLEAN",
+      "stage": "distribution",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/distribution.sh",
+      "id": "SC-INSTALL-REPAIR",
+      "stage": "distribution",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/distribution.sh",
+      "id": "SC-INSTALL-UNINSTALL",
+      "stage": "distribution",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "tests/publish-preflight.sh",
+      "id": "SC-PUBLISH-CONTRACT",
+      "stage": "publish-preflight",
+      "status": "legacy-stage"
+    }
+  ],
+  "schema": 1,
+  "stages": [
+    {
+      "name": "static",
+      "order": 10,
+      "release": true,
+      "timeout_seconds": 120
+    },
+    {
+      "name": "gate-contract",
+      "order": 20,
+      "release": true,
+      "timeout_seconds": 300
+    },
+    {
+      "name": "swift",
+      "order": 30,
+      "release": true,
+      "timeout_seconds": 1200
+    },
+    {
+      "name": "quality-contracts",
+      "order": 40,
+      "release": true,
+      "timeout_seconds": 1200
+    },
+    {
+      "name": "app",
+      "order": 50,
+      "release": true,
+      "timeout_seconds": 2400
+    },
+    {
+      "name": "ui-e2e",
+      "order": 60,
+      "release": true,
+      "timeout_seconds": 40
+    },
+    {
+      "name": "codex",
+      "order": 70,
+      "release": true,
+      "timeout_seconds": 1200
+    },
+    {
+      "name": "claude",
+      "order": 80,
+      "release": true,
+      "timeout_seconds": 1200
+    },
+    {
+      "name": "distribution",
+      "order": 90,
+      "release": true,
+      "timeout_seconds": 1200
+    },
+    {
+      "name": "tmux-runtime",
+      "order": 100,
+      "release": true,
+      "timeout_seconds": 1200
+    },
+    {
+      "name": "release-preflight",
+      "order": 110,
+      "release": true,
+      "timeout_seconds": 900
+    },
+    {
+      "name": "publish-preflight",
+      "order": 120,
+      "release": true,
+      "timeout_seconds": 900
+    },
+    {
+      "name": "release-workflow",
+      "order": 130,
+      "release": false,
+      "timeout_seconds": 900
+    },
+    {
+      "name": "release-budget",
+      "order": 140,
+      "release": true,
+      "timeout_seconds": 1
+    }
+  ],
+  "test_domains": [
+    {
+      "capabilities": "quality-system",
+      "id": "policy",
+      "stages": "static,gate-contract"
+    },
+    {
+      "capabilities": "documentation",
+      "id": "docs",
+      "stages": "static"
+    },
+    {
+      "capabilities": "session-lifecycle",
+      "id": "state-runtime",
+      "stages": "static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "power-protection",
+      "id": "power",
+      "stages": "static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "app-experience",
+      "id": "swift-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "onboarding",
+      "id": "onboarding-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "settings",
+      "id": "settings-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "update",
+      "id": "update-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "diagnostics",
+      "id": "diagnostics-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle",
+      "id": "runtime-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle,app-experience",
+      "id": "session-ui-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "quality-system",
+      "id": "swift-test",
+      "stages": "static,swift,quality-contracts,release-budget"
+    },
+    {
+      "capabilities": "installation,update",
+      "id": "package",
+      "stages": "static,swift,quality-contracts,app,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle",
+      "id": "cli",
+      "stages": "static,app,codex,claude,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "installation",
+      "id": "install",
+      "stages": "static,app,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle",
+      "id": "tmux-build",
+      "stages": "static,app,codex,claude,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "update,publication",
+      "id": "release-tool",
+      "stages": "static,app,release-preflight,publish-preflight,release-workflow,release-budget"
+    },
+    {
+      "capabilities": "installation",
+      "id": "app-script",
+      "stages": "static,app,tmux-runtime,release-preflight,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle",
+      "id": "codex-test",
+      "stages": "static,app,codex,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle",
+      "id": "claude-test",
+      "stages": "static,app,claude,release-budget"
+    },
+    {
+      "capabilities": "installation",
+      "id": "distribution-test",
+      "stages": "static,app,distribution,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle,power-protection",
+      "id": "runtime-test",
+      "stages": "static,app,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "app-experience",
+      "id": "ui-test",
+      "stages": "static,app,release-budget"
+    },
+    {
+      "capabilities": "update",
+      "id": "release-preflight-test",
+      "stages": "static,release-preflight,release-budget"
+    },
+    {
+      "capabilities": "publication",
+      "id": "publish-preflight-test",
+      "stages": "static,publish-preflight,release-budget"
+    },
+    {
+      "capabilities": "update,publication",
+      "id": "release-workflow-test",
+      "stages": "static,release-workflow,release-budget"
+    },
+    {
+      "capabilities": "quality-system",
+      "id": "metadata",
+      "stages": "static"
+    },
+    {
+      "capabilities": "*",
+      "id": "unknown",
+      "stages": "*"
+    }
+  ]
+}

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,0 +1,272 @@
+schema	1
+policy	13
+limit	pr_feedback_seconds	600
+limit	local_feedback_seconds	120
+limit	review_seconds	180
+limit	merge_wait_seconds	300
+limit	max_repair_loops	2
+stage	10	static	120	true
+stage	20	gate-contract	300	true
+stage	30	swift	1200	true
+stage	40	quality-contracts	1200	true
+stage	50	app	2400	true
+stage	60	ui-e2e	40	true
+stage	70	codex	1200	true
+stage	80	claude	1200	true
+stage	90	distribution	1200	true
+stage	100	tmux-runtime	1200	true
+stage	110	release-preflight	900	true
+stage	120	publish-preflight	900	true
+stage	130	release-workflow	900	false
+stage	140	release-budget	1	true
+dependency	app	ui-e2e
+test-domain	policy	static,gate-contract	quality-system
+test-domain	docs	static	documentation
+test-domain	state-runtime	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
+test-domain	power	static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget	power-protection
+test-domain	swift-source	static,swift,quality-contracts,app,release-budget	app-experience
+test-domain	onboarding-source	static,swift,quality-contracts,app,release-budget	onboarding
+test-domain	settings-source	static,swift,quality-contracts,app,release-budget	settings
+test-domain	update-source	static,swift,quality-contracts,app,release-budget	update
+test-domain	diagnostics-source	static,swift,quality-contracts,app,release-budget	diagnostics
+test-domain	runtime-source	static,swift,quality-contracts,app,release-budget	session-lifecycle
+test-domain	session-ui-source	static,swift,quality-contracts,app,release-budget	session-lifecycle,app-experience
+test-domain	swift-test	static,swift,quality-contracts,release-budget	quality-system
+test-domain	package	static,swift,quality-contracts,app,tmux-runtime,release-budget	installation,update
+test-domain	cli	static,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
+test-domain	install	static,app,distribution,tmux-runtime,release-budget	installation
+test-domain	tmux-build	static,app,codex,claude,tmux-runtime,release-budget	session-lifecycle
+test-domain	release-tool	static,app,release-preflight,publish-preflight,release-workflow,release-budget	update,publication
+test-domain	app-script	static,app,tmux-runtime,release-preflight,release-budget	installation
+test-domain	codex-test	static,app,codex,release-budget	session-lifecycle
+test-domain	claude-test	static,app,claude,release-budget	session-lifecycle
+test-domain	distribution-test	static,app,distribution,release-budget	installation
+test-domain	runtime-test	static,app,tmux-runtime,release-budget	session-lifecycle,power-protection
+test-domain	ui-test	static,app,release-budget	app-experience
+test-domain	release-preflight-test	static,release-preflight,release-budget	update
+test-domain	publish-preflight-test	static,publish-preflight,release-budget	publication
+test-domain	release-workflow-test	static,release-workflow,release-budget	update,publication
+test-domain	metadata	static	quality-system
+test-domain	unknown	*	*
+release-domain	safe	-	false
+release-domain	install	install	false
+release-domain	lid	lid	false
+release-domain	both	install,lid	false
+release-domain	unknown	install,lid	true
+route	1000	quality/*	policy	safe	docs/specs/documentation.md
+route	1000	.github/workflows/quality-gates.yml	policy	safe	docs/specs/documentation.md
+route	1000	docs/quality-gates.md	policy	safe	docs/specs/documentation.md
+route	1000	docs/testing.md	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-gate	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-policy	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_policy.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-dashboard	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_dashboard.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-history	policy	safe	docs/specs/documentation.md
+route	1000	scripts/test	policy	safe	docs/specs/documentation.md
+route	1000	tests/quality-*	policy	safe	docs/specs/documentation.md
+route	1000	tests/release-budget*	policy	safe	docs/specs/documentation.md
+route	1000	tests/shell-safety*	policy	safe	docs/specs/documentation.md
+route	1000	tests/test-suite-contract.sh	policy	safe	docs/specs/documentation.md
+route	990	tests/docs-contract.sh	docs	safe	docs/specs/documentation.md
+route	950	*.md	docs	safe	docs/specs/documentation.md
+route	950	docs/assets/*	docs	safe	docs/specs/documentation.md
+route	960	AGENTS.md	docs	safe	docs/specs/documentation.md
+route	960	CLAUDE.md	docs	safe	docs/specs/documentation.md
+route	900	app/Sources/DetachKit/DetachState*.swift	state-runtime	safe	docs/specs/runtime.md
+route	900	app/Sources/DetachKit/Session*.swift	state-runtime	safe	docs/specs/runtime.md
+route	900	app/Sources/DetachKit/Storage*.swift	state-runtime	safe	docs/specs/runtime.md
+route	900	app/Sources/DetachState/*.swift	state-runtime	safe	docs/specs/runtime.md
+route	900	app/Sources/DetachKit/DetachPower*.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachKit/Power*.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachKit/ClamshellLockRunner.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachKit/BoundedProcessRunner.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachPower/*.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachPowerHelper/*.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachWatchdog/*.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachApp/InstallationStore.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachApp/PowerHelper*.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachApp/Watchdog*.swift	power	both	docs/specs/power.md
+route	880	app/Sources/DetachApp/DetachApp.swift	onboarding-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/Onboarding*.swift	onboarding-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/RootView.swift	onboarding-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/SetupGuidance.swift	onboarding-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/Settings*.swift	settings-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/UpdaterService.swift	update-source	install	docs/specs/app.md
+route	880	app/Sources/DetachKit/DetachCLI.swift	runtime-source	install	docs/specs/app.md
+route	880	app/Sources/DetachKit/DoctorReport.swift	diagnostics-source	install	docs/specs/app.md
+route	880	app/Sources/DetachKit/Localization.swift	onboarding-source	install	docs/specs/app.md
+route	880	app/Sources/DetachKit/UpdateConfiguration.swift	update-source	install	docs/specs/app.md
+route	870	app/Sources/DetachApp/EmptySessionsView.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/LogTextView.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/MenuBar*.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/NewSessionSheet.swift	session-ui-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/Session*.swift	session-ui-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/SidebarView.swift	session-ui-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/TextSize.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/Theme.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/TipsBar.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/UIE2E*.swift	swift-source	safe	docs/specs/app.md
+route	850	app/Sources/DetachApp/*.swift	swift-source	unknown	docs/specs/app.md
+route	870	app/Sources/DetachKit/ANSIText.swift	swift-source	safe	docs/specs/runtime.md
+route	870	app/Sources/DetachKit/LogPoller.swift	swift-source	safe	docs/specs/runtime.md
+route	870	app/Sources/DetachKit/Terminal*.swift	runtime-source	safe	docs/specs/runtime.md
+route	870	app/Sources/DetachKit/Tip.swift	swift-source	safe	docs/specs/runtime.md
+route	870	app/Sources/DetachKit/Tmux*.swift	runtime-source	safe	docs/specs/runtime.md
+route	840	app/Sources/DetachKit/*.swift	swift-source	unknown	docs/specs/runtime.md
+route	800	app/Sources/*	swift-source	unknown	docs/specs/app.md
+route	800	app/Tests/*	swift-test	safe	docs/specs/app.md
+route	900	app/Resources/en.lproj/*	package	install	docs/specs/app.md
+route	900	app/Resources/ru.lproj/*	package	install	docs/specs/app.md
+route	900	app/Resources/Info.plist	package	install	docs/specs/app.md
+route	900	app/Resources/Detach.entitlements	package	install	docs/specs/app.md
+route	900	app/Resources/DetachDevelopment.entitlements	package	install	docs/specs/app.md
+route	900	app/Resources/DetachWatchdog*	package	both	docs/specs/power.md
+route	900	app/Resources/dev.tsarev.detach.power-*	package	both	docs/specs/power.md
+route	900	app/Resources/Detach.icns	package	safe	docs/specs/app.md
+route	900	app/Resources/ThirdParty/*	package	safe	docs/specs/release.md
+route	800	app/Resources/*	package	unknown	docs/specs/app.md
+route	900	app/Package.swift	package	unknown	docs/specs/app.md
+route	900	app/Package.resolved	package	unknown	docs/specs/app.md
+route	900	bin/detach	cli	lid	docs/specs/runtime.md
+route	900	bin/detach-core	cli	lid	docs/specs/runtime.md
+route	800	bin/*	cli	unknown	docs/specs/runtime.md
+route	900	install.sh	install	install	docs/specs/runtime.md
+route	900	scripts/install.sh	install	install	docs/specs/runtime.md
+route	900	scripts/build-tmux.sh	tmux-build	safe	docs/specs/runtime.md
+route	900	scripts/release-lid-probe	release-tool	lid	docs/specs/release.md
+route	900	app/scripts/make-dmg.sh	release-tool	install	docs/specs/release.md
+route	900	app/scripts/make-app.sh	app-script	unknown	docs/specs/release.md
+route	900	app/scripts/release.sh	release-tool	unknown	docs/specs/release.md
+route	900	app/scripts/bundle-modes.sh	app-script	unknown	docs/specs/release.md
+route	890	app/scripts/publish-release.sh	release-tool	safe	docs/specs/release.md
+route	890	app/scripts/verify-appcast.sh	release-tool	safe	docs/specs/release.md
+route	880	app/scripts/*	app-script	safe	docs/specs/release.md
+route	900	scripts/release-version	release-tool	safe	docs/specs/release.md
+route	900	scripts/release-impact	release-tool	safe	docs/specs/release.md
+route	800	scripts/*	unknown	unknown	docs/specs/documentation.md
+route	900	tests/run.sh	codex-test	safe	docs/specs/runtime.md
+route	900	tests/fake-codex	codex-test	safe	docs/specs/runtime.md
+route	900	tests/run-claude.sh	claude-test	safe	docs/specs/runtime.md
+route	900	tests/fake-claude	claude-test	safe	docs/specs/runtime.md
+route	900	tests/distribution.sh	distribution-test	safe	docs/specs/runtime.md
+route	900	tests/tmux-runtime.sh	runtime-test	safe	docs/specs/runtime.md
+route	900	tests/power-smoke.sh	runtime-test	safe	docs/specs/power.md
+route	900	tests/ui-e2e.sh	ui-test	safe	docs/specs/app.md
+route	900	tests/ui-e2e-contract.sh	ui-test	safe	docs/specs/app.md
+route	900	tests/fake-ui-cli	ui-test	safe	docs/specs/app.md
+route	900	tests/release-preflight.sh	release-preflight-test	safe	docs/specs/release.md
+route	900	tests/publish-preflight.sh	publish-preflight-test	safe	docs/specs/release.md
+route	900	tests/release-impact.sh	release-workflow-test	safe	docs/specs/release.md
+route	900	tests/release-workflow.sh	release-workflow-test	safe	docs/specs/release.md
+route	500	tests/*	unknown	safe	docs/specs/documentation.md
+route	900	VERSION	release-tool	safe	docs/specs/release.md
+route	900	BUILD	release-tool	safe	docs/specs/release.md
+route	900	README.md	docs	safe	docs/specs/documentation.md
+route	900	.gitignore	metadata	safe	docs/specs/documentation.md
+route	900	.gitattributes	metadata	safe	docs/specs/documentation.md
+route	800	.github/*	unknown	safe	docs/specs/documentation.md
+route	700	app/.gitignore	metadata	safe	docs/specs/documentation.md
+route	100	*.sh	unknown	unknown	docs/specs/documentation.md
+capability	quality-system	docs/specs/documentation.md	-	J-QUALITY-CHANGE
+capability	documentation	docs/specs/documentation.md	-	J-DOCS-CONSISTENCY
+capability	session-lifecycle	docs/specs/runtime.md	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	J-SESSION-CREATE,J-SESSION-PERSIST,J-SESSION-RECOVER,J-SESSION-STOP,J-SESSION-DELETE
+capability	power-protection	docs/specs/power.md	QC-POWER-ASSERTION,QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC,QC-POWER-PROTECTION,QC-POWER-CLI,QC-POWER-PLATFORM	J-POWER-ENABLE,J-POWER-LOW-BATTERY,J-POWER-HELPER-LEASE,J-POWER-CLOSED-LID
+capability	app-experience	docs/specs/app.md	QC-HEALTH-FRESHNESS,QC-HEALTH-PRESENTATION,QC-APP-TIPS	J-APP-DASHBOARD,J-APP-EMPTY,J-APP-FAILURE,J-APP-FOCUS
+capability	onboarding	docs/specs/app.md	QC-APP-ONBOARDING	J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL
+capability	settings	docs/specs/app.md	QC-APP-SETTINGS	J-SETTINGS-CHANGE
+capability	update	docs/specs/app.md	QC-APP-UPDATE	J-UPDATE-CHECK,J-UPDATE-APPLY
+capability	diagnostics	docs/specs/app.md	QC-APP-DOCTOR	J-DOCTOR-REPORT
+capability	installation	docs/specs/release.md	QC-RELEASE-INSTALL	J-INSTALL-CLEAN,J-INSTALL-REPAIR,J-INSTALL-UNINSTALL
+capability	publication	docs/specs/release.md	QC-RELEASE-PUBLISH	J-PUBLISH-ARTIFACTS
+journey	J-QUALITY-CHANGE	quality-system	-	SC-POLICY-CONTRACT	A policy change keeps local feedback focused and hosted evidence complete.
+journey	J-DOCS-CONSISTENCY	documentation	-	SC-DOCS-CONTRACT	Documentation and executable contracts stay synchronized.
+journey	J-SESSION-CREATE	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP	SC-SESSION-CREATE-CODEX,SC-SESSION-CREATE-CLAUDE	A user creates a managed provider session.
+journey	J-SESSION-PERSIST	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-STORAGE	SC-SESSION-PERSIST-CODEX,SC-SESSION-PERSIST-CLAUDE	A live session remains available after the app exits.
+journey	J-SESSION-RECOVER	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	SC-SESSION-RECOVER-CODEX,SC-SESSION-RECOVER-CLAUDE	A user recovers the exact owned session after interruption.
+journey	J-SESSION-STOP	session-lifecycle	QC-RUNTIME-OWNERSHIP	SC-SESSION-STOP-CODEX,SC-SESSION-STOP-CLAUDE	A user stops only the selected owned session.
+journey	J-SESSION-DELETE	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE	A user deletes one completed session without affecting another session.
+journey	J-POWER-ENABLE	power-protection	QC-POWER-ASSERTION,QC-POWER-LEASE	SC-POWER-UNIT	A protected session acquires both required power protections.
+journey	J-POWER-LOW-BATTERY	power-protection	QC-POWER-PROTECTION	SC-POWER-LOW-BATTERY	Low battery removes unsafe protection and reports the reason.
+journey	J-POWER-HELPER-LEASE	power-protection	QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC	SC-POWER-HELPER	The helper accepts only an authorized bounded lease.
+journey	J-POWER-CLOSED-LID	power-protection	QC-POWER-PROTECTION	SC-POWER-CLOSED-LID	A protected session continues on supervised supported hardware with the lid closed.
+journey	J-APP-DASHBOARD	app-experience	QC-HEALTH-FRESHNESS,QC-HEALTH-PRESENTATION	SC-UI-DASHBOARD	A user sees fresh typed session health on the dashboard.
+journey	J-APP-EMPTY	app-experience	QC-HEALTH-PRESENTATION,QC-APP-TIPS	SC-UI-EMPTY	A user sees useful empty-state guidance.
+journey	J-APP-FAILURE	app-experience	QC-HEALTH-PRESENTATION	SC-UI-FAILURE	A user sees an actionable failure without parsed terminal claims.
+journey	J-APP-FOCUS	app-experience	QC-HEALTH-PRESENTATION	SC-UI-FOCUS	Background status checks do not steal keyboard focus.
+journey	J-ONBOARD-FIRST-RUN	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-FIRST-RUN	A new user completes the first-run setup.
+journey	J-ONBOARD-PROVIDER	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-PROVIDER	Onboarding detects an authenticated supported provider.
+journey	J-ONBOARD-APPROVAL	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-APPROVAL	Onboarding explains and observes required macOS approvals.
+journey	J-SETTINGS-CHANGE	settings	QC-APP-SETTINGS	SC-UI-SETTINGS	A user changes a setting and observes the persisted result.
+journey	J-UPDATE-CHECK	update	QC-APP-UPDATE	SC-UPDATE-CHECK	A user receives a typed update state.
+journey	J-UPDATE-APPLY	update	QC-APP-UPDATE	SC-UPDATE-APPLY	A valid update preserves the arm64 and signature contract.
+journey	J-DOCTOR-REPORT	diagnostics	QC-APP-DOCTOR	SC-DOCTOR-REPORT	A user receives a typed actionable doctor report.
+journey	J-INSTALL-CLEAN	installation	QC-RELEASE-INSTALL	SC-INSTALL-CLEAN	A user installs one immutable self-contained payload.
+journey	J-INSTALL-REPAIR	installation	QC-RELEASE-INSTALL	SC-INSTALL-REPAIR	Repair restores the exact immutable payload.
+journey	J-INSTALL-UNINSTALL	installation	QC-RELEASE-INSTALL	SC-INSTALL-UNINSTALL	Uninstall removes only Detach-owned data selected by the user.
+journey	J-PUBLISH-ARTIFACTS	publication	QC-RELEASE-PUBLISH	SC-PUBLISH-CONTRACT	Publication exposes only verified allowlisted artifacts.
+scenario	SC-POLICY-CONTRACT	gate-contract	automated	tests/quality-policy.sh
+scenario	SC-DOCS-CONTRACT	static	automated	tests/docs-contract.sh
+scenario	SC-SESSION-CREATE-CODEX	codex	legacy-stage	tests/run.sh
+scenario	SC-SESSION-CREATE-CLAUDE	claude	legacy-stage	tests/run-claude.sh
+scenario	SC-SESSION-PERSIST-CODEX	codex	legacy-stage	tests/run.sh
+scenario	SC-SESSION-PERSIST-CLAUDE	claude	legacy-stage	tests/run-claude.sh
+scenario	SC-SESSION-RECOVER-CODEX	codex	legacy-stage	tests/run.sh
+scenario	SC-SESSION-RECOVER-CLAUDE	claude	legacy-stage	tests/run-claude.sh
+scenario	SC-SESSION-STOP-CODEX	codex	legacy-stage	tests/run.sh
+scenario	SC-SESSION-STOP-CLAUDE	claude	legacy-stage	tests/run-claude.sh
+scenario	SC-SESSION-DELETE-CODEX	codex	legacy-stage	tests/run.sh
+scenario	SC-SESSION-DELETE-CLAUDE	claude	legacy-stage	tests/run-claude.sh
+scenario	SC-POWER-UNIT	swift	legacy-stage	cd app && swift test --filter Power
+scenario	SC-POWER-LOW-BATTERY	swift	legacy-stage	cd app && swift test --filter PowerProtection
+scenario	SC-POWER-HELPER	swift	legacy-stage	cd app && swift test --filter PowerHelper
+scenario	SC-POWER-CLOSED-LID	release-budget	manual-release	scripts/release-lid-probe
+scenario	SC-UI-DASHBOARD	ui-e2e	legacy-stage	tests/ui-e2e.sh
+scenario	SC-UI-EMPTY	ui-e2e	legacy-stage	tests/ui-e2e.sh
+scenario	SC-UI-FAILURE	ui-e2e	planned	pending out-of-process UI journey
+scenario	SC-UI-FOCUS	ui-e2e	legacy-stage	tests/ui-e2e.sh
+scenario	SC-UI-ONBOARD-FIRST-RUN	ui-e2e	planned	pending out-of-process UI journey
+scenario	SC-UI-ONBOARD-PROVIDER	ui-e2e	planned	pending out-of-process UI journey
+scenario	SC-UI-ONBOARD-APPROVAL	ui-e2e	planned	pending out-of-process UI journey
+scenario	SC-UI-SETTINGS	ui-e2e	planned	pending out-of-process UI journey
+scenario	SC-UPDATE-CHECK	release-preflight	legacy-stage	tests/release-preflight.sh
+scenario	SC-UPDATE-APPLY	publish-preflight	legacy-stage	tests/publish-preflight.sh
+scenario	SC-DOCTOR-REPORT	distribution	legacy-stage	tests/distribution.sh
+scenario	SC-INSTALL-CLEAN	distribution	legacy-stage	tests/distribution.sh
+scenario	SC-INSTALL-REPAIR	distribution	legacy-stage	tests/distribution.sh
+scenario	SC-INSTALL-UNINSTALL	distribution	legacy-stage	tests/distribution.sh
+scenario	SC-PUBLISH-CONTRACT	publish-preflight	legacy-stage	tests/publish-preflight.sh
+critical	app/Sources/DetachKit/SessionHealth.swift	QC-HEALTH-FRESHNESS	99.10
+critical	app/Sources/DetachKit/DetachState.swift	QC-RUNTIME-STATE	99.03
+critical	app/Sources/DetachKit/DetachStateCommand.swift	QC-RUNTIME-STATE	96.70
+critical	app/Sources/DetachKit/Storage.swift	QC-RUNTIME-STORAGE	95.28
+critical	app/Sources/DetachKit/StorageStore.swift	QC-RUNTIME-STORAGE	100.00
+critical	app/Sources/DetachKit/Tip.swift	QC-APP-TIPS	100.00
+critical	app/Sources/DetachKit/DetachPowerCommand.swift	QC-POWER-CLI	95.21
+critical	app/Sources/DetachKit/DetachPowerExecutable.swift	QC-POWER-CLI	100.00
+critical	app/Sources/DetachKit/PowerHelperLeaseService.swift	QC-POWER-LEASE	98.21
+critical	app/Sources/DetachKit/PowerHelperXPC.swift	QC-POWER-XPC	82.23
+critical	app/Sources/DetachKit/PowerHelperPlatform.swift	QC-POWER-PLATFORM	84.54
+critical	app/Sources/DetachKit/SessionStore.swift	QC-RUNTIME-OWNERSHIP	98.11
+critical	app/Sources/DetachKit/DoctorReport.swift	QC-APP-DOCTOR	100.00
+requirement	QC-RUNTIME-STATE	docs/specs/runtime.md	Typed state is the only shared state mutation boundary.
+requirement	QC-RUNTIME-OWNERSHIP	docs/specs/runtime.md	Session operations prove the exact run token and process ownership.
+requirement	QC-RUNTIME-STORAGE	docs/specs/runtime.md	Restores validate path, symlink, identity, and JSONL data before replacement.
+requirement	QC-POWER-ASSERTION	docs/specs/power.md	Power protection owns a user IOKit assertion.
+requirement	QC-POWER-AUTH	docs/specs/power.md	Helper authorization binds audit token, console user, signing, and deadline.
+requirement	QC-POWER-LEASE	docs/specs/power.md	The root helper lease is bounded and ownership safe.
+requirement	QC-POWER-XPC	docs/specs/power.md	The helper accepts only the typed power protocol.
+requirement	QC-POWER-PROTECTION	docs/specs/power.md	Low battery fails safe.
+requirement	QC-POWER-CLI	docs/specs/power.md	The power command reports and enforces typed protection state.
+requirement	QC-POWER-PLATFORM	docs/specs/power.md	Platform power operations preserve the helper safety boundary.
+requirement	QC-HEALTH-FRESHNESS	docs/specs/app.md	Health claims use typed fresh state.
+requirement	QC-HEALTH-PRESENTATION	docs/specs/app.md	The app presents typed health state without parsing terminal text.
+requirement	QC-RUNTIME-TRANSITION	docs/specs/runtime.md	Session transitions preserve exact process identity.
+requirement	QC-APP-TIPS	docs/specs/app.md	Session tips remain deterministic and user visible.
+requirement	QC-APP-DOCTOR	docs/specs/app.md	Doctor output derives from typed runtime state.
+requirement	QC-APP-ONBOARDING	docs/specs/app.md	Onboarding leads a new user through supported provider and approval setup.
+requirement	QC-APP-SETTINGS	docs/specs/app.md	Settings changes persist and affect only their declared behavior.
+requirement	QC-APP-UPDATE	docs/specs/app.md	Update state and application preserve the signed arm64 contract.
+requirement	QC-RELEASE-INSTALL	docs/specs/release.md	Install, repair, and uninstall mutate only Detach-owned payloads and selected state.
+requirement	QC-RELEASE-PUBLISH	docs/specs/release.md	Publication exposes only independently verified allowlisted artifacts.

--- a/scripts/quality-dashboard
+++ b/scripts/quality-dashboard
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality-dashboard: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tools/quality_dashboard.py" "$@"

--- a/scripts/quality-gate
+++ b/scripts/quality-gate
@@ -3,8 +3,15 @@
 set -euo pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
-POLICY_VERSION=12
+QUALITY_POLICY="$ROOT/scripts/quality-policy"
+[ -x "$QUALITY_POLICY" ] || {
+  printf 'quality-gate: quality policy reader is missing or not executable\n' >&2
+  exit 2
+}
+POLICY_VERSION="$("$QUALITY_POLICY" version)"
 MODE=change
+REQUESTED_AUTHORITY="${DETACH_QUALITY_AUTHORITY:-}"
+AUTHORITY=""
 BASE_REF=""
 PLAN_ONLY=0
 DIAGNOSTIC_STAGE=""
@@ -38,9 +45,17 @@ SOURCE_COMMIT="$(git -C "$ROOT" rev-parse --verify HEAD)"
 INPUT_FINGERPRINT=""
 RELEASE_BUDGET="$ROOT/tests/release-budget.tsv"
 
-ALL_STAGES=(static gate-contract swift quality-contracts app ui-e2e codex claude distribution tmux-runtime release-preflight publish-preflight release-workflow release-budget)
-RELEASE_STAGES=(static gate-contract swift quality-contracts app ui-e2e codex claude distribution tmux-runtime release-preflight publish-preflight release-budget)
+ALL_STAGES=()
+while IFS= read -r stage; do
+  [ -z "$stage" ] || ALL_STAGES+=("$stage")
+done < <("$QUALITY_POLICY" stages all)
+RELEASE_STAGES=()
+while IFS= read -r stage; do
+  [ -z "$stage" ] || RELEASE_STAGES+=("$stage")
+done < <("$QUALITY_POLICY" stages release)
 SELECTED=()
+SELECTED_CAPABILITIES=()
+SELECTED_JOURNEYS=()
 EXPLANATIONS=()
 
 usage() {
@@ -52,7 +67,8 @@ usage: scripts/quality-gate [--mode change|repository|release] [--base GIT_REF] 
        scripts/quality-gate --list-stages
        scripts/quality-gate --stage NAME
 
-The normal modes are readiness evidence. --stage is a diagnostic rerun only.
+Local modes produce diagnostic evidence. Hosted CI and release modes can
+produce authoritative evidence. --stage is a diagnostic rerun only.
 EOF
 }
 
@@ -77,16 +93,46 @@ add_stage() {
   [ -z "$reason" ] || EXPLANATIONS+=("$reason -> $stage")
 }
 
+add_capability() {
+  local wanted="$1" existing
+  for existing in "${SELECTED_CAPABILITIES[@]:-}"; do
+    [ "$existing" = "$wanted" ] && return 0
+  done
+  SELECTED_CAPABILITIES+=("$wanted")
+}
+
+add_journey() {
+  local wanted="$1" existing
+  for existing in "${SELECTED_JOURNEYS[@]:-}"; do
+    [ "$existing" = "$wanted" ] && return 0
+  done
+  SELECTED_JOURNEYS+=("$wanted")
+}
+
+select_all_impacts() {
+  local identifier
+  SELECTED_CAPABILITIES=()
+  while IFS=$'\t' read -r identifier _; do
+    [ -z "$identifier" ] || SELECTED_CAPABILITIES+=("$identifier")
+  done < <("$QUALITY_POLICY" capabilities)
+  SELECTED_JOURNEYS=()
+  while IFS=$'\t' read -r identifier _; do
+    [ -z "$identifier" ] || SELECTED_JOURNEYS+=("$identifier")
+  done < <("$QUALITY_POLICY" journeys)
+}
+
 select_all() {
   local reason="${1:-full repository policy}" stage
   SELECTED=("${ALL_STAGES[@]}")
   for stage in "${ALL_STAGES[@]}"; do
     EXPLANATIONS+=("$reason -> $stage")
   done
+  select_all_impacts
 }
 
 select_release() {
   SELECTED=("${RELEASE_STAGES[@]}")
+  select_all_impacts
 }
 
 while [ "$#" -gt 0 ]; do
@@ -154,6 +200,33 @@ case "$TEST_DIRECT" in 0|1) ;; *) die 'DETACH_QUALITY_GATE_TEST_DIRECT must be 0
 [ "$TEST_MODE" = 1 ] || [ "$TEST_REAL_STATIC" = 0 ] || die 'real static fixture mode is test-only'
 [ "$TEST_MODE" = 1 ] || [ "$TEST_DIRECT" = 0 ] || die 'direct fixture mode is test-only'
 case "$MODE" in change|repository|release) ;; *) die "invalid mode: $MODE" ;; esac
+if [ -z "$REQUESTED_AUTHORITY" ]; then
+  if [ "$MODE" = release ]; then
+    AUTHORITY=release
+  else
+    AUTHORITY=local-diagnostic
+  fi
+else
+  AUTHORITY="$REQUESTED_AUTHORITY"
+fi
+case "$AUTHORITY" in
+  local-diagnostic)
+    [ "$MODE" != release ] || die 'release mode requires release authority'
+    ;;
+  ci-merge|ci-main)
+    [ "${GITHUB_ACTIONS:-}" = true ] || die "$AUTHORITY authority is restricted to GitHub Actions"
+    [ "$MODE" = repository ] || die "$AUTHORITY authority requires repository mode"
+    [ -z "$DIAGNOSTIC_STAGE" ] || die "$AUTHORITY authority cannot run one diagnostic stage"
+    ;;
+  release)
+    if [ "$MODE" != release ]; then
+      [ "${GITHUB_ACTIONS:-}" = true ] && [ "$MODE" = repository ] || \
+        die 'release authority requires release mode or repository mode in GitHub Actions'
+    fi
+    [ -z "$DIAGNOSTIC_STAGE" ] || die 'release authority cannot run one diagnostic stage'
+    ;;
+  *) die "invalid quality authority: $AUTHORITY" ;;
+esac
 if [ -n "$RELEASE_TIMING_OVERRIDE" ]; then
   [[ "$RELEASE_TIMING_OVERRIDE" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@v[0-9A-Za-z._+-]+$ ]] || \
     die 'DETACH_RELEASE_TIMING_OVERRIDE must be an exact owner/repository@tag'
@@ -212,83 +285,29 @@ if [ -n "$BASE_REF" ]; then
 fi
 
 select_for_path() {
-  local path="$1" change="${2:-changed}"
+  local path="$1" change="${2:-changed}" classification test_domain release_domain spec stages
+  local release_gates release_unknown route_pattern route_priority capabilities journeys stage item
   IMPACT_REASON="$change $path"
-  add_stage static
-  case "$path" in
-    .github/workflows/quality-gates.yml|docs/quality-gates.md|scripts/quality-gate|scripts/quality-history|scripts/test|tests/quality-gate.sh|tests/quality-contracts.sh|tests/quality-baseline.tsv|tests/quality-file-baseline.tsv|tests/quality-ratchet.sh|tests/quality-ratchet-contract.sh|tests/release-budget.tsv|tests/release-budget-ratchet.sh|tests/release-budget-ratchet-contract.sh|tests/shell-safety.sh|tests/shell-safety-contract.sh|tests/quality-history-contract.sh|tests/test-suite-contract.sh)
-      select_all "$change gate policy file $path"
-      ;;
-    tests/docs-contract.sh)
-      ;;
-    *.md|docs/assets/*|AGENTS.md|CLAUDE.md)
-      ;;
-    app/Sources/DetachKit/DetachState*.swift|app/Sources/DetachKit/Session*.swift|app/Sources/DetachKit/Storage*.swift|app/Sources/DetachState/*.swift)
-      add_stage swift; add_stage quality-contracts; add_stage app; add_stage codex; add_stage claude
-      add_stage distribution; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    app/Sources/DetachKit/DetachPower*.swift|app/Sources/DetachKit/Power*.swift|app/Sources/DetachPower/*.swift|app/Sources/DetachPowerHelper/*.swift)
-      add_stage swift; add_stage quality-contracts; add_stage app; add_stage distribution
-      add_stage tmux-runtime; add_stage release-budget
-      ;;
-    app/Sources/*)
-      add_stage swift; add_stage quality-contracts; add_stage app; add_stage release-budget
-      ;;
-    app/Tests/*)
-      add_stage swift; add_stage quality-contracts; add_stage release-budget
-      ;;
-    app/Package.swift|app/Package.resolved)
-      add_stage swift; add_stage quality-contracts; add_stage app; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    app/Resources/*)
-      add_stage swift; add_stage quality-contracts; add_stage app; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    bin/*)
-      add_stage app; add_stage codex; add_stage claude; add_stage distribution; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    install.sh|scripts/install.sh)
-      add_stage app; add_stage distribution; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    scripts/build-tmux.sh)
-      add_stage app; add_stage codex; add_stage claude; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    app/scripts/release.sh|app/scripts/publish-release.sh|app/scripts/make-dmg.sh|app/scripts/verify-appcast.sh|scripts/release-version|scripts/release-impact|scripts/release-lid-probe|VERSION|BUILD)
-      add_stage app; add_stage release-preflight; add_stage publish-preflight; add_stage release-workflow; add_stage release-budget
-      ;;
-    app/scripts/*)
-      add_stage app; add_stage tmux-runtime; add_stage release-preflight; add_stage release-budget
-      ;;
-    tests/run.sh|tests/fake-codex)
-      add_stage app; add_stage codex; add_stage release-budget
-      ;;
-    tests/run-claude.sh|tests/fake-claude)
-      add_stage app; add_stage claude; add_stage release-budget
-      ;;
-    tests/distribution.sh)
-      add_stage app; add_stage distribution; add_stage release-budget
-      ;;
-    tests/tmux-runtime.sh|tests/power-smoke.sh)
-      add_stage app; add_stage tmux-runtime; add_stage release-budget
-      ;;
-    tests/ui-e2e.sh|tests/ui-e2e-contract.sh|tests/fake-ui-cli)
-      add_stage app; add_stage release-budget
-      ;;
-    tests/release-preflight.sh)
-      add_stage release-preflight; add_stage release-budget
-      ;;
-    tests/publish-preflight.sh)
-      add_stage publish-preflight; add_stage release-budget
-      ;;
-    tests/release-impact.sh|tests/release-workflow.sh)
-      add_stage release-workflow; add_stage release-budget
-      ;;
-    .gitignore|.gitattributes)
-      ;;
-    *)
-      printf 'quality-gate: unknown impact for %s; selecting repository gate\n' "$path" >&2
-      select_all "$change unclassified path $path"
-      ;;
-  esac
+  classification="$("$QUALITY_POLICY" classify "$path")" || die "cannot classify path: $path"
+  IFS=$'\t' read -r classification test_domain release_domain spec stages \
+    release_gates release_unknown route_pattern route_priority capabilities journeys <<<"$classification"
+  if [ "$classification" = unknown ]; then
+    printf 'quality-gate: unknown impact for %s; selecting repository gate\n' "$path" >&2
+    select_all "$change unclassified path $path"
+    return
+  fi
+  IFS=, read -r -a domain_stages <<<"$stages"
+  for stage in "${domain_stages[@]}"; do
+    add_stage "$stage" "$change $test_domain domain $path"
+  done
+  IFS=, read -r -a domain_capabilities <<<"$capabilities"
+  for item in "${domain_capabilities[@]}"; do
+    add_capability "$item"
+  done
+  IFS=, read -r -a domain_journeys <<<"$journeys"
+  for item in "${domain_journeys[@]}"; do
+    add_journey "$item"
+  done
 }
 
 if [ -n "$DIAGNOSTIC_STAGE" ]; then
@@ -315,10 +334,18 @@ else
   fi
 fi
 
-# A selected packaged-app build is never readiness evidence by itself. Its
-# hermetic accessibility smoke must exercise that exact fresh executable.
-if contains_stage app && [ -z "$DIAGNOSTIC_STAGE" ]; then
-  add_stage ui-e2e 'mandatory packaged-app prerequisite'
+# Apply policy-owned transitive stage dependencies to a fixed point.
+if [ -z "$DIAGNOSTIC_STAGE" ]; then
+  dependency_changed=1
+  while [ "$dependency_changed" = 1 ]; do
+    dependency_changed=0
+    while IFS=$'\t' read -r prerequisite dependent; do
+      if contains_stage "$prerequisite" && ! contains_stage "$dependent"; then
+        add_stage "$dependent" "mandatory $prerequisite prerequisite"
+        dependency_changed=1
+      fi
+    done < <("$QUALITY_POLICY" dependencies)
+  done
 fi
 
 # Preserve the canonical cheap-to-expensive order after taking the union.
@@ -337,6 +364,8 @@ fi
 
 EFFECTIVE_MODE="$([ -n "$DIAGNOSTIC_STAGE" ] && printf diagnostic || printf '%s' "$MODE")"
 STAGE_LIST="$(IFS=,; printf '%s' "${SELECTED[*]}")"
+CAPABILITY_LIST="$(IFS=,; printf '%s' "${SELECTED_CAPABILITIES[*]:-}")"
+JOURNEY_LIST="$(IFS=,; printf '%s' "${SELECTED_JOURNEYS[*]:-}")"
 
 compute_input_fingerprint() {
   {
@@ -353,11 +382,25 @@ compute_input_fingerprint() {
 }
 
 INPUT_FINGERPRINT="$(compute_input_fingerprint)"
-FINGERPRINT="$(printf 'input=%s\nmode=%s\nstages=%s\n' "$INPUT_FINGERPRINT" "$EFFECTIVE_MODE" "$STAGE_LIST" | shasum -a 256 | awk '{print $1}')"
+FINGERPRINT="$(printf 'input=%s\nmode=%s\nauthority=%s\nstages=%s\ncapabilities=%s\njourneys=%s\n' \
+  "$INPUT_FINGERPRINT" "$EFFECTIVE_MODE" "$AUTHORITY" "$STAGE_LIST" \
+  "$CAPABILITY_LIST" "$JOURNEY_LIST" | shasum -a 256 | awk '{print $1}')"
 
 if [ "$OUTPUT_FORMAT" = json ]; then
-  printf '{"policy":%s,"mode":"%s","source_commit":"%s","base_commit":"%s","input_fingerprint":"%s","fingerprint":"%s","stages":[' \
-    "$POLICY_VERSION" "$EFFECTIVE_MODE" "$SOURCE_COMMIT" "$RESOLVED_BASE" "$INPUT_FINGERPRINT" "$FINGERPRINT"
+  printf '{"policy":%s,"mode":"%s","authority":"%s","source_commit":"%s","base_commit":"%s","input_fingerprint":"%s","fingerprint":"%s","capabilities":[' \
+    "$POLICY_VERSION" "$EFFECTIVE_MODE" "$AUTHORITY" "$SOURCE_COMMIT" "$RESOLVED_BASE" "$INPUT_FINGERPRINT" "$FINGERPRINT"
+  separator=""
+  for capability in "${SELECTED_CAPABILITIES[@]:-}"; do
+    printf '%s"%s"' "$separator" "$capability"
+    separator=,
+  done
+  printf '],"journeys":['
+  separator=""
+  for journey in "${SELECTED_JOURNEYS[@]:-}"; do
+    printf '%s"%s"' "$separator" "$journey"
+    separator=,
+  done
+  printf '],"stages":['
   separator=""
   for stage in "${SELECTED[@]}"; do
     printf '%s"%s"' "$separator" "$stage"
@@ -365,8 +408,9 @@ if [ "$OUTPUT_FORMAT" = json ]; then
   done
   printf ']}\n'
 else
-  printf 'quality-gate policy=%s mode=%s fingerprint=%s stages=%s\n' \
-    "$POLICY_VERSION" "$EFFECTIVE_MODE" "$FINGERPRINT" "$STAGE_LIST"
+  printf 'quality-gate policy=%s mode=%s authority=%s fingerprint=%s stages=%s capabilities=%s journeys=%s\n' \
+    "$POLICY_VERSION" "$EFFECTIVE_MODE" "$AUTHORITY" "$FINGERPRINT" "$STAGE_LIST" \
+    "$CAPABILITY_LIST" "$JOURNEY_LIST"
   if [ "$EXPLAIN" = 1 ]; then
     for explanation in "${EXPLANATIONS[@]}"; do
       printf 'quality-gate: reason %s\n' "$explanation"
@@ -455,14 +499,17 @@ write_manifest() {
     [ "$timing_wall_seconds" -gt 0 ] || timing_wall_seconds="$duration"
   fi
   {
-    printf 'schema\t3\n'
+    printf 'schema\t4\n'
     printf 'policy\t%s\n' "$POLICY_VERSION"
     printf 'mode\t%s\n' "$EFFECTIVE_MODE"
+    printf 'authority\t%s\n' "$AUTHORITY"
     printf 'source_commit\t%s\n' "$SOURCE_COMMIT"
     printf 'base_commit\t%s\n' "$RESOLVED_BASE"
     printf 'input_fingerprint\t%s\n' "$INPUT_FINGERPRINT"
     printf 'fingerprint\t%s\n' "$FINGERPRINT"
     printf 'stages\t%s\n' "$STAGE_LIST"
+    printf 'capabilities\t%s\n' "$CAPABILITY_LIST"
+    printf 'journeys\t%s\n' "$JOURNEY_LIST"
     printf 'started_at\t%s\n' "$RUN_STARTED_AT"
     printf 'finished_at\t%s\n' "$finished_at"
     printf 'duration_seconds\t%s\n' "$duration"
@@ -509,8 +556,9 @@ resolve_latest_resume() {
   while IFS= read -r candidate; do
     manifest="$candidate/manifest.tsv"
     [ -f "$manifest" ] && [ ! -L "$manifest" ] || continue
-    [ "$(manifest_value "$manifest" schema 2>/dev/null || true)" = 3 ] || continue
+    [ "$(manifest_value "$manifest" schema 2>/dev/null || true)" = 4 ] || continue
     [ "$(manifest_value "$manifest" policy 2>/dev/null || true)" = "$POLICY_VERSION" ] || continue
+    [ "$(manifest_value "$manifest" authority 2>/dev/null || true)" = "$AUTHORITY" ] || continue
     [ "$(manifest_value "$manifest" source_commit 2>/dev/null || true)" = "$SOURCE_COMMIT" ] || continue
     [ "$(manifest_value "$manifest" base_commit 2>/dev/null || true)" = "$RESOLVED_BASE" ] || continue
     [ "$(manifest_value "$manifest" input_fingerprint 2>/dev/null || true)" = "$INPUT_FINGERPRINT" ] || continue
@@ -574,8 +622,9 @@ validate_resume() {
   [ -f "$RESUME_DIR/summary.tsv" ] && [ ! -L "$RESUME_DIR/summary.tsv" ] || die 'resume summary is missing or unsafe'
   [ -f "$RESUME_DIR/environment.tsv" ] && [ ! -L "$RESUME_DIR/environment.tsv" ] || die 'resume environment evidence is missing or unsafe'
   [ -f "$RESUME_DIR/artifacts.tsv" ] && [ ! -L "$RESUME_DIR/artifacts.tsv" ] || die 'resume artifact evidence is missing or unsafe'
-  [ "$(manifest_value "$RESUME_DIR/manifest.tsv" schema)" = 3 ] || die 'resume evidence schema is unsupported'
+  [ "$(manifest_value "$RESUME_DIR/manifest.tsv" schema)" = 4 ] || die 'resume evidence schema is unsupported'
   [ "$(manifest_value "$RESUME_DIR/manifest.tsv" policy)" = "$POLICY_VERSION" ] || die 'resume evidence uses another policy version'
+  [ "$(manifest_value "$RESUME_DIR/manifest.tsv" authority)" = "$AUTHORITY" ] || die 'resume evidence uses another authority'
   [ "$(manifest_value "$RESUME_DIR/manifest.tsv" source_commit)" = "$SOURCE_COMMIT" ] || die 'resume evidence uses another source commit'
   [ "$(manifest_value "$RESUME_DIR/manifest.tsv" base_commit)" = "$RESOLVED_BASE" ] || die 'resume evidence uses another base commit'
   [ "$(manifest_value "$RESUME_DIR/manifest.tsv" input_fingerprint)" = "$INPUT_FINGERPRINT" ] || die 'resume evidence does not match the current input'
@@ -615,8 +664,9 @@ validate_resume() {
     [ -f "$resume_parent_manifest" ] && [ ! -L "$resume_parent_manifest" ] || die 'resume evidence parent manifest is missing or unsafe'
     actual_parent_digest="$(shasum -a 256 "$resume_parent_manifest" | awk '{print $1}')"
     [ "$actual_parent_digest" = "$resume_parent_digest" ] || die 'resume evidence parent manifest digest does not match'
-    [ "$(manifest_value "$resume_parent_manifest" schema)" = 3 ] || die 'resume evidence parent schema is unsupported'
+    [ "$(manifest_value "$resume_parent_manifest" schema)" = 4 ] || die 'resume evidence parent schema is unsupported'
     [ "$(manifest_value "$resume_parent_manifest" policy)" = "$POLICY_VERSION" ] || die 'resume evidence parent policy does not match'
+    [ "$(manifest_value "$resume_parent_manifest" authority)" = "$AUTHORITY" ] || die 'resume evidence parent authority does not match'
     [ "$(manifest_value "$resume_parent_manifest" source_commit)" = "$SOURCE_COMMIT" ] || die 'resume evidence parent source commit does not match'
     [ "$(manifest_value "$resume_parent_manifest" base_commit)" = "$RESOLVED_BASE" ] || die 'resume evidence parent base commit does not match'
     [ "$(manifest_value "$resume_parent_manifest" input_fingerprint)" = "$INPUT_FINGERPRINT" ] || die 'resume evidence parent input does not match'
@@ -670,8 +720,11 @@ write_markdown() {
     printf '# Quality gate\n\n'
     printf -- '- Policy: `%s`\n' "$POLICY_VERSION"
     printf -- '- Mode: `%s`\n' "$EFFECTIVE_MODE"
+    printf -- '- Authority: `%s`\n' "$AUTHORITY"
     printf -- '- Source: `%s`\n' "$SOURCE_COMMIT"
     printf -- '- Fingerprint: `%s`\n\n' "$FINGERPRINT"
+    printf -- '- Capabilities: `%s`\n' "${CAPABILITY_LIST:--}"
+    printf -- '- Journeys: `%s`\n\n' "${JOURNEY_LIST:--}"
     printf '| Stage | Status | Seconds | Log | Origin |\n'
     printf '| --- | --- | ---: | --- | --- |\n'
     while IFS=$'\t' read -r _ _ stage status duration log _ origin_run; do
@@ -712,15 +765,7 @@ on_signal() {
 trap on_signal INT TERM HUP
 
 timeout_for_stage() {
-  case "$1" in
-    static) printf 120 ;;
-    gate-contract) printf 300 ;;
-    swift|quality-contracts) printf 1200 ;;
-    app) printf 2400 ;;
-    ui-e2e) printf 40 ;;
-    codex|claude|distribution|tmux-runtime) printf 1200 ;;
-    release-preflight|publish-preflight|release-workflow) printf 900 ;;
-  esac
+  "$QUALITY_POLICY" timeout "$1"
 }
 
 effective_timeout_for_stage() {
@@ -777,7 +822,7 @@ run_static() {
   while IFS= read -r -d '' file; do
     [ -f "$ROOT/$file" ] || continue
     case "$file" in
-      *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/release-version|scripts/release-impact|scripts/release-lid-probe)
+      *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-policy|scripts/release-version|scripts/release-impact|scripts/release-lid-probe)
         /bin/bash -n "$ROOT/$file"
         ;;
     esac
@@ -872,6 +917,16 @@ run_stage_command() {
           grep -Fx 'Quality history contract tests passed'
       ) >"$contract_root/quality-history.log" 2>&1 &
       contract_pids+=("$!")
+      (
+        "$ROOT/tests/quality-policy.sh" |
+          grep -Fx 'Quality policy contracts passed'
+      ) >"$contract_root/quality-policy.log" 2>&1 &
+      contract_pids+=("$!")
+      (
+        "$ROOT/tests/quality-dashboard.sh" |
+          grep -Fx 'Quality dashboard contracts passed'
+      ) >"$contract_root/quality-dashboard.log" 2>&1 &
+      contract_pids+=("$!")
       contract_status=0
       for contract_pid in "${contract_pids[@]}"; do
         if ! wait "$contract_pid"; then
@@ -930,7 +985,7 @@ run_stage_command() {
   esac
 }
 
-export ROOT BASE_REF RESOLVED_BASE MODE DIAGNOSTIC_STAGE TEST_MODE TEST_REAL_STATIC TEST_DIRECT RUN_DIR
+export ROOT QUALITY_POLICY BASE_REF RESOLVED_BASE MODE DIAGNOSTIC_STAGE TEST_MODE TEST_REAL_STATIC TEST_DIRECT RUN_DIR
 export -f die changed_entries static_shell_files run_static run_tmux_socket_preflight run_stage_command
 
 stage_result_file() {
@@ -1244,12 +1299,21 @@ write_markdown
 
 if [ "$OVERALL_STATUS" -ne 0 ]; then
   write_manifest failed
-  printf 'quality-gate: FAIL policy=%s fingerprint=%s failures=%s evidence=%s junit=%s markdown=%s\n' "$POLICY_VERSION" "$FINGERPRINT" "$FAILURE_COUNT" "$SUMMARY" "$JUNIT" "$MARKDOWN" >&2
+  if [ "$AUTHORITY" = local-diagnostic ]; then
+    result_label='DIAGNOSTIC FAIL'
+  else
+    result_label=FAIL
+  fi
+  printf 'quality-gate: %s policy=%s authority=%s fingerprint=%s failures=%s evidence=%s junit=%s markdown=%s\n' "$result_label" "$POLICY_VERSION" "$AUTHORITY" "$FINGERPRINT" "$FAILURE_COUNT" "$SUMMARY" "$JUNIT" "$MARKDOWN" >&2
   exit "$OVERALL_STATUS"
 elif [ -n "$DIAGNOSTIC_STAGE" ]; then
   write_manifest diagnostic
   printf 'quality-gate: diagnostic stage passed; this is not readiness evidence\n'
 else
   write_manifest passed
-  printf 'quality-gate: PASS policy=%s fingerprint=%s evidence=%s junit=%s markdown=%s\n' "$POLICY_VERSION" "$FINGERPRINT" "$SUMMARY" "$JUNIT" "$MARKDOWN"
+  if [ "$AUTHORITY" = local-diagnostic ]; then
+    printf 'quality-gate: DIAGNOSTIC PASS policy=%s authority=%s fingerprint=%s evidence=%s junit=%s markdown=%s\n' "$POLICY_VERSION" "$AUTHORITY" "$FINGERPRINT" "$SUMMARY" "$JUNIT" "$MARKDOWN"
+  else
+    printf 'quality-gate: PASS policy=%s authority=%s fingerprint=%s evidence=%s junit=%s markdown=%s\n' "$POLICY_VERSION" "$AUTHORITY" "$FINGERPRINT" "$SUMMARY" "$JUNIT" "$MARKDOWN"
+  fi
 fi

--- a/scripts/quality-policy
+++ b/scripts/quality-policy
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality-policy: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tools/quality_policy.py" "$@"

--- a/scripts/release-impact
+++ b/scripts/release-impact
@@ -5,6 +5,11 @@ set +x
 export LC_ALL=C
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+QUALITY_POLICY="$ROOT/scripts/quality-policy"
+[ -x "$QUALITY_POLICY" ] || {
+  printf 'release-impact: quality policy reader is missing or not executable\n' >&2
+  exit 1
+}
 
 die() {
   printf 'release-impact: %s\n' "$*" >&2
@@ -142,108 +147,25 @@ apply_semantic_review() {
 }
 
 classify_path() {
-  local path="$1"
-  case "$path" in
-    README.md|AGENTS.md|CLAUDE.md|VERSION|BUILD|.gitignore|.gitattributes|\
-    .github/*|docs/*|app/Tests/*|tests/*)
-      ;;
-
-    app/Sources/DetachPower/*|app/Sources/DetachPowerHelper/*|\
-    app/Sources/DetachWatchdog/*|app/Sources/DetachKit/ClamshellLockRunner.swift|\
-    app/Sources/DetachKit/BoundedProcessRunner.swift|\
-    app/Sources/DetachKit/DetachPower*.swift|app/Sources/DetachKit/Power*.swift|\
-    app/Sources/DetachApp/InstallationStore.swift|\
-    app/Sources/DetachApp/PowerHelper*.swift|app/Sources/DetachApp/Watchdog*.swift)
-      require_install_matrix "$path"
-      require_lid_test "$path"
-      ;;
-
-    bin/detach|bin/detach-core)
-      require_lid_test "$path"
-      ;;
-
-    app/Sources/DetachApp/DetachApp.swift|\
-    app/Sources/DetachApp/Onboarding*.swift|\
-    app/Sources/DetachApp/RootView.swift|\
-    app/Sources/DetachApp/SetupGuidance.swift|\
-    app/Sources/DetachApp/Settings*.swift|\
-    app/Sources/DetachApp/UpdaterService.swift|\
-    app/Sources/DetachKit/DetachCLI.swift|\
-    app/Sources/DetachKit/DoctorReport.swift|\
-    app/Sources/DetachKit/Localization.swift|\
-    app/Sources/DetachKit/UpdateConfiguration.swift)
-      require_install_matrix "$path"
-      ;;
-
-    app/Sources/DetachApp/EmptySessionsView.swift|\
-    app/Sources/DetachApp/LogTextView.swift|\
-    app/Sources/DetachApp/MenuBar*.swift|\
-    app/Sources/DetachApp/NewSessionSheet.swift|\
-    app/Sources/DetachApp/Session*.swift|\
-    app/Sources/DetachApp/SidebarView.swift|\
-    app/Sources/DetachApp/TextSize.swift|\
-    app/Sources/DetachApp/Theme.swift|\
-    app/Sources/DetachApp/TipsBar.swift|\
-    app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift|\
-    app/Sources/DetachApp/UIE2E*.swift|\
-    app/Sources/DetachKit/ANSIText.swift|\
-    app/Sources/DetachKit/DetachState*.swift|\
-    app/Sources/DetachKit/LogPoller.swift|\
-    app/Sources/DetachKit/Session*.swift|\
-    app/Sources/DetachKit/Storage*.swift|\
-    app/Sources/DetachKit/Terminal*.swift|\
-    app/Sources/DetachKit/Tip.swift|\
-    app/Sources/DetachKit/Tmux*.swift|\
-    app/Sources/DetachState/main.swift|scripts/build-tmux.sh)
-      ;;
-
-    app/Sources/DetachKit/*|app/Sources/*)
-      require_both_unknown "$path"
-      ;;
-
-    app/Resources/en.lproj/*|app/Resources/ru.lproj/*|\
-    app/Resources/Info.plist|app/Resources/Detach.entitlements|\
-    app/Resources/DetachDevelopment.entitlements)
-      require_install_matrix "$path"
-      ;;
-
-    app/Resources/DetachWatchdog*|app/Resources/dev.tsarev.detach.power-*)
-      require_install_matrix "$path"
-      require_lid_test "$path"
-      ;;
-
-    app/Resources/Detach.icns|app/Resources/ThirdParty/*)
-      ;;
-
-    app/Resources/*|app/Package.swift|app/Package.resolved|\
-    app/scripts/make-app.sh|app/scripts/release.sh|app/scripts/bundle-modes.sh)
-      require_both_unknown "$path"
-      ;;
-
-    install.sh|scripts/install.sh)
-      require_install_matrix "$path"
-      ;;
-
-    scripts/release-lid-probe)
-      require_lid_test "$path"
-      ;;
-
-    app/scripts/make-dmg.sh)
-      require_install_matrix "$path"
-      ;;
-
-    scripts/release-version|scripts/release-impact|scripts/quality-gate|\
-    scripts/quality-history|scripts/test|\
-    app/scripts/make-icon.sh|\
-    app/scripts/publish-release.sh|app/scripts/render-icon.swift|\
-    app/scripts/sparkle-public-key.sh|app/scripts/verify-app.sh|\
-    app/scripts/verify-appcast.sh)
-      ;;
-
-    *)
-      require_both_unknown "$path"
-      ;;
-  esac
+  local path="$1" status test_domain release_domain spec stages gates unknown
+  local route_pattern route_priority capabilities journeys gate
+  IFS=$'\t' read -r status test_domain release_domain spec stages gates unknown \
+    route_pattern route_priority capabilities journeys < <("$QUALITY_POLICY" classify "$path") || \
+    die "cannot classify path: $path"
+  if [ "$status" = unknown ] || [ "$unknown" = true ]; then
+    UNKNOWN_IMPACT=true
+    add_unique UNKNOWN_REASONS "$path"
+  fi
+  [ "$gates" = - ] || {
+    IFS=, read -r -a selected_gates <<<"$gates"
+    for gate in "${selected_gates[@]}"; do
+      case "$gate" in
+        install) require_install_matrix "$path" ;;
+        lid) require_lid_test "$path" ;;
+        *) die "quality policy selected an unknown release gate: $gate" ;;
+      esac
+    done
+  }
 }
 
 while IFS= read -r -d '' status && IFS= read -r -d '' path; do

--- a/scripts/test
+++ b/scripts/test
@@ -13,9 +13,9 @@ critical  Fast safety-critical Swift and shell behavior.
 unit      Every Swift unit test without packaging or coverage analysis.
 coverage  Every Swift unit test with the enforced coverage contracts.
 smoke     Fresh packaged-app Accessibility and bundled-runtime smoke.
-full      Every automated repository readiness check.
+full      Every automated repository check as a local diagnostic.
 
-Only full is readiness evidence. Every other suite is a focused diagnostic.
+All local suites are diagnostics. Hosted pull-request CI is merge authority.
 EOF
 }
 

--- a/tests/docs-contract.sh
+++ b/tests/docs-contract.sh
@@ -70,4 +70,12 @@ git -C "$ROOT" check-ignore -q docs/work/example.md ||
 git -C "$ROOT" check-ignore -q presentations/internal.html ||
   fail 'internal presentation sources must remain ignored'
 
+grep -F 'Hosted pull-request CI is readiness authority.' "$ROOT/AGENTS.md" >/dev/null ||
+  fail 'agent instructions must identify hosted CI as readiness authority'
+grep -F 'They never claim merge readiness.' \
+  "$ROOT/docs/specs/documentation.md" >/dev/null ||
+  fail 'documentation spec must keep local gates diagnostic'
+! grep -F 'Only full is readiness evidence.' "$ROOT/scripts/test" >/dev/null ||
+  fail 'local full suite must not claim readiness authority'
+
 printf 'Documentation and context contracts passed\n'

--- a/tests/quality-contracts.sh
+++ b/tests/quality-contracts.sh
@@ -18,21 +18,10 @@ baseline_value() {
   awk -F '\t' -v wanted="$key" '$1 == wanted {count++; value=$2} END {if (count != 1) exit 1; print value}' "$BASELINE"
 }
 
-critical_files=(
-  Sources/DetachKit/SessionHealth.swift
-  Sources/DetachKit/DetachState.swift
-  Sources/DetachKit/DetachStateCommand.swift
-  Sources/DetachKit/Storage.swift
-  Sources/DetachKit/StorageStore.swift
-  Sources/DetachKit/Tip.swift
-  Sources/DetachKit/DetachPowerCommand.swift
-  Sources/DetachKit/DetachPowerExecutable.swift
-  Sources/DetachKit/PowerHelperLeaseService.swift
-  Sources/DetachKit/PowerHelperXPC.swift
-  Sources/DetachKit/PowerHelperPlatform.swift
-  Sources/DetachKit/SessionStore.swift
-  Sources/DetachKit/DoctorReport.swift
-)
+critical_files=()
+while IFS=$'\t' read -r source _ _; do
+  critical_files+=("${source#app/}")
+done < <("$ROOT/scripts/quality-policy" critical)
 
 [ -f "$BASELINE" ] && [ ! -L "$BASELINE" ] || {
   printf 'quality contracts: baseline is missing or unsafe\n' >&2

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-quality-dashboard.XXXXXX")"
+RESULT_ROOT="$TMP_ROOT/results"
+RUN_DIR="$RESULT_ROOT/20260811T100000Z-1"
+OUTPUT="$TMP_ROOT/dashboard"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() {
+  printf 'quality-dashboard-contract: %s\n' "$*" >&2
+  exit 1
+}
+
+mkdir -p "$RUN_DIR"
+printf 'policy\tmode\tstage\tstatus\tduration_seconds\tlog\tlog_sha256\torigin_run\n' \
+  >"$RUN_DIR/summary.tsv"
+for record in \
+  'static passed 2' \
+  'swift passed 8' \
+  'quality-contracts passed 3' \
+  'app passed 12' \
+  'ui-e2e passed 4' \
+  'release-budget passed 0'; do
+  read -r stage status duration <<<"$record"
+  printf '13\trepository\t%s\t%s\t%s\t%s.log\tdigest\t-\n' \
+    "$stage" "$status" "$duration" "$stage" >>"$RUN_DIR/summary.tsv"
+done
+summary_digest="$(shasum -a 256 "$RUN_DIR/summary.tsv" | awk '{print $1}')"
+cat >"$RUN_DIR/manifest.tsv" <<EOF
+schema	4
+policy	13
+mode	repository
+authority	ci-merge
+source_commit	0123456789abcdef0123456789abcdef01234567
+base_commit	fedcba9876543210fedcba9876543210fedcba98
+input_fingerprint	0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+fingerprint	abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+stages	static,swift,quality-contracts,app,ui-e2e,release-budget
+capabilities	onboarding
+journeys	J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL
+started_at	2026-08-11T10:00:00Z
+finished_at	2026-08-11T10:00:29Z
+duration_seconds	29
+timing_wall_seconds	29
+resumed_from_run	-
+resumed_from_manifest_sha256	-
+environment_sha256	0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+artifacts_sha256	abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+summary_sha256	$summary_digest
+result	passed
+EOF
+
+"$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+  --output "$OUTPUT" --run-url 'https://github.example/actions/runs/1' >/dev/null
+[ -f "$OUTPUT/index.html" ] && [ -f "$OUTPUT/data.json" ] || \
+  fail 'dashboard artifacts are missing'
+first_html="$(shasum -a 256 "$OUTPUT/index.html" | awk '{print $1}')"
+first_data="$(shasum -a 256 "$OUTPUT/data.json" | awk '{print $1}')"
+"$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+  --output "$OUTPUT" --run-url 'https://github.example/actions/runs/1' >/dev/null
+[ "$first_html" = "$(shasum -a 256 "$OUTPUT/index.html" | awk '{print $1}')" ] || \
+  fail 'HTML generation is not deterministic'
+[ "$first_data" = "$(shasum -a 256 "$OUTPUT/data.json" | awk '{print $1}')" ] || \
+  fail 'dashboard data generation is not deterministic'
+
+grep -F '<main>' "$OUTPUT/index.html" >/dev/null || fail 'semantic main element is missing'
+grep -F 'aria-label="Run summary"' "$OUTPUT/index.html" >/dev/null || \
+  fail 'summary accessibility label is missing'
+grep -F '@media (max-width:560px)' "$OUTPUT/index.html" >/dev/null || \
+  fail 'responsive layout contract is missing'
+grep -F 'STALE ·' "$OUTPUT/index.html" >/dev/null || fail 'stale evidence state is missing'
+grep -F 'J-ONBOARD-FIRST-RUN' "$OUTPUT/index.html" >/dev/null || \
+  fail 'impacted journey is missing'
+grep -F 'planned' "$OUTPUT/index.html" >/dev/null || fail 'planned gap is hidden'
+! grep -F '<svg' "$OUTPUT/index.html" >/dev/null || fail 'dashboard contains hand-drawn SVG'
+
+python3 - "$OUTPUT/data.json" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as source:
+    data = json.load(source)
+assert data["schema"] == 1
+assert data["run"]["authority"] == "ci-merge"
+assert data["run"]["result"] == "passed"
+assert data["quality"]["planned_scenarios"] == 3
+assert [journey["id"] for journey in data["journeys"]] == [
+    "J-ONBOARD-FIRST-RUN", "J-ONBOARD-PROVIDER", "J-ONBOARD-APPROVAL"
+]
+PY
+
+PYTHONDONTWRITEBYTECODE=1 python3 - "$ROOT/tools/quality_dashboard.py" "$OUTPUT" <<'PY'
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+import sys
+
+spec = importlib.util.spec_from_file_location("quality_dashboard", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class FakeServer:
+    server_address = ("127.0.0.1", 43210)
+    def __init__(self, address, handler): self.closed = False
+    def serve_forever(self): pass
+    def shutdown(self): pass
+    def server_close(self): self.closed = True
+
+class FakeTimer:
+    instance = None
+    def __init__(self, seconds, callback):
+        self.seconds, self.callback, self.daemon = seconds, callback, False
+        self.started = self.cancelled = False
+        FakeTimer.instance = self
+    def start(self): self.started = True
+    def cancel(self): self.cancelled = True
+
+arguments = SimpleNamespace(directory=Path(sys.argv[2]), port=0, seconds=1)
+output = io.StringIO()
+with patch.object(module, "ThreadingHTTPServer", FakeServer), \
+     patch.object(module.threading, "Timer", FakeTimer), redirect_stdout(output):
+    assert module.serve(arguments) == 0
+assert FakeTimer.instance.seconds == 1
+assert FakeTimer.instance.started and FakeTimer.instance.cancelled
+assert "stops after 1s" in output.getvalue()
+PY
+
+printf 'tamper\n' >>"$RUN_DIR/summary.tsv"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/tampered" >"$TMP_ROOT/tampered.out" 2>&1; then
+  fail 'tampered summary was accepted'
+fi
+grep -F 'summary digest does not match' "$TMP_ROOT/tampered.out" >/dev/null || \
+  fail 'tampered summary failure is unclear'
+
+printf 'Quality dashboard contracts passed\n'

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Contract fixtures choose their authority explicitly. Do not let the parent
+# quality-gates job turn nested local diagnostics into CI merge evidence.
+unset DETACH_QUALITY_AUTHORITY GITHUB_ACTIONS
+
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-quality-gate-test.XXXXXX")"
 TEMPLATE_REPO="$TMP_ROOT/template"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -11,21 +11,44 @@ cleanup() {
 }
 trap cleanup EXIT
 
-grep -F 'run: scripts/quality-gate --base "$BASE_SHA" --without-release-budget' \
+grep -F 'timeout-minutes: 10' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'DETACH_QUALITY_AUTHORITY: ci-merge' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'run: scripts/quality-gate --mode repository --base "$BASE_SHA" --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-gate --mode repository --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F -- '- "detach-release/**"' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+! grep -E 'uses:[[:space:]]+[^[:space:]]+@v[0-9]' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null || {
+  printf 'quality gate workflow contains a mutable Action tag\n' >&2
+  exit 1
+}
+grep -F 'quality-dashboard:' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'pages: write' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'scripts/quality-dashboard generate' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 
 prepare_template() {
   local stage
   mkdir -p "$TEMPLATE_REPO/scripts" "$TEMPLATE_REPO/tests/quality-gate-fixtures" \
-    "$TEMPLATE_REPO/app/build"
+    "$TEMPLATE_REPO/app/build" "$TEMPLATE_REPO/quality/generated" "$TEMPLATE_REPO/tools"
   install -m 0755 "$ROOT/scripts/quality-gate" "$TEMPLATE_REPO/scripts/quality-gate"
+  install -m 0755 "$ROOT/scripts/quality-policy" "$TEMPLATE_REPO/scripts/quality-policy"
+  install -m 0755 "$ROOT/scripts/quality-dashboard" "$TEMPLATE_REPO/scripts/quality-dashboard"
+  install -m 0755 "$ROOT/scripts/release-impact" "$TEMPLATE_REPO/scripts/release-impact"
+  install -m 0644 "$ROOT/tools/quality_policy.py" "$TEMPLATE_REPO/tools/quality_policy.py"
+  install -m 0644 "$ROOT/tools/quality_dashboard.py" "$TEMPLATE_REPO/tools/quality_dashboard.py"
   install -m 0755 "$ROOT/scripts/test" "$TEMPLATE_REPO/scripts/test"
+  install -m 0644 "$ROOT/quality/policy.tsv" "$TEMPLATE_REPO/quality/policy.tsv"
+  install -m 0644 "$ROOT/quality/generated/policy.json" \
+    "$TEMPLATE_REPO/quality/generated/policy.json"
   install -m 0755 "$ROOT/tests/quality-ratchet.sh" "$ROOT/tests/release-budget-ratchet.sh" \
-    "$ROOT/tests/shell-safety.sh" "$TEMPLATE_REPO/tests/"
+    "$ROOT/tests/shell-safety.sh" "$ROOT/tests/quality-policy.sh" \
+    "$ROOT/tests/quality-dashboard.sh" "$TEMPLATE_REPO/tests/"
   install -m 0644 "$ROOT/tests/quality-baseline.tsv" "$ROOT/tests/quality-file-baseline.tsv" \
     "$ROOT/tests/release-budget.tsv" \
     "$TEMPLATE_REPO/tests/"
@@ -145,6 +168,14 @@ printf '%s\n' 'struct ChangedPower {}' >"$REPO/app/Sources/DetachKit/PowerHelper
 plan="$(gate --plan)"
 [[ "$plan" = *'stages=static,swift,quality-contracts,app,ui-e2e,distribution,tmux-runtime,release-budget' ]]
 
+setup_fixture onboarding-journey-impact
+mkdir -p "$REPO/app/Sources/DetachApp"
+printf '%s\n' 'struct ChangedOnboarding {}' \
+  >"$REPO/app/Sources/DetachApp/OnboardingFuture.swift"
+plan="$(gate --plan)"
+[[ "$plan" = *'capabilities=onboarding'* ]]
+[[ "$plan" = *'journeys=J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL'* ]]
+
 setup_fixture package
 mkdir -p "$REPO/app"
 printf '%s\n' '// changed package' >"$REPO/app/Package.swift"
@@ -187,7 +218,7 @@ setup_fixture quality-file-baseline
 printf 'Sources/DetachKit/NewCritical.swift\t95.00\n' \
   >>"$REPO/tests/quality-file-baseline.tsv"
 plan="$(gate --plan)"
-[[ "$plan" = *'stages=static,gate-contract,swift,quality-contracts,app,ui-e2e,codex,claude,distribution,tmux-runtime,release-preflight,publish-preflight,release-workflow,release-budget' ]]
+[[ "$plan" = *'stages=static,gate-contract' ]]
 
 setup_fixture unknown
 printf '%s\n' unknown >"$REPO/new-contract.data"
@@ -217,7 +248,7 @@ mkdir -p "$REPO/app/Sources/DetachKit"
 printf '%s\n' 'struct OddName {}' >"$REPO/app/Sources/DetachKit/line
 break.swift"
 plan="$(gate --plan --format json)"
-[[ "$plan" = '{"policy":12,"mode":"change","source_commit":"'* ]]
+[[ "$plan" = '{"policy":13,"mode":"change","authority":"local-diagnostic","source_commit":"'* ]]
 [[ "$plan" = *'"base_commit":"","input_fingerprint":"'* ]]
 [[ "$plan" = *'"stages":["static","swift","quality-contracts","app","ui-e2e","release-budget"]}' ]]
 
@@ -246,11 +277,21 @@ if ! gate --mode release >"$REPO/release.out" 2>&1; then
 fi
 ! grep -Fx release-workflow "$ACTION_LOG" >/dev/null
 [ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 12 ]
+grep -F 'quality-gate: PASS policy=13 authority=release' "$REPO/release.out" >/dev/null
 
 setup_fixture github-budget
-plan="$(GITHUB_ACTIONS=true gate --mode repository --without-release-budget --plan)"
+plan="$(GITHUB_ACTIONS=true DETACH_QUALITY_AUTHORITY=ci-merge \
+  gate --mode repository --without-release-budget --plan)"
 [[ "$plan" = *'stages=static,gate-contract,swift,quality-contracts,app,ui-e2e,codex,claude,distribution,tmux-runtime,release-preflight,publish-preflight,release-workflow' ]]
 [[ "$plan" != *'release-budget'* ]]
+[[ "$plan" = *'authority=ci-merge'* ]]
+if DETACH_QUALITY_AUTHORITY=ci-merge gate --mode repository --plan \
+    >"$REPO/spoof-authority.out" 2>&1; then
+  printf 'quality gate accepted spoofed CI merge authority\n' >&2
+  exit 1
+fi
+grep -F 'ci-merge authority is restricted to GitHub Actions' \
+  "$REPO/spoof-authority.out" >/dev/null
 
 setup_fixture release-timing-override
 if production_plan --mode release --without-release-budget --plan \
@@ -607,7 +648,7 @@ chmod 0755 \
   "$REPO/tests/quality-gate-fixtures/release-workflow"
 GATE_PARALLEL_ROOT="$PARALLEL_ROOT" gate --mode repository >"$REPO/parallel.out"
 [ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 11 ]
-grep -F 'quality-gate: PASS' "$REPO/parallel.out" >/dev/null
+grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/parallel.out" >/dev/null
 
 setup_fixture resource-order
 ORDER_ROOT="$REPO/order"
@@ -654,7 +695,7 @@ chmod 0755 \
   "$REPO/tests/quality-gate-fixtures/publish-preflight" \
   "$REPO/tests/quality-gate-fixtures/release-workflow"
 GATE_ORDER_ROOT="$ORDER_ROOT" gate --mode repository >"$REPO/resource-order.out"
-grep -F 'quality-gate: PASS' "$REPO/resource-order.out" >/dev/null
+grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/resource-order.out" >/dev/null
 
 setup_fixture release-budget-wall
 set_manifest_value "$REPO/tests/release-budget.tsv" wall_seconds_max 1
@@ -690,7 +731,7 @@ grep -F 'stage budget: static regressed: 3s > 2s' "$RESULT_ROOT"/*/static.log >/
 grep -F $'static\tfailed\t3' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 
 setup_fixture github-no-timing-budgets
-if ! GITHUB_ACTIONS=true \
+if ! GITHUB_ACTIONS=true DETACH_QUALITY_AUTHORITY=ci-merge \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_STATIC=300 \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_SWIFT=300 \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_APP=300 \
@@ -701,6 +742,9 @@ if ! GITHUB_ACTIONS=true \
   exit 1
 fi
 ! grep -F 'stage budget:' "$REPO/github-no-budgets.out" >/dev/null
+grep -F 'quality-gate: PASS policy=13 authority=ci-merge' \
+  "$REPO/github-no-budgets.out" >/dev/null
+grep -F $'authority\tci-merge' "$RESULT_ROOT"/*/manifest.tsv >/dev/null
 grep -F $'swift\tpassed' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 grep -F $'app\tpassed' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 grep -F $'publish-preflight\tpassed' "$RESULT_ROOT"/*/summary.tsv >/dev/null
@@ -718,7 +762,10 @@ setup_fixture evidence
 printf '%s\n' docs >>"$REPO/README.md"
 gate >"$REPO/evidence.out"
 run_dir="$(find "$RESULT_ROOT" -mindepth 1 -maxdepth 1 -type d -print | head -1)"
-grep -F $'schema\t3' "$run_dir/manifest.tsv" >/dev/null
+grep -F $'schema\t4' "$run_dir/manifest.tsv" >/dev/null
+grep -F $'authority\tlocal-diagnostic' "$run_dir/manifest.tsv" >/dev/null
+grep -F $'capabilities\tdocumentation' "$run_dir/manifest.tsv" >/dev/null
+grep -F $'journeys\tJ-DOCS-CONSISTENCY' "$run_dir/manifest.tsv" >/dev/null
 grep -F $'input_fingerprint\t' "$run_dir/manifest.tsv" >/dev/null
 grep -E $'^started_at\t[0-9]{4}-' "$run_dir/manifest.tsv" >/dev/null
 grep -E $'^finished_at\t[0-9]{4}-' "$run_dir/manifest.tsv" >/dev/null
@@ -755,7 +802,7 @@ printf '%s\n' docs >>"$REPO/README.md"
   DETACH_QUALITY_GATE_TEST_MODE=1 DETACH_QUALITY_GATE_TEST_REAL_STATIC=1 \
     DETACH_QUALITY_GATE_RESULT_ROOT="$RESULT_ROOT" "$REPO/scripts/quality-gate"
 ) >"$REPO/targeted-static.out"
-grep -F 'quality-gate: PASS' "$REPO/targeted-static.out" >/dev/null
+grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/targeted-static.out" >/dev/null
 if (
   cd -P "$REPO"
   DETACH_QUALITY_GATE_TEST_MODE=1 DETACH_QUALITY_GATE_TEST_REAL_STATIC=1 \

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -109,7 +109,7 @@ fi
 grep -F 'references unknown scenario: SC-UI-SETTINGS' \
   "$TMP_ROOT/missing-scenario.out" >/dev/null || fail 'missing scenario failure is unclear'
 
-! rg -F 'case "$path" in' "$ROOT/scripts/quality-gate" "$ROOT/scripts/release-impact" >/dev/null || \
+! grep -F 'case "$path" in' "$ROOT/scripts/quality-gate" "$ROOT/scripts/release-impact" >/dev/null || \
   fail 'a second path classifier remains in a production script'
 
 printf 'Quality policy contracts passed\n'

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-quality-policy.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() {
+  printf 'quality-policy-contract: %s\n' "$*" >&2
+  exit 1
+}
+
+field() {
+  printf '%s\n' "$1" | awk -F '\t' -v column="$2" '{print $column}'
+}
+
+expect_route() {
+  local path="$1" expected_test="$2" expected_release="$3" expected_unknown="$4" result
+  result="$("$ROOT/scripts/quality-policy" classify "$path")"
+  [ "$(field "$result" 1)" = known ] || fail "expected a known route for $path"
+  [ "$(field "$result" 2)" = "$expected_test" ] || fail "unexpected test domain for $path"
+  [ "$(field "$result" 3)" = "$expected_release" ] || fail "unexpected release domain for $path"
+  [ "$(field "$result" 7)" = "$expected_unknown" ] || fail "unexpected unknown flag for $path"
+}
+
+"$ROOT/scripts/quality-policy" validate >/dev/null
+"$ROOT/scripts/quality-policy" generate --check
+[ "$("$ROOT/scripts/quality-policy" version)" = 13 ] || fail 'unexpected policy version'
+[ "$("$ROOT/scripts/quality-policy" stages all | wc -l | tr -d ' ')" = 14 ] || \
+  fail 'unexpected stage count'
+[ "$("$ROOT/scripts/quality-policy" stages release | tail -1)" = release-budget ] || \
+  fail 'release stage order is incorrect'
+[ "$("$ROOT/scripts/quality-policy" timeout app)" = 2400 ] || fail 'app timeout is not policy owned'
+[ "$("$ROOT/scripts/quality-policy" dependencies)" = $'app\tui-e2e' ] || \
+  fail 'packaged UI dependency is missing'
+[ "$("$ROOT/scripts/quality-policy" critical | wc -l | tr -d ' ')" = 13 ] || \
+  fail 'critical source inventory is incomplete'
+[ "$("$ROOT/scripts/quality-policy" requirements | wc -l | tr -d ' ')" = 20 ] || \
+  fail 'critical requirement inventory is incomplete'
+[ "$("$ROOT/scripts/quality-policy" capabilities | wc -l | tr -d ' ')" = 11 ] || \
+  fail 'capability inventory is incomplete'
+[ "$("$ROOT/scripts/quality-policy" journeys | wc -l | tr -d ' ')" = 26 ] || \
+  fail 'journey inventory is incomplete'
+[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 31 ] || \
+  fail 'scenario inventory is incomplete'
+first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
+second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
+[ "$first_json" = "$second_json" ] || fail 'generated policy JSON is not deterministic'
+
+expect_route docs/testing.md policy safe false
+expect_route app/Sources/DetachKit/DetachStateCommand.swift state-runtime safe false
+expect_route app/Sources/DetachKit/PowerProtection.swift power both false
+expect_route app/Sources/DetachKit/TerminalLauncher.swift runtime-source safe false
+expect_route app/Sources/DetachApp/OnboardingView.swift onboarding-source install false
+expect_route app/Sources/DetachApp/FutureFlow.swift swift-source unknown true
+expect_route scripts/release-lid-probe release-tool lid false
+
+onboarding="$("$ROOT/scripts/quality-policy" classify app/Sources/DetachApp/OnboardingView.swift)"
+[ "$(field "$onboarding" 10)" = onboarding ] || fail 'onboarding capability impact is missing'
+[[ "$(field "$onboarding" 11)" = *J-ONBOARD-FIRST-RUN* ]] || \
+  fail 'onboarding journey impact is missing'
+session="$("$ROOT/scripts/quality-policy" classify app/Sources/DetachKit/SessionStore.swift)"
+[ "$(field "$session" 10)" = session-lifecycle ] || fail 'session capability impact is missing'
+[[ "$(field "$session" 11)" = *J-SESSION-RECOVER* ]] || \
+  fail 'session recovery journey impact is missing'
+
+unknown="$("$ROOT/scripts/quality-policy" classify product/new-runtime)"
+[ "$(field "$unknown" 1)" = unknown ] || fail 'new product path must fail safe'
+[ "$(field "$unknown" 5)" = "$("$ROOT/scripts/quality-policy" stages all | paste -sd, -)" ] || \
+  fail 'unknown product path must select every stage'
+[ "$(field "$unknown" 6)" = install,lid ] || fail 'unknown product path must select both release gates'
+
+cp "$ROOT/quality/policy.tsv" "$TMP_ROOT/duplicate.tsv"
+printf '%s\n' $'route\t950\tREADME.md\tdocs\tsafe\tdocs/specs/documentation.md' \
+  >>"$TMP_ROOT/duplicate.tsv"
+if DETACH_QUALITY_POLICY="$TMP_ROOT/duplicate.tsv" \
+    "$ROOT/scripts/quality-policy" classify README.md >"$TMP_ROOT/duplicate.out" 2>&1; then
+  fail 'equal-priority routes were accepted'
+fi
+grep -F 'equal-priority routes' "$TMP_ROOT/duplicate.out" >/dev/null || \
+  fail 'equal-priority route failure is unclear'
+
+awk -F '\t' -v OFS='\t' \
+  '$1 == "test-domain" && $2 == "docs" {$3="static,missing-stage"} {print}' \
+  "$ROOT/quality/policy.tsv" >"$TMP_ROOT/missing-stage.tsv"
+if DETACH_QUALITY_POLICY="$TMP_ROOT/missing-stage.tsv" \
+    "$ROOT/scripts/quality-policy" validate >"$TMP_ROOT/missing-stage.out" 2>&1; then
+  fail 'unresolved stage reference was accepted'
+fi
+grep -F 'references unknown stage: missing-stage' "$TMP_ROOT/missing-stage.out" >/dev/null || \
+  fail 'unresolved stage failure is unclear'
+
+awk -F '\t' -v OFS='\t' \
+  '!($1 == "requirement" && $2 == "QC-POWER-CLI") {print}' \
+  "$ROOT/quality/policy.tsv" >"$TMP_ROOT/missing-requirement.tsv"
+if DETACH_QUALITY_POLICY="$TMP_ROOT/missing-requirement.tsv" \
+    "$ROOT/scripts/quality-policy" validate >"$TMP_ROOT/missing-requirement.out" 2>&1; then
+  fail 'unresolved critical requirement was accepted'
+fi
+
+awk -F '\t' -v OFS='\t' \
+  '!($1 == "scenario" && $2 == "SC-UI-SETTINGS") {print}' \
+  "$ROOT/quality/policy.tsv" >"$TMP_ROOT/missing-scenario.tsv"
+if DETACH_QUALITY_POLICY="$TMP_ROOT/missing-scenario.tsv" \
+    "$ROOT/scripts/quality-policy" validate >"$TMP_ROOT/missing-scenario.out" 2>&1; then
+  fail 'unresolved journey scenario was accepted'
+fi
+grep -F 'references unknown scenario: SC-UI-SETTINGS' \
+  "$TMP_ROOT/missing-scenario.out" >/dev/null || fail 'missing scenario failure is unclear'
+
+! rg -F 'case "$path" in' "$ROOT/scripts/quality-gate" "$ROOT/scripts/release-impact" >/dev/null || \
+  fail 'a second path classifier remains in a production script'
+
+printf 'Quality policy contracts passed\n'

--- a/tests/quality-ratchet.sh
+++ b/tests/quality-ratchet.sh
@@ -10,6 +10,7 @@ FILE_BASELINE="${DETACH_QUALITY_FILE_BASELINE:-$ROOT/tests/quality-file-baseline
 PRIOR_FILE_OVERRIDE="${DETACH_QUALITY_PRIOR_FILE_BASELINE:-}"
 BASE_COMMIT="${RESOLVED_BASE:-}"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-quality-ratchet.XXXXXX")"
+CRITICAL_POLICY="$TMP_ROOT/critical.tsv"
 
 cleanup() {
   rm -rf "$TMP_ROOT"
@@ -26,21 +27,11 @@ if [ "$TEST_MODE" != 1 ] && {
 fi
 
 keys=(ui_test_count_min business_test_count_min ui_line_coverage_min business_line_coverage_min)
-critical_files=(
-  Sources/DetachKit/SessionHealth.swift
-  Sources/DetachKit/DetachState.swift
-  Sources/DetachKit/DetachStateCommand.swift
-  Sources/DetachKit/Storage.swift
-  Sources/DetachKit/StorageStore.swift
-  Sources/DetachKit/Tip.swift
-  Sources/DetachKit/DetachPowerCommand.swift
-  Sources/DetachKit/DetachPowerExecutable.swift
-  Sources/DetachKit/PowerHelperLeaseService.swift
-  Sources/DetachKit/PowerHelperXPC.swift
-  Sources/DetachKit/PowerHelperPlatform.swift
-  Sources/DetachKit/SessionStore.swift
-  Sources/DetachKit/DoctorReport.swift
-)
+"$ROOT/scripts/quality-policy" critical >"$CRITICAL_POLICY"
+critical_files=()
+while IFS=$'\t' read -r source _ _; do
+  critical_files+=("${source#app/}")
+done <"$CRITICAL_POLICY"
 
 baseline_value() {
   local file="$1" key="$2"
@@ -120,22 +111,10 @@ hard_floor() {
 }
 
 file_hard_floor() {
-  case "$1" in
-    Sources/DetachKit/SessionHealth.swift) printf 99.10 ;;
-    Sources/DetachKit/DetachState.swift) printf 99.03 ;;
-    Sources/DetachKit/DetachStateCommand.swift) printf 96.70 ;;
-    Sources/DetachKit/Storage.swift) printf 95.28 ;;
-    Sources/DetachKit/StorageStore.swift) printf 100.00 ;;
-    Sources/DetachKit/Tip.swift) printf 100.00 ;;
-    Sources/DetachKit/DetachPowerCommand.swift) printf 95.21 ;;
-    Sources/DetachKit/DetachPowerExecutable.swift) printf 100.00 ;;
-    Sources/DetachKit/PowerHelperLeaseService.swift) printf 98.21 ;;
-    Sources/DetachKit/PowerHelperXPC.swift) printf 82.23 ;;
-    Sources/DetachKit/PowerHelperPlatform.swift) printf 84.54 ;;
-    Sources/DetachKit/SessionStore.swift) printf 98.11 ;;
-    Sources/DetachKit/DoctorReport.swift) printf 100.00 ;;
-    *) return 1 ;;
-  esac
+  local wanted="app/$1"
+  awk -F '\t' -v wanted="$wanted" \
+    '$1 == wanted {count++; value=$3} END {if (count != 1) exit 1; print value}' \
+    "$CRITICAL_POLICY"
 }
 
 assert_not_lower() {

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -8,16 +8,21 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-release-impact.XXXXXX")"
 REPO="$TMP_ROOT/repo"
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 
-mkdir -p "$REPO/scripts"
+mkdir -p "$REPO/scripts" "$REPO/quality" "$REPO/tools"
 cp "$ROOT/scripts/release-impact" "$REPO/scripts/release-impact"
+cp "$ROOT/scripts/quality-policy" "$REPO/scripts/quality-policy"
+cp "$ROOT/tools/quality_policy.py" "$REPO/tools/quality_policy.py"
+cp "$ROOT/quality/policy.tsv" "$REPO/quality/policy.tsv"
 chmod 0755 "$REPO/scripts/release-impact"
+chmod 0755 "$REPO/scripts/quality-policy"
 git -C "$REPO" init -q
 git -C "$REPO" checkout -qb main
 git -C "$REPO" config user.name 'Detach Tests'
 git -C "$REPO" config user.email 'detach-tests@example.invalid'
 printf '%s\n' baseline >"$REPO/README.md"
 printf '%s\n' 'app/build/' >"$REPO/.gitignore"
-git -C "$REPO" add .gitignore README.md scripts/release-impact
+git -C "$REPO" add .gitignore README.md quality/policy.tsv \
+  scripts/quality-policy scripts/release-impact tools/quality_policy.py
 git -C "$REPO" commit -qm baseline
 
 commit_path() {

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -37,13 +37,17 @@ setup_fixture() {
   ACTION_LOG="$FIXTURE/actions.log"
   PUBLISHED_MANIFEST="$FIXTURE/published-manifest.json"
   mkdir -p "$REPO/scripts" "$REPO/tests/quality-gate-fixtures" "$REPO/app/scripts" \
-    "$REPO/app/.build/artifacts/sparkle/Sparkle/bin" "$BIN" "$APPS" \
+    "$REPO/app/.build/artifacts/sparkle/Sparkle/bin" "$REPO/quality" "$REPO/tools" \
+    "$BIN" "$APPS" \
     "$REMOTE_ASSETS"
 
   install -m 0755 "$ROOT/scripts/release-version" "$REPO/scripts/release-version"
   install -m 0755 "$ROOT/scripts/release-impact" "$REPO/scripts/release-impact"
   install -m 0755 "$ROOT/scripts/release-lid-probe" "$REPO/scripts/release-lid-probe"
   install -m 0755 "$ROOT/scripts/quality-gate" "$REPO/scripts/quality-gate"
+  install -m 0755 "$ROOT/scripts/quality-policy" "$REPO/scripts/quality-policy"
+  install -m 0644 "$ROOT/tools/quality_policy.py" "$REPO/tools/quality_policy.py"
+  install -m 0644 "$ROOT/quality/policy.tsv" "$REPO/quality/policy.tsv"
   install -m 0755 "$ROOT/app/scripts/verify-appcast.sh" \
     "$REPO/app/scripts/verify-appcast.sh"
   printf '%s\n' 1.2.3 >"$REPO/VERSION"

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -432,6 +432,7 @@ run_workflow() {
       DETACH_RELEASE_TEST_LID_MIN_SECONDS=0 \
       DETACH_RELEASE_TEST_FAIL_AFTER="$fail_after" \
       DETACH_RELEASE_IGNORE_TIMING="$ignore_timing" \
+      DETACH_QUALITY_AUTHORITY= \
       DETACH_CONFIRM_RELEASE="$release_confirmation" \
       DETACH_CONFIRM_INSTALL_MATRIX="$install_confirmation" \
       DETACH_CONFIRM_LID_TEST="$lid_confirmation" \

--- a/tests/shell-safety.sh
+++ b/tests/shell-safety.sh
@@ -16,7 +16,7 @@ failures=0
 while IFS= read -r -d '' file; do
   case "$file" in
     tests/shell-safety-contract.sh) continue ;;
-    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
+    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-policy|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
     *) continue ;;
   esac
   [ -f "$ROOT/$file" ] || continue

--- a/tests/test-suite-contract.sh
+++ b/tests/test-suite-contract.sh
@@ -75,7 +75,7 @@ for command in \
 done
 
 [ "$full" = 'full: scripts/quality-gate --mode repository' ] ||
-  fail 'full suite must delegate to the repository quality gate'
+  fail 'full diagnostic must delegate to the repository quality gate'
 
 if "$ROOT/scripts/test" --plan unknown >"${TMPDIR:-/tmp}/detach-test-suite.out.$$" 2>&1; then
   rm -f "${TMPDIR:-/tmp}/detach-test-suite.out.$$"

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Generate and serve the deterministic Detach quality dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import statistics
+import sys
+import threading
+from typing import Any, NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RESULT_ROOT = ROOT / "app/build/quality-gates"
+DEFAULT_OUTPUT = ROOT / "app/build/quality-dashboard"
+POLICY_JSON = ROOT / "quality/generated/policy.json"
+SUMMARY_HEADER = [
+    "policy",
+    "mode",
+    "stage",
+    "status",
+    "duration_seconds",
+    "log",
+    "log_sha256",
+    "origin_run",
+]
+FAILURE_STATUSES = {"failed", "environment-failed", "timeout", "interrupted"}
+PASS_STATUSES = {"passed", "reused"}
+
+
+class DashboardError(Exception):
+    """Invalid, unsafe, or incomplete dashboard evidence."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-dashboard: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def safe_file(path: Path, label: str) -> Path:
+    if not path.is_file() or path.is_symlink():
+        raise DashboardError(f"{label} is missing or unsafe: {path}")
+    return path
+
+
+def read_manifest(run_dir: Path) -> dict[str, str]:
+    manifest_path = safe_file(run_dir / "manifest.tsv", "manifest")
+    values: dict[str, str] = {}
+    for line_number, line in enumerate(manifest_path.read_text(encoding="utf-8").splitlines(), 1):
+        fields = line.split("\t")
+        if len(fields) != 2 or not fields[0] or fields[0] in values:
+            raise DashboardError(f"manifest has a malformed or duplicate record at line {line_number}")
+        values[fields[0]] = fields[1]
+    required = {
+        "schema",
+        "policy",
+        "mode",
+        "authority",
+        "source_commit",
+        "fingerprint",
+        "stages",
+        "capabilities",
+        "journeys",
+        "started_at",
+        "finished_at",
+        "duration_seconds",
+        "timing_wall_seconds",
+        "summary_sha256",
+        "result",
+    }
+    missing = required - values.keys()
+    if missing:
+        raise DashboardError(f"manifest is missing: {sorted(missing)[0]}")
+    if values["schema"] != "4":
+        raise DashboardError("manifest schema is unsupported")
+    if values["authority"] not in ("local-diagnostic", "ci-merge", "ci-main", "release"):
+        raise DashboardError("manifest authority is invalid")
+    if values["result"] not in ("passed", "failed", "interrupted", "diagnostic"):
+        raise DashboardError("manifest result is invalid")
+    for key in ("duration_seconds", "timing_wall_seconds"):
+        if not values[key].isdigit():
+            raise DashboardError(f"manifest {key} is invalid")
+    if not values["finished_at"]:
+        raise DashboardError("manifest describes an unfinished run")
+    return values
+
+
+def read_summary(run_dir: Path, manifest: dict[str, str]) -> list[dict[str, Any]]:
+    summary_path = safe_file(run_dir / "summary.tsv", "summary")
+    digest = hashlib.sha256(summary_path.read_bytes()).hexdigest()
+    if digest != manifest["summary_sha256"]:
+        raise DashboardError("summary digest does not match the manifest")
+    lines = summary_path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].split("\t") != SUMMARY_HEADER:
+        raise DashboardError("summary schema is invalid")
+    stages: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for line_number, line in enumerate(lines[1:], 2):
+        fields = line.split("\t")
+        if len(fields) != len(SUMMARY_HEADER):
+            raise DashboardError(f"summary line {line_number} is malformed")
+        record = dict(zip(SUMMARY_HEADER, fields))
+        stage = record["stage"]
+        if stage in seen or not record["duration_seconds"].isdigit():
+            raise DashboardError(f"summary line {line_number} is duplicate or invalid")
+        seen.add(stage)
+        record["duration_seconds"] = int(record["duration_seconds"])
+        stages.append(record)
+    expected = [stage for stage in manifest["stages"].split(",") if stage]
+    if [record["stage"] for record in stages] != expected:
+        raise DashboardError("summary stages do not match the manifest plan")
+    return stages
+
+
+def read_policy() -> dict[str, Any]:
+    policy_path = safe_file(POLICY_JSON, "generated policy")
+    try:
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeError) as error:
+        raise DashboardError(f"generated policy JSON is invalid: {error}") from error
+    if policy.get("schema") != 1 or not isinstance(policy.get("policy"), int):
+        raise DashboardError("generated policy schema is invalid")
+    return policy
+
+
+def split_csv(value: str) -> list[str]:
+    return [item for item in value.split(",") if item]
+
+
+def percentile(values: list[int], percent: int) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    index = (len(ordered) * percent + 99) // 100
+    return ordered[max(0, index - 1)]
+
+
+def collect_trends(result_root: Path, current: Path) -> list[dict[str, Any]]:
+    trends: list[dict[str, Any]] = []
+    if not result_root.is_dir() or result_root.is_symlink():
+        return trends
+    for candidate in sorted(result_root.iterdir())[-20:]:
+        if not candidate.is_dir() or candidate.is_symlink():
+            continue
+        try:
+            manifest = read_manifest(candidate)
+        except DashboardError:
+            continue
+        trends.append(
+            {
+                "run": candidate.name,
+                "current": candidate.resolve() == current.resolve(),
+                "commit": manifest["source_commit"],
+                "authority": manifest["authority"],
+                "result": manifest["result"],
+                "finished_at": manifest["finished_at"],
+                "duration_seconds": int(manifest["duration_seconds"]),
+                "wall_seconds": int(manifest["timing_wall_seconds"]),
+            }
+        )
+    return trends
+
+
+def latest_run(result_root: Path) -> Path:
+    if not result_root.is_dir() or result_root.is_symlink():
+        raise DashboardError("quality result root is missing or unsafe")
+    candidates = [
+        path for path in sorted(result_root.iterdir())
+        if path.is_dir() and not path.is_symlink() and (path / "manifest.tsv").is_file()
+    ]
+    if not candidates:
+        raise DashboardError("no quality run evidence exists")
+    return candidates[-1]
+
+
+def build_data(run_dir: Path, result_root: Path, run_url: str) -> dict[str, Any]:
+    manifest = read_manifest(run_dir)
+    stages = read_summary(run_dir, manifest)
+    policy = read_policy()
+    if int(manifest["policy"]) != policy["policy"]:
+        raise DashboardError("run policy does not match the generated policy view")
+    stage_by_id = {stage["stage"]: stage for stage in stages}
+    journeys_by_id = {journey["id"]: journey for journey in policy["journeys"]}
+    scenarios_by_id = {scenario["id"]: scenario for scenario in policy["scenarios"]}
+    impacted_journeys = split_csv(manifest["journeys"])
+    journey_evidence: list[dict[str, Any]] = []
+    passed_scenarios = 0
+    automatable_scenarios = 0
+    planned_scenarios = 0
+    manual_scenarios = 0
+    for journey_id in impacted_journeys:
+        journey = journeys_by_id.get(journey_id)
+        if journey is None:
+            raise DashboardError(f"manifest references an unknown journey: {journey_id}")
+        scenario_evidence: list[dict[str, Any]] = []
+        for scenario_id in journey["scenarios"]:
+            scenario = scenarios_by_id[scenario_id]
+            stage = stage_by_id.get(scenario["stage"])
+            if scenario["status"] == "planned":
+                status = "planned"
+                planned_scenarios += 1
+                automatable_scenarios += 1
+            elif scenario["status"] == "manual-release":
+                status = "manual-release"
+                manual_scenarios += 1
+            elif stage is None:
+                status = "not-selected"
+                automatable_scenarios += 1
+            elif stage["status"] in PASS_STATUSES:
+                status = "passed"
+                passed_scenarios += 1
+                automatable_scenarios += 1
+            elif stage["status"] in FAILURE_STATUSES:
+                status = "failed"
+                automatable_scenarios += 1
+            else:
+                status = stage["status"]
+                automatable_scenarios += 1
+            scenario_evidence.append({**scenario, "evidence_status": status})
+        statuses = {scenario["evidence_status"] for scenario in scenario_evidence}
+        if "failed" in statuses:
+            journey_status = "failed"
+        elif "planned" in statuses or "not-selected" in statuses:
+            journey_status = "incomplete"
+        elif statuses == {"manual-release"}:
+            journey_status = "manual-release"
+        else:
+            journey_status = "passed"
+        journey_evidence.append({**journey, "status": journey_status, "scenario_evidence": scenario_evidence})
+    durations = [stage["duration_seconds"] for stage in stages]
+    trends = collect_trends(result_root, run_dir)
+    trend_walls = [trend["wall_seconds"] for trend in trends]
+    slowest = max(stages, key=lambda stage: stage["duration_seconds"], default=None)
+    return {
+        "schema": 1,
+        "run": {
+            "id": run_dir.name,
+            "commit": manifest["source_commit"],
+            "fingerprint": manifest["fingerprint"],
+            "policy": int(manifest["policy"]),
+            "authority": manifest["authority"],
+            "mode": manifest["mode"],
+            "result": manifest["result"],
+            "started_at": manifest["started_at"],
+            "finished_at": manifest["finished_at"],
+            "duration_seconds": int(manifest["duration_seconds"]),
+            "wall_seconds": int(manifest["timing_wall_seconds"]),
+            "url": run_url,
+        },
+        "capabilities": split_csv(manifest["capabilities"]),
+        "journeys": journey_evidence,
+        "stages": stages,
+        "quality": {
+            "passed_scenarios": passed_scenarios,
+            "automatable_scenarios": automatable_scenarios,
+            "planned_scenarios": planned_scenarios,
+            "manual_release_scenarios": manual_scenarios,
+            "scenario_percent": round(100 * passed_scenarios / automatable_scenarios)
+            if automatable_scenarios else 0,
+            "slowest_stage": slowest["stage"] if slowest else "-",
+            "slowest_stage_seconds": slowest["duration_seconds"] if slowest else 0,
+            "stage_duration_p50_seconds": round(statistics.median(durations)) if durations else 0,
+            "run_wall_p50_seconds": percentile(trend_walls, 50),
+            "run_wall_p95_seconds": percentile(trend_walls, 95),
+            "coverage": "not-yet-emitted",
+            "mutation": "not-yet-emitted",
+            "review": "not-yet-emitted",
+            "security": "not-yet-emitted",
+        },
+        "trends": trends,
+    }
+
+
+def status_class(status: str) -> str:
+    if status in ("passed", "reused"):
+        return "good"
+    if status in (
+        "planned", "not-selected", "incomplete", "manual-release", "blocked", "diagnostic"
+    ):
+        return "warn"
+    return "bad"
+
+
+def render_html(data: dict[str, Any]) -> str:
+    run = data["run"]
+    quality = data["quality"]
+    overall_class = (
+        "good" if run["result"] == "passed" else "warn" if run["result"] == "diagnostic" else "bad"
+    )
+    authority_label = html.escape(run["authority"])
+    run_link = (
+        f'<a href="{html.escape(run["url"], quote=True)}">Open exact CI run</a>'
+        if run["url"] else "Local evidence"
+    )
+    stage_rows = "\n".join(
+        f'<tr><td><code>{html.escape(stage["stage"])}</code></td>'
+        f'<td><span class="status {status_class(stage["status"])}">{html.escape(stage["status"])}</span></td>'
+        f'<td class="number">{stage["duration_seconds"]}</td>'
+        f'<td><code>{html.escape(stage["log"])}</code></td></tr>'
+        for stage in data["stages"]
+    )
+    journey_sections = "\n".join(
+        '<article class="journey">'
+        f'<div><span class="eyebrow">{html.escape(journey["capability"])}</span>'
+        f'<h3>{html.escape(journey["id"])}</h3>'
+        f'<p>{html.escape(journey["summary"])}</p></div>'
+        f'<span class="status {status_class(journey["status"])}">{html.escape(journey["status"])}</span>'
+        '<ul>'
+        + "".join(
+            f'<li><code>{html.escape(scenario["id"])}</code>'
+            f'<span>{html.escape(scenario["evidence_status"])}</span></li>'
+            for scenario in journey["scenario_evidence"]
+        )
+        + '</ul></article>'
+        for journey in data["journeys"]
+    ) or '<p class="empty">No user journey impact was recorded for this diagnostic stage.</p>'
+    trend_rows = "\n".join(
+        f'<tr><td><code>{html.escape(trend["commit"][:10])}</code></td>'
+        f'<td>{html.escape(trend["authority"])}</td>'
+        f'<td><span class="status {status_class(trend["result"])}">{html.escape(trend["result"])}</span></td>'
+        f'<td class="number">{trend["wall_seconds"]}</td><td>{html.escape(trend["finished_at"])}</td></tr>'
+        for trend in reversed(data["trends"])
+    ) or '<tr><td colspan="5">No retained trend evidence.</td></tr>'
+    capability_text = ", ".join(data["capabilities"]) or "none"
+    return f'''<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <title>Detach quality — {html.escape(run["result"])}</title>
+  <style>
+    :root {{ --paper:#f3f0e8; --ink:#17211f; --muted:#62706b; --line:#c8cec8; --panel:#fffdf7; --accent:#d85b32; --good:#176b4b; --warn:#9a5b08; --bad:#a83232; }}
+    * {{ box-sizing:border-box; }}
+    body {{ margin:0; background:var(--paper); color:var(--ink); font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }}
+    a {{ color:var(--ink); text-underline-offset:3px; }}
+    code,.number {{ font-family:"SFMono-Regular",Consolas,monospace; }}
+    header,main,footer {{ width:min(1180px,calc(100% - 32px)); margin:auto; }}
+    header {{ padding:38px 0 24px; border-bottom:2px solid var(--ink); display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; }}
+    h1 {{ margin:3px 0 0; font-size:clamp(28px,5vw,58px); letter-spacing:-.045em; line-height:1; }}
+    h2 {{ margin:0 0 18px; font-size:22px; }} h3 {{ margin:3px 0 6px; font-size:16px; }} p {{ margin:0; }}
+    .eyebrow {{ color:var(--muted); font:700 11px/1.2 "SFMono-Regular",monospace; letter-spacing:.11em; text-transform:uppercase; }}
+    .hero-status {{ text-align:right; }} .hero-status strong {{ display:block; font:700 22px/1.2 "SFMono-Regular",monospace; color:var(--{overall_class}); }}
+    main {{ padding:24px 0 48px; }}
+    .metrics {{ display:grid; grid-template-columns:repeat(5,minmax(0,1fr)); border:1px solid var(--line); background:var(--panel); }}
+    .metric {{ padding:18px; border-right:1px solid var(--line); }} .metric:last-child {{ border:0; }} .metric strong {{ display:block; margin-top:5px; font-size:25px; }}
+    section {{ margin-top:30px; }}
+    .meta {{ display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px 24px; padding:18px 0; border-bottom:1px solid var(--line); }}
+    .meta div {{ min-width:0; }} .meta code {{ overflow-wrap:anywhere; }}
+    .status {{ font:700 11px/1 "SFMono-Regular",monospace; letter-spacing:.04em; text-transform:uppercase; }}
+    .status.good {{ color:var(--good); }} .status.warn {{ color:var(--warn); }} .status.bad {{ color:var(--bad); }}
+    .table-wrap {{ overflow:auto; border:1px solid var(--line); background:var(--panel); }}
+    table {{ width:100%; border-collapse:collapse; }} th,td {{ padding:11px 13px; text-align:left; border-bottom:1px solid var(--line); white-space:nowrap; }} th {{ color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.07em; }} tr:last-child td {{ border-bottom:0; }} .number {{ text-align:right; }}
+    .journeys {{ display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px; }}
+    .journey {{ display:grid; grid-template-columns:1fr auto; gap:16px; padding:17px; background:var(--panel); border:1px solid var(--line); border-top:3px solid var(--accent); }}
+    .journey ul {{ grid-column:1/-1; list-style:none; margin:4px 0 0; padding:0; border-top:1px solid var(--line); }}
+    .journey li {{ display:flex; justify-content:space-between; gap:12px; padding:7px 0; border-bottom:1px solid var(--line); }} .journey li:last-child {{ border:0; }}
+    .gaps {{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; background:var(--line); border:1px solid var(--line); }} .gap {{ padding:14px; background:var(--panel); }}
+    .empty {{ padding:20px; border:1px dashed var(--line); }}
+    footer {{ padding:20px 0 36px; border-top:1px solid var(--line); color:var(--muted); }}
+    #freshness.stale {{ color:var(--bad); font-weight:700; }}
+    @media (max-width:850px) {{ .metrics {{ grid-template-columns:repeat(2,1fr); }} .metric {{ border-bottom:1px solid var(--line); }} .journeys {{ grid-template-columns:1fr; }} .gaps {{ grid-template-columns:repeat(2,1fr); }} }}
+    @media (max-width:560px) {{ header {{ grid-template-columns:1fr; }} .hero-status {{ text-align:left; }} .metrics,.meta,.gaps {{ grid-template-columns:1fr; }} .metric {{ border-right:0; }} }}
+    @media (prefers-reduced-motion:reduce) {{ * {{ scroll-behavior:auto!important; }} }}
+  </style>
+</head>
+<body>
+  <header>
+    <div><span class="eyebrow">Quality control / policy {run["policy"]}</span><h1>Detach run evidence</h1></div>
+    <div class="hero-status"><span class="eyebrow">{authority_label}</span><strong>{html.escape(run["result"]).upper()}</strong>{run_link}</div>
+  </header>
+  <main>
+    <section class="metrics" aria-label="Run summary">
+      <div class="metric"><span class="eyebrow">Wall time</span><strong>{run["wall_seconds"]}s</strong></div>
+      <div class="metric"><span class="eyebrow">Scenario evidence</span><strong>{quality["scenario_percent"]}%</strong></div>
+      <div class="metric"><span class="eyebrow">Verified scenarios</span><strong>{quality["passed_scenarios"]}/{quality["automatable_scenarios"]}</strong></div>
+      <div class="metric"><span class="eyebrow">Planned gaps</span><strong>{quality["planned_scenarios"]}</strong></div>
+      <div class="metric"><span class="eyebrow">Run p95</span><strong>{quality["run_wall_p95_seconds"]}s</strong></div>
+    </section>
+    <div class="meta">
+      <div><span class="eyebrow">Commit</span><br><code>{html.escape(run["commit"])}</code></div>
+      <div><span class="eyebrow">Fingerprint</span><br><code>{html.escape(run["fingerprint"])}</code></div>
+      <div><span class="eyebrow">Capabilities</span><br>{html.escape(capability_text)}</div>
+      <div><span class="eyebrow">Freshness</span><br><span id="freshness" data-finished="{html.escape(run["finished_at"], quote=True)}">{html.escape(run["finished_at"])}</span></div>
+    </div>
+    <section><h2>Stages</h2><div class="table-wrap"><table><thead><tr><th>Stage</th><th>Status</th><th class="number">Seconds</th><th>Log</th></tr></thead><tbody>{stage_rows}</tbody></table></div></section>
+    <section><h2>User journeys</h2><div class="journeys">{journey_sections}</div></section>
+    <section><h2>Evidence still to add</h2><div class="gaps">
+      <div class="gap"><span class="eyebrow">Coverage</span><p>{quality["coverage"]}</p></div>
+      <div class="gap"><span class="eyebrow">Mutation</span><p>{quality["mutation"]}</p></div>
+      <div class="gap"><span class="eyebrow">Agent review</span><p>{quality["review"]}</p></div>
+      <div class="gap"><span class="eyebrow">Security</span><p>{quality["security"]}</p></div>
+    </div></section>
+    <section><h2>Recent runs</h2><div class="table-wrap"><table><thead><tr><th>Commit</th><th>Authority</th><th>Result</th><th class="number">Wall</th><th>Finished</th></tr></thead><tbody>{trend_rows}</tbody></table></div></section>
+  </main>
+  <footer>Generated from digest-bound quality evidence. No result is inferred from terminal text.</footer>
+  <script>
+    (() => {{ const node=document.getElementById('freshness'); const finished=Date.parse(node.dataset.finished); if (!Number.isFinite(finished)) return; const hours=(Date.now()-finished)/36e5; if (hours>24) {{ node.classList.add('stale'); node.textContent=`STALE · ${{Math.floor(hours)}}h · ${{node.dataset.finished}}`; }} }})();
+  </script>
+</body>
+</html>
+'''
+
+
+def atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.is_symlink():
+        raise DashboardError(f"output target is a symlink: {path}")
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_bytes(content)
+    os.chmod(temporary, 0o644)
+    os.replace(temporary, path)
+
+
+def generate(arguments: argparse.Namespace) -> int:
+    result_root = arguments.result_root.resolve()
+    run_dir = arguments.run.resolve() if arguments.run else latest_run(result_root)
+    if run_dir.parent != result_root:
+        raise DashboardError("run must be directly under the selected result root")
+    data = build_data(run_dir, result_root, arguments.run_url)
+    output = arguments.output.resolve()
+    if output == Path("/") or output == ROOT:
+        raise DashboardError("dashboard output path is too broad")
+    rendered_data = (json.dumps(data, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    rendered_html = render_html(data).encode("utf-8")
+    atomic_write(output / "data.json", rendered_data)
+    atomic_write(output / "index.html", rendered_html)
+    print(f"quality-dashboard: generated {output / 'index.html'}")
+    return 0
+
+
+def serve(arguments: argparse.Namespace) -> int:
+    root = arguments.directory.resolve()
+    safe_file(root / "index.html", "dashboard index")
+    if arguments.seconds < 1 or arguments.seconds > 3600:
+        raise DashboardError("serve timeout must be from 1 to 3600 seconds")
+    handler = lambda *args, **kwargs: SimpleHTTPRequestHandler(  # noqa: E731
+        *args, directory=str(root), **kwargs
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", arguments.port), handler)
+    timer = threading.Timer(arguments.seconds, server.shutdown)
+    timer.daemon = True
+    timer.start()
+    host, port = server.server_address
+    print(f"quality-dashboard: http://{host}:{port}/ (stops after {arguments.seconds}s)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        timer.cancel()
+        server.server_close()
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    command_parser = argparse.ArgumentParser(prog="scripts/quality-dashboard")
+    commands = command_parser.add_subparsers(dest="command", required=True)
+    generate_parser = commands.add_parser("generate", help="generate static dashboard files")
+    generate_parser.add_argument("--result-root", type=Path, default=DEFAULT_RESULT_ROOT)
+    generate_parser.add_argument("--run", type=Path)
+    generate_parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    generate_parser.add_argument("--run-url", default="")
+    generate_parser.set_defaults(function=generate)
+    serve_parser = commands.add_parser("serve", help="serve a generated dashboard for a bounded time")
+    serve_parser.add_argument("--directory", type=Path, default=DEFAULT_OUTPUT)
+    serve_parser.add_argument("--port", type=int, default=8765)
+    serve_parser.add_argument("--seconds", type=int, default=300)
+    serve_parser.set_defaults(function=serve)
+    return command_parser
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    return arguments.function(arguments)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DashboardError as error:
+        fail(str(error))

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Validate and query Detach's single quality-policy manifest."""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Iterable, NoReturn
+
+
+ROOT = Path(__file__).resolve().parent.parent
+POLICY_FILE = Path(os.environ.get("DETACH_QUALITY_POLICY", ROOT / "quality/policy.tsv"))
+IDENTIFIER = re.compile(r"^[a-z0-9-]+$")
+LIMIT_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+ROUTE_PATTERN = re.compile(r"^[A-Za-z0-9_.*\/-]+$")
+SPEC_PATH = re.compile(r"^docs/specs/[a-z0-9-]+\.md$")
+SOURCE_PATH = re.compile(r"^app/Sources/[A-Za-z0-9_./-]+\.swift$")
+REQUIREMENT_ID = re.compile(r"^QC-[A-Z0-9-]+$")
+JOURNEY_ID = re.compile(r"^J-[A-Z0-9-]+$")
+SCENARIO_ID = re.compile(r"^SC-[A-Z0-9-]+$")
+POSITIVE_INTEGER = re.compile(r"^[1-9][0-9]*$")
+NUMBER = re.compile(r"^[0-9]+(?:\.[0-9]+)?$")
+
+
+class PolicyError(Exception):
+    """A fail-closed policy validation or query error."""
+
+
+@dataclass(frozen=True)
+class Stage:
+    order: int
+    name: str
+    timeout: int
+    release: bool
+
+
+@dataclass(frozen=True)
+class Route:
+    priority: int
+    pattern: str
+    test_domain: str
+    release_domain: str
+    spec: str
+
+
+@dataclass(frozen=True)
+class Classification:
+    status: str
+    test_domain: str
+    release_domain: str
+    spec: str
+    stages: str
+    release_gates: str
+    unknown: bool
+    pattern: str
+    priority: int
+    capabilities: str
+    journeys: str
+
+    def tsv(self) -> str:
+        return "\t".join(
+            (
+                self.status,
+                self.test_domain,
+                self.release_domain,
+                self.spec,
+                self.stages,
+                self.release_gates,
+                str(self.unknown).lower(),
+                self.pattern,
+                str(self.priority),
+                self.capabilities,
+                self.journeys,
+            )
+        )
+
+
+class Policy:
+    def __init__(self, path: Path) -> None:
+        if not path.is_file() or path.is_symlink():
+            raise PolicyError("policy must be a regular, non-symlink file")
+        self.path = path
+        self.schema: int | None = None
+        self.version: int | None = None
+        self.limits: dict[str, int] = {}
+        self.stages_by_name: dict[str, Stage] = {}
+        self.stage_orders: set[int] = set()
+        self.dependencies: list[tuple[str, str]] = []
+        self.test_domains: dict[str, tuple[str, str]] = {}
+        self.release_domains: dict[str, tuple[str, bool]] = {}
+        self.routes: list[Route] = []
+        self.capabilities: dict[str, tuple[str, str, str]] = {}
+        self.journeys: dict[str, tuple[str, str, str, str]] = {}
+        self.scenarios: dict[str, tuple[str, str, str]] = {}
+        self.critical: list[tuple[str, str, str]] = []
+        self.requirements: dict[str, tuple[str, str]] = {}
+        self._parse()
+        self._validate_references()
+
+    @property
+    def stages(self) -> list[Stage]:
+        return sorted(self.stages_by_name.values(), key=lambda stage: stage.order)
+
+    @property
+    def all_stages_csv(self) -> str:
+        return ",".join(stage.name for stage in self.stages)
+
+    @staticmethod
+    def _csv(value: str, *, allow_dash: bool = False) -> bool:
+        if allow_dash and value == "-":
+            return True
+        names = value.split(",")
+        return bool(names) and all(IDENTIFIER.fullmatch(name) for name in names)
+
+    @staticmethod
+    def _boolean(value: str, line: int) -> bool:
+        if value not in ("true", "false"):
+            raise PolicyError(f"line {line}: expected true or false")
+        return value == "true"
+
+    @staticmethod
+    def _unique(mapping: dict[str, object], key: str, label: str, line: int) -> None:
+        if key in mapping:
+            raise PolicyError(f"line {line}: duplicate {label}: {key}")
+
+    def _parse(self) -> None:
+        try:
+            lines = self.path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as error:
+            raise PolicyError(f"cannot read policy: {error}") from error
+        if not lines:
+            raise PolicyError("policy is empty")
+        critical_paths: set[str] = set()
+        dependency_pairs: set[tuple[str, str]] = set()
+        for line_number, line in enumerate(lines, 1):
+            if not line:
+                raise PolicyError(f"line {line_number}: blank records are not allowed")
+            fields = line.split("\t")
+            kind = fields[0]
+            values = fields[1:]
+            if kind == "schema":
+                self._expect_count(kind, values, 1, line_number)
+                if self.schema is not None or values[0] != "1":
+                    raise PolicyError(f"line {line_number}: schema must occur once and equal 1")
+                self.schema = 1
+            elif kind == "policy":
+                self._expect_count(kind, values, 1, line_number)
+                if self.version is not None or not POSITIVE_INTEGER.fullmatch(values[0]):
+                    raise PolicyError(f"line {line_number}: policy must be one positive integer")
+                self.version = int(values[0])
+            elif kind == "limit":
+                self._expect_count(kind, values, 2, line_number)
+                name, raw_value = values
+                if not LIMIT_NAME.fullmatch(name) or not POSITIVE_INTEGER.fullmatch(raw_value):
+                    raise PolicyError(f"line {line_number}: invalid limit")
+                self._unique(self.limits, name, "limit", line_number)
+                self.limits[name] = int(raw_value)
+            elif kind == "stage":
+                self._expect_count(kind, values, 4, line_number)
+                raw_order, name, raw_timeout, raw_release = values
+                if (
+                    not POSITIVE_INTEGER.fullmatch(raw_order)
+                    or not IDENTIFIER.fullmatch(name)
+                    or not POSITIVE_INTEGER.fullmatch(raw_timeout)
+                ):
+                    raise PolicyError(f"line {line_number}: invalid stage")
+                order = int(raw_order)
+                self._unique(self.stages_by_name, name, "stage", line_number)
+                if order in self.stage_orders:
+                    raise PolicyError(f"line {line_number}: duplicate stage order: {order}")
+                self.stage_orders.add(order)
+                self.stages_by_name[name] = Stage(
+                    order, name, int(raw_timeout), self._boolean(raw_release, line_number)
+                )
+            elif kind == "dependency":
+                self._expect_count(kind, values, 2, line_number)
+                pair = (values[0], values[1])
+                if not all(IDENTIFIER.fullmatch(name) for name in pair) or pair in dependency_pairs:
+                    raise PolicyError(f"line {line_number}: invalid or duplicate dependency")
+                dependency_pairs.add(pair)
+                self.dependencies.append(pair)
+            elif kind == "test-domain":
+                self._expect_count(kind, values, 3, line_number)
+                name, stages, capabilities = values
+                if (
+                    not IDENTIFIER.fullmatch(name)
+                    or not (stages == "*" or self._csv(stages))
+                    or not (capabilities == "*" or self._csv(capabilities))
+                ):
+                    raise PolicyError(f"line {line_number}: invalid test domain")
+                self._unique(self.test_domains, name, "test domain", line_number)
+                self.test_domains[name] = (stages, capabilities)
+            elif kind == "release-domain":
+                self._expect_count(kind, values, 3, line_number)
+                name, gates, raw_unknown = values
+                if not IDENTIFIER.fullmatch(name) or not self._csv(gates, allow_dash=True):
+                    raise PolicyError(f"line {line_number}: invalid release domain")
+                if gates != "-" and any(gate not in ("install", "lid") for gate in gates.split(",")):
+                    raise PolicyError(f"line {line_number}: unknown release gate")
+                self._unique(self.release_domains, name, "release domain", line_number)
+                self.release_domains[name] = (gates, self._boolean(raw_unknown, line_number))
+            elif kind == "route":
+                self._expect_count(kind, values, 5, line_number)
+                raw_priority, pattern, test_domain, release_domain, spec = values
+                if (
+                    not POSITIVE_INTEGER.fullmatch(raw_priority)
+                    or not ROUTE_PATTERN.fullmatch(pattern)
+                    or not IDENTIFIER.fullmatch(test_domain)
+                    or not IDENTIFIER.fullmatch(release_domain)
+                    or not SPEC_PATH.fullmatch(spec)
+                ):
+                    raise PolicyError(f"line {line_number}: invalid route")
+                self.routes.append(Route(int(raw_priority), pattern, test_domain, release_domain, spec))
+            elif kind == "capability":
+                self._expect_count(kind, values, 4, line_number)
+                identifier, spec, requirements, journeys = values
+                if (
+                    not IDENTIFIER.fullmatch(identifier)
+                    or not SPEC_PATH.fullmatch(spec)
+                    or not self._references(requirements, REQUIREMENT_ID, allow_dash=True)
+                    or not self._references(journeys, JOURNEY_ID)
+                ):
+                    raise PolicyError(f"line {line_number}: invalid capability")
+                self._unique(self.capabilities, identifier, "capability", line_number)
+                self.capabilities[identifier] = (spec, requirements, journeys)
+            elif kind == "journey":
+                self._expect_count(kind, values, 5, line_number)
+                identifier, capability, requirements, scenarios, summary = values
+                if (
+                    not JOURNEY_ID.fullmatch(identifier)
+                    or not IDENTIFIER.fullmatch(capability)
+                    or not self._references(requirements, REQUIREMENT_ID, allow_dash=True)
+                    or not self._references(scenarios, SCENARIO_ID)
+                    or not summary
+                ):
+                    raise PolicyError(f"line {line_number}: invalid journey")
+                self._unique(self.journeys, identifier, "journey", line_number)
+                self.journeys[identifier] = (capability, requirements, scenarios, summary)
+            elif kind == "scenario":
+                self._expect_count(kind, values, 4, line_number)
+                identifier, stage, status, command = values
+                if (
+                    not SCENARIO_ID.fullmatch(identifier)
+                    or not IDENTIFIER.fullmatch(stage)
+                    or status not in ("automated", "legacy-stage", "planned", "manual-release")
+                    or not command
+                ):
+                    raise PolicyError(f"line {line_number}: invalid scenario")
+                self._unique(self.scenarios, identifier, "scenario", line_number)
+                self.scenarios[identifier] = (stage, status, command)
+            elif kind == "critical":
+                self._expect_count(kind, values, 3, line_number)
+                source, requirement, floor = values
+                if (
+                    not SOURCE_PATH.fullmatch(source)
+                    or not REQUIREMENT_ID.fullmatch(requirement)
+                    or not NUMBER.fullmatch(floor)
+                    or float(floor) > 100
+                    or source in critical_paths
+                ):
+                    raise PolicyError(f"line {line_number}: invalid or duplicate critical source")
+                critical_paths.add(source)
+                self.critical.append((source, requirement, floor))
+            elif kind == "requirement":
+                self._expect_count(kind, values, 3, line_number)
+                identifier, spec, summary = values
+                if (
+                    not REQUIREMENT_ID.fullmatch(identifier)
+                    or not SPEC_PATH.fullmatch(spec)
+                    or not summary
+                ):
+                    raise PolicyError(f"line {line_number}: invalid requirement")
+                self._unique(self.requirements, identifier, "requirement", line_number)
+                self.requirements[identifier] = (spec, summary)
+            else:
+                raise PolicyError(f"line {line_number}: unsupported record: {kind}")
+
+    @staticmethod
+    def _expect_count(kind: str, values: list[str], expected: int, line: int) -> None:
+        if len(values) != expected:
+            raise PolicyError(f"line {line}: {kind} requires {expected} values")
+
+    @staticmethod
+    def _references(value: str, pattern: re.Pattern[str], *, allow_dash: bool = False) -> bool:
+        if allow_dash and value == "-":
+            return True
+        references = value.split(",")
+        return bool(references) and all(pattern.fullmatch(reference) for reference in references)
+
+    def _validate_references(self) -> None:
+        if self.schema != 1 or self.version is None:
+            raise PolicyError("schema and policy records are required")
+        if "static" not in self.stages_by_name:
+            raise PolicyError("static stage is required")
+        if "unknown" not in self.test_domains or "unknown" not in self.release_domains:
+            raise PolicyError("unknown test and release domains are required")
+        for prerequisite, dependent in self.dependencies:
+            if (
+                prerequisite not in self.stages_by_name
+                or dependent not in self.stages_by_name
+                or prerequisite == dependent
+            ):
+                raise PolicyError(f"unresolved dependency: {prerequisite} -> {dependent}")
+        for domain, (stages, capabilities) in self.test_domains.items():
+            if stages == "*":
+                pass
+            else:
+                for stage in stages.split(","):
+                    if stage not in self.stages_by_name:
+                        raise PolicyError(f"test domain {domain} references unknown stage: {stage}")
+            if capabilities != "*":
+                for capability in capabilities.split(","):
+                    if capability not in self.capabilities:
+                        raise PolicyError(
+                            f"test domain {domain} references unknown capability: {capability}"
+                        )
+        for route in self.routes:
+            if route.test_domain not in self.test_domains:
+                raise PolicyError(f"route references unknown test domain: {route.test_domain}")
+            if route.release_domain not in self.release_domains:
+                raise PolicyError(f"route references unknown release domain: {route.release_domain}")
+        for source, requirement, _ in self.critical:
+            if requirement not in self.requirements:
+                raise PolicyError(f"critical source {source} references unknown requirement: {requirement}")
+        referenced_requirements: set[str] = {requirement for _, requirement, _ in self.critical}
+        referenced_journeys: set[str] = set()
+        referenced_scenarios: set[str] = set()
+        for capability, (_, requirements, journeys) in self.capabilities.items():
+            if requirements != "-":
+                for requirement in requirements.split(","):
+                    if requirement not in self.requirements:
+                        raise PolicyError(
+                            f"capability {capability} references unknown requirement: {requirement}"
+                        )
+                    referenced_requirements.add(requirement)
+            for journey in journeys.split(","):
+                if journey not in self.journeys:
+                    raise PolicyError(f"capability {capability} references unknown journey: {journey}")
+                if self.journeys[journey][0] != capability:
+                    raise PolicyError(f"journey {journey} belongs to another capability")
+                referenced_journeys.add(journey)
+        for journey, (capability, requirements, scenarios, _) in self.journeys.items():
+            if capability not in self.capabilities:
+                raise PolicyError(f"journey {journey} references unknown capability: {capability}")
+            if requirements != "-":
+                for requirement in requirements.split(","):
+                    if requirement not in self.requirements:
+                        raise PolicyError(
+                            f"journey {journey} references unknown requirement: {requirement}"
+                        )
+                    referenced_requirements.add(requirement)
+            for scenario in scenarios.split(","):
+                if scenario not in self.scenarios:
+                    raise PolicyError(f"journey {journey} references unknown scenario: {scenario}")
+                referenced_scenarios.add(scenario)
+        for scenario, (stage, _, _) in self.scenarios.items():
+            if stage not in self.stages_by_name:
+                raise PolicyError(f"scenario {scenario} references unknown stage: {stage}")
+        orphan_journeys = set(self.journeys) - referenced_journeys
+        orphan_scenarios = set(self.scenarios) - referenced_scenarios
+        orphan_requirements = set(self.requirements) - referenced_requirements
+        if orphan_journeys:
+            raise PolicyError(f"orphan journey: {sorted(orphan_journeys)[0]}")
+        if orphan_scenarios:
+            raise PolicyError(f"orphan scenario: {sorted(orphan_scenarios)[0]}")
+        if orphan_requirements:
+            raise PolicyError(f"orphan requirement: {sorted(orphan_requirements)[0]}")
+
+    def classify(self, path: str) -> Classification:
+        matches = [route for route in self.routes if fnmatch.fnmatchcase(path, route.pattern)]
+        if not matches:
+            gates, unknown = self.release_domains["unknown"]
+            return Classification(
+                "unknown", "unknown", "unknown", "-", self.all_stages_csv,
+                gates, unknown, "-", 0, ",".join(self.capabilities), ",".join(self.journeys)
+            )
+        priority = max(route.priority for route in matches)
+        winners = [route for route in matches if route.priority == priority]
+        if len(winners) != 1:
+            raise PolicyError(f"path has {len(winners)} equal-priority routes: {path}")
+        route = winners[0]
+        stages, capabilities = self.test_domains[route.test_domain]
+        if stages == "*":
+            stages = self.all_stages_csv
+        if capabilities == "*":
+            capabilities = ",".join(self.capabilities)
+        selected_journeys: list[str] = []
+        for capability in capabilities.split(","):
+            for journey in self.capabilities[capability][2].split(","):
+                if journey not in selected_journeys:
+                    selected_journeys.append(journey)
+        gates, unknown = self.release_domains[route.release_domain]
+        return Classification(
+            "known", route.test_domain, route.release_domain, route.spec, stages,
+            gates, unknown, route.pattern, route.priority, capabilities,
+            ",".join(selected_journeys)
+        )
+
+    def tracked_paths(self) -> Iterable[str]:
+        try:
+            result = subprocess.run(
+                (
+                    "git", "-C", str(ROOT), "ls-files", "-z", "--cached", "--others",
+                    "--exclude-standard",
+                ),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as error:
+            raise PolicyError(f"cannot list repository paths: {error}") from error
+        for raw_path in result.stdout.split(b"\0"):
+            if raw_path:
+                yield os.fsdecode(raw_path)
+
+    def validate_tracked_paths(self) -> None:
+        for path in self.tracked_paths():
+            classification = self.classify(path)
+            if classification.status != "known":
+                raise PolicyError(f"unclassified tracked path: {path}")
+
+    def document(self) -> dict[str, object]:
+        return {
+            "schema": self.schema,
+            "policy": self.version,
+            "limits": self.limits,
+            "stages": [
+                {
+                    "order": stage.order,
+                    "name": stage.name,
+                    "timeout_seconds": stage.timeout,
+                    "release": stage.release,
+                }
+                for stage in self.stages
+            ],
+            "dependencies": [
+                {"prerequisite": prerequisite, "dependent": dependent}
+                for prerequisite, dependent in self.dependencies
+            ],
+            "test_domains": [
+                {"id": identifier, "stages": stages, "capabilities": capabilities}
+                for identifier, (stages, capabilities) in self.test_domains.items()
+            ],
+            "release_domains": [
+                {"id": identifier, "gates": gates, "unknown": unknown}
+                for identifier, (gates, unknown) in self.release_domains.items()
+            ],
+            "routes": [
+                {
+                    "priority": route.priority,
+                    "pattern": route.pattern,
+                    "test_domain": route.test_domain,
+                    "release_domain": route.release_domain,
+                    "spec": route.spec,
+                }
+                for route in self.routes
+            ],
+            "capabilities": [
+                {
+                    "id": identifier,
+                    "spec": spec,
+                    "requirements": self._list_or_empty(requirements),
+                    "journeys": journeys.split(","),
+                }
+                for identifier, (spec, requirements, journeys) in self.capabilities.items()
+            ],
+            "journeys": [
+                {
+                    "id": identifier,
+                    "capability": capability,
+                    "requirements": self._list_or_empty(requirements),
+                    "scenarios": scenarios.split(","),
+                    "summary": summary,
+                }
+                for identifier, (capability, requirements, scenarios, summary) in self.journeys.items()
+            ],
+            "scenarios": [
+                {
+                    "id": identifier,
+                    "stage": stage,
+                    "status": status,
+                    "command": command,
+                }
+                for identifier, (stage, status, command) in self.scenarios.items()
+            ],
+            "critical_sources": [
+                {"path": path, "requirement": requirement, "coverage_floor": float(floor)}
+                for path, requirement, floor in self.critical
+            ],
+            "requirements": [
+                {"id": identifier, "spec": spec, "summary": summary}
+                for identifier, (spec, summary) in self.requirements.items()
+            ],
+        }
+
+    @staticmethod
+    def _list_or_empty(value: str) -> list[str]:
+        return [] if value == "-" else value.split(",")
+
+
+def usage(stream: object = sys.stdout) -> None:
+    print(
+        """usage: scripts/quality-policy validate
+       scripts/quality-policy version
+       scripts/quality-policy stages all|release
+       scripts/quality-policy timeout STAGE
+       scripts/quality-policy dependencies
+       scripts/quality-policy classify PATH
+       scripts/quality-policy critical
+       scripts/quality-policy requirements
+       scripts/quality-policy capabilities
+       scripts/quality-policy journeys
+       scripts/quality-policy scenarios
+       scripts/quality-policy render-json
+       scripts/quality-policy generate [--check]
+       scripts/quality-policy check-paths [PATH ...]""",
+        file=stream,
+    )
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-policy: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def require_count(arguments: list[str], expected: int, message: str) -> None:
+    if len(arguments) != expected:
+        raise PolicyError(message)
+
+
+def main(arguments: list[str]) -> int:
+    if not arguments:
+        usage(sys.stderr)
+        return 2
+    command, *values = arguments
+    if command in ("-h", "--help", "help"):
+        usage()
+        return 0
+    policy = Policy(POLICY_FILE)
+    if command == "validate":
+        require_count(values, 0, "validate takes no arguments")
+        policy.validate_tracked_paths()
+        print("Quality policy is valid")
+    elif command == "version":
+        require_count(values, 0, "version takes no arguments")
+        print(policy.version)
+    elif command == "stages":
+        require_count(values, 1, "stages requires all or release")
+        if values[0] not in ("all", "release"):
+            raise PolicyError("stages requires all or release")
+        for stage in policy.stages:
+            if values[0] == "all" or stage.release:
+                print(stage.name)
+    elif command == "timeout":
+        require_count(values, 1, "timeout requires one stage")
+        stage = policy.stages_by_name.get(values[0])
+        if stage is None:
+            raise PolicyError(f"unknown stage: {values[0]}")
+        print(stage.timeout)
+    elif command == "dependencies":
+        require_count(values, 0, "dependencies takes no arguments")
+        for prerequisite, dependent in policy.dependencies:
+            print(f"{prerequisite}\t{dependent}")
+    elif command == "classify":
+        require_count(values, 1, "classify requires one path")
+        print(policy.classify(values[0]).tsv())
+    elif command == "critical":
+        require_count(values, 0, "critical takes no arguments")
+        for source, requirement, floor in policy.critical:
+            print(f"{source}\t{requirement}\t{floor}")
+    elif command == "requirements":
+        require_count(values, 0, "requirements takes no arguments")
+        for identifier, (spec, summary) in policy.requirements.items():
+            print(f"{identifier}\t{spec}\t{summary}")
+    elif command == "capabilities":
+        require_count(values, 0, "capabilities takes no arguments")
+        for identifier, (spec, requirements, journeys) in policy.capabilities.items():
+            print(f"{identifier}\t{spec}\t{requirements}\t{journeys}")
+    elif command == "journeys":
+        require_count(values, 0, "journeys takes no arguments")
+        for identifier, (capability, requirements, scenarios, summary) in policy.journeys.items():
+            print(f"{identifier}\t{capability}\t{requirements}\t{scenarios}\t{summary}")
+    elif command == "scenarios":
+        require_count(values, 0, "scenarios takes no arguments")
+        for identifier, (stage, status, scenario_command) in policy.scenarios.items():
+            print(f"{identifier}\t{stage}\t{status}\t{scenario_command}")
+    elif command == "render-json":
+        require_count(values, 0, "render-json takes no arguments")
+        print(json.dumps(policy.document(), indent=2, sort_keys=True))
+    elif command == "generate":
+        if values not in ([], ["--check"]):
+            raise PolicyError("generate accepts only --check")
+        target = ROOT / "quality/generated/policy.json"
+        rendered = json.dumps(policy.document(), indent=2, sort_keys=True) + "\n"
+        if values == ["--check"]:
+            if not target.is_file() or target.is_symlink():
+                raise PolicyError("generated policy view is missing or unsafe")
+            if target.read_text(encoding="utf-8") != rendered:
+                raise PolicyError(
+                    "generated policy view is stale; run scripts/quality-policy generate"
+                )
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists() and target.is_symlink():
+                raise PolicyError("generated policy view target is a symlink")
+            temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+            temporary.write_text(rendered, encoding="utf-8")
+            os.chmod(temporary, 0o644)
+            os.replace(temporary, target)
+    elif command == "check-paths":
+        if values:
+            for path in values:
+                policy.classify(path)
+        else:
+            policy.validate_tracked_paths()
+    else:
+        usage(sys.stderr)
+        raise PolicyError(f"unknown command: {command}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except PolicyError as error:
+        fail(str(error))


### PR DESCRIPTION
## Outcome
- make one typed policy own test impact, release impact, timeouts, critical sources, requirements, capabilities, journeys, and scenarios
- keep local gates diagnostic while pull-request CI runs the full repository matrix once with ci-merge authority
- generate a deterministic local quality dashboard and deploy green main evidence to GitHub Pages
- pin every Action used by the quality workflow to an immutable commit

## Focused local evidence
- quality policy, dashboard, documentation, test-suite, ratchet, shell-safety, release-impact, and release-workflow contracts passed
- packaged UI diagnostic passed outside the declared managed-sandbox limitation
- static stage returned to 1s without raising its 2s ceiling
- git diff --check and generated-policy drift check passed

No real power test, signing, notarization, tagging, upload, publication, or release was run.