### PR TITLE
Drop historical quality policy decoder

### DIFF
--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -502,7 +502,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 15,
+  "policy": 16,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	15
+policy	16
 limit	pr_feedback_seconds	600
 limit	local_feedback_seconds	120
 limit	review_seconds	180

--- a/tests/quality_metrics_contract.py
+++ b/tests/quality_metrics_contract.py
@@ -404,39 +404,6 @@ def main() -> None:
         )
         require_text(old_floor_only, "has no quality metrics")
 
-        write_json(changed, {})
-        historical_metrics = root / "historical-policy-14.json"
-        historical_document = json.loads(original_metrics)
-        historical_document["policy"] = 14
-        historical_document["comparison"]["baseline_policy"] = 13
-        historical_document["comparison"]["baseline_source_commit"] = "c" * 40
-        historical_document["comparison"]["mode"] = "policy-13-bootstrap"
-        historical_document["comparison"]["status"] = "passed"
-        write_json(historical_metrics, historical_document)
-        historical_root = root / "historical-policy-14"
-        create_baseline(
-            historical_root,
-            historical_metrics,
-            manifest_policy=14,
-        )
-        historical = root / "historical-result.json"
-        invoke(
-            evaluate_arguments(
-                coverage,
-                tests,
-                historical,
-                changed,
-                baseline=historical_root,
-                authority="ci-merge",
-            )
-        )
-        historical_result = json.loads(historical.read_text(encoding="utf-8"))
-        if (
-            historical_result["comparison"]["mode"] != "green-main-artifact"
-            or historical_result["comparison"]["baseline_policy"] != 14
-        ):
-            raise AssertionError("historical policy-14 metrics were not used as measured facts")
-
         removed_bootstrap_flag = invoke(
             [
                 *evaluate_arguments(
@@ -468,7 +435,7 @@ def main() -> None:
         legacy_path = root / "legacy-mode.json"
         write_json(legacy_path, legacy_mode)
         legacy_result = invoke(["validate", str(legacy_path)], expected=2)
-        require_text(legacy_result, "historical bootstrap policy is invalid")
+        require_text(legacy_result, "comparison baseline is invalid")
 
     print("Quality metrics contracts passed")
 

--- a/tools/quality_metrics.py
+++ b/tools/quality_metrics.py
@@ -452,7 +452,7 @@ def validate_metrics(document: Any, *, expected_policy: Optional[int] = None) ->
         not isinstance(baseline_policy, int)
         or baseline_policy < 0
         or (baseline_source and not HEX_COMMIT.fullmatch(baseline_source))
-        or comparison["mode"] not in ("none", "green-main-artifact", "policy-13-bootstrap")
+        or comparison["mode"] not in ("none", "green-main-artifact")
     ):
         raise MetricsError("quality metrics comparison baseline is invalid")
     if comparison["mode"] == "none":
@@ -460,10 +460,6 @@ def validate_metrics(document: Any, *, expected_policy: Optional[int] = None) ->
             raise MetricsError("quality metrics no-baseline comparison is inconsistent")
     elif not baseline_source or baseline_policy <= 0:
         raise MetricsError("quality metrics baseline comparison is incomplete")
-    if comparison["mode"] == "policy-13-bootstrap" and (
-        document["policy"] != 14 or baseline_policy != 13
-    ):
-        raise MetricsError("quality metrics historical bootstrap policy is invalid")
     expected_comparison_status = (
         "not-available"
         if not baseline_source


### PR DESCRIPTION
Removes the one-step policy-14 metrics compatibility branch after the first strict policy-15 main artifact. Old bootstrap flags and modes remain only as negative inputs that current policy rejects.\n\nLocal impact-selected evidence: static 1s; gate-contract 72s.