### PR TITLE
Add executable specification traceability

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -3,7 +3,9 @@
 `quality/policy.tsv` is the single quality policy. It owns path impact,
 capabilities, user journeys, requirements, stages, time limits, critical
 sources, and release impact. `scripts/quality-policy` validates this source and
-generates `quality/generated/policy.json`. Generated data must match the source.
+generates `quality/generated/policy.json` and
+`quality/generated/spec-traceability.md`. The policy contains only current
+state. Git stores its history. Generated data must match the source.
 
 `scripts/quality-gate` applies the policy. Local runs are diagnostics. Hosted
 pull request CI runs every functional stage on the current merge commit and is
@@ -12,7 +14,7 @@ the only ordinary merge authority. Unknown paths select the full plan.
 ## Commands
 
 - `scripts/quality-gate --plan --explain` shows affected capabilities,
-  journeys, stages, and the path that selected each stage.
+  specifications, journeys, stages, and the path that selected each stage.
 - `scripts/quality-gate` checks the working-tree diff and writes local
   diagnostic evidence.
 - `scripts/quality-gate --base <ref>` also checks committed changes after the
@@ -31,6 +33,9 @@ the only ordinary merge authority. Unknown paths select the full plan.
   evidence finalization and process-group cleanup.
 - `scripts/quality-history [RESULT_ROOT]` reports run and failure counts plus
   p50 and p95 wall and stage durations. It cannot produce readiness evidence.
+- `scripts/quality-policy specs` lists current durable specs.
+  `scripts/quality-policy render-specs` prints their requirement, journey, and
+  scenario links.
 - `scripts/quality-dashboard generate` writes deterministic static HTML and
   JSON. `scripts/quality-dashboard serve` binds to loopback and stops after its
   deadline.
@@ -61,8 +66,9 @@ at most the last 100 log lines.
 
 The manifest binds the evidence to the policy, authority, source and base
 commits, exact input and plan fingerprints, selected capabilities, journeys,
-stages, timestamps, inherited timing, parent evidence, environment, artifacts,
-summary, and every stage log. A failure, timeout, interruption, blocked
+owning specifications, stages, timestamps, inherited timing, parent evidence,
+environment, artifacts, summary, and every stage log. A failure, timeout,
+interruption, blocked
 dependency, unsafe file, malformed record, or digest mismatch cannot produce
 PASS. Failure output gives the exact diagnostic rerun.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -33,6 +33,12 @@ ownership paths, and verification. Explain why only where it prevents a likely
 wrong implementation. Do not copy code, maintain a file inventory, preserve
 task history, or prescribe incidental implementation detail.
 
+`quality/policy.tsv` registers each current durable spec. It owns the stable
+spec identity and the links from requirements to user journeys and automated
+scenarios. `quality/generated/spec-traceability.md` is the generated readable
+view. Do not copy this metadata into individual specs or edit the generated
+view.
+
 Change the narrowest owning spec whenever behavior or an invariant changes.
 Keep task progress and rejected experiments in the local ExecPlan, not here.
 A finished spec describes the system as it is, not the sequence used to build it.

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -47,6 +47,13 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   policy schemas. The last green metrics artifact can use an earlier policy
   number only when its evidence schema is current. This preserves metric
   continuity and does not decode an old policy.
+- The quality policy registers each tracked durable spec exactly once. It has
+  no spec-history or lifecycle-status field. Each registered spec owns a route,
+  a capability, and a requirement. Each requirement links to a user journey
+  and at least one automated scenario. Generated JSON and Markdown views must
+  match the policy.
+- Retained gate results contain execution history for timing and quality
+  trends. They are not policy history and cannot restore an old policy state.
 - Instrumented user scenarios emit addressable begin and pass events. Gate
   evidence records their requirement and journey links, duration, result, and
   bounded rerun command. A passed stage with missing scenario events fails.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,7 +38,10 @@
   granularity until it gets scenario markers.
 - `scripts/quality-history [RESULT_ROOT]` reports p50/p95 wall and stage timing,
   ordinary failures, and execution-environment failures across retained local
-  or downloaded gate evidence. It is telemetry, not readiness evidence.
+  or downloaded gate evidence. It is run telemetry, not policy history or
+  readiness evidence.
+- `scripts/quality-policy generate --check` checks both generated policy JSON
+  and the readable current-spec traceability table.
 - `scripts/quality-dashboard generate` creates
   `app/build/quality-dashboard/{index.html,data.json}` from the newest schema-4
   evidence. `scripts/quality-dashboard serve --seconds 300` serves it only on

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -5,7 +5,9 @@
       "journeys": [
         "J-QUALITY-CHANGE"
       ],
-      "requirements": [],
+      "requirements": [
+        "QC-QUALITY-POLICY"
+      ],
       "spec": "docs/specs/documentation.md"
     },
     {
@@ -13,7 +15,9 @@
       "journeys": [
         "J-DOCS-CONSISTENCY"
       ],
-      "requirements": [],
+      "requirements": [
+        "QC-DOC-CONSISTENCY"
+      ],
       "spec": "docs/specs/documentation.md"
     },
     {
@@ -275,7 +279,9 @@
     {
       "capability": "quality-system",
       "id": "J-QUALITY-CHANGE",
-      "requirements": [],
+      "requirements": [
+        "QC-QUALITY-POLICY"
+      ],
       "scenarios": [
         "SC-POLICY-CONTRACT"
       ],
@@ -284,7 +290,9 @@
     {
       "capability": "documentation",
       "id": "J-DOCS-CONSISTENCY",
-      "requirements": [],
+      "requirements": [
+        "QC-DOC-CONSISTENCY"
+      ],
       "scenarios": [
         "SC-DOCS-CONTRACT"
       ],
@@ -362,7 +370,9 @@
       "id": "J-POWER-ENABLE",
       "requirements": [
         "QC-POWER-ASSERTION",
-        "QC-POWER-LEASE"
+        "QC-POWER-LEASE",
+        "QC-POWER-CLI",
+        "QC-POWER-PLATFORM"
       ],
       "scenarios": [
         "SC-POWER-UNIT"
@@ -479,6 +489,7 @@
         "QC-APP-ONBOARDING"
       ],
       "scenarios": [
+        "SC-APP-ONBOARDING-UNIT",
         "SC-UI-ONBOARD-FIRST-RUN"
       ],
       "summary": "A new user completes the first-run setup."
@@ -512,6 +523,7 @@
         "QC-APP-SETTINGS"
       ],
       "scenarios": [
+        "SC-APP-SETTINGS-UNIT",
         "SC-UI-SETTINGS"
       ],
       "summary": "A user changes a setting and observes the persisted result."
@@ -606,7 +618,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 21,
+  "policy": 22,
   "release_domains": [
     {
       "gates": "-",
@@ -748,6 +760,16 @@
       "id": "QC-RELEASE-PUBLISH",
       "spec": "docs/specs/release.md",
       "summary": "Publication exposes only independently verified allowlisted artifacts."
+    },
+    {
+      "id": "QC-QUALITY-POLICY",
+      "spec": "docs/specs/documentation.md",
+      "summary": "One current policy owns quality selection and traceability."
+    },
+    {
+      "id": "QC-DOC-CONSISTENCY",
+      "spec": "docs/specs/documentation.md",
+      "summary": "Durable documentation and generated quality views stay synchronized."
     }
   ],
   "routes": [
@@ -1739,6 +1761,18 @@
       "status": "manual-release"
     },
     {
+      "command": "cd app && swift test --filter Onboarding",
+      "id": "SC-APP-ONBOARDING-UNIT",
+      "stage": "swift",
+      "status": "legacy-stage"
+    },
+    {
+      "command": "cd app && swift test --filter Settings",
+      "id": "SC-APP-SETTINGS-UNIT",
+      "stage": "swift",
+      "status": "legacy-stage"
+    },
+    {
       "command": "tests/ui-e2e.sh",
       "id": "SC-UI-DASHBOARD",
       "stage": "ui-e2e",
@@ -1866,6 +1900,797 @@
     }
   ],
   "schema": 1,
+  "specifications": [
+    {
+      "capabilities": [
+        "quality-system",
+        "documentation"
+      ],
+      "id": "documentation",
+      "journeys": [
+        "J-QUALITY-CHANGE",
+        "J-DOCS-CONSISTENCY"
+      ],
+      "owned_patterns": [
+        "*.md",
+        "*.sh",
+        ".gitattributes",
+        ".github/*",
+        ".github/workflows/quality-gates.yml",
+        ".github/workflows/quality-mutations.yml",
+        ".gitignore",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "README.md",
+        "app/.gitignore",
+        "docs/assets/*",
+        "docs/quality-gates.md",
+        "docs/testing.md",
+        "quality/*",
+        "scripts/*",
+        "scripts/quality-baseline",
+        "scripts/quality-dashboard",
+        "scripts/quality-gate",
+        "scripts/quality-history",
+        "scripts/quality-metrics",
+        "scripts/quality-mutation",
+        "scripts/quality-policy",
+        "scripts/quality-scenarios",
+        "scripts/test",
+        "tests/*",
+        "tests/docs-contract.sh",
+        "tests/quality-*",
+        "tests/quality_*",
+        "tests/release-budget*",
+        "tests/shell-safety*",
+        "tests/test-suite-contract.sh",
+        "tools/quality_baseline.py",
+        "tools/quality_dashboard.py",
+        "tools/quality_gate.py",
+        "tools/quality_metrics.py",
+        "tools/quality_mutation.py",
+        "tools/quality_policy.py",
+        "tools/quality_scenarios.py"
+      ],
+      "path": "docs/specs/documentation.md",
+      "requirements": [
+        {
+          "id": "QC-QUALITY-POLICY",
+          "journeys": [
+            "J-QUALITY-CHANGE"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/quality-policy.sh",
+              "id": "SC-POLICY-CONTRACT",
+              "stage": "gate-contract",
+              "status": "automated"
+            }
+          ],
+          "summary": "One current policy owns quality selection and traceability."
+        },
+        {
+          "id": "QC-DOC-CONSISTENCY",
+          "journeys": [
+            "J-DOCS-CONSISTENCY"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/docs-contract.sh",
+              "id": "SC-DOCS-CONTRACT",
+              "stage": "static",
+              "status": "automated"
+            }
+          ],
+          "summary": "Durable documentation and generated quality views stay synchronized."
+        }
+      ],
+      "summary": "Agent context, specifications, and quality automation stay synchronized."
+    },
+    {
+      "capabilities": [
+        "session-lifecycle"
+      ],
+      "id": "runtime",
+      "journeys": [
+        "J-SESSION-CREATE",
+        "J-SESSION-PERSIST",
+        "J-SESSION-RECOVER",
+        "J-SESSION-STOP",
+        "J-SESSION-DELETE"
+      ],
+      "owned_patterns": [
+        "app/Sources/DetachKit/*.swift",
+        "app/Sources/DetachKit/ANSIText.swift",
+        "app/Sources/DetachKit/DetachState*.swift",
+        "app/Sources/DetachKit/LogPoller.swift",
+        "app/Sources/DetachKit/Session*.swift",
+        "app/Sources/DetachKit/Storage*.swift",
+        "app/Sources/DetachKit/Terminal*.swift",
+        "app/Sources/DetachKit/Tip.swift",
+        "app/Sources/DetachKit/Tmux*.swift",
+        "app/Sources/DetachState/*.swift",
+        "bin/*",
+        "bin/detach",
+        "bin/detach-core",
+        "install.sh",
+        "scripts/build-tmux.sh",
+        "scripts/install.sh",
+        "tests/distribution.sh",
+        "tests/fake-claude",
+        "tests/fake-codex",
+        "tests/run-claude.sh",
+        "tests/run.sh",
+        "tests/tmux-runtime.sh"
+      ],
+      "path": "docs/specs/runtime.md",
+      "requirements": [
+        {
+          "id": "QC-RUNTIME-STATE",
+          "journeys": [
+            "J-SESSION-CREATE",
+            "J-SESSION-PERSIST"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-CREATE-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-CREATE-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-PERSIST-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-PERSIST-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Typed state is the only shared state mutation boundary."
+        },
+        {
+          "id": "QC-RUNTIME-OWNERSHIP",
+          "journeys": [
+            "J-SESSION-CREATE",
+            "J-SESSION-RECOVER",
+            "J-SESSION-STOP",
+            "J-SESSION-DELETE"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-CREATE-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-CREATE-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-RECOVER-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-RECOVER-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-STOP-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-STOP-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-SESSION-STOP",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-DELETE-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-DELETE-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-SESSION-DELETE",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Session operations prove the exact run token and process ownership."
+        },
+        {
+          "id": "QC-RUNTIME-STORAGE",
+          "journeys": [
+            "J-SESSION-PERSIST",
+            "J-SESSION-RECOVER",
+            "J-SESSION-DELETE"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-PERSIST-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-PERSIST-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-RECOVER-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-RECOVER-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-DELETE-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-DELETE-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-SESSION-DELETE",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Restores validate path, symlink, identity, and JSONL data before replacement."
+        },
+        {
+          "id": "QC-RUNTIME-TRANSITION",
+          "journeys": [
+            "J-SESSION-RECOVER"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-RECOVER-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-RECOVER-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Session transitions preserve exact process identity."
+        }
+      ],
+      "summary": "Runtime state and session operations preserve exact ownership."
+    },
+    {
+      "capabilities": [
+        "power-protection"
+      ],
+      "id": "power",
+      "journeys": [
+        "J-POWER-ENABLE",
+        "J-POWER-LOW-BATTERY",
+        "J-POWER-HELPER-LEASE",
+        "J-POWER-CLOSED-LID"
+      ],
+      "owned_patterns": [
+        "app/Resources/DetachWatchdog*",
+        "app/Resources/dev.tsarev.detach.power-*",
+        "app/Sources/DetachApp/InstallationStore.swift",
+        "app/Sources/DetachApp/PowerHelper*.swift",
+        "app/Sources/DetachApp/Watchdog*.swift",
+        "app/Sources/DetachKit/BoundedProcessRunner.swift",
+        "app/Sources/DetachKit/ClamshellLockRunner.swift",
+        "app/Sources/DetachKit/DetachPower*.swift",
+        "app/Sources/DetachKit/Power*.swift",
+        "app/Sources/DetachPower/*.swift",
+        "app/Sources/DetachPowerHelper/*.swift",
+        "app/Sources/DetachWatchdog/*.swift",
+        "tests/power-smoke.sh"
+      ],
+      "path": "docs/specs/power.md",
+      "requirements": [
+        {
+          "id": "QC-POWER-ASSERTION",
+          "journeys": [
+            "J-POWER-ENABLE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter Power",
+              "id": "SC-POWER-UNIT",
+              "stage": "swift",
+              "status": "legacy-stage"
+            }
+          ],
+          "summary": "Power protection owns a user IOKit assertion."
+        },
+        {
+          "id": "QC-POWER-AUTH",
+          "journeys": [
+            "J-POWER-HELPER-LEASE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter PowerHelper",
+              "id": "SC-POWER-HELPER",
+              "stage": "swift",
+              "status": "legacy-stage"
+            }
+          ],
+          "summary": "Helper authorization binds audit token, console user, signing, and deadline."
+        },
+        {
+          "id": "QC-POWER-LEASE",
+          "journeys": [
+            "J-POWER-ENABLE",
+            "J-POWER-HELPER-LEASE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter Power",
+              "id": "SC-POWER-UNIT",
+              "stage": "swift",
+              "status": "legacy-stage"
+            },
+            {
+              "command": "cd app && swift test --filter PowerHelper",
+              "id": "SC-POWER-HELPER",
+              "stage": "swift",
+              "status": "legacy-stage"
+            }
+          ],
+          "summary": "The root helper lease is bounded and ownership safe."
+        },
+        {
+          "id": "QC-POWER-XPC",
+          "journeys": [
+            "J-POWER-HELPER-LEASE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter PowerHelper",
+              "id": "SC-POWER-HELPER",
+              "stage": "swift",
+              "status": "legacy-stage"
+            }
+          ],
+          "summary": "The helper accepts only the typed power protocol."
+        },
+        {
+          "id": "QC-POWER-PROTECTION",
+          "journeys": [
+            "J-POWER-LOW-BATTERY",
+            "J-POWER-CLOSED-LID"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter PowerProtection",
+              "id": "SC-POWER-LOW-BATTERY",
+              "stage": "swift",
+              "status": "legacy-stage"
+            },
+            {
+              "command": "scripts/release-lid-probe",
+              "id": "SC-POWER-CLOSED-LID",
+              "stage": "release-budget",
+              "status": "manual-release"
+            }
+          ],
+          "summary": "Low battery fails safe."
+        },
+        {
+          "id": "QC-POWER-CLI",
+          "journeys": [
+            "J-POWER-ENABLE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter Power",
+              "id": "SC-POWER-UNIT",
+              "stage": "swift",
+              "status": "legacy-stage"
+            }
+          ],
+          "summary": "The power command reports and enforces typed protection state."
+        },
+        {
+          "id": "QC-POWER-PLATFORM",
+          "journeys": [
+            "J-POWER-ENABLE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter Power",
+              "id": "SC-POWER-UNIT",
+              "stage": "swift",
+              "status": "legacy-stage"
+            }
+          ],
+          "summary": "Platform power operations preserve the helper safety boundary."
+        }
+      ],
+      "summary": "Power protection fails safe across both required layers."
+    },
+    {
+      "capabilities": [
+        "app-experience",
+        "onboarding",
+        "settings",
+        "update",
+        "diagnostics"
+      ],
+      "id": "app",
+      "journeys": [
+        "J-APP-DASHBOARD",
+        "J-APP-DETAIL",
+        "J-APP-EMPTY",
+        "J-APP-FAILURE",
+        "J-APP-FOCUS",
+        "J-APP-NEW-SESSION",
+        "J-ONBOARD-FIRST-RUN",
+        "J-ONBOARD-PROVIDER",
+        "J-ONBOARD-APPROVAL",
+        "J-SETTINGS-CHANGE",
+        "J-UPDATE-CHECK",
+        "J-UPDATE-APPLY",
+        "J-DOCTOR-REPORT"
+      ],
+      "owned_patterns": [
+        "app/Package.resolved",
+        "app/Package.swift",
+        "app/Resources/*",
+        "app/Resources/Detach.entitlements",
+        "app/Resources/Detach.icns",
+        "app/Resources/DetachDevelopment.entitlements",
+        "app/Resources/Info.plist",
+        "app/Resources/en.lproj/*",
+        "app/Resources/ru.lproj/*",
+        "app/Sources/*",
+        "app/Sources/DetachApp/*.swift",
+        "app/Sources/DetachApp/DetachApp.swift",
+        "app/Sources/DetachApp/EmptySessionsView.swift",
+        "app/Sources/DetachApp/LogTextView.swift",
+        "app/Sources/DetachApp/MenuBar*.swift",
+        "app/Sources/DetachApp/NewSessionSheet.swift",
+        "app/Sources/DetachApp/Onboarding*.swift",
+        "app/Sources/DetachApp/RootView.swift",
+        "app/Sources/DetachApp/Session*.swift",
+        "app/Sources/DetachApp/Settings*.swift",
+        "app/Sources/DetachApp/SetupGuidance.swift",
+        "app/Sources/DetachApp/SidebarView.swift",
+        "app/Sources/DetachApp/TextSize.swift",
+        "app/Sources/DetachApp/Theme.swift",
+        "app/Sources/DetachApp/TipsBar.swift",
+        "app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift",
+        "app/Sources/DetachApp/UIE2E*.swift",
+        "app/Sources/DetachApp/UpdaterService.swift",
+        "app/Sources/DetachKit/DetachCLI.swift",
+        "app/Sources/DetachKit/DoctorReport.swift",
+        "app/Sources/DetachKit/Localization.swift",
+        "app/Sources/DetachKit/UpdateConfiguration.swift",
+        "app/Tests/*",
+        "tests/fake-ui-cli",
+        "tests/ui-e2e-contract.sh",
+        "tests/ui-e2e.sh"
+      ],
+      "path": "docs/specs/app.md",
+      "requirements": [
+        {
+          "id": "QC-HEALTH-FRESHNESS",
+          "journeys": [
+            "J-APP-DASHBOARD"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-DASHBOARD",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Health claims use typed fresh state."
+        },
+        {
+          "id": "QC-HEALTH-PRESENTATION",
+          "journeys": [
+            "J-APP-DASHBOARD",
+            "J-APP-DETAIL",
+            "J-APP-EMPTY",
+            "J-APP-FAILURE",
+            "J-APP-FOCUS",
+            "J-APP-NEW-SESSION"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-DASHBOARD",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-SESSION-DETAIL",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-EMPTY",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            },
+            {
+              "command": "pending hermetic packaged-app journey",
+              "id": "SC-UI-FAILURE",
+              "stage": "ui-e2e",
+              "status": "planned"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-FOCUS",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-NEW-SESSION",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "The app presents typed health state without parsing terminal text."
+        },
+        {
+          "id": "QC-APP-TIPS",
+          "journeys": [
+            "J-APP-EMPTY"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/ui-e2e.sh",
+              "id": "SC-UI-EMPTY",
+              "stage": "ui-e2e",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Session tips remain deterministic and user visible."
+        },
+        {
+          "id": "QC-APP-DOCTOR",
+          "journeys": [
+            "J-DOCTOR-REPORT"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/distribution.sh",
+              "id": "SC-DOCTOR-REPORT",
+              "stage": "distribution",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Doctor output derives from typed runtime state."
+        },
+        {
+          "id": "QC-APP-ONBOARDING",
+          "journeys": [
+            "J-ONBOARD-FIRST-RUN",
+            "J-ONBOARD-PROVIDER",
+            "J-ONBOARD-APPROVAL"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter Onboarding",
+              "id": "SC-APP-ONBOARDING-UNIT",
+              "stage": "swift",
+              "status": "legacy-stage"
+            },
+            {
+              "command": "pending hermetic packaged-app journey",
+              "id": "SC-UI-ONBOARD-FIRST-RUN",
+              "stage": "ui-e2e",
+              "status": "planned"
+            },
+            {
+              "command": "pending hermetic packaged-app journey",
+              "id": "SC-UI-ONBOARD-PROVIDER",
+              "stage": "ui-e2e",
+              "status": "planned"
+            },
+            {
+              "command": "pending hermetic packaged-app journey",
+              "id": "SC-UI-ONBOARD-APPROVAL",
+              "stage": "ui-e2e",
+              "status": "planned"
+            }
+          ],
+          "summary": "Onboarding leads a new user through supported provider and approval setup."
+        },
+        {
+          "id": "QC-APP-SETTINGS",
+          "journeys": [
+            "J-SETTINGS-CHANGE"
+          ],
+          "scenarios": [
+            {
+              "command": "cd app && swift test --filter Settings",
+              "id": "SC-APP-SETTINGS-UNIT",
+              "stage": "swift",
+              "status": "legacy-stage"
+            },
+            {
+              "command": "pending hermetic packaged-app journey",
+              "id": "SC-UI-SETTINGS",
+              "stage": "ui-e2e",
+              "status": "planned"
+            }
+          ],
+          "summary": "Settings changes persist and affect only their declared behavior."
+        },
+        {
+          "id": "QC-APP-UPDATE",
+          "journeys": [
+            "J-UPDATE-CHECK",
+            "J-UPDATE-APPLY"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/release-preflight.sh",
+              "id": "SC-UPDATE-CHECK",
+              "stage": "release-preflight",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/publish-preflight.sh",
+              "id": "SC-UPDATE-APPLY",
+              "stage": "publish-preflight",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/release-workflow.sh",
+              "id": "SC-RELEASE-WORKFLOW",
+              "stage": "release-workflow",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Update state and application preserve the signed arm64 contract."
+        }
+      ],
+      "summary": "The app presents and changes only typed product state."
+    },
+    {
+      "capabilities": [
+        "installation",
+        "publication"
+      ],
+      "id": "release",
+      "journeys": [
+        "J-INSTALL-CLEAN",
+        "J-INSTALL-REPAIR",
+        "J-INSTALL-UNINSTALL",
+        "J-PUBLISH-ARTIFACTS"
+      ],
+      "owned_patterns": [
+        "BUILD",
+        "VERSION",
+        "app/Resources/ThirdParty/*",
+        "app/scripts/*",
+        "app/scripts/bundle-modes.sh",
+        "app/scripts/make-app.sh",
+        "app/scripts/make-dmg.sh",
+        "app/scripts/publish-release.sh",
+        "app/scripts/release.sh",
+        "app/scripts/verify-appcast.sh",
+        "scripts/release-impact",
+        "scripts/release-lid-probe",
+        "scripts/release-version",
+        "tests/publish-preflight.sh",
+        "tests/release-impact.sh",
+        "tests/release-preflight.sh",
+        "tests/release-workflow.sh"
+      ],
+      "path": "docs/specs/release.md",
+      "requirements": [
+        {
+          "id": "QC-RELEASE-INSTALL",
+          "journeys": [
+            "J-INSTALL-CLEAN",
+            "J-INSTALL-REPAIR",
+            "J-INSTALL-UNINSTALL"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/distribution.sh",
+              "id": "SC-INSTALL-CLEAN",
+              "stage": "distribution",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/tmux-runtime.sh",
+              "id": "SC-RUNTIME-PACKAGE",
+              "stage": "tmux-runtime",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/distribution.sh",
+              "id": "SC-INSTALL-REPAIR",
+              "stage": "distribution",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/distribution.sh",
+              "id": "SC-INSTALL-UNINSTALL",
+              "stage": "distribution",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Install, repair, and uninstall mutate only Detach-owned payloads and selected state."
+        },
+        {
+          "id": "QC-RELEASE-PUBLISH",
+          "journeys": [
+            "J-PUBLISH-ARTIFACTS"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/publish-preflight.sh",
+              "id": "SC-PUBLISH-CONTRACT",
+              "stage": "publish-preflight",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Publication exposes only independently verified allowlisted artifacts."
+        }
+      ],
+      "summary": "Distribution and publication preserve verified immutable artifacts."
+    }
+  ],
   "stages": [
     {
       "name": "static",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -1,0 +1,223 @@
+# Generated specification traceability
+
+This file is generated from `quality/policy.tsv`. Do not edit it.
+It lists current specification ownership and verification links.
+
+## `documentation`
+
+- Path: `docs/specs/documentation.md`
+- Summary: Agent context, specifications, and quality automation stay synchronized.
+- Capabilities: `quality-system`, `documentation`
+
+### Owned path patterns
+
+- `*.md`
+- `*.sh`
+- `.gitattributes`
+- `.github/*`
+- `.github/workflows/quality-gates.yml`
+- `.github/workflows/quality-mutations.yml`
+- `.gitignore`
+- `AGENTS.md`
+- `CLAUDE.md`
+- `README.md`
+- `app/.gitignore`
+- `docs/assets/*`
+- `docs/quality-gates.md`
+- `docs/testing.md`
+- `quality/*`
+- `scripts/*`
+- `scripts/quality-baseline`
+- `scripts/quality-dashboard`
+- `scripts/quality-gate`
+- `scripts/quality-history`
+- `scripts/quality-metrics`
+- `scripts/quality-mutation`
+- `scripts/quality-policy`
+- `scripts/quality-scenarios`
+- `scripts/test`
+- `tests/*`
+- `tests/docs-contract.sh`
+- `tests/quality-*`
+- `tests/quality_*`
+- `tests/release-budget*`
+- `tests/shell-safety*`
+- `tests/test-suite-contract.sh`
+- `tools/quality_baseline.py`
+- `tools/quality_dashboard.py`
+- `tools/quality_gate.py`
+- `tools/quality_metrics.py`
+- `tools/quality_mutation.py`
+- `tools/quality_policy.py`
+- `tools/quality_scenarios.py`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
+| `QC-QUALITY-POLICY` | `J-QUALITY-CHANGE` | `SC-POLICY-CONTRACT` (automated, `gate-contract`) | One current policy owns quality selection and traceability. |
+| `QC-DOC-CONSISTENCY` | `J-DOCS-CONSISTENCY` | `SC-DOCS-CONTRACT` (automated, `static`) | Durable documentation and generated quality views stay synchronized. |
+
+## `runtime`
+
+- Path: `docs/specs/runtime.md`
+- Summary: Runtime state and session operations preserve exact ownership.
+- Capabilities: `session-lifecycle`
+
+### Owned path patterns
+
+- `app/Sources/DetachKit/*.swift`
+- `app/Sources/DetachKit/ANSIText.swift`
+- `app/Sources/DetachKit/DetachState*.swift`
+- `app/Sources/DetachKit/LogPoller.swift`
+- `app/Sources/DetachKit/Session*.swift`
+- `app/Sources/DetachKit/Storage*.swift`
+- `app/Sources/DetachKit/Terminal*.swift`
+- `app/Sources/DetachKit/Tip.swift`
+- `app/Sources/DetachKit/Tmux*.swift`
+- `app/Sources/DetachState/*.swift`
+- `bin/*`
+- `bin/detach`
+- `bin/detach-core`
+- `install.sh`
+- `scripts/build-tmux.sh`
+- `scripts/install.sh`
+- `tests/distribution.sh`
+- `tests/fake-claude`
+- `tests/fake-codex`
+- `tests/run-claude.sh`
+- `tests/run.sh`
+- `tests/tmux-runtime.sh`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
+| `QC-RUNTIME-STATE` | `J-SESSION-CREATE`<br>`J-SESSION-PERSIST` | `SC-SESSION-CREATE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-CREATE-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-PERSIST-CODEX` (instrumented, `codex`)<br>`SC-SESSION-PERSIST-CLAUDE` (instrumented, `claude`) | Typed state is the only shared state mutation boundary. |
+| `QC-RUNTIME-OWNERSHIP` | `J-SESSION-CREATE`<br>`J-SESSION-RECOVER`<br>`J-SESSION-STOP`<br>`J-SESSION-DELETE` | `SC-SESSION-CREATE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-CREATE-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-STOP-CODEX` (instrumented, `codex`)<br>`SC-SESSION-STOP-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-STOP` (instrumented, `ui-e2e`)<br>`SC-SESSION-DELETE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-DELETE-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-DELETE` (instrumented, `ui-e2e`) | Session operations prove the exact run token and process ownership. |
+| `QC-RUNTIME-STORAGE` | `J-SESSION-PERSIST`<br>`J-SESSION-RECOVER`<br>`J-SESSION-DELETE` | `SC-SESSION-PERSIST-CODEX` (instrumented, `codex`)<br>`SC-SESSION-PERSIST-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-DELETE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-DELETE-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-DELETE` (instrumented, `ui-e2e`) | Restores validate path, symlink, identity, and JSONL data before replacement. |
+| `QC-RUNTIME-TRANSITION` | `J-SESSION-RECOVER` | `SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`) | Session transitions preserve exact process identity. |
+
+## `power`
+
+- Path: `docs/specs/power.md`
+- Summary: Power protection fails safe across both required layers.
+- Capabilities: `power-protection`
+
+### Owned path patterns
+
+- `app/Resources/DetachWatchdog*`
+- `app/Resources/dev.tsarev.detach.power-*`
+- `app/Sources/DetachApp/InstallationStore.swift`
+- `app/Sources/DetachApp/PowerHelper*.swift`
+- `app/Sources/DetachApp/Watchdog*.swift`
+- `app/Sources/DetachKit/BoundedProcessRunner.swift`
+- `app/Sources/DetachKit/ClamshellLockRunner.swift`
+- `app/Sources/DetachKit/DetachPower*.swift`
+- `app/Sources/DetachKit/Power*.swift`
+- `app/Sources/DetachPower/*.swift`
+- `app/Sources/DetachPowerHelper/*.swift`
+- `app/Sources/DetachWatchdog/*.swift`
+- `tests/power-smoke.sh`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
+| `QC-POWER-ASSERTION` | `J-POWER-ENABLE` | `SC-POWER-UNIT` (legacy-stage, `swift`) | Power protection owns a user IOKit assertion. |
+| `QC-POWER-AUTH` | `J-POWER-HELPER-LEASE` | `SC-POWER-HELPER` (legacy-stage, `swift`) | Helper authorization binds audit token, console user, signing, and deadline. |
+| `QC-POWER-LEASE` | `J-POWER-ENABLE`<br>`J-POWER-HELPER-LEASE` | `SC-POWER-UNIT` (legacy-stage, `swift`)<br>`SC-POWER-HELPER` (legacy-stage, `swift`) | The root helper lease is bounded and ownership safe. |
+| `QC-POWER-XPC` | `J-POWER-HELPER-LEASE` | `SC-POWER-HELPER` (legacy-stage, `swift`) | The helper accepts only the typed power protocol. |
+| `QC-POWER-PROTECTION` | `J-POWER-LOW-BATTERY`<br>`J-POWER-CLOSED-LID` | `SC-POWER-LOW-BATTERY` (legacy-stage, `swift`)<br>`SC-POWER-CLOSED-LID` (manual-release, `release-budget`) | Low battery fails safe. |
+| `QC-POWER-CLI` | `J-POWER-ENABLE` | `SC-POWER-UNIT` (legacy-stage, `swift`) | The power command reports and enforces typed protection state. |
+| `QC-POWER-PLATFORM` | `J-POWER-ENABLE` | `SC-POWER-UNIT` (legacy-stage, `swift`) | Platform power operations preserve the helper safety boundary. |
+
+## `app`
+
+- Path: `docs/specs/app.md`
+- Summary: The app presents and changes only typed product state.
+- Capabilities: `app-experience`, `onboarding`, `settings`, `update`, `diagnostics`
+
+### Owned path patterns
+
+- `app/Package.resolved`
+- `app/Package.swift`
+- `app/Resources/*`
+- `app/Resources/Detach.entitlements`
+- `app/Resources/Detach.icns`
+- `app/Resources/DetachDevelopment.entitlements`
+- `app/Resources/Info.plist`
+- `app/Resources/en.lproj/*`
+- `app/Resources/ru.lproj/*`
+- `app/Sources/*`
+- `app/Sources/DetachApp/*.swift`
+- `app/Sources/DetachApp/DetachApp.swift`
+- `app/Sources/DetachApp/EmptySessionsView.swift`
+- `app/Sources/DetachApp/LogTextView.swift`
+- `app/Sources/DetachApp/MenuBar*.swift`
+- `app/Sources/DetachApp/NewSessionSheet.swift`
+- `app/Sources/DetachApp/Onboarding*.swift`
+- `app/Sources/DetachApp/RootView.swift`
+- `app/Sources/DetachApp/Session*.swift`
+- `app/Sources/DetachApp/Settings*.swift`
+- `app/Sources/DetachApp/SetupGuidance.swift`
+- `app/Sources/DetachApp/SidebarView.swift`
+- `app/Sources/DetachApp/TextSize.swift`
+- `app/Sources/DetachApp/Theme.swift`
+- `app/Sources/DetachApp/TipsBar.swift`
+- `app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift`
+- `app/Sources/DetachApp/UIE2E*.swift`
+- `app/Sources/DetachApp/UpdaterService.swift`
+- `app/Sources/DetachKit/DetachCLI.swift`
+- `app/Sources/DetachKit/DoctorReport.swift`
+- `app/Sources/DetachKit/Localization.swift`
+- `app/Sources/DetachKit/UpdateConfiguration.swift`
+- `app/Tests/*`
+- `tests/fake-ui-cli`
+- `tests/ui-e2e-contract.sh`
+- `tests/ui-e2e.sh`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
+| `QC-HEALTH-FRESHNESS` | `J-APP-DASHBOARD` | `SC-UI-DASHBOARD` (instrumented, `ui-e2e`) | Health claims use typed fresh state. |
+| `QC-HEALTH-PRESENTATION` | `J-APP-DASHBOARD`<br>`J-APP-DETAIL`<br>`J-APP-EMPTY`<br>`J-APP-FAILURE`<br>`J-APP-FOCUS`<br>`J-APP-NEW-SESSION` | `SC-UI-DASHBOARD` (instrumented, `ui-e2e`)<br>`SC-UI-SESSION-DETAIL` (instrumented, `ui-e2e`)<br>`SC-UI-EMPTY` (instrumented, `ui-e2e`)<br>`SC-UI-FAILURE` (planned, `ui-e2e`)<br>`SC-UI-FOCUS` (instrumented, `ui-e2e`)<br>`SC-UI-NEW-SESSION` (instrumented, `ui-e2e`) | The app presents typed health state without parsing terminal text. |
+| `QC-APP-TIPS` | `J-APP-EMPTY` | `SC-UI-EMPTY` (instrumented, `ui-e2e`) | Session tips remain deterministic and user visible. |
+| `QC-APP-DOCTOR` | `J-DOCTOR-REPORT` | `SC-DOCTOR-REPORT` (instrumented, `distribution`) | Doctor output derives from typed runtime state. |
+| `QC-APP-ONBOARDING` | `J-ONBOARD-FIRST-RUN`<br>`J-ONBOARD-PROVIDER`<br>`J-ONBOARD-APPROVAL` | `SC-APP-ONBOARDING-UNIT` (legacy-stage, `swift`)<br>`SC-UI-ONBOARD-FIRST-RUN` (planned, `ui-e2e`)<br>`SC-UI-ONBOARD-PROVIDER` (planned, `ui-e2e`)<br>`SC-UI-ONBOARD-APPROVAL` (planned, `ui-e2e`) | Onboarding leads a new user through supported provider and approval setup. |
+| `QC-APP-SETTINGS` | `J-SETTINGS-CHANGE` | `SC-APP-SETTINGS-UNIT` (legacy-stage, `swift`)<br>`SC-UI-SETTINGS` (planned, `ui-e2e`) | Settings changes persist and affect only their declared behavior. |
+| `QC-APP-UPDATE` | `J-UPDATE-CHECK`<br>`J-UPDATE-APPLY` | `SC-UPDATE-CHECK` (instrumented, `release-preflight`)<br>`SC-UPDATE-APPLY` (instrumented, `publish-preflight`)<br>`SC-RELEASE-WORKFLOW` (instrumented, `release-workflow`) | Update state and application preserve the signed arm64 contract. |
+
+## `release`
+
+- Path: `docs/specs/release.md`
+- Summary: Distribution and publication preserve verified immutable artifacts.
+- Capabilities: `installation`, `publication`
+
+### Owned path patterns
+
+- `BUILD`
+- `VERSION`
+- `app/Resources/ThirdParty/*`
+- `app/scripts/*`
+- `app/scripts/bundle-modes.sh`
+- `app/scripts/make-app.sh`
+- `app/scripts/make-dmg.sh`
+- `app/scripts/publish-release.sh`
+- `app/scripts/release.sh`
+- `app/scripts/verify-appcast.sh`
+- `scripts/release-impact`
+- `scripts/release-lid-probe`
+- `scripts/release-version`
+- `tests/publish-preflight.sh`
+- `tests/release-impact.sh`
+- `tests/release-preflight.sh`
+- `tests/release-workflow.sh`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
+| `QC-RELEASE-INSTALL` | `J-INSTALL-CLEAN`<br>`J-INSTALL-REPAIR`<br>`J-INSTALL-UNINSTALL` | `SC-INSTALL-CLEAN` (instrumented, `distribution`)<br>`SC-RUNTIME-PACKAGE` (instrumented, `tmux-runtime`)<br>`SC-INSTALL-REPAIR` (instrumented, `distribution`)<br>`SC-INSTALL-UNINSTALL` (instrumented, `distribution`) | Install, repair, and uninstall mutate only Detach-owned payloads and selected state. |
+| `QC-RELEASE-PUBLISH` | `J-PUBLISH-ARTIFACTS` | `SC-PUBLISH-CONTRACT` (instrumented, `publish-preflight`) | Publication exposes only independently verified allowlisted artifacts. |

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,10 @@
 schema	1
-policy	21
+policy	22
+spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
+spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
+spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
+spec	app	docs/specs/app.md	The app presents and changes only typed product state.
+spec	release	docs/specs/release.md	Distribution and publication preserve verified immutable artifacts.
 limit	pr_feedback_seconds	600
 limit	local_feedback_seconds	120
 limit	review_seconds	180
@@ -191,8 +196,8 @@ route	900	.gitattributes	metadata	safe	docs/specs/documentation.md
 route	800	.github/*	unknown	safe	docs/specs/documentation.md
 route	700	app/.gitignore	metadata	safe	docs/specs/documentation.md
 route	100	*.sh	unknown	unknown	docs/specs/documentation.md
-capability	quality-system	docs/specs/documentation.md	-	J-QUALITY-CHANGE
-capability	documentation	docs/specs/documentation.md	-	J-DOCS-CONSISTENCY
+capability	quality-system	docs/specs/documentation.md	QC-QUALITY-POLICY	J-QUALITY-CHANGE
+capability	documentation	docs/specs/documentation.md	QC-DOC-CONSISTENCY	J-DOCS-CONSISTENCY
 capability	session-lifecycle	docs/specs/runtime.md	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	J-SESSION-CREATE,J-SESSION-PERSIST,J-SESSION-RECOVER,J-SESSION-STOP,J-SESSION-DELETE
 capability	power-protection	docs/specs/power.md	QC-POWER-ASSERTION,QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC,QC-POWER-PROTECTION,QC-POWER-CLI,QC-POWER-PLATFORM	J-POWER-ENABLE,J-POWER-LOW-BATTERY,J-POWER-HELPER-LEASE,J-POWER-CLOSED-LID
 capability	app-experience	docs/specs/app.md	QC-HEALTH-FRESHNESS,QC-HEALTH-PRESENTATION,QC-APP-TIPS	J-APP-DASHBOARD,J-APP-DETAIL,J-APP-EMPTY,J-APP-FAILURE,J-APP-FOCUS,J-APP-NEW-SESSION
@@ -202,14 +207,14 @@ capability	update	docs/specs/app.md	QC-APP-UPDATE	J-UPDATE-CHECK,J-UPDATE-APPLY
 capability	diagnostics	docs/specs/app.md	QC-APP-DOCTOR	J-DOCTOR-REPORT
 capability	installation	docs/specs/release.md	QC-RELEASE-INSTALL	J-INSTALL-CLEAN,J-INSTALL-REPAIR,J-INSTALL-UNINSTALL
 capability	publication	docs/specs/release.md	QC-RELEASE-PUBLISH	J-PUBLISH-ARTIFACTS
-journey	J-QUALITY-CHANGE	quality-system	-	SC-POLICY-CONTRACT	A policy change keeps local feedback focused and hosted evidence complete.
-journey	J-DOCS-CONSISTENCY	documentation	-	SC-DOCS-CONTRACT	Documentation and executable contracts stay synchronized.
+journey	J-QUALITY-CHANGE	quality-system	QC-QUALITY-POLICY	SC-POLICY-CONTRACT	A policy change keeps local feedback focused and hosted evidence complete.
+journey	J-DOCS-CONSISTENCY	documentation	QC-DOC-CONSISTENCY	SC-DOCS-CONTRACT	Documentation and executable contracts stay synchronized.
 journey	J-SESSION-CREATE	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP	SC-SESSION-CREATE-CODEX,SC-SESSION-CREATE-CLAUDE	A user creates a managed provider session.
 journey	J-SESSION-PERSIST	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-STORAGE	SC-SESSION-PERSIST-CODEX,SC-SESSION-PERSIST-CLAUDE	A live session remains available after the app exits.
 journey	J-SESSION-RECOVER	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	SC-SESSION-RECOVER-CODEX,SC-SESSION-RECOVER-CLAUDE	A user recovers the exact owned session after interruption.
 journey	J-SESSION-STOP	session-lifecycle	QC-RUNTIME-OWNERSHIP	SC-SESSION-STOP-CODEX,SC-SESSION-STOP-CLAUDE,SC-UI-SESSION-STOP	A user stops only the selected owned session.
 journey	J-SESSION-DELETE	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE,SC-UI-SESSION-DELETE	A user deletes one completed session without affecting another session.
-journey	J-POWER-ENABLE	power-protection	QC-POWER-ASSERTION,QC-POWER-LEASE	SC-POWER-UNIT	A protected session acquires both required power protections.
+journey	J-POWER-ENABLE	power-protection	QC-POWER-ASSERTION,QC-POWER-LEASE,QC-POWER-CLI,QC-POWER-PLATFORM	SC-POWER-UNIT	A protected session acquires both required power protections.
 journey	J-POWER-LOW-BATTERY	power-protection	QC-POWER-PROTECTION	SC-POWER-LOW-BATTERY	Low battery removes unsafe protection and reports the reason.
 journey	J-POWER-HELPER-LEASE	power-protection	QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC	SC-POWER-HELPER	The helper accepts only an authorized bounded lease.
 journey	J-POWER-CLOSED-LID	power-protection	QC-POWER-PROTECTION	SC-POWER-CLOSED-LID	A protected session continues on supervised supported hardware with the lid closed.
@@ -219,10 +224,10 @@ journey	J-APP-EMPTY	app-experience	QC-HEALTH-PRESENTATION,QC-APP-TIPS	SC-UI-EMPT
 journey	J-APP-FAILURE	app-experience	QC-HEALTH-PRESENTATION	SC-UI-FAILURE	A user sees an actionable failure without parsed terminal claims.
 journey	J-APP-FOCUS	app-experience	QC-HEALTH-PRESENTATION	SC-UI-FOCUS	Background status checks do not steal keyboard focus.
 journey	J-APP-NEW-SESSION	app-experience	QC-HEALTH-PRESENTATION	SC-UI-NEW-SESSION	A user opens the new-session form and cannot launch without a project.
-journey	J-ONBOARD-FIRST-RUN	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-FIRST-RUN	A new user completes the first-run setup.
+journey	J-ONBOARD-FIRST-RUN	onboarding	QC-APP-ONBOARDING	SC-APP-ONBOARDING-UNIT,SC-UI-ONBOARD-FIRST-RUN	A new user completes the first-run setup.
 journey	J-ONBOARD-PROVIDER	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-PROVIDER	Onboarding detects an authenticated supported provider.
 journey	J-ONBOARD-APPROVAL	onboarding	QC-APP-ONBOARDING	SC-UI-ONBOARD-APPROVAL	Onboarding explains and observes required macOS approvals.
-journey	J-SETTINGS-CHANGE	settings	QC-APP-SETTINGS	SC-UI-SETTINGS	A user changes a setting and observes the persisted result.
+journey	J-SETTINGS-CHANGE	settings	QC-APP-SETTINGS	SC-APP-SETTINGS-UNIT,SC-UI-SETTINGS	A user changes a setting and observes the persisted result.
 journey	J-UPDATE-CHECK	update	QC-APP-UPDATE	SC-UPDATE-CHECK	A user receives a typed update state.
 journey	J-UPDATE-APPLY	update	QC-APP-UPDATE	SC-UPDATE-APPLY,SC-RELEASE-WORKFLOW	A valid update preserves the arm64 and signature contract.
 journey	J-DOCTOR-REPORT	diagnostics	QC-APP-DOCTOR	SC-DOCTOR-REPORT	A user receives a typed actionable doctor report.
@@ -246,6 +251,8 @@ scenario	SC-POWER-UNIT	swift	legacy-stage	cd app && swift test --filter Power
 scenario	SC-POWER-LOW-BATTERY	swift	legacy-stage	cd app && swift test --filter PowerProtection
 scenario	SC-POWER-HELPER	swift	legacy-stage	cd app && swift test --filter PowerHelper
 scenario	SC-POWER-CLOSED-LID	release-budget	manual-release	scripts/release-lid-probe
+scenario	SC-APP-ONBOARDING-UNIT	swift	legacy-stage	cd app && swift test --filter Onboarding
+scenario	SC-APP-SETTINGS-UNIT	swift	legacy-stage	cd app && swift test --filter Settings
 scenario	SC-UI-DASHBOARD	ui-e2e	instrumented	tests/ui-e2e.sh
 scenario	SC-UI-SESSION-DETAIL	ui-e2e	instrumented	tests/ui-e2e.sh
 scenario	SC-UI-SESSION-DELETE	ui-e2e	instrumented	tests/ui-e2e.sh
@@ -312,3 +319,5 @@ requirement	QC-APP-SETTINGS	docs/specs/app.md	Settings changes persist and affec
 requirement	QC-APP-UPDATE	docs/specs/app.md	Update state and application preserve the signed arm64 contract.
 requirement	QC-RELEASE-INSTALL	docs/specs/release.md	Install, repair, and uninstall mutate only Detach-owned payloads and selected state.
 requirement	QC-RELEASE-PUBLISH	docs/specs/release.md	Publication exposes only independently verified allowlisted artifacts.
+requirement	QC-QUALITY-POLICY	docs/specs/documentation.md	One current policy owns quality selection and traceability.
+requirement	QC-DOC-CONSISTENCY	docs/specs/documentation.md	Durable documentation and generated quality views stay synchronized.

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -80,6 +80,7 @@ base_commit	fedcba9876543210fedcba9876543210fedcba98
 input_fingerprint	0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 fingerprint	abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
 stages	static,swift,quality-contracts,app,ui-e2e,release-budget
+specs	app
 capabilities	onboarding
 journeys	J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL
 started_at	2026-08-11T10:00:00Z
@@ -93,6 +94,12 @@ artifacts_sha256	$artifacts_digest
 summary_sha256	$summary_digest
 result	passed
 EOF
+
+PRIOR_RUN="$RESULT_ROOT/20260810T100000Z-1"
+mkdir -p "$PRIOR_RUN"
+awk -F '\t' -v OFS='\t' \
+  '$1 == "policy" {$2=21} $1 != "specs" {print}' \
+  "$RUN_DIR/manifest.tsv" >"$PRIOR_RUN/manifest.tsv"
 
 cat >"$MUTATION_SUMMARY" <<JSON
 {
@@ -144,6 +151,8 @@ grep -F '@media (max-width:560px)' "$OUTPUT/index.html" >/dev/null || \
 grep -F 'STALE ·' "$OUTPUT/index.html" >/dev/null || fail 'stale evidence state is missing'
 grep -F 'J-ONBOARD-FIRST-RUN' "$OUTPUT/index.html" >/dev/null || \
   fail 'impacted journey is missing'
+grep -F 'Specifications</span><br>app' "$OUTPUT/index.html" >/dev/null || \
+  fail 'impacted specification is missing'
 grep -F 'planned' "$OUTPUT/index.html" >/dev/null || fail 'planned gap is hidden'
 grep -F 'changed lines 90.00%' "$OUTPUT/index.html" >/dev/null || \
   fail 'measured changed-line coverage is missing'
@@ -159,13 +168,26 @@ with open(sys.argv[1], encoding="utf-8") as source:
 assert data["schema"] == 1
 assert data["run"]["authority"] == "ci-merge"
 assert data["run"]["result"] == "passed"
+assert [spec["id"] for spec in data["specifications"]] == ["app"]
 assert data["quality"]["planned_scenarios"] == 3
 assert data["quality"]["coverage"]["comparison"]["mode"] == "green-main-artifact"
 assert data["quality"]["mutation"]["score_percent"] == 100
+assert len(data["trends"]) == 2
 assert [journey["id"] for journey in data["journeys"]] == [
     "J-ONBOARD-FIRST-RUN", "J-ONBOARD-PROVIDER", "J-ONBOARD-APPROVAL"
 ]
 PY
+
+cp "$RUN_DIR/manifest.tsv" "$TMP_ROOT/current-manifest.tsv"
+awk -F '\t' '$1 != "specs" {print}' "$TMP_ROOT/current-manifest.tsv" \
+  >"$RUN_DIR/manifest.tsv"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/missing-specs" >"$TMP_ROOT/missing-specs.out" 2>&1; then
+  fail 'current evidence without affected specs was accepted'
+fi
+grep -F 'manifest is missing: specs' "$TMP_ROOT/missing-specs.out" >/dev/null || \
+  fail 'missing affected-spec failure is unclear'
+mv "$TMP_ROOT/current-manifest.tsv" "$RUN_DIR/manifest.tsv"
 
 PYTHONDONTWRITEBYTECODE=1 python3 - "$ROOT/tools/quality_dashboard.py" "$OUTPUT" <<'PY'
 import importlib.util

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -137,7 +137,7 @@ refresh_summary_digest() {
 
 CONTRACT_SHARD="${DETACH_QUALITY_GATE_CONTRACT_SHARD:-all}"
 case "$CONTRACT_SHARD" in
-  all|selection|execution|failures|evidence|evidence-resume|evidence-resume-a|evidence-resume-b|evidence-runtime) ;;
+  all|selection|execution|failures|evidence|evidence-resume|evidence-resume-a|evidence-resume-b|evidence-runtime|evidence-runtime-a|evidence-runtime-b) ;;
   *) printf 'invalid quality-gate contract shard\n' >&2; exit 2 ;;
 esac
 
@@ -187,6 +187,7 @@ mkdir -p "$REPO/app/Sources/DetachApp"
 printf '%s\n' 'struct ChangedOnboarding {}' \
   >"$REPO/app/Sources/DetachApp/OnboardingFuture.swift"
 plan="$(gate --plan)"
+[[ "$plan" = *'specs=app'* ]]
 [[ "$plan" = *'capabilities=onboarding'* ]]
 [[ "$plan" = *'journeys=J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL'* ]]
 
@@ -606,7 +607,8 @@ grep -F 'resume summary contains invalid or duplicate stage records' "$REPO/inva
 fi
 
 if [ "$CONTRACT_SHARD" = all ] || [ "$CONTRACT_SHARD" = execution ] || \
-   [ "$CONTRACT_SHARD" = evidence ] || [ "$CONTRACT_SHARD" = evidence-runtime ]; then
+   [ "$CONTRACT_SHARD" = evidence ] || [ "$CONTRACT_SHARD" = evidence-runtime ] || \
+   [ "$CONTRACT_SHARD" = evidence-runtime-a ]; then
 setup_fixture stage-timeout
 printf '#!/bin/bash\nsleep 5\n' >"$REPO/tests/quality-gate-fixtures/static"
 chmod 0755 "$REPO/tests/quality-gate-fixtures/static"
@@ -740,6 +742,11 @@ grep -F $'inherited_wall_seconds\t2' "$RESULT_ROOT"/*/release-budget.log >/dev/n
   exit 1
 }
 grep -F 'wall time regressed: 2s > 1s' "$RESULT_ROOT"/*/release-budget.log >/dev/null
+fi
+
+if [ "$CONTRACT_SHARD" = all ] || [ "$CONTRACT_SHARD" = execution ] || \
+   [ "$CONTRACT_SHARD" = evidence ] || [ "$CONTRACT_SHARD" = evidence-runtime ] || \
+   [ "$CONTRACT_SHARD" = evidence-runtime-b ]; then
 
 setup_fixture static-only-budget
 printf '%s\n' docs >>"$REPO/README.md"
@@ -784,6 +791,7 @@ gate >"$REPO/evidence.out"
 run_dir="$(find "$RESULT_ROOT" -mindepth 1 -maxdepth 1 -type d -print | head -1)"
 grep -F $'schema\t4' "$run_dir/manifest.tsv" >/dev/null
 grep -F $'authority\tlocal-diagnostic' "$run_dir/manifest.tsv" >/dev/null
+grep -F $'specs\tdocumentation' "$run_dir/manifest.tsv" >/dev/null
 grep -F $'capabilities\tdocumentation' "$run_dir/manifest.tsv" >/dev/null
 grep -F $'journeys\tJ-DOCS-CONSISTENCY' "$run_dir/manifest.tsv" >/dev/null
 grep -F $'input_fingerprint\t' "$run_dir/manifest.tsv" >/dev/null
@@ -805,6 +813,7 @@ grep -F '"id":"SC-DOCS-CONTRACT"' "$run_dir/scenarios.jsonl" >/dev/null
 grep -F '"journeys":["J-DOCS-CONSISTENCY"]' "$run_dir/scenarios.jsonl" >/dev/null
 grep -F '<testsuite name="detach-quality-scenarios"' "$run_dir/scenarios.junit.xml" >/dev/null
 grep -F '# Quality gate' "$run_dir/summary.md" >/dev/null
+grep -F -- '- Specifications: `documentation`' "$run_dir/summary.md" >/dev/null
 grep -F '| `static` | passed |' "$run_dir/summary.md" >/dev/null
 grep -F '| `SC-DOCS-CONTRACT` | `static` | passed |' "$run_dir/summary.md" >/dev/null
 grep -F 'markdown=' "$REPO/evidence.out" >/dev/null
@@ -850,4 +859,6 @@ case "$CONTRACT_SHARD" in
   evidence-resume-a) printf 'Quality gate resume provenance tests passed\n' ;;
   evidence-resume-b) printf 'Quality gate resume integrity tests passed\n' ;;
   evidence-runtime) printf 'Quality gate runtime evidence tests passed\n' ;;
+  evidence-runtime-a) printf 'Quality gate runtime evidence A tests passed\n' ;;
+  evidence-runtime-b) printf 'Quality gate runtime evidence B tests passed\n' ;;
 esac

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -26,8 +26,11 @@ expect_route() {
 
 "$ROOT/scripts/quality-policy" validate >/dev/null
 "$ROOT/scripts/quality-policy" generate --check
+python3 "$ROOT/tests/quality_policy_contract.py"
 policy_version="$("$ROOT/scripts/quality-policy" version)"
 [[ "$policy_version" =~ ^[1-9][0-9]*$ ]] || fail 'invalid policy version'
+[ "$("$ROOT/scripts/quality-policy" specs | wc -l | tr -d ' ')" = 5 ] || \
+  fail 'current specification inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" stages all | wc -l | tr -d ' ')" = 14 ] || \
   fail 'unexpected stage count'
 [ "$("$ROOT/scripts/quality-policy" stages release | tail -1)" = release-budget ] || \
@@ -39,13 +42,13 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'critical source inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" suites | wc -l | tr -d ' ')" = 12 ] || \
   fail 'required Swift suite inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" requirements | wc -l | tr -d ' ')" = 20 ] || \
+[ "$("$ROOT/scripts/quality-policy" requirements | wc -l | tr -d ' ')" = 22 ] || \
   fail 'critical requirement inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" capabilities | wc -l | tr -d ' ')" = 11 ] || \
   fail 'capability inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" journeys | wc -l | tr -d ' ')" = 28 ] || \
   fail 'journey inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 37 ] || \
+[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 39 ] || \
   fail 'scenario inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" coverage-exclusions | wc -l | tr -d ' ')" = 4 ] || \
   fail 'coverage exclusion inventory is incomplete'
@@ -54,6 +57,15 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
 first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 [ "$first_json" = "$second_json" ] || fail 'generated policy JSON is not deterministic'
+first_specs="$("$ROOT/scripts/quality-policy" render-specs | shasum -a 256 | awk '{print $1}')"
+second_specs="$("$ROOT/scripts/quality-policy" render-specs | shasum -a 256 | awk '{print $1}')"
+[ "$first_specs" = "$second_specs" ] || fail 'generated specification view is not deterministic'
+grep -F '# Generated specification traceability' \
+  "$ROOT/quality/generated/spec-traceability.md" >/dev/null || \
+  fail 'generated specification view has no title'
+grep -F '`QC-QUALITY-POLICY`' \
+  "$ROOT/quality/generated/spec-traceability.md" >/dev/null || \
+  fail 'generated specification view omits the policy requirement'
 
 expect_route docs/testing.md policy safe false
 expect_route app/Sources/DetachKit/DetachStateCommand.swift state-runtime safe false

--- a/tests/quality_policy_contract.py
+++ b/tests/quality_policy_contract.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Deterministic contracts for specification traceability in the quality policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+from quality_policy import Policy, PolicyError  # noqa: E402
+
+
+POLICY = ROOT / "quality/policy.tsv"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_error(source: str, expected: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="detach-quality-policy-contract.") as directory:
+        candidate = Path(directory) / "policy.tsv"
+        candidate.write_text(source, encoding="utf-8")
+        try:
+            Policy(candidate)
+        except PolicyError as error:
+            require(expected in str(error), f"unexpected policy error: {error}")
+        else:
+            raise AssertionError(f"policy accepted invalid input: {expected}")
+
+
+def main() -> None:
+    source = POLICY.read_text(encoding="utf-8")
+    policy = Policy(POLICY)
+    specs = policy.specification_document()
+
+    require(len(specs) == 5, "expected five current specifications")
+    require(
+        {spec["id"] for spec in specs}
+        == {"documentation", "runtime", "power", "app", "release"},
+        "specification identities changed unexpectedly",
+    )
+    require(
+        all("status" not in spec for spec in specs),
+        "the runtime policy contains specification history state",
+    )
+    require(
+        policy.render_spec_traceability() == policy.render_spec_traceability(),
+        "the specification view is not deterministic",
+    )
+
+    requirements = {
+        requirement["id"]: requirement
+        for spec in specs
+        for requirement in spec["requirements"]
+    }
+    require(
+        set(requirements) == set(policy.requirements),
+        "the specification view omits a requirement",
+    )
+    for identifier, requirement in requirements.items():
+        require(requirement["journeys"], f"{identifier} has no user journey")
+        automated = [
+            scenario
+            for scenario in requirement["scenarios"]
+            if scenario["status"] not in {"planned", "manual-release"}
+        ]
+        require(automated, f"{identifier} has no automated scenario")
+
+    expect_error(
+        source.replace(
+            "spec\tdocumentation\tdocs/specs/documentation.md\t",
+            "spec\tdocumentation\tdocs/specs/documentation.md\thistorical\t",
+            1,
+        ),
+        "spec requires 3 values",
+    )
+    expect_error(
+        "\n".join(
+            line
+            for line in source.splitlines()
+            if not line.startswith("spec\tdocumentation\t")
+        )
+        + "\n",
+        "route references unknown spec: docs/specs/documentation.md",
+    )
+    expect_error(
+        source.replace(
+            "journey\tJ-POWER-ENABLE\tpower-protection\t"
+            "QC-POWER-ASSERTION,QC-POWER-LEASE,QC-POWER-CLI,QC-POWER-PLATFORM\t",
+            "journey\tJ-POWER-ENABLE\tpower-protection\t"
+            "QC-POWER-ASSERTION,QC-POWER-LEASE,QC-POWER-PLATFORM\t",
+            1,
+        ),
+        "capability requirement has no journey: power-protection#QC-POWER-CLI",
+    )
+    expect_error(
+        source.replace(
+            "requirement\tQC-APP-SETTINGS\tdocs/specs/app.md\t",
+            "requirement\tQC-APP-SETTINGS\tdocs/specs/runtime.md\t",
+            1,
+        ),
+        "capability settings references requirement from another spec: QC-APP-SETTINGS",
+    )
+    expect_error(
+        source.replace(
+            "scenario\tSC-APP-SETTINGS-UNIT\tswift\tlegacy-stage\t",
+            "scenario\tSC-APP-SETTINGS-UNIT\tswift\tplanned\t",
+            1,
+        ),
+        "requirement has no automated verification scenario: QC-APP-SETTINGS",
+    )
+
+    print("Quality policy Python contracts passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -82,6 +82,11 @@ def read_manifest(run_dir: Path) -> dict[str, str]:
         raise DashboardError(f"manifest is missing: {sorted(missing)[0]}")
     if values["schema"] != "4":
         raise DashboardError("manifest schema is unsupported")
+    if not values["policy"].isdigit():
+        raise DashboardError("manifest policy is invalid")
+    if int(values["policy"]) >= 22 and not values.get("specs"):
+        raise DashboardError("manifest is missing: specs")
+    values.setdefault("specs", "")
     if values["authority"] not in ("local-diagnostic", "ci-merge", "ci-main", "release"):
         raise DashboardError("manifest authority is invalid")
     if values["result"] not in ("passed", "failed", "interrupted", "diagnostic"):
@@ -243,6 +248,13 @@ def build_data(
     stage_by_id = {stage["stage"]: stage for stage in stages}
     journeys_by_id = {journey["id"]: journey for journey in policy["journeys"]}
     scenarios_by_id = {scenario["id"]: scenario for scenario in policy["scenarios"]}
+    specs_by_id = {spec["id"]: spec for spec in policy["specifications"]}
+    impacted_specs: list[dict[str, Any]] = []
+    for spec_id in split_csv(manifest["specs"]):
+        spec = specs_by_id.get(spec_id)
+        if spec is None:
+            raise DashboardError(f"manifest references an unknown spec: {spec_id}")
+        impacted_specs.append(spec)
     impacted_journeys = split_csv(manifest["journeys"])
     journey_evidence: list[dict[str, Any]] = []
     passed_scenarios = 0
@@ -310,6 +322,7 @@ def build_data(
             "wall_seconds": int(manifest["timing_wall_seconds"]),
             "url": run_url,
         },
+        "specifications": impacted_specs,
         "capabilities": split_csv(manifest["capabilities"]),
         "journeys": journey_evidence,
         "stages": stages,
@@ -385,6 +398,9 @@ def render_html(data: dict[str, Any]) -> str:
         for trend in reversed(data["trends"])
     ) or '<tr><td colspan="5">No retained trend evidence.</td></tr>'
     capability_text = ", ".join(data["capabilities"]) or "none"
+    specification_text = ", ".join(
+        spec["id"] for spec in data["specifications"]
+    ) or "none"
     coverage = quality["coverage"]
     if isinstance(coverage, dict):
         ui_coverage = coverage["suites"]["ui"]["line_coverage"]["percent"]
@@ -462,6 +478,7 @@ def render_html(data: dict[str, Any]) -> str:
     <div class="meta">
       <div><span class="eyebrow">Commit</span><br><code>{html.escape(run["commit"])}</code></div>
       <div><span class="eyebrow">Fingerprint</span><br><code>{html.escape(run["fingerprint"])}</code></div>
+      <div><span class="eyebrow">Specifications</span><br>{html.escape(specification_text)}</div>
       <div><span class="eyebrow">Capabilities</span><br>{html.escape(capability_text)}</div>
       <div><span class="eyebrow">Freshness</span><br><span id="freshness" data-finished="{html.escape(run["finished_at"], quote=True)}">{html.escape(run["finished_at"])}</span></div>
     </div>

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -277,6 +277,7 @@ class QualityGate:
         self.resolved_base = ""
         self.source_commit = git_text(["rev-parse", "--verify", "HEAD"])
         self.selected: list[str] = []
+        self.specs: list[str] = []
         self.capabilities: list[str] = []
         self.journeys: list[str] = []
         self.explanations: list[str] = []
@@ -440,6 +441,7 @@ class QualityGate:
         return entries
 
     def select_all_impacts(self) -> None:
+        self.specs = list(self.policy.specs)
         self.capabilities = list(self.policy.capabilities)
         self.journeys = list(self.policy.journeys)
 
@@ -469,6 +471,12 @@ class QualityGate:
             return
         for stage in classification.stages.split(","):
             self.add_stage(stage, f"{change} {classification.test_domain} domain {path}")
+        spec_identifier = next(
+            identifier
+            for identifier, (spec_path, _) in self.policy.specs.items()
+            if spec_path == classification.spec
+        )
+        self.add_unique(self.specs, spec_identifier)
         for capability in classification.capabilities.split(","):
             self.add_unique(self.capabilities, capability)
         for journey in classification.journeys.split(","):
@@ -538,6 +546,7 @@ class QualityGate:
         fact = (
             f"input={self.input_fingerprint}\nmode={self.effective_mode}\n"
             f"authority={self.authority}\nstages={','.join(self.selected)}\n"
+            f"specs={','.join(self.specs)}\n"
             f"capabilities={','.join(self.capabilities)}\n"
             f"journeys={','.join(self.journeys)}\n"
         )
@@ -553,6 +562,7 @@ class QualityGate:
                 "base_commit": self.resolved_base,
                 "input_fingerprint": self.input_fingerprint,
                 "fingerprint": self.fingerprint,
+                "specs": self.specs,
                 "capabilities": self.capabilities,
                 "journeys": self.journeys,
                 "stages": self.selected,
@@ -562,7 +572,8 @@ class QualityGate:
         print(
             f"quality-gate policy={self.policy_version} mode={self.effective_mode} "
             f"authority={self.authority} fingerprint={self.fingerprint} "
-            f"stages={','.join(self.selected)} capabilities={','.join(self.capabilities)} "
+            f"stages={','.join(self.selected)} specs={','.join(self.specs)} "
+            f"capabilities={','.join(self.capabilities)} "
             f"journeys={','.join(self.journeys)}"
         )
         if self.options.explain:
@@ -728,6 +739,7 @@ class QualityGate:
             ("input_fingerprint", self.input_fingerprint),
             ("fingerprint", self.fingerprint),
             ("stages", ",".join(self.selected)),
+            ("specs", ",".join(self.specs)),
             ("capabilities", ",".join(self.capabilities)),
             ("journeys", ",".join(self.journeys)),
             ("started_at", self.started_at),
@@ -1472,6 +1484,7 @@ class QualityGate:
         write_private(self.junit, "\n".join(lines) + "\n")
 
     def write_markdown(self) -> None:
+        specs = ",".join(self.specs) or "-"
         capabilities = ",".join(self.capabilities) or "-"
         journeys = ",".join(self.journeys) or "-"
         lines = [
@@ -1483,6 +1496,7 @@ class QualityGate:
             f"- Source: `{self.source_commit}`",
             f"- Fingerprint: `{self.fingerprint}`",
             "",
+            f"- Specifications: `{specs}`",
             f"- Capabilities: `{capabilities}`",
             f"- Journeys: `{journeys}`",
             "",
@@ -1707,10 +1721,16 @@ def run_gate_contract_stage(root: Path) -> int:
             "Quality gate resume integrity tests passed",
         ),
         (
-            "orchestrator-evidence-runtime.log",
+            "orchestrator-evidence-runtime-a.log",
             [str(root / "tests/quality-gate.sh")],
-            {"DETACH_QUALITY_GATE_CONTRACT_SHARD": "evidence-runtime"},
-            "Quality gate runtime evidence tests passed",
+            {"DETACH_QUALITY_GATE_CONTRACT_SHARD": "evidence-runtime-a"},
+            "Quality gate runtime evidence A tests passed",
+        ),
+        (
+            "orchestrator-evidence-runtime-b.log",
+            [str(root / "tests/quality-gate.sh")],
+            {"DETACH_QUALITY_GATE_CONTRACT_SHARD": "evidence-runtime-b"},
+            "Quality gate runtime evidence B tests passed",
         ),
         (
             "quality-metrics.log",
@@ -1774,7 +1794,7 @@ def run_gate_contract_stage(root: Path) -> int:
         ),
     ]
     contract_root = Path(tempfile.mkdtemp(prefix="detach-gate-contract."))
-    processes: list[tuple[Path, subprocess.Popen[bytes], TextIO, str]] = []
+    processes: list[tuple[Path, subprocess.Popen[bytes], TextIO, str, float]] = []
     try:
         for filename, command, additions, expected in contracts:
             path = contract_root / filename
@@ -1788,20 +1808,32 @@ def run_gate_contract_stage(root: Path) -> int:
                 stdout=output,
                 stderr=subprocess.STDOUT,
             )
-            processes.append((path, process, output, expected))
+            processes.append((path, process, output, expected, time.monotonic()))
         failed = False
-        for _, process, output, _ in processes:
-            if process.wait() != 0:
-                failed = True
-            output.close()
-        for path, _, _, expected in sorted(processes, key=lambda item: item[0].name):
+        durations: dict[Path, int] = {}
+        pending = set(range(len(processes)))
+        while pending:
+            for index in list(pending):
+                path, process, output, _, started = processes[index]
+                status = process.poll()
+                if status is None:
+                    continue
+                if status != 0:
+                    failed = True
+                durations[path] = max(0, round(time.monotonic() - started))
+                output.close()
+                pending.remove(index)
+            if pending:
+                time.sleep(0.05)
+        for path, _, _, expected, _ in sorted(processes, key=lambda item: item[0].name):
             content = path.read_text(encoding="utf-8", errors="replace")
             sys.stdout.write(content)
             if expected not in content.splitlines():
                 failed = True
+            print(f"quality-contract {path.stem} completed in {durations[path]}s")
         return 1 if failed else 0
     finally:
-        for _, process, output, _ in processes:
+        for _, process, output, _, _ in processes:
             if process.poll() is None:
                 process.terminate()
                 process.wait()

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -88,6 +88,7 @@ class Policy:
         self.path = path
         self.schema: int | None = None
         self.version: int | None = None
+        self.specs: dict[str, tuple[str, str]] = {}
         self.limits: dict[str, int] = {}
         self.stages_by_name: dict[str, Stage] = {}
         self.stage_orders: set[int] = set()
@@ -143,6 +144,7 @@ class Policy:
         coverage_patterns: set[str] = set()
         coverage_region_keys: set[tuple[str, str]] = set()
         dependency_pairs: set[tuple[str, str]] = set()
+        spec_paths: set[str] = set()
         for line_number, line in enumerate(lines, 1):
             if not line:
                 raise PolicyError(f"line {line_number}: blank records are not allowed")
@@ -159,6 +161,19 @@ class Policy:
                 if self.version is not None or not POSITIVE_INTEGER.fullmatch(values[0]):
                     raise PolicyError(f"line {line_number}: policy must be one positive integer")
                 self.version = int(values[0])
+            elif kind == "spec":
+                self._expect_count(kind, values, 3, line_number)
+                identifier, path, summary = values
+                if (
+                    not IDENTIFIER.fullmatch(identifier)
+                    or path != f"docs/specs/{identifier}.md"
+                    or not summary
+                    or path in spec_paths
+                ):
+                    raise PolicyError(f"line {line_number}: invalid or duplicate spec")
+                self._unique(self.specs, identifier, "spec", line_number)
+                spec_paths.add(path)
+                self.specs[identifier] = (path, summary)
             elif kind == "limit":
                 self._expect_count(kind, values, 2, line_number)
                 name, raw_value = values
@@ -356,6 +371,9 @@ class Policy:
     def _validate_references(self) -> None:
         if self.schema != 1 or self.version is None:
             raise PolicyError("schema and policy records are required")
+        if not self.specs:
+            raise PolicyError("at least one current specification is required")
+        registered_specs = {path for path, _ in self.specs.values()}
         if "static" not in self.stages_by_name:
             raise PolicyError("static stage is required")
         if "unknown" not in self.test_domains or "unknown" not in self.release_domains:
@@ -385,6 +403,8 @@ class Policy:
                 raise PolicyError(f"route references unknown test domain: {route.test_domain}")
             if route.release_domain not in self.release_domains:
                 raise PolicyError(f"route references unknown release domain: {route.release_domain}")
+            if route.spec not in registered_specs:
+                raise PolicyError(f"route references unknown spec: {route.spec}")
         for source, requirement in self.critical:
             if requirement not in self.requirements:
                 raise PolicyError(f"critical source {source} references unknown requirement: {requirement}")
@@ -417,12 +437,22 @@ class Policy:
         referenced_requirements: set[str] = {requirement for _, requirement in self.critical}
         referenced_journeys: set[str] = set()
         referenced_scenarios: set[str] = set()
-        for capability, (_, requirements, journeys) in self.capabilities.items():
+        requirement_journeys: dict[str, list[str]] = {
+            requirement: [] for requirement in self.requirements
+        }
+        for capability, (spec, requirements, journeys) in self.capabilities.items():
+            if spec not in registered_specs:
+                raise PolicyError(f"capability {capability} references unknown spec: {spec}")
             if requirements != "-":
                 for requirement in requirements.split(","):
                     if requirement not in self.requirements:
                         raise PolicyError(
                             f"capability {capability} references unknown requirement: {requirement}"
+                        )
+                    if self.requirements[requirement][0] != spec:
+                        raise PolicyError(
+                            f"capability {capability} references requirement from another spec: "
+                            f"{requirement}"
                         )
                     referenced_requirements.add(requirement)
             for journey in journeys.split(","):
@@ -434,13 +464,20 @@ class Policy:
         for journey, (capability, requirements, scenarios, _) in self.journeys.items():
             if capability not in self.capabilities:
                 raise PolicyError(f"journey {journey} references unknown capability: {capability}")
+            capability_requirements = set(self._list_or_empty(self.capabilities[capability][1]))
             if requirements != "-":
                 for requirement in requirements.split(","):
                     if requirement not in self.requirements:
                         raise PolicyError(
                             f"journey {journey} references unknown requirement: {requirement}"
                         )
+                    if requirement not in capability_requirements:
+                        raise PolicyError(
+                            f"journey {journey} references requirement outside its capability: "
+                            f"{requirement}"
+                        )
                     referenced_requirements.add(requirement)
+                    requirement_journeys[requirement].append(journey)
             for scenario in scenarios.split(","):
                 if scenario not in self.scenarios:
                     raise PolicyError(f"journey {journey} references unknown scenario: {scenario}")
@@ -457,6 +494,35 @@ class Policy:
             raise PolicyError(f"orphan scenario: {sorted(orphan_scenarios)[0]}")
         if orphan_requirements:
             raise PolicyError(f"orphan requirement: {sorted(orphan_requirements)[0]}")
+        for capability, (_, requirements, journeys) in self.capabilities.items():
+            journey_requirements = {
+                requirement
+                for journey in journeys.split(",")
+                for requirement in self._list_or_empty(self.journeys[journey][1])
+            }
+            missing = set(self._list_or_empty(requirements)) - journey_requirements
+            if missing:
+                raise PolicyError(
+                    f"capability requirement has no journey: {capability}#{sorted(missing)[0]}"
+                )
+        for requirement, journeys in requirement_journeys.items():
+            automated = {
+                scenario
+                for journey in journeys
+                for scenario in self.journeys[journey][2].split(",")
+                if self.scenarios[scenario][1] not in ("planned", "manual-release")
+            }
+            if not automated:
+                raise PolicyError(
+                    f"requirement has no automated verification scenario: {requirement}"
+                )
+        for identifier, (path, _) in self.specs.items():
+            if not any(route.spec == path for route in self.routes):
+                raise PolicyError(f"spec has no owned route: {identifier}")
+            if not any(spec == path for spec, _, _ in self.capabilities.values()):
+                raise PolicyError(f"spec has no capability: {identifier}")
+            if not any(spec == path for spec, _ in self.requirements.values()):
+                raise PolicyError(f"spec has no requirement: {identifier}")
 
     def classify(self, path: str) -> Classification:
         matches = [route for route in self.routes if fnmatch.fnmatchcase(path, route.pattern)]
@@ -571,6 +637,19 @@ class Policy:
 
     def validate_tracked_paths(self) -> None:
         paths = list(self.tracked_paths())
+        tracked = set(paths)
+        tracked_specs = {
+            path
+            for path in tracked
+            if SPEC_PATH.fullmatch(path) and path != "docs/specs/README.md"
+        }
+        registered_specs = {path for path, _ in self.specs.values()}
+        missing_specs = tracked_specs - registered_specs
+        orphan_specs = registered_specs - tracked_specs
+        if missing_specs:
+            raise PolicyError(f"unregistered durable spec: {sorted(missing_specs)[0]}")
+        if orphan_specs:
+            raise PolicyError(f"registered spec is missing: {sorted(orphan_specs)[0]}")
         for path in paths:
             classification = self.classify(path)
             if classification.status != "known":
@@ -580,15 +659,120 @@ class Policy:
         for _, pattern, _, _ in self.coverage_exclusions:
             if not any(fnmatch.fnmatchcase(path, pattern) for path in paths):
                 raise PolicyError(f"orphan coverage exclusion: {pattern}")
-        tracked = set(paths)
         for _, source, _, _, _ in self.coverage_regions:
             if source not in tracked:
                 raise PolicyError(f"orphan coverage-region source: {source}")
+
+    def specification_document(self) -> list[dict[str, object]]:
+        records: list[dict[str, object]] = []
+        for identifier, (path, summary) in self.specs.items():
+            capabilities = [
+                capability
+                for capability, (spec, _, _) in self.capabilities.items()
+                if spec == path
+            ]
+            journeys = [
+                journey
+                for capability in capabilities
+                for journey in self.capabilities[capability][2].split(",")
+            ]
+            requirements: list[dict[str, object]] = []
+            for requirement, (spec, requirement_summary) in self.requirements.items():
+                if spec != path:
+                    continue
+                requirement_journeys = [
+                    journey
+                    for journey in journeys
+                    if requirement in self._list_or_empty(self.journeys[journey][1])
+                ]
+                scenario_ids: list[str] = []
+                for journey in requirement_journeys:
+                    for scenario in self.journeys[journey][2].split(","):
+                        if scenario not in scenario_ids:
+                            scenario_ids.append(scenario)
+                requirements.append(
+                    {
+                        "id": requirement,
+                        "summary": requirement_summary,
+                        "journeys": requirement_journeys,
+                        "scenarios": [
+                            {
+                                "id": scenario,
+                                "stage": self.scenarios[scenario][0],
+                                "status": self.scenarios[scenario][1],
+                                "command": self.scenarios[scenario][2],
+                            }
+                            for scenario in scenario_ids
+                        ],
+                    }
+                )
+            records.append(
+                {
+                    "id": identifier,
+                    "path": path,
+                    "summary": summary,
+                    "owned_patterns": sorted(
+                        {route.pattern for route in self.routes if route.spec == path}
+                    ),
+                    "capabilities": capabilities,
+                    "journeys": journeys,
+                    "requirements": requirements,
+                }
+            )
+        return records
+
+    def render_spec_traceability(self) -> str:
+        lines = [
+            "# Generated specification traceability",
+            "",
+            "This file is generated from `quality/policy.tsv`. Do not edit it.",
+            "It lists current specification ownership and verification links.",
+        ]
+        for spec in self.specification_document():
+            lines.extend(
+                [
+                    "",
+                    f"## `{spec['id']}`",
+                    "",
+                    f"- Path: `{spec['path']}`",
+                    f"- Summary: {spec['summary']}",
+                    "- Capabilities: "
+                    + ", ".join(f"`{value}`" for value in spec["capabilities"]),
+                    "",
+                    "### Owned path patterns",
+                    "",
+                ]
+            )
+            lines.extend(f"- `{pattern}`" for pattern in spec["owned_patterns"])
+            lines.extend(
+                [
+                    "",
+                    "### Requirement verification",
+                    "",
+                    "| Requirement | Journeys | Scenarios | Outcome |",
+                    "| --- | --- | --- | --- |",
+                ]
+            )
+            for requirement in spec["requirements"]:
+                journey_text = "<br>".join(
+                    f"`{journey}`" for journey in requirement["journeys"]
+                )
+                scenario_text = "<br>".join(
+                    f"`{scenario['id']}` ({scenario['status']}, `{scenario['stage']}`)"
+                    for scenario in requirement["scenarios"]
+                )
+                summary = str(requirement["summary"]).replace("|", "\\|")
+                lines.append(
+                    f"| `{requirement['id']}` | {journey_text} | "
+                    f"{scenario_text} | {summary} |"
+                )
+        return "\n".join(lines) + "\n"
 
     def document(self) -> dict[str, object]:
         return {
             "schema": self.schema,
             "policy": self.version,
+            "specifications": self.specification_document(),
             "limits": self.limits,
             "stages": [
                 {
@@ -691,6 +875,7 @@ def usage(stream: object = sys.stdout) -> None:
        scripts/quality-policy stages all|release
        scripts/quality-policy timeout STAGE
        scripts/quality-policy dependencies
+       scripts/quality-policy specs
        scripts/quality-policy classify PATH
        scripts/quality-policy critical
        scripts/quality-policy requirements
@@ -701,6 +886,7 @@ def usage(stream: object = sys.stdout) -> None:
        scripts/quality-policy coverage-regions
        scripts/quality-policy suites
        scripts/quality-policy render-json
+       scripts/quality-policy render-specs
        scripts/quality-policy generate [--check]
        scripts/quality-policy check-paths [PATH ...]""",
         file=stream,
@@ -750,6 +936,10 @@ def main(arguments: list[str]) -> int:
         require_count(values, 0, "dependencies takes no arguments")
         for prerequisite, dependent in policy.dependencies:
             print(f"{prerequisite}\t{dependent}")
+    elif command == "specs":
+        require_count(values, 0, "specs takes no arguments")
+        for identifier, (path, summary) in policy.specs.items():
+            print(f"{identifier}\t{path}\t{summary}")
     elif command == "classify":
         require_count(values, 1, "classify requires one path")
         print(policy.classify(values[0]).tsv())
@@ -788,26 +978,37 @@ def main(arguments: list[str]) -> int:
     elif command == "render-json":
         require_count(values, 0, "render-json takes no arguments")
         print(json.dumps(policy.document(), indent=2, sort_keys=True))
+    elif command == "render-specs":
+        require_count(values, 0, "render-specs takes no arguments")
+        print(policy.render_spec_traceability(), end="")
     elif command == "generate":
         if values not in ([], ["--check"]):
             raise PolicyError("generate accepts only --check")
-        target = ROOT / "quality/generated/policy.json"
-        rendered = json.dumps(policy.document(), indent=2, sort_keys=True) + "\n"
+        targets = {
+            ROOT / "quality/generated/policy.json": (
+                json.dumps(policy.document(), indent=2, sort_keys=True) + "\n"
+            ),
+            ROOT / "quality/generated/spec-traceability.md": (
+                policy.render_spec_traceability()
+            ),
+        }
         if values == ["--check"]:
-            if not target.is_file() or target.is_symlink():
-                raise PolicyError("generated policy view is missing or unsafe")
-            if target.read_text(encoding="utf-8") != rendered:
-                raise PolicyError(
-                    "generated policy view is stale; run scripts/quality-policy generate"
-                )
+            for target, rendered in targets.items():
+                if not target.is_file() or target.is_symlink():
+                    raise PolicyError(f"generated policy view is missing or unsafe: {target.name}")
+                if target.read_text(encoding="utf-8") != rendered:
+                    raise PolicyError(
+                        "generated policy view is stale; run scripts/quality-policy generate"
+                    )
         else:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            if target.exists() and target.is_symlink():
-                raise PolicyError("generated policy view target is a symlink")
-            temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
-            temporary.write_text(rendered, encoding="utf-8")
-            os.chmod(temporary, 0o644)
-            os.replace(temporary, target)
+            for target, rendered in targets.items():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists() and target.is_symlink():
+                    raise PolicyError("generated policy view target is a symlink")
+                temporary = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+                temporary.write_text(rendered, encoding="utf-8")
+                os.chmod(temporary, 0o644)
+                os.replace(temporary, target)
     elif command == "check-paths":
         if values:
             for path in values:


### PR DESCRIPTION
## Summary
- register each current durable specification in the single quality policy
- validate spec, requirement, journey, and automated scenario traceability
- publish generated JSON/Markdown and affected specs in gate and dashboard evidence
- keep policy history in Git while preserving prior run telemetry for trends
- split the slow runtime evidence contract to keep the 100-second local budget

## Local evidence
- `scripts/quality-gate --plan --explain`: `static,gate-contract` only
- focused diagnostic PASS: static 1s, gate-contract 68s
- policy, documentation, dashboard, selection, runtime evidence, and test-suite contracts PASS
- no product matrix or release action ran locally

## Safety
- `presentations/` remains ignored and excluded
- existing internal HTML files remain untracked and are not in this PR
- hosted `quality-gates` is the only merge-readiness authority