### PR TITLE
Add scenario-addressable quality evidence

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -25,6 +25,10 @@ the only ordinary merge authority. Unknown paths select the full plan.
   `--resume latest` selects the newest compatible local run.
 - `scripts/quality-gate --stage <name>` reruns one diagnostic stage. It is not
   readiness evidence.
+- `scripts/quality-scenarios rerun SC-ID` runs the owning diagnostic stage for
+  an instrumented scenario, or its direct policy command otherwise. The owning
+  stage process deadline bounds both forms. The helper has 30 seconds for
+  evidence finalization and process-group cleanup.
 - `scripts/quality-history [RESULT_ROOT]` reports run and failure counts plus
   p50 and p95 wall and stage durations. It cannot produce readiness evidence.
 - `scripts/quality-dashboard generate` writes deterministic static HTML and
@@ -49,8 +53,11 @@ Every manifest records one authority:
 
 The repository gate writes private evidence under
 `app/build/quality-gates/`. One run contains a schema-versioned TSV summary,
-JUnit, Markdown, stage logs, safe environment facts, a provenance manifest,
-and a digest inventory. Coverage runs also contain `quality-metrics.json`.
+gate and scenario JUnit, scenario JSONL, Markdown, stage logs, safe environment
+facts, a provenance manifest, and a digest inventory. Coverage runs also
+contain `quality-metrics.json`. A failed scenario adds a bounded
+`repair-bundle.json` with its requirement and journey links, exact rerun, and
+at most the last 100 log lines.
 
 The manifest binds the evidence to the policy, authority, source and base
 commits, exact input and plan fingerprints, selected capabilities, journeys,
@@ -58,6 +65,12 @@ stages, timestamps, inherited timing, parent evidence, environment, artifacts,
 summary, and every stage log. A failure, timeout, interruption, blocked
 dependency, unsafe file, malformed record, or digest mismatch cannot produce
 PASS. Failure output gives the exact diagnostic rerun.
+
+An instrumented scenario writes one begin event and one pass event. Missing,
+duplicate, reordered, unknown, or cross-stage events fail closed. Legacy stage
+records remain explicit until the owning suite gets markers. Planned scenario
+records remain visible gaps. Only the supervised closed-lid release gate is
+manual because it needs physical evidence.
 
 Resume requires the same policy, authority, source commit, base commit, and
 input fingerprint. The old plan must contain every selected stage. Reused logs

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -42,6 +42,12 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - Resume evidence retains stage timing and digest-bound logs, binds its parent,
   requires the same authority, and cannot turn a prior time-budget regression
   into authoritative evidence.
+- Quality policy files contain only the current policy version and state. Git
+  is the policy history. Runtime tools do not keep migration decoders for old
+  policy schemas.
+- Instrumented user scenarios emit addressable begin and pass events. Gate
+  evidence records their requirement and journey links, duration, result, and
+  bounded rerun command. A passed stage with missing scenario events fails.
 - A local timing-budget failure creates performance work. Warm-cache or
   variance reruns cannot turn it into readiness; an unchanged rerun is allowed
   only for an evidenced unrelated external transient whose cause is recorded.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,6 +30,12 @@
   its policy, exact source/base commits, input fingerprint, and stage coverage
   still match. `--keep-going` improves diagnosis but never turns a failed or
   blocked stage into readiness evidence.
+- `scripts/quality-scenarios rerun SC-ID` runs the owning diagnostic stage for
+  an instrumented scenario, or its direct policy command otherwise. The stage
+  process deadline bounds both forms. The helper has 30 seconds for evidence
+  finalization and process-group cleanup. Instrumented suites also write
+  scenario-level durations. A monolithic legacy suite reports only stage
+  granularity until it gets scenario markers.
 - `scripts/quality-history [RESULT_ROOT]` reports p50/p95 wall and stage timing,
   ordinary failures, and execution-environment failures across retained local
   or downloaded gate evidence. It is telemetry, not readiness evidence.
@@ -53,21 +59,13 @@
   owner-confirmed `DETACH_RELEASE_IGNORE_TIMING=1 scripts/release-version X.Y.Z`
   path may omit them for one intentionally busy-machine release, with the
   waiver recorded in private evidence. `--stage` is diagnostic only and is not
-  proof that a change is ready. Policy 4 keeps SwiftPM work exclusive, then
-  runs the isolated Codex and Claude suites concurrently against the verified
-  bundled tmux and state helper. Policy 5 additionally rejects wall time above
-  180 seconds, individual stage regressions, and any attempt to lower quality
-  floors or raise time budgets relative to their merge-base values. Policy 6
-  adds the fast documentation/context contract to the existing static stage.
-  Policy 7 adds the mandatory packaged-app `ui-e2e` stage after every selected app
-  build, without raising the 180-second wall budget. Policy 8 makes resume
-  inherit timing and parent provenance, preserves bounded failure diagnostics,
-  classifies known execution-environment denials without weakening FAIL,
-  applies stage budgets to ordinary local partial plans, exempts only the
-  explicit GitHub-only budget-free plan, and raises the established UI floors.
-  Policy 9 adds contract-locked `critical`, `unit`, `coverage`, `smoke`, and
-  `full` operator entry points. Policy 10 adds the exact-owner-confirmed busy-machine
-  release timing waiver without removing any functional or hardware gate.
+  proof that a change is ready. The current policy keeps SwiftPM work
+  exclusive, then runs the isolated Codex and Claude suites concurrently
+  against the verified bundled tmux and state helper. It rejects reference-Mac
+  wall or stage regressions and rejects attempts to lower quality floors or
+  raise time budgets relative to their merge-base values. Resume inherits
+  timing and parent provenance. It preserves bounded failure diagnostics and
+  classifies known execution-environment denials without weakening FAIL.
 
 - `DETACH_TEST_TMUX_BIN="$PWD/app/build/Detach.app/Contents/Resources/DetachCLI/tmux" tests/run.sh`
   — hermetic Codex integration with a fake provider, private tmux
@@ -129,6 +127,14 @@ timing-policy ratchet, and `git diff --check`. Stdlib Python owns quality-gate
 planning, scheduling, evidence, and policy decisions. Shell entry points only
 locate Python. Behavioral shell integrations remain runtime evidence for shell
 products and macOS processes.
+
+Each selected stage writes scenario evidence to `scenarios.jsonl` and
+`scenarios.junit.xml`. Instrumented scenarios fail closed when their begin or
+pass event is missing. Failed scenario records also produce
+`repair-bundle.json`. The bundle contains requirement and journey links, the
+exact bounded rerun, and at most the last 100 log lines. Planned scenarios stay
+visible as gaps. The closed-lid scenario remains a supervised release-only
+gate because software automation cannot prove physical lid behavior.
 
 `tests/docs-contract.sh` is the focused check for agent instructions, durable
 specs, and the documentation workflow. It does not replace the selected gate.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -432,7 +432,8 @@
         "QC-APP-UPDATE"
       ],
       "scenarios": [
-        "SC-UPDATE-APPLY"
+        "SC-UPDATE-APPLY",
+        "SC-RELEASE-WORKFLOW"
       ],
       "summary": "A valid update preserves the arm64 and signature contract."
     },
@@ -454,7 +455,8 @@
         "QC-RELEASE-INSTALL"
       ],
       "scenarios": [
-        "SC-INSTALL-CLEAN"
+        "SC-INSTALL-CLEAN",
+        "SC-RUNTIME-PACKAGE"
       ],
       "summary": "A user installs one immutable self-contained payload."
     },
@@ -502,7 +504,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 17,
+  "policy": 18,
   "release_domains": [
     {
       "gates": "-",
@@ -684,6 +686,20 @@
     },
     {
       "pattern": "tools/quality_gate.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-scenarios",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_scenarios.py",
       "priority": 1000,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -1540,61 +1556,61 @@
       "command": "tests/run.sh",
       "id": "SC-SESSION-CREATE-CODEX",
       "stage": "codex",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run-claude.sh",
       "id": "SC-SESSION-CREATE-CLAUDE",
       "stage": "claude",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run.sh",
       "id": "SC-SESSION-PERSIST-CODEX",
       "stage": "codex",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run-claude.sh",
       "id": "SC-SESSION-PERSIST-CLAUDE",
       "stage": "claude",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run.sh",
       "id": "SC-SESSION-RECOVER-CODEX",
       "stage": "codex",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run-claude.sh",
       "id": "SC-SESSION-RECOVER-CLAUDE",
       "stage": "claude",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run.sh",
       "id": "SC-SESSION-STOP-CODEX",
       "stage": "codex",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run-claude.sh",
       "id": "SC-SESSION-STOP-CLAUDE",
       "stage": "claude",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run.sh",
       "id": "SC-SESSION-DELETE-CODEX",
       "stage": "codex",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/run-claude.sh",
       "id": "SC-SESSION-DELETE-CLAUDE",
       "stage": "claude",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "cd app && swift test --filter Power",
@@ -1624,13 +1640,13 @@
       "command": "tests/ui-e2e.sh",
       "id": "SC-UI-DASHBOARD",
       "stage": "ui-e2e",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/ui-e2e.sh",
       "id": "SC-UI-EMPTY",
       "stage": "ui-e2e",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "pending out-of-process UI journey",
@@ -1642,7 +1658,7 @@
       "command": "tests/ui-e2e.sh",
       "id": "SC-UI-FOCUS",
       "stage": "ui-e2e",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "pending out-of-process UI journey",
@@ -1672,43 +1688,55 @@
       "command": "tests/release-preflight.sh",
       "id": "SC-UPDATE-CHECK",
       "stage": "release-preflight",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/publish-preflight.sh",
       "id": "SC-UPDATE-APPLY",
       "stage": "publish-preflight",
-      "status": "legacy-stage"
+      "status": "instrumented"
+    },
+    {
+      "command": "tests/release-workflow.sh",
+      "id": "SC-RELEASE-WORKFLOW",
+      "stage": "release-workflow",
+      "status": "instrumented"
     },
     {
       "command": "tests/distribution.sh",
       "id": "SC-DOCTOR-REPORT",
       "stage": "distribution",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/distribution.sh",
       "id": "SC-INSTALL-CLEAN",
       "stage": "distribution",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/distribution.sh",
       "id": "SC-INSTALL-REPAIR",
       "stage": "distribution",
-      "status": "legacy-stage"
+      "status": "instrumented"
     },
     {
       "command": "tests/distribution.sh",
       "id": "SC-INSTALL-UNINSTALL",
       "stage": "distribution",
-      "status": "legacy-stage"
+      "status": "instrumented"
+    },
+    {
+      "command": "tests/tmux-runtime.sh",
+      "id": "SC-RUNTIME-PACKAGE",
+      "stage": "tmux-runtime",
+      "status": "instrumented"
     },
     {
       "command": "tests/publish-preflight.sh",
       "id": "SC-PUBLISH-CONTRACT",
       "stage": "publish-preflight",
-      "status": "legacy-stage"
+      "status": "instrumented"
     }
   ],
   "schema": 1,

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	17
+policy	18
 limit	pr_feedback_seconds	600
 limit	local_feedback_seconds	120
 limit	review_seconds	180
@@ -62,6 +62,8 @@ route	1000	docs/quality-gates.md	policy	safe	docs/specs/documentation.md
 route	1000	docs/testing.md	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-gate	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_gate.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-scenarios	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_scenarios.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-policy	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_policy.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-metrics	policy	safe	docs/specs/documentation.md
@@ -212,43 +214,45 @@ journey	J-ONBOARD-PROVIDER	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-PROVIDER	O
 journey	J-ONBOARD-APPROVAL	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-APPROVAL	Onboarding explains and observes required macOS approvals.
 journey	J-SETTINGS-CHANGE	settings	QC-APP-SETTINGS	SC-UI-SETTINGS	A user changes a setting and observes the persisted result.
 journey	J-UPDATE-CHECK	update	QC-APP-UPDATE	SC-UPDATE-CHECK	A user receives a typed update state.
-journey	J-UPDATE-APPLY	update	QC-APP-UPDATE	SC-UPDATE-APPLY	A valid update preserves the arm64 and signature contract.
+journey	J-UPDATE-APPLY	update	QC-APP-UPDATE	SC-UPDATE-APPLY,SC-RELEASE-WORKFLOW	A valid update preserves the arm64 and signature contract.
 journey	J-DOCTOR-REPORT	diagnostics	QC-APP-DOCTOR	SC-DOCTOR-REPORT	A user receives a typed actionable doctor report.
-journey	J-INSTALL-CLEAN	installation	QC-RELEASE-INSTALL	SC-INSTALL-CLEAN	A user installs one immutable self-contained payload.
+journey	J-INSTALL-CLEAN	installation	QC-RELEASE-INSTALL	SC-INSTALL-CLEAN,SC-RUNTIME-PACKAGE	A user installs one immutable self-contained payload.
 journey	J-INSTALL-REPAIR	installation	QC-RELEASE-INSTALL	SC-INSTALL-REPAIR	Repair restores the exact immutable payload.
 journey	J-INSTALL-UNINSTALL	installation	QC-RELEASE-INSTALL	SC-INSTALL-UNINSTALL	Uninstall removes only Detach-owned data selected by the user.
 journey	J-PUBLISH-ARTIFACTS	publication	QC-RELEASE-PUBLISH	SC-PUBLISH-CONTRACT	Publication exposes only verified allowlisted artifacts.
 scenario	SC-POLICY-CONTRACT	gate-contract	automated	tests/quality-policy.sh
 scenario	SC-DOCS-CONTRACT	static	automated	tests/docs-contract.sh
-scenario	SC-SESSION-CREATE-CODEX	codex	legacy-stage	tests/run.sh
-scenario	SC-SESSION-CREATE-CLAUDE	claude	legacy-stage	tests/run-claude.sh
-scenario	SC-SESSION-PERSIST-CODEX	codex	legacy-stage	tests/run.sh
-scenario	SC-SESSION-PERSIST-CLAUDE	claude	legacy-stage	tests/run-claude.sh
-scenario	SC-SESSION-RECOVER-CODEX	codex	legacy-stage	tests/run.sh
-scenario	SC-SESSION-RECOVER-CLAUDE	claude	legacy-stage	tests/run-claude.sh
-scenario	SC-SESSION-STOP-CODEX	codex	legacy-stage	tests/run.sh
-scenario	SC-SESSION-STOP-CLAUDE	claude	legacy-stage	tests/run-claude.sh
-scenario	SC-SESSION-DELETE-CODEX	codex	legacy-stage	tests/run.sh
-scenario	SC-SESSION-DELETE-CLAUDE	claude	legacy-stage	tests/run-claude.sh
+scenario	SC-SESSION-CREATE-CODEX	codex	instrumented	tests/run.sh
+scenario	SC-SESSION-CREATE-CLAUDE	claude	instrumented	tests/run-claude.sh
+scenario	SC-SESSION-PERSIST-CODEX	codex	instrumented	tests/run.sh
+scenario	SC-SESSION-PERSIST-CLAUDE	claude	instrumented	tests/run-claude.sh
+scenario	SC-SESSION-RECOVER-CODEX	codex	instrumented	tests/run.sh
+scenario	SC-SESSION-RECOVER-CLAUDE	claude	instrumented	tests/run-claude.sh
+scenario	SC-SESSION-STOP-CODEX	codex	instrumented	tests/run.sh
+scenario	SC-SESSION-STOP-CLAUDE	claude	instrumented	tests/run-claude.sh
+scenario	SC-SESSION-DELETE-CODEX	codex	instrumented	tests/run.sh
+scenario	SC-SESSION-DELETE-CLAUDE	claude	instrumented	tests/run-claude.sh
 scenario	SC-POWER-UNIT	swift	legacy-stage	cd app && swift test --filter Power
 scenario	SC-POWER-LOW-BATTERY	swift	legacy-stage	cd app && swift test --filter PowerProtection
 scenario	SC-POWER-HELPER	swift	legacy-stage	cd app && swift test --filter PowerHelper
 scenario	SC-POWER-CLOSED-LID	release-budget	manual-release	scripts/release-lid-probe
-scenario	SC-UI-DASHBOARD	ui-e2e	legacy-stage	tests/ui-e2e.sh
-scenario	SC-UI-EMPTY	ui-e2e	legacy-stage	tests/ui-e2e.sh
+scenario	SC-UI-DASHBOARD	ui-e2e	instrumented	tests/ui-e2e.sh
+scenario	SC-UI-EMPTY	ui-e2e	instrumented	tests/ui-e2e.sh
 scenario	SC-UI-FAILURE	ui-e2e	planned	pending out-of-process UI journey
-scenario	SC-UI-FOCUS	ui-e2e	legacy-stage	tests/ui-e2e.sh
+scenario	SC-UI-FOCUS	ui-e2e	instrumented	tests/ui-e2e.sh
 scenario	SC-UI-ONBOARD-FIRST-RUN	ui-e2e	planned	pending out-of-process UI journey
 scenario	SC-UI-ONBOARD-PROVIDER	ui-e2e	planned	pending out-of-process UI journey
 scenario	SC-UI-ONBOARD-APPROVAL	ui-e2e	planned	pending out-of-process UI journey
 scenario	SC-UI-SETTINGS	ui-e2e	planned	pending out-of-process UI journey
-scenario	SC-UPDATE-CHECK	release-preflight	legacy-stage	tests/release-preflight.sh
-scenario	SC-UPDATE-APPLY	publish-preflight	legacy-stage	tests/publish-preflight.sh
-scenario	SC-DOCTOR-REPORT	distribution	legacy-stage	tests/distribution.sh
-scenario	SC-INSTALL-CLEAN	distribution	legacy-stage	tests/distribution.sh
-scenario	SC-INSTALL-REPAIR	distribution	legacy-stage	tests/distribution.sh
-scenario	SC-INSTALL-UNINSTALL	distribution	legacy-stage	tests/distribution.sh
-scenario	SC-PUBLISH-CONTRACT	publish-preflight	legacy-stage	tests/publish-preflight.sh
+scenario	SC-UPDATE-CHECK	release-preflight	instrumented	tests/release-preflight.sh
+scenario	SC-UPDATE-APPLY	publish-preflight	instrumented	tests/publish-preflight.sh
+scenario	SC-RELEASE-WORKFLOW	release-workflow	instrumented	tests/release-workflow.sh
+scenario	SC-DOCTOR-REPORT	distribution	instrumented	tests/distribution.sh
+scenario	SC-INSTALL-CLEAN	distribution	instrumented	tests/distribution.sh
+scenario	SC-INSTALL-REPAIR	distribution	instrumented	tests/distribution.sh
+scenario	SC-INSTALL-UNINSTALL	distribution	instrumented	tests/distribution.sh
+scenario	SC-RUNTIME-PACKAGE	tmux-runtime	instrumented	tests/tmux-runtime.sh
+scenario	SC-PUBLISH-CONTRACT	publish-preflight	instrumented	tests/publish-preflight.sh
 suite	DetachAppTests.InstallationStorePowerStateTests
 suite	DetachAppTests.MenuBarPresentationTests
 suite	DetachAppTests.SetupGuidanceTests

--- a/scripts/quality-scenarios
+++ b/scripts/quality-scenarios
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality-scenarios: python3 is required\n' >&2
+  exit 2
+}
+PYTHONDONTWRITEBYTECODE=1 exec python3 "$ROOT/tools/quality_scenarios.py" "$@"

--- a/tests/distribution.sh
+++ b/tests/distribution.sh
@@ -229,6 +229,7 @@ PLIST
 # App launches inherit a synthetic PATH that already contains ~/.local/bin.
 # Shell setup must still configure every zsh startup mode and preserve a file
 # that existed before Detach, including its missing final newline.
+"$ROOT/scripts/quality-scenarios" event begin SC-INSTALL-CLEAN
 printf '%s' 'export DETACH_ZSHENV_SENTINEL=all' >"$TEST_HOME/.zshenv"
 cp -p "$TEST_HOME/.zshenv" "$TMP_ROOT/zshenv.original"
 
@@ -498,9 +499,11 @@ fi
   --version-file "$payload_v2/VERSION"
 [ ! -e "$foreign_watchdog" ]
 [ ! -e "$LEGACY_WATCHDOG_STATE" ]
+"$ROOT/scripts/quality-scenarios" event pass SC-INSTALL-CLEAN
 
 # Repair must restore from the pristine source recorded in the manifest, not
 # clone corrupted bytes from the active immutable directory.
+"$ROOT/scripts/quality-scenarios" event begin SC-INSTALL-REPAIR
 active_dir="$(cd -P "$(dirname "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")")" && pwd)"
 printf '\n# corruption\n' >>"$active_dir/detach-core"
 PATH="$DETACH_INSTALL_BIN_DIR:/usr/bin:/bin" \
@@ -515,6 +518,7 @@ grep -F '# corruption' "$active_dir/detach-core" >/dev/null
 "$DETACH_INSTALL_BIN_DIR/detach" repair
 [ "$(shasum -a 256 "$active_dir/detach-core" | awk '{print $1}')" = \
   "$(shasum -a 256 "$payload_v2/detach-core" | awk '{print $1}')" ]
+"$ROOT/scripts/quality-scenarios" event pass SC-INSTALL-REPAIR
 
 # BUILD participates in downgrade prevention even when semver is unchanged.
 payload_v2_build2="$(make_payload v2-build2 0.2.0 2)"
@@ -534,6 +538,7 @@ payload_old="$(make_payload old 0.1.5)"
 # The installed runtime is self-contained: doctor resolves immutable sibling
 # helpers even from a sparse PATH and does not ask for the dependencies Detach
 # now owns itself.
+"$ROOT/scripts/quality-scenarios" event begin SC-DOCTOR-REPORT
 active_dir="$(cd -P "$(dirname "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")")" && pwd)"
 doctor_json="$TMP_ROOT/doctor.json"
 env -u DETACH_TMUX_BIN -u DETACH_STATE_BIN -u DETACH_POWER_BIN \
@@ -607,9 +612,11 @@ plutil -extract state raw -o - - <<<"$power_json" | grep -qx allowed
 plutil -extract helper_reachable raw -o - - <<<"$power_json" | grep -qx true
 plutil -extract thermal_state raw -o - - <<<"$power_json" | grep -qx nominal
 plutil -extract thermal_safety_active raw -o - - <<<"$power_json" | grep -qx false
+"$ROOT/scripts/quality-scenarios" event pass SC-DOCTOR-REPORT
 
 # Direct CLI uninstall must not strand the app-owned SMAppService without its
 # executable. Detach.app unregisters the helper before invoking the installer.
+"$ROOT/scripts/quality-scenarios" event begin SC-INSTALL-UNINSTALL
 export FAKE_APP_WATCHDOG=1
 if "$DETACH_INSTALL_BIN_DIR/detach" uninstall --keep-state; then
   printf 'uninstall unexpectedly ignored the app-owned watchdog\n' >&2
@@ -1063,4 +1070,5 @@ for shell_case_pid in "${shell_case_pids[@]}"; do
 done
 [ "$shell_case_status" -eq 0 ]
 
+"$ROOT/scripts/quality-scenarios" event pass SC-INSTALL-UNINSTALL
 printf 'Detach distribution tests passed\n'

--- a/tests/publish-preflight.sh
+++ b/tests/publish-preflight.sh
@@ -4,6 +4,7 @@ set -eu
 set -o pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+"$ROOT/scripts/quality-scenarios" event begin SC-UPDATE-APPLY
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-publish-preflight-test.XXXXXX")"
 TEST_REPO="$TMP_ROOT/repo"
 TEST_APP="$TEST_REPO/app"
@@ -376,6 +377,8 @@ grep -F 'hdiutil|attach -readonly -nobrowse -owners on -mountpoint ' \
   "$TMP_ROOT/validation.log" >/dev/null
 grep -F 'spctl|--assess --type open --context context:primary-signature --verbose=2' \
   "$TMP_ROOT/validation.log" >/dev/null
+"$ROOT/scripts/quality-scenarios" event pass SC-UPDATE-APPLY
+"$ROOT/scripts/quality-scenarios" event begin SC-PUBLISH-CONTRACT
 
 # The release orchestrator can continue from a clean tooling descendant while
 # the tag and manifest stay bound to the built release commit. Direct use keeps
@@ -526,4 +529,5 @@ PATH="$FAKE_BIN:/usr/bin:/bin" \
 [ "$(grep -c '^release upload' "$GH_LOG")" = 1 ]
 grep -F 'Published Detach 1.2.3' "$TMP_ROOT/resume-published.stdout" >/dev/null
 
+"$ROOT/scripts/quality-scenarios" event pass SC-PUBLISH-CONTRACT
 printf 'Detach publish preflight tests passed\n'

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -48,6 +48,7 @@ prepare_template() {
   install -m 0755 "$ROOT/scripts/quality-dashboard" "$TEMPLATE_REPO/scripts/quality-dashboard"
   install -m 0755 "$ROOT/scripts/release-impact" "$TEMPLATE_REPO/scripts/release-impact"
   install -m 0644 "$ROOT/tools/quality_gate.py" "$TEMPLATE_REPO/tools/quality_gate.py"
+  install -m 0644 "$ROOT/tools/quality_scenarios.py" "$TEMPLATE_REPO/tools/quality_scenarios.py"
   install -m 0644 "$ROOT/tools/quality_policy.py" "$TEMPLATE_REPO/tools/quality_policy.py"
   install -m 0644 "$ROOT/tools/quality_metrics.py" "$TEMPLATE_REPO/tools/quality_metrics.py"
   install -m 0644 "$ROOT/tools/quality_dashboard.py" "$TEMPLATE_REPO/tools/quality_dashboard.py"
@@ -791,8 +792,14 @@ grep -F $'architecture\t' "$run_dir/environment.tsv" >/dev/null
 grep -F $'xcode\t' "$run_dir/environment.tsv" >/dev/null
 grep -F $'swift\t' "$run_dir/environment.tsv" >/dev/null
 grep -F $'schema\t1' "$run_dir/artifacts.tsv" >/dev/null
+grep -F $'scenarios.jsonl\t' "$run_dir/artifacts.tsv" >/dev/null
+grep -F $'scenarios.junit.xml\t' "$run_dir/artifacts.tsv" >/dev/null
+grep -F '"id":"SC-DOCS-CONTRACT"' "$run_dir/scenarios.jsonl" >/dev/null
+grep -F '"journeys":["J-DOCS-CONSISTENCY"]' "$run_dir/scenarios.jsonl" >/dev/null
+grep -F '<testsuite name="detach-quality-scenarios"' "$run_dir/scenarios.junit.xml" >/dev/null
 grep -F '# Quality gate' "$run_dir/summary.md" >/dev/null
 grep -F '| `static` | passed |' "$run_dir/summary.md" >/dev/null
+grep -F '| `SC-DOCS-CONTRACT` | `static` | passed |' "$run_dir/summary.md" >/dev/null
 grep -F 'markdown=' "$REPO/evidence.out" >/dev/null
 
 setup_fixture result-symlink

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -45,7 +45,7 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'capability inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" journeys | wc -l | tr -d ' ')" = 26 ] || \
   fail 'journey inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 31 ] || \
+[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 33 ] || \
   fail 'scenario inventory is incomplete'
 first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"

--- a/tests/quality_scenarios_contract.py
+++ b/tests/quality_scenarios_contract.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Deterministic contracts for scenario event and result evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT / "tools"))
+
+from quality_policy import POLICY_FILE, Policy  # noqa: E402
+from quality_scenarios import (  # noqa: E402
+    ScenarioError,
+    assemble,
+    finalize_stage,
+    read_jsonl,
+    record_event,
+    rerun,
+    run_bounded,
+)
+
+
+class QualityScenarioContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = Policy(POLICY_FILE)
+
+    @staticmethod
+    def scenario_record(**overrides: object) -> dict[str, object]:
+        record: dict[str, object] = {
+            "schema": 1,
+            "id": "SC-UPDATE-CHECK",
+            "stage": "release-preflight",
+            "policy_status": "instrumented",
+            "status": "failed",
+            "granularity": "scenario",
+            "duration_ms": 12,
+            "requirements": ["QC-APP-UPDATE"],
+            "journeys": ["J-UPDATE-CHECK"],
+            "rerun": "scripts/quality-scenarios rerun SC-UPDATE-CHECK",
+            "command": "tests/release-preflight.sh",
+            "log": "release-preflight.log",
+            "message": "failed",
+        }
+        record.update(overrides)
+        return record
+
+    def test_instrumented_events_produce_addressable_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            events = root / "events.jsonl"
+            output = root / "stage" / "release-preflight.jsonl"
+            output.parent.mkdir()
+            environment = {
+                "DETACH_QUALITY_SCENARIO_EVENTS": str(events),
+                "DETACH_QUALITY_SCENARIO_STAGE": "release-preflight",
+            }
+            with patch.dict("os.environ", environment, clear=False):
+                record_event("begin", "SC-UPDATE-CHECK")
+                record_event("pass", "SC-UPDATE-CHECK")
+            errors = finalize_stage(
+                policy=self.policy,
+                stage="release-preflight",
+                stage_status="passed",
+                stage_duration_seconds=3,
+                stage_log="release-preflight.log",
+                event_path=events,
+                output_path=output,
+            )
+            records = read_jsonl(output, "result")
+        self.assertEqual(errors, [])
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["id"], "SC-UPDATE-CHECK")
+        self.assertEqual(records[0]["status"], "passed")
+        self.assertEqual(records[0]["granularity"], "scenario")
+        self.assertIn("QC-APP-UPDATE", records[0]["requirements"])
+        self.assertEqual(records[0]["journeys"], ["J-UPDATE-CHECK"])
+
+    def test_pass_without_begin_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = {
+                "DETACH_QUALITY_SCENARIO_EVENTS": str(Path(directory) / "events.jsonl"),
+                "DETACH_QUALITY_SCENARIO_STAGE": "release-preflight",
+            }
+            with patch.dict("os.environ", environment, clear=False):
+                with self.assertRaisesRegex(ScenarioError, "passed without one begin"):
+                    record_event("pass", "SC-UPDATE-CHECK")
+
+    def test_missing_marker_is_a_contract_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "stage.jsonl"
+            errors = finalize_stage(
+                policy=self.policy,
+                stage="release-preflight",
+                stage_status="passed",
+                stage_duration_seconds=3,
+                stage_log="release-preflight.log",
+                event_path=root / "missing-events.jsonl",
+                output_path=output,
+            )
+            records = read_jsonl(output, "result")
+        self.assertEqual(errors, ["SC-UPDATE-CHECK emitted no markers"])
+        self.assertEqual(records[0]["status"], "missing")
+
+    def test_aggregate_writes_junit_and_bounded_repair_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stage = root / "stage.jsonl"
+            log = root / "release-preflight.log"
+            log.write_text("\n".join(f"line-{index}" for index in range(150)), encoding="utf-8")
+            record = self.scenario_record(log=log.name)
+            stage.write_text(json.dumps(record) + "\n", encoding="utf-8")
+            output = root / "scenarios.jsonl"
+            junit = root / "scenarios.junit.xml"
+            repair = root / "repair-bundle.json"
+            assemble(
+                stage_paths=[stage],
+                output_jsonl=output,
+                output_junit=junit,
+                repair_bundle=repair,
+                run_dir=root,
+                expected_stages=["release-preflight"],
+            )
+            repair_document = json.loads(repair.read_text(encoding="utf-8"))
+            junit_text = junit.read_text(encoding="utf-8")
+        self.assertIn('failures="1"', junit_text)
+        self.assertEqual(len(repair_document["failures"][0]["log_tail"]), 100)
+
+    def test_aggregate_rejects_unsafe_or_incomplete_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stage = root / "stage.jsonl"
+            stage.write_text(
+                json.dumps(self.scenario_record(log="../private.log")) + "\n",
+                encoding="utf-8",
+            )
+            arguments = {
+                "stage_paths": [stage],
+                "output_jsonl": root / "scenarios.jsonl",
+                "output_junit": root / "scenarios.junit.xml",
+                "repair_bundle": root / "repair-bundle.json",
+                "run_dir": root,
+                "expected_stages": ["release-preflight"],
+            }
+            with self.assertRaisesRegex(ScenarioError, "log is unsafe"):
+                assemble(**arguments)
+            stage.write_text("", encoding="utf-8")
+            with self.assertRaisesRegex(ScenarioError, "coverage mismatch"):
+                assemble(**arguments)
+
+    def test_instrumented_rerun_uses_the_bounded_owning_stage(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {"DETACH_QUALITY_AUTHORITY": "ci-merge", "GITHUB_ACTIONS": "true"},
+            clear=False,
+        ), patch("quality_scenarios.run_bounded", return_value=0) as run:
+            self.assertEqual(rerun("SC-SESSION-CREATE-CODEX"), 0)
+        arguments = run.call_args.args[0]
+        keywords = run.call_args.kwargs
+        self.assertEqual(
+            arguments,
+            [str(ROOT / "scripts/quality-gate"), "--stage", "codex"],
+        )
+        self.assertEqual(
+            keywords["timeout"],
+            self.policy.stages_by_name["codex"].timeout + 30,
+        )
+        self.assertNotIn("DETACH_QUALITY_AUTHORITY", keywords["environment"])
+        self.assertNotIn("GITHUB_ACTIONS", keywords["environment"])
+
+    def test_legacy_rerun_uses_the_bounded_owning_stage(self) -> None:
+        with patch("quality_scenarios.run_bounded", return_value=0) as run:
+            self.assertEqual(rerun("SC-POWER-UNIT"), 0)
+        self.assertEqual(
+            run.call_args.args[0],
+            [str(ROOT / "scripts/quality-gate"), "--stage", "swift"],
+        )
+
+    def test_bounded_runner_terminates_a_hung_process_group(self) -> None:
+        with self.assertRaises(subprocess.TimeoutExpired):
+            run_bounded(
+                [sys.executable, "-c", "import time; time.sleep(10)"],
+                environment=os.environ.copy(),
+                timeout=1,
+            )
+
+
+def main() -> int:
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(QualityScenarioContract)
+    result = unittest.TextTestRunner(verbosity=0).run(suite)
+    if not result.wasSuccessful():
+        return 1
+    print("Quality scenario contracts passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/release-budget-ratchet-contract.sh
+++ b/tests/release-budget-ratchet-contract.sh
@@ -54,8 +54,8 @@ if DETACH_RELEASE_BUDGET_RATCHET_TEST_MODE=1 DETACH_RELEASE_BUDGET="$current" "$
 fi
 grep -F 'increased above locked-ceiling' "$TMP_ROOT/ui-e2e.out" >/dev/null
 
-# Policy 7 adds the UI stage without invalidating an otherwise valid policy 6
-# merge-base budget. The new stage is still held to its locked ceiling above.
+# A new UI stage does not invalidate an otherwise valid merge-base budget. The
+# new stage is still held to its locked ceiling above.
 cp "$SOURCE" "$current"
 cp "$SOURCE" "$prior"
 set_value "$prior" schema 1

--- a/tests/release-preflight.sh
+++ b/tests/release-preflight.sh
@@ -4,6 +4,7 @@ set -eu
 set -o pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+"$ROOT/scripts/quality-scenarios" event begin SC-UPDATE-CHECK
 APPCAST_VERIFIER="$ROOT/app/scripts/verify-appcast.sh"
 MAKE_DMG="$ROOT/app/scripts/make-dmg.sh"
 BUNDLE_MODE_POLICY="$ROOT/app/scripts/bundle-modes.sh"
@@ -291,4 +292,5 @@ grep -Fx 'source-mode 755' "$TMP_ROOT/hdiutil.log" >/dev/null || {
   shasum -a 256 -c "$(basename "$HOSTILE_DMG").sha256" >/dev/null
 )
 
+"$ROOT/scripts/quality-scenarios" event pass SC-UPDATE-CHECK
 printf 'Detach release preflight tests passed\n'

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+"$ROOT/scripts/quality-scenarios" event begin SC-RELEASE-WORKFLOW
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-release-workflow-test.XXXXXX")"
 PUBLIC_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 IDENTITY='Developer ID Application: Detach Tests (TESTTEAM)'
@@ -47,6 +48,7 @@ setup_fixture() {
   install -m 0755 "$ROOT/scripts/quality-gate" "$REPO/scripts/quality-gate"
   install -m 0755 "$ROOT/scripts/quality-policy" "$REPO/scripts/quality-policy"
   install -m 0644 "$ROOT/tools/quality_gate.py" "$REPO/tools/quality_gate.py"
+  install -m 0644 "$ROOT/tools/quality_scenarios.py" "$REPO/tools/quality_scenarios.py"
   install -m 0644 "$ROOT/tools/quality_policy.py" "$REPO/tools/quality_policy.py"
   install -m 0644 "$ROOT/quality/policy.tsv" "$REPO/quality/policy.tsv"
   install -m 0755 "$ROOT/app/scripts/verify-appcast.sh" \
@@ -664,4 +666,5 @@ for release_case_index in "${!release_case_pids[@]}"; do
 done
 [ "$release_case_status" -eq 0 ] || exit 1
 
+"$ROOT/scripts/quality-scenarios" event pass SC-RELEASE-WORKFLOW
 printf 'Detach release workflow tests passed\n'

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -265,6 +265,11 @@ literal_prompt="spaces ; \$(touch $marker) * \"quotes\""
 mkdir -p "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
 # The display label stays out of tmux and filesystem identifiers, remains
 # usable for every lifecycle command, and survives resume/recovery.
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-CREATE-CLAUDE
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-PERSIST-CLAUDE
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-RECOVER-CLAUDE
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-STOP-CLAUDE
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-DELETE-CLAUDE
 reset_fake_claude_ready
 "$SCRIPT" claude --name "$human_label" --detach -- \
   --name display-name "$literal_prompt" --add-dir "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
@@ -293,6 +298,7 @@ session="$("$STATE_HELPER" meta get "$meta" session_name)"
 [ "$("$STATE_HELPER" meta get "$meta" display_name)" = "$human_label" ]
 "$SCRIPT" claude status "$human_label" | \
   grep -F "Name:           $human_label" >/dev/null
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-CREATE-CLAUDE
 session_dir="$(dirname "$meta")"
 checkpoint="$session_dir/checkpoint"
 
@@ -311,6 +317,7 @@ live_pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_pane_
 [ "$(tmux -L "$SOCKET" display-message -p -t "$live_pane_id" '#{pane_dead}')" = "0" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -w -t "$live_pane_id" remain-on-exit)" = off ]
 [ "$(tmux -L "$SOCKET" show-options -qv -p -t "$live_pane_id" remain-on-exit)" = on ]
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-PERSIST-CLAUDE
 session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_color)"
 [[ "$session_color" =~ ^#[[:xdigit:]]{6}$ ]]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_status)" = "running" ]
@@ -527,6 +534,7 @@ stopped_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
 grep -Fx "release --session $session --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-STOP-CLAUDE
 
 # Simulate losing primary metadata during a power failure. Recovery must use
 # checkpoint metadata and resume the exact Claude session UUID.
@@ -614,6 +622,7 @@ grep -Fx -- "$TMP_ROOT/extra-b" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 [ -s "$CLAUDE_CONFIG_DIR/tasks/$session_id/task.json" ]
 [ -s "$CLAUDE_CONFIG_DIR/tasks/session-${session_id:0:8}/task.json" ]
 [ -s "$CLAUDE_CONFIG_DIR/teams/session-${session_id:0:8}/config.json" ]
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-RECOVER-CLAUDE
 
 "$SCRIPT" claude stop "$human_label"
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
@@ -743,4 +752,5 @@ done
 "$SCRIPT" claude delete --force "$second_default_session"
 [ ! -e "$FAKE_GIT_MARKER" ]
 
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-DELETE-CLAUDE
 printf 'Claude detach integration tests passed\n'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -555,11 +555,17 @@ DETACH="$SCRIPT"
 marker="$TMP_ROOT/must-not-exist"
 literal_prompt="spaces ; \$(touch $marker) * \"quotes\""
 export FAKE_CODEX_SLEEP=12
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-CREATE-CODEX
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-PERSIST-CODEX
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-RECOVER-CODEX
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-STOP-CODEX
+"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-DELETE-CODEX
 run_codex --name integration --detach -- "$literal_prompt"
 
 wait_for_tmux_option "$SESSION" @detach_status running
 tmux -L "$SOCKET" has-session -t "=$SESSION"
 "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-CREATE-CODEX
 mkdir -p "$TMP_ROOT/unrelated-tmux-tmpdir"
 TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
   "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
@@ -573,6 +579,7 @@ pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_status)" = "running" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -w -t "$pane_id" remain-on-exit)" = off ]
 [ "$(tmux -L "$SOCKET" show-options -qv -p -t "$pane_id" remain-on-exit)" = on ]
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-PERSIST-CODEX
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_tmux_style)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_style_snapshot)" = "1" ]
 session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_color)"
@@ -890,6 +897,7 @@ run_codex stop integration
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
 grep -Fx "release --session $SESSION --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-STOP-CODEX
 
 # Simulate losing the primary metadata in a power failure. Auto-recovery must
 # use the checkpoint metadata and resume the exact saved UUID.
@@ -913,6 +921,7 @@ case "$worker_pid" in
   ''|*[!0-9]*) printf 'recovered pane has invalid worker PID: %s\n' "$worker_pid" >&2; exit 1 ;;
 esac
 worker_pgid="$(wait_for_process_group_id "$worker_pid")"
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-RECOVER-CODEX
 
 run_codex stop integration
 ! kill -0 "$worker_pid" 2>/dev/null
@@ -1499,4 +1508,5 @@ fi
 grep -Fx 'do not delete' "$unsafe_target/$SESSION/sentinel" >/dev/null
 [ ! -e "$FAKE_GIT_MARKER" ]
 
+"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-DELETE-CODEX
 printf 'Codex detach integration tests passed\n'

--- a/tests/shell-safety.sh
+++ b/tests/shell-safety.sh
@@ -16,7 +16,7 @@ failures=0
 while IFS= read -r -d '' file; do
   case "$file" in
     tests/shell-safety-contract.sh) continue ;;
-    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
+    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
     *) continue ;;
   esac
   [ -f "$ROOT/$file" ] || continue

--- a/tests/tmux-runtime.sh
+++ b/tests/tmux-runtime.sh
@@ -4,6 +4,7 @@ set -eu
 set -o pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+"$ROOT/scripts/quality-scenarios" event begin SC-RUNTIME-PACKAGE
 BUILDER="$ROOT/scripts/build-tmux.sh"
 MAKE_APP="$ROOT/app/scripts/make-app.sh"
 VERIFY_APP="$ROOT/app/scripts/verify-app.sh"
@@ -439,4 +440,5 @@ for plist in \
   ! plutil -p "$plist" | grep -Fi Amphetamine >/dev/null
 done
 
+"$ROOT/scripts/quality-scenarios" event pass SC-RUNTIME-PACKAGE
 printf 'Bundled runtime packaging contract tests passed\n'

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -131,6 +131,10 @@ printf '#!/bin/bash\nprintf breach >%q\nexit 91\n' "$BREACH" \
   >"$TEST_HOME/.local/bin/detach"
 chmod 0755 "$TEST_HOME/.local/bin/detach"
 
+"$ROOT/scripts/quality-scenarios" event begin SC-UI-DASHBOARD
+"$ROOT/scripts/quality-scenarios" event begin SC-UI-EMPTY
+"$ROOT/scripts/quality-scenarios" event begin SC-UI-FOCUS
+
 HOME="$TEST_HOME" \
 CFFIXED_USER_HOME="$TEST_HOME" \
 XDG_STATE_HOME="$TEST_ROOT/state" \
@@ -220,6 +224,17 @@ for check in \
       "$check_index" "$actual" "$check" >&2
     exit 1
   }
+  case "$check" in
+    dashboard-accessible)
+      "$ROOT/scripts/quality-scenarios" event pass SC-UI-DASHBOARD
+      ;;
+    empty-dashboard-state)
+      "$ROOT/scripts/quality-scenarios" event pass SC-UI-EMPTY
+      ;;
+    installed-app-focus-undisturbed)
+      "$ROOT/scripts/quality-scenarios" event pass SC-UI-FOCUS
+      ;;
+  esac
   check_index=$((check_index + 1))
 done
 

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -21,6 +21,12 @@ from datetime import datetime, timezone
 from typing import Iterable, NoReturn, TextIO
 
 from quality_policy import POLICY_FILE, Policy, PolicyError
+from quality_scenarios import (
+    ScenarioError,
+    assemble as assemble_scenarios,
+    finalize_stage as finalize_scenario_stage,
+    record_event as record_scenario_event,
+)
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -303,6 +309,7 @@ class QualityGate:
         self.failure_count = 0
         self.prior_manifest: dict[str, str | None] = {}
         self.prior_results: dict[str, StageResult] = {}
+        self.scenario_records: list[dict[str, object]] = []
 
     def validate_options(self) -> None:
         if self.test_real_static and not self.test_mode:
@@ -579,6 +586,8 @@ class QualityGate:
         write_private(self.summary, RESULT_HEADER)
         write_private(self.environment, self.environment_document())
         write_private(self.artifacts, "schema\t1\n")
+        (self.run_dir / "scenario-events").mkdir(mode=0o700)
+        (self.run_dir / "stage-scenarios").mkdir(mode=0o700)
         self.write_static_files()
 
     def command_version(self, arguments: list[str], *, first_line: bool = False) -> str:
@@ -642,10 +651,15 @@ class QualityGate:
         metrics = self.run_dir / "quality-metrics.json"
         if metrics.exists():
             files.append(metrics)
+        for name in ("scenarios.jsonl", "scenarios.junit.xml", "repair-bundle.json"):
+            path = self.run_dir / name
+            if path.exists():
+                files.append(path)
         for directory_name in (
             "ui-e2e-artifacts",
             "codex-artifacts",
             "claude-artifacts",
+            "stage-scenarios",
         ):
             directory = self.run_dir / directory_name
             if directory.is_dir() and not directory.is_symlink():
@@ -873,6 +887,10 @@ class QualityGate:
                 raise GateError("resume artifact inventory path is unsafe")
             if not (
                 relative == "quality-metrics.json"
+                or relative == "scenarios.jsonl"
+                or relative == "scenarios.junit.xml"
+                or relative == "repair-bundle.json"
+                or relative.startswith("stage-scenarios/")
                 or relative.startswith("ui-e2e-artifacts/")
                 or relative.startswith("codex-artifacts/")
                 or relative.startswith("claude-artifacts/")
@@ -953,7 +971,38 @@ class QualityGate:
     def stage_result_path(self, stage: str) -> Path:
         return self.run_dir / f".stage-{stage}.result"
 
-    def record_result(self, stage: str, result: StageResult) -> None:
+    def record_result(
+        self,
+        stage: str,
+        result: StageResult,
+        *,
+        scenario_source: Path | None = None,
+    ) -> None:
+        scenario_output = self.run_dir / "stage-scenarios" / f"{stage}.jsonl"
+        if scenario_source is not None:
+            if not scenario_source.is_file() or scenario_source.is_symlink():
+                raise GateError(f"reused scenario evidence is missing or unsafe: {stage}")
+            shutil.copyfile(scenario_source, scenario_output)
+            scenario_output.chmod(0o600)
+        else:
+            errors = finalize_scenario_stage(
+                policy=self.policy,
+                stage=stage,
+                stage_status=result.status,
+                stage_duration_seconds=result.duration,
+                stage_log=result.log,
+                event_path=self.run_dir / "scenario-events" / f"{stage}.jsonl",
+                output_path=scenario_output,
+            )
+            if errors and result.status in ("passed", "reused"):
+                log = result.log
+                if log == "-":
+                    log = f"{stage}.log"
+                    write_private(self.run_dir / log, "")
+                with (self.run_dir / log).open("a", encoding="utf-8") as output:
+                    for error in errors:
+                        output.write(f"scenario evidence: {error}\n")
+                result = StageResult("failed", result.duration, log, 1, result.origin_run)
         self.results[stage] = result
         write_private(
             self.stage_result_path(stage),
@@ -993,7 +1042,7 @@ class QualityGate:
             raise GateError(f"timeout for {stage} must be a positive integer")
         return int(value)
 
-    def stage_environment(self) -> dict[str, str]:
+    def stage_environment(self, stage: str) -> dict[str, str]:
         environment = os.environ.copy()
         for name in (
             "DETACH_RELEASE_TIMING_OVERRIDE",
@@ -1027,6 +1076,10 @@ class QualityGate:
                 "DETACH_QUALITY_GATE_TEST_REAL_STATIC": str(
                     int(self.test_real_static)
                 ),
+                "DETACH_QUALITY_SCENARIO_STAGE": stage,
+                "DETACH_QUALITY_SCENARIO_EVENTS": str(
+                    self.run_dir / "scenario-events" / f"{stage}.jsonl"
+                ),
             }
         )
         if not self.test_direct:
@@ -1055,7 +1108,9 @@ class QualityGate:
                 shutil.copyfile(metrics, self.run_dir / "quality-metrics.json")
                 (self.run_dir / "quality-metrics.json").chmod(0o600)
             self.record_result(
-                stage, StageResult("reused", prior.duration, reused_log, 0, origin)
+                stage,
+                StageResult("reused", prior.duration, reused_log, 0, origin),
+                scenario_source=self.resume_dir / "stage-scenarios" / f"{stage}.jsonl",
             )
             return
         if self.prerequisite_failed(stage):
@@ -1074,7 +1129,7 @@ class QualityGate:
             process = subprocess.Popen(
                 [sys.executable, str(Path(__file__).resolve()), "__run-stage", stage],
                 cwd=ROOT,
-                env=self.stage_environment(),
+                env=self.stage_environment(stage),
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
@@ -1364,6 +1419,23 @@ class QualityGate:
             )
         write_private(self.summary, "\n".join(lines) + "\n")
 
+    def write_scenario_outputs(self) -> None:
+        self.scenario_records = assemble_scenarios(
+            stage_paths=(
+                self.run_dir / "stage-scenarios" / f"{stage}.jsonl"
+                for stage in self.selected
+            ),
+            output_jsonl=self.run_dir / "scenarios.jsonl",
+            output_junit=self.run_dir / "scenarios.junit.xml",
+            repair_bundle=self.run_dir / "repair-bundle.json",
+            run_dir=self.run_dir,
+            expected_stages=self.selected,
+        )
+        event_directory = self.run_dir / "scenario-events"
+        if not event_directory.is_dir() or event_directory.is_symlink():
+            raise GateError("scenario event directory is missing or unsafe")
+        shutil.rmtree(event_directory)
+
     def write_junit(self) -> None:
         tests = len(self.selected)
         failures = sum(
@@ -1424,6 +1496,20 @@ class QualityGate:
                 f"| `{stage}` | {result.status} | {result.duration} | "
                 f"`{result.log}` | `{result.origin_run}` |"
             )
+        lines.extend(
+            [
+                "",
+                "## Scenarios",
+                "",
+                "| Scenario | Stage | Status | Granularity | Milliseconds | Rerun |",
+                "| --- | --- | --- | --- | ---: | --- |",
+            ]
+        )
+        for record in self.scenario_records:
+            lines.append(
+                f"| `{record['id']}` | `{record['stage']}` | {record['status']} | "
+                f"{record['granularity']} | {record['duration_ms']} | `{record['rerun']}` |"
+            )
         write_private(self.markdown, "\n".join(lines) + "\n")
 
     def interrupt(self) -> NoReturn:
@@ -1442,7 +1528,11 @@ class QualityGate:
                 stage, StageResult("interrupted", duration, f"{stage}.log", 130)
             )
         self.active.clear()
+        for stage in self.selected:
+            if stage not in self.results:
+                self.record_result(stage, StageResult("interrupted", 0, "-", 130))
         self.assemble_summary()
+        self.write_scenario_outputs()
         self.write_manifest("interrupted")
         self.write_junit()
         self.write_markdown()
@@ -1498,6 +1588,7 @@ class QualityGate:
                 signal.signal(signum, handler)
 
         self.assemble_summary()
+        self.write_scenario_outputs()
         self.write_junit()
         self.write_markdown()
         if self.overall_status:
@@ -1549,6 +1640,7 @@ def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -
         "bin/detach",
         "bin/detach-core",
         "scripts/quality-gate",
+        "scripts/quality-scenarios",
         "scripts/quality-policy",
         "scripts/quality-metrics",
         "scripts/quality-mutation",
@@ -1662,6 +1754,12 @@ def run_gate_contract_stage(root: Path) -> int:
             "Quality gate Python contracts passed",
         ),
         (
+            "quality-scenarios.log",
+            [sys.executable, str(root / "tests/quality_scenarios_contract.py")],
+            {},
+            "Quality scenario contracts passed",
+        ),
+        (
             "quality-policy.log",
             [str(root / "tests/quality-policy.sh")],
             {},
@@ -1773,7 +1871,19 @@ def run_stage_worker(stage: str) -> int:
                     "DETACH_QUALITY_AUTHORITY": authority,
                 }
             )
-        return child_run([str(fixture)], cwd=root, env=environment)
+        policy = Policy(POLICY_FILE)
+        instrumented = [
+            scenario_id
+            for scenario_id, (scenario_stage, status, _) in policy.scenarios.items()
+            if scenario_stage == stage and status == "instrumented"
+        ]
+        for scenario_id in instrumented:
+            record_scenario_event("begin", scenario_id)
+        status = child_run([str(fixture)], cwd=root, env=environment)
+        if status == 0:
+            for scenario_id in instrumented:
+                record_scenario_event("pass", scenario_id)
+        return status
 
     if stage == "static":
         return run_static_stage(root, run_dir, mode, resolved_base)
@@ -1877,5 +1987,12 @@ def main(arguments: list[str]) -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main(sys.argv[1:]))
-    except (GateError, PolicyError, OSError, UnicodeError, ValueError) as error:
+    except (
+        GateError,
+        PolicyError,
+        ScenarioError,
+        OSError,
+        UnicodeError,
+        ValueError,
+    ) as error:
         fail(str(error))

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -249,7 +249,13 @@ class Policy:
                 if (
                     not SCENARIO_ID.fullmatch(identifier)
                     or not IDENTIFIER.fullmatch(stage)
-                    or status not in ("automated", "legacy-stage", "planned", "manual-release")
+                    or status not in (
+                        "instrumented",
+                        "automated",
+                        "legacy-stage",
+                        "planned",
+                        "manual-release",
+                    )
                     or not command
                 ):
                     raise PolicyError(f"line {line_number}: invalid scenario")

--- a/tools/quality_scenarios.py
+++ b/tools/quality_scenarios.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""Record and assemble scenario-addressable quality evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from typing import Any, Iterable, NoReturn
+
+from quality_policy import POLICY_FILE, Policy, PolicyError
+
+
+ROOT = Path(__file__).resolve().parent.parent
+EVENT_SCHEMA = 1
+RESULT_SCHEMA = 1
+EVENT_KINDS = {"begin", "pass"}
+STAGE_FAILURES = {"failed", "environment-failed", "timeout", "interrupted"}
+SCENARIO_FAILURES = STAGE_FAILURES | {"missing"}
+SAFE_ID = re.compile(r"^SC-[A-Z0-9-]+$")
+SAFE_STAGE = re.compile(r"^[a-z0-9-]+$")
+SAFE_LOG = re.compile(r"^[a-z0-9-]+\.log$")
+RESULT_STATUSES = {
+    "passed",
+    "failed",
+    "environment-failed",
+    "timeout",
+    "interrupted",
+    "blocked",
+    "not-run",
+    "missing",
+    "planned",
+    "manual-release",
+}
+LOG_TAIL_BYTES = 65_536
+LOG_TAIL_LINES = 100
+RERUN_FINALIZE_SECONDS = 30
+
+
+class ScenarioError(Exception):
+    """Malformed, incomplete, or unsafe scenario evidence."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-scenarios: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def canonical(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def safe_output(path: Path, label: str) -> None:
+    if path.exists() and (not path.is_file() or path.is_symlink()):
+        raise ScenarioError(f"{label} must be a regular non-symlink file")
+    if not path.parent.is_dir() or path.parent.is_symlink():
+        raise ScenarioError(f"{label} parent must be a non-symlink directory")
+
+
+def write_private(path: Path, text: str) -> None:
+    safe_output(path, "scenario output")
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o600)
+
+
+def read_jsonl(path: Path, label: str) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    if not path.is_file() or path.is_symlink():
+        raise ScenarioError(f"{label} is missing or unsafe")
+    records: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise ScenarioError(f"cannot read {label}: {error}") from error
+    for line_number, line in enumerate(lines, 1):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ScenarioError(f"{label} line {line_number} is malformed: {error}") from error
+        if not isinstance(value, dict):
+            raise ScenarioError(f"{label} line {line_number} is not an object")
+        records.append(value)
+    return records
+
+
+def append_event(path: Path, record: dict[str, Any]) -> None:
+    safe_output(path, "scenario event file")
+    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError as error:
+        raise ScenarioError(f"cannot open scenario event file: {error}") from error
+    try:
+        os.write(descriptor, (canonical(record) + "\n").encode("utf-8"))
+    finally:
+        os.close(descriptor)
+    path.chmod(0o600)
+
+
+def scenario_context(policy: Policy) -> dict[str, dict[str, list[str]]]:
+    result: dict[str, dict[str, list[str]]] = {
+        identifier: {"journeys": [], "requirements": []}
+        for identifier in policy.scenarios
+    }
+    for journey_id, (_, requirements, scenarios, _) in policy.journeys.items():
+        journey_requirements = [] if requirements == "-" else requirements.split(",")
+        for scenario_id in scenarios.split(","):
+            context = result[scenario_id]
+            if journey_id not in context["journeys"]:
+                context["journeys"].append(journey_id)
+            for requirement in journey_requirements:
+                if requirement not in context["requirements"]:
+                    context["requirements"].append(requirement)
+    return result
+
+
+def record_event(kind: str, scenario_id: str) -> None:
+    if kind not in EVENT_KINDS:
+        raise ScenarioError(f"invalid event kind: {kind}")
+    if not SAFE_ID.fullmatch(scenario_id):
+        raise ScenarioError(f"invalid scenario id: {scenario_id}")
+    raw_path = os.environ.get("DETACH_QUALITY_SCENARIO_EVENTS", "")
+    if not raw_path:
+        return
+    stage = os.environ.get("DETACH_QUALITY_SCENARIO_STAGE", "")
+    if not SAFE_STAGE.fullmatch(stage):
+        raise ScenarioError("scenario stage is missing or invalid")
+    policy = Policy(POLICY_FILE)
+    scenario = policy.scenarios.get(scenario_id)
+    if scenario is None:
+        raise ScenarioError(f"unknown scenario: {scenario_id}")
+    expected_stage, policy_status, _ = scenario
+    if expected_stage != stage:
+        raise ScenarioError(
+            f"scenario {scenario_id} belongs to {expected_stage}, not {stage}"
+        )
+    if policy_status != "instrumented":
+        raise ScenarioError(f"scenario {scenario_id} is not instrumented in policy")
+    path = Path(raw_path)
+    prior = read_jsonl(path, "scenario events")
+    kinds = [event.get("kind") for event in prior if event.get("id") == scenario_id]
+    if kind == "begin" and kinds:
+        raise ScenarioError(f"scenario {scenario_id} began more than once")
+    if kind == "pass" and kinds != ["begin"]:
+        raise ScenarioError(f"scenario {scenario_id} passed without one begin event")
+    append_event(
+        path,
+        {
+            "schema": EVENT_SCHEMA,
+            "id": scenario_id,
+            "stage": stage,
+            "kind": kind,
+            "time_ns": time.monotonic_ns(),
+        },
+    )
+
+
+def validate_events(
+    events: Iterable[dict[str, Any]], stage: str, policy: Policy
+) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    last_time = 0
+    for event in events:
+        if set(event) != {"schema", "id", "stage", "kind", "time_ns"}:
+            raise ScenarioError("scenario event has unknown or missing fields")
+        schema = event["schema"]
+        scenario_id = event["id"]
+        event_stage = event["stage"]
+        kind = event["kind"]
+        event_time = event["time_ns"]
+        if schema != EVENT_SCHEMA:
+            raise ScenarioError("scenario event schema is unsupported")
+        if not isinstance(scenario_id, str) or not SAFE_ID.fullmatch(scenario_id):
+            raise ScenarioError("scenario event id is invalid")
+        if event_stage != stage:
+            raise ScenarioError("scenario event stage does not match its file")
+        scenario = policy.scenarios.get(scenario_id)
+        if scenario is None or scenario[0] != stage or scenario[1] != "instrumented":
+            raise ScenarioError(f"unexpected instrumented scenario event: {scenario_id}")
+        if kind not in EVENT_KINDS:
+            raise ScenarioError(f"scenario event kind is invalid: {scenario_id}")
+        if not isinstance(event_time, int) or event_time <= 0 or event_time < last_time:
+            raise ScenarioError("scenario event time is invalid or unordered")
+        last_time = event_time
+        grouped.setdefault(scenario_id, []).append(event)
+    for scenario_id, records in grouped.items():
+        kinds = [record["kind"] for record in records]
+        if kinds not in (["begin"], ["begin", "pass"]):
+            raise ScenarioError(f"scenario event order is invalid: {scenario_id}")
+    return grouped
+
+
+def stage_outcome(status: str) -> str:
+    if status in ("passed", "reused"):
+        return "passed"
+    if status in STAGE_FAILURES:
+        return status
+    if status == "blocked":
+        return "blocked"
+    return "not-run"
+
+
+def finalize_stage(
+    *,
+    policy: Policy,
+    stage: str,
+    stage_status: str,
+    stage_duration_seconds: int,
+    stage_log: str,
+    event_path: Path,
+    output_path: Path,
+) -> list[str]:
+    context = scenario_context(policy)
+    events = validate_events(read_jsonl(event_path, "scenario events"), stage, policy)
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for scenario_id, (scenario_stage, policy_status, command) in policy.scenarios.items():
+        if scenario_stage != stage:
+            continue
+        outcome = "not-run"
+        duration_ms = 0
+        granularity = "stage"
+        message = ""
+        scenario_events = events.get(scenario_id, [])
+        if policy_status == "instrumented":
+            granularity = "scenario"
+            if len(scenario_events) == 2:
+                outcome = "passed"
+                duration_ms = max(
+                    0, (scenario_events[1]["time_ns"] - scenario_events[0]["time_ns"]) // 1_000_000
+                )
+            elif len(scenario_events) == 1:
+                outcome = stage_outcome(stage_status)
+                if outcome == "passed":
+                    outcome = "missing"
+                    errors.append(f"{scenario_id} has no pass marker")
+                message = "scenario began but did not emit a pass marker"
+            else:
+                outcome = "missing" if stage_status in ("passed", "reused") else stage_outcome(stage_status)
+                message = "scenario emitted no markers"
+                if outcome == "missing":
+                    errors.append(f"{scenario_id} emitted no markers")
+        elif policy_status in ("automated", "legacy-stage"):
+            outcome = stage_outcome(stage_status)
+            duration_ms = max(0, stage_duration_seconds * 1000)
+            granularity = "command" if policy_status == "automated" else "legacy-stage"
+        elif policy_status == "planned":
+            outcome = "planned"
+            granularity = "planned"
+        elif policy_status == "manual-release":
+            outcome = "manual-release"
+            granularity = "manual-release"
+        else:
+            raise ScenarioError(f"unsupported scenario policy status: {policy_status}")
+        records.append(
+            {
+                "schema": RESULT_SCHEMA,
+                "id": scenario_id,
+                "stage": stage,
+                "policy_status": policy_status,
+                "status": outcome,
+                "granularity": granularity,
+                "duration_ms": duration_ms,
+                "requirements": context[scenario_id]["requirements"],
+                "journeys": context[scenario_id]["journeys"],
+                "rerun": f"scripts/quality-scenarios rerun {scenario_id}",
+                "command": command,
+                "log": stage_log,
+                "message": message,
+            }
+        )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.parent.is_symlink():
+        raise ScenarioError("stage scenario output directory is unsafe")
+    write_private(output_path, "".join(canonical(record) + "\n" for record in records))
+    return errors
+
+
+def validate_result(
+    record: dict[str, Any],
+    policy: Policy,
+    context: dict[str, dict[str, list[str]]],
+) -> None:
+    required = {
+        "schema",
+        "id",
+        "stage",
+        "policy_status",
+        "status",
+        "granularity",
+        "duration_ms",
+        "requirements",
+        "journeys",
+        "rerun",
+        "command",
+        "log",
+        "message",
+    }
+    if set(record) != required or record.get("schema") != RESULT_SCHEMA:
+        raise ScenarioError("scenario result schema is invalid")
+    if not isinstance(record["id"], str) or not SAFE_ID.fullmatch(record["id"]):
+        raise ScenarioError("scenario result id is invalid")
+    if not isinstance(record["stage"], str) or not SAFE_STAGE.fullmatch(record["stage"]):
+        raise ScenarioError("scenario result stage is invalid")
+    if not isinstance(record["duration_ms"], int) or record["duration_ms"] < 0:
+        raise ScenarioError("scenario result duration is invalid")
+    for key in (
+        "policy_status",
+        "status",
+        "granularity",
+        "rerun",
+        "command",
+        "log",
+        "message",
+    ):
+        if not isinstance(record[key], str):
+            raise ScenarioError(f"scenario result {key} is invalid")
+    scenario = policy.scenarios.get(record["id"])
+    if scenario is None:
+        raise ScenarioError(f"unknown scenario result: {record['id']}")
+    expected_stage, expected_policy_status, expected_command = scenario
+    if record["stage"] != expected_stage:
+        raise ScenarioError(f"scenario result stage does not match policy: {record['id']}")
+    if record["policy_status"] != expected_policy_status:
+        raise ScenarioError(f"scenario result policy status does not match: {record['id']}")
+    if record["command"] != expected_command:
+        raise ScenarioError(f"scenario result command does not match policy: {record['id']}")
+    if record["rerun"] != f"scripts/quality-scenarios rerun {record['id']}":
+        raise ScenarioError(f"scenario result rerun is invalid: {record['id']}")
+    if record["status"] not in RESULT_STATUSES:
+        raise ScenarioError(f"scenario result status is invalid: {record['id']}")
+    expected_granularity = {
+        "instrumented": "scenario",
+        "automated": "command",
+        "legacy-stage": "legacy-stage",
+        "planned": "planned",
+        "manual-release": "manual-release",
+    }[expected_policy_status]
+    if record["granularity"] != expected_granularity:
+        raise ScenarioError(f"scenario result granularity is invalid: {record['id']}")
+    if expected_policy_status == "planned" and record["status"] != "planned":
+        raise ScenarioError(f"planned scenario result has an invalid status: {record['id']}")
+    if expected_policy_status == "manual-release" and record["status"] != "manual-release":
+        raise ScenarioError(f"manual scenario result has an invalid status: {record['id']}")
+    if expected_policy_status not in ("planned", "manual-release") and record["status"] in (
+        "planned",
+        "manual-release",
+    ):
+        raise ScenarioError(f"automated scenario result has an invalid status: {record['id']}")
+    if record["log"] != "-" and not SAFE_LOG.fullmatch(record["log"]):
+        raise ScenarioError(f"scenario result log is unsafe: {record['id']}")
+    if len(record["message"]) > 4096:
+        raise ScenarioError(f"scenario result message is too large: {record['id']}")
+    for key in ("requirements", "journeys"):
+        if not isinstance(record[key], list) or not all(
+            isinstance(value, str) for value in record[key]
+        ):
+            raise ScenarioError(f"scenario result {key} is invalid")
+        if record[key] != context[record["id"]][key]:
+            raise ScenarioError(f"scenario result {key} does not match policy")
+
+
+def xml_escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def bounded_log_tail(path: Path) -> list[str]:
+    try:
+        with path.open("rb") as source:
+            source.seek(0, os.SEEK_END)
+            size = source.tell()
+            start = max(0, size - LOG_TAIL_BYTES)
+            source.seek(start)
+            content = source.read(LOG_TAIL_BYTES)
+    except OSError as error:
+        raise ScenarioError(f"cannot read scenario failure log: {error}") from error
+    if start and b"\n" in content:
+        content = content.split(b"\n", 1)[1]
+    return content.decode("utf-8", errors="replace").splitlines()[-LOG_TAIL_LINES:]
+
+
+def assemble(
+    *,
+    stage_paths: Iterable[Path],
+    output_jsonl: Path,
+    output_junit: Path,
+    repair_bundle: Path,
+    run_dir: Path,
+    expected_stages: Iterable[str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    policy = Policy(POLICY_FILE)
+    context = scenario_context(policy)
+    for path in stage_paths:
+        for record in read_jsonl(path, "stage scenario results"):
+            validate_result(record, policy, context)
+            if record["id"] in seen:
+                raise ScenarioError(f"duplicate scenario result: {record['id']}")
+            seen.add(record["id"])
+            records.append(record)
+    selected = set(expected_stages)
+    expected = {
+        scenario_id
+        for scenario_id, (stage, _, _) in policy.scenarios.items()
+        if stage in selected
+    }
+    if seen != expected:
+        missing = ",".join(sorted(expected - seen)) or "-"
+        unexpected = ",".join(sorted(seen - expected)) or "-"
+        raise ScenarioError(
+            f"scenario result coverage mismatch: missing={missing} unexpected={unexpected}"
+        )
+    write_private(output_jsonl, "".join(canonical(record) + "\n" for record in records))
+    failures = [record for record in records if record["status"] in SCENARIO_FAILURES]
+    skipped = [
+        record
+        for record in records
+        if record["status"] in {"blocked", "not-run", "planned", "manual-release"}
+    ]
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<testsuite name="detach-quality-scenarios" tests="{len(records)}" '
+            f'failures="{len(failures)}" skipped="{len(skipped)}">'
+        ),
+    ]
+    for record in records:
+        body = ""
+        if record in failures:
+            body = (
+                f'<failure message="{xml_escape(record["status"])}">'
+                f'{xml_escape(record["rerun"])}</failure>'
+            )
+        elif record in skipped:
+            body = f'<skipped message="{xml_escape(record["status"])}"/>'
+        lines.append(
+            f'  <testcase classname="quality-scenario.{xml_escape(record["stage"])}" '
+            f'name="{xml_escape(record["id"])}" '
+            f'time="{record["duration_ms"] / 1000:.3f}">{body}</testcase>'
+        )
+    lines.append("</testsuite>")
+    write_private(output_junit, "\n".join(lines) + "\n")
+
+    if failures:
+        bundle_records = []
+        for record in failures:
+            log_tail: list[str] = []
+            if record["log"] != "-":
+                log_path = run_dir / record["log"]
+                if log_path.is_file() and not log_path.is_symlink():
+                    log_tail = bounded_log_tail(log_path)
+            bundle_records.append(
+                {
+                    "id": record["id"],
+                    "stage": record["stage"],
+                    "status": record["status"],
+                    "requirements": record["requirements"],
+                    "journeys": record["journeys"],
+                    "rerun": record["rerun"],
+                    "log": record["log"],
+                    "log_tail": log_tail,
+                }
+            )
+        write_private(
+            repair_bundle,
+            json.dumps(
+                {"schema": 1, "failures": bundle_records},
+                ensure_ascii=False,
+                sort_keys=True,
+                indent=2,
+            )
+            + "\n",
+        )
+    elif repair_bundle.exists():
+        repair_bundle.unlink()
+    return records
+
+
+def run_bounded(
+    arguments: list[str], *, environment: dict[str, str], timeout: int
+) -> int:
+    process = subprocess.Popen(
+        arguments,
+        cwd=ROOT,
+        env=environment,
+        start_new_session=True,
+    )
+    try:
+        return process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+        raise
+
+
+def rerun(scenario_id: str) -> int:
+    policy = Policy(POLICY_FILE)
+    scenario = policy.scenarios.get(scenario_id)
+    if scenario is None:
+        raise ScenarioError(f"unknown scenario: {scenario_id}")
+    stage, policy_status, command = scenario
+    if policy_status not in ("instrumented", "automated", "legacy-stage"):
+        raise ScenarioError(f"scenario is not automated: {scenario_id}")
+    environment = os.environ.copy()
+    timeout = policy.stages_by_name[stage].timeout
+    if policy_status in ("instrumented", "legacy-stage"):
+        arguments = [str(ROOT / "scripts/quality-gate"), "--stage", stage]
+        environment.pop("DETACH_QUALITY_AUTHORITY", None)
+        environment.pop("GITHUB_ACTIONS", None)
+        timeout += RERUN_FINALIZE_SECONDS
+    else:
+        arguments = shlex.split(command)
+        if not arguments or any(value in {"&&", "||", ";", "|"} for value in arguments):
+            raise ScenarioError(f"scenario command is not directly executable: {scenario_id}")
+    try:
+        return run_bounded(
+            arguments,
+            environment=environment,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"quality-scenarios: {scenario_id} timed out after {timeout}s", file=sys.stderr)
+        return 124
+    except OSError as error:
+        raise ScenarioError(f"cannot run scenario {scenario_id}: {error}") from error
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(prog="scripts/quality-scenarios", description=__doc__)
+    subparsers = result.add_subparsers(dest="command", required=True)
+    event = subparsers.add_parser("event")
+    event.add_argument("kind", choices=sorted(EVENT_KINDS))
+    event.add_argument("scenario_id")
+    rerun_parser = subparsers.add_parser("rerun")
+    rerun_parser.add_argument("scenario_id")
+    return result
+
+
+def main(arguments: list[str]) -> int:
+    options = parser().parse_args(arguments)
+    if options.command == "event":
+        record_event(options.kind, options.scenario_id)
+        return 0
+    if options.command == "rerun":
+        return rerun(options.scenario_id)
+    raise ScenarioError("unknown command")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except (ScenarioError, PolicyError, OSError, UnicodeError, ValueError) as error:
+        fail(str(error))


### PR DESCRIPTION
Adds policy-18 scenario IDs to provider, distribution, runtime, UI, update, publish, and hermetic release integrations. The quality gate now publishes digest-bound scenario JSONL and JUnit, fails closed on missing markers, and creates bounded repair bundles with exact reruns. Structured orchestration stays in stdlib Python behind a thin shell wrapper.\n\nLocal diagnostic: policy-18 impact gate PASS in 176 seconds. No release, signing, notarization, upload, real power, or closed-lid test was run. Internal presentations and unrelated local HTML files are not part of this PR.