### PR TITLE
Reuse exact PR quality evidence on main

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
   group: quality-gates-${{ github.workflow }}-${{ github.ref }}
@@ -26,7 +27,23 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+      - id: promoted-main
+        name: Promote exact pull-request evidence
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          error_log="$RUNNER_TEMP/quality-promotion-error.log"
+          if promotion_root="$(scripts/quality-promote 2>"$error_log")"; then
+            printf 'promoted=true\n' >>"$GITHUB_OUTPUT"
+            printf 'root=%s\n' "$promotion_root" >>"$GITHUB_OUTPUT"
+          else
+            cat "$error_log" >&2
+            printf 'Promotion was unavailable; running the full main gate.\n' >&2
+            printf 'promoted=false\n' >>"$GITHUB_OUTPUT"
+          fi
       - name: Restore last green main quality metrics
+        if: steps.promoted-main.outputs.promoted != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -34,6 +51,7 @@ jobs:
           printf 'DETACH_QUALITY_BASELINE_ROOT=%s\n' "$baseline_root" >>"$GITHUB_ENV"
       - name: Restore Swift and tmux caches
         id: swift-cache
+        if: steps.promoted-main.outputs.promoted != 'true'
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
@@ -49,7 +67,7 @@ jobs:
           DETACH_QUALITY_AUTHORITY: ci-merge
         run: scripts/quality-gate --mode repository --base "$BASE_SHA" --keep-going --without-release-budget
       - name: Run main repository gate
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.promoted-main.outputs.promoted != 'true')
         env:
           DETACH_QUALITY_AUTHORITY: ci-main
         run: scripts/quality-gate --mode repository --keep-going --without-release-budget
@@ -59,7 +77,7 @@ jobs:
           DETACH_QUALITY_AUTHORITY: release
         run: scripts/quality-gate --mode repository --keep-going --without-release-budget
       - name: Save Swift and tmux caches
-        if: always() && steps.swift-cache.outputs.cache-hit != 'true'
+        if: always() && steps.promoted-main.outputs.promoted != 'true' && steps.swift-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
@@ -77,6 +95,10 @@ jobs:
           latest="${runs[${#runs[@]}-1]}"
           {
             printf '## Quality gate evidence\n\n'
+            if [ -f "$latest/promotion.md" ]; then
+              cat "$latest/promotion.md"
+              printf '\n'
+            fi
             if [ -f "$latest/summary.md" ]; then
               cat "$latest/summary.md"
             else

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Local presentation sources are internal working material. They are not
 # repository inputs and must not affect impact analysis or quality gates.
 /presentations/
+/docs/assets/*.html
 __pycache__/
 *.pyc
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -41,6 +41,8 @@ the only ordinary merge authority. Unknown paths select the full plan.
   deadline.
 - `scripts/quality-mutation` validates and runs the deterministic safety mutant
   corpus. Mutation work does not add to pull request latency.
+- `scripts/quality-promote` binds a successful pull-request artifact to its
+  final `main` merge commit. It runs only in the hosted main-push workflow.
 
 `--without-release-budget` disables reference-Mac time comparisons. Hosted CI
 uses this option because hosted timing is not release timing. Functional
@@ -55,6 +57,13 @@ Every manifest records one authority:
 - `ci-merge` for the pull request merge commit;
 - `ci-main` for the current `main` commit;
 - `release` for the owner-confirmed release flow.
+
+An ordinary main merge keeps the original `ci-merge` manifest immutable. A
+separate promotion record supplies `ci-main` authority only when GitHub and Git
+facts prove that the tested synthetic merge and final merge have the same tree
+and ordered parents. The dashboard shows both commits and the source run. The
+next metrics comparison uses the final main commit. A direct or ambiguous main
+push runs the complete repository gate instead.
 
 The repository gate writes private evidence under
 `app/build/quality-gates/`. One run contains a schema-versioned TSV summary,

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -78,9 +78,14 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   extend pull-request feedback time.
 - A deterministic static dashboard reads only validated gate evidence. The
   same artifact opens locally and deploys to GitHub Pages only after a green
-  `main` repository run or a green scheduled mutation run. It shows measured
-  coverage and the latest valid mutation score when they exist. Only deploy
-  jobs have Pages write permission.
+  `main` run with direct or promoted evidence, or a green scheduled mutation
+  run. It shows measured coverage and the latest valid mutation score when
+  they exist. Only deploy jobs have Pages write permission.
+- An ordinary merged pull request does not repeat the full functional matrix
+  on `main`. The main workflow promotes the successful pull-request artifact
+  only when the tested merge and final merge have the same tree and ordered
+  parents. Promotion keeps both commit identities and every original digest.
+  Missing or ambiguous proof falls back to a full `ci-main` repository gate.
 - The active GitHub ruleset for `main` has no bypass actors. It requires the
   GitHub Actions `quality-gates` job. An administrator cannot use an unchecked
   push as a substitute for CI. A release commit first gets the same check on

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,10 @@
   readiness evidence.
 - `scripts/quality-policy generate --check` checks both generated policy JSON
   and the readable current-spec traceability table.
+- `scripts/quality-promote` is the hosted post-merge path. It downloads the
+  exact successful pull-request artifact and proves tree and parent equality.
+  It does not run locally or change the tested evidence. A failed proof makes
+  the workflow run the full main repository gate.
 - `scripts/quality-dashboard generate` creates
   `app/build/quality-dashboard/{index.html,data.json}` from the newest schema-4
   evidence. `scripts/quality-dashboard serve --seconds 300` serves it only on

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -283,7 +283,8 @@
         "QC-QUALITY-POLICY"
       ],
       "scenarios": [
-        "SC-POLICY-CONTRACT"
+        "SC-POLICY-CONTRACT",
+        "SC-PROMOTION-CONTRACT"
       ],
       "summary": "A policy change keeps local feedback focused and hosted evidence complete."
     },
@@ -618,7 +619,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 22,
+  "policy": 23,
   "release_domains": [
     {
       "gates": "-",
@@ -866,6 +867,20 @@
     },
     {
       "pattern": "tools/quality_baseline.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-promote",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_promote.py",
       "priority": 1000,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -1671,6 +1686,12 @@
       "status": "automated"
     },
     {
+      "command": "tests/quality-promote.sh",
+      "id": "SC-PROMOTION-CONTRACT",
+      "stage": "gate-contract",
+      "status": "automated"
+    },
+    {
       "command": "tests/docs-contract.sh",
       "id": "SC-DOCS-CONTRACT",
       "stage": "static",
@@ -1935,6 +1956,7 @@
         "scripts/quality-metrics",
         "scripts/quality-mutation",
         "scripts/quality-policy",
+        "scripts/quality-promote",
         "scripts/quality-scenarios",
         "scripts/test",
         "tests/*",
@@ -1950,6 +1972,7 @@
         "tools/quality_metrics.py",
         "tools/quality_mutation.py",
         "tools/quality_policy.py",
+        "tools/quality_promote.py",
         "tools/quality_scenarios.py"
       ],
       "path": "docs/specs/documentation.md",
@@ -1963,6 +1986,12 @@
             {
               "command": "tests/quality-policy.sh",
               "id": "SC-POLICY-CONTRACT",
+              "stage": "gate-contract",
+              "status": "automated"
+            },
+            {
+              "command": "tests/quality-promote.sh",
+              "id": "SC-PROMOTION-CONTRACT",
               "stage": "gate-contract",
               "status": "automated"
             }

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -34,6 +34,7 @@ It lists current specification ownership and verification links.
 - `scripts/quality-metrics`
 - `scripts/quality-mutation`
 - `scripts/quality-policy`
+- `scripts/quality-promote`
 - `scripts/quality-scenarios`
 - `scripts/test`
 - `tests/*`
@@ -49,13 +50,14 @@ It lists current specification ownership and verification links.
 - `tools/quality_metrics.py`
 - `tools/quality_mutation.py`
 - `tools/quality_policy.py`
+- `tools/quality_promote.py`
 - `tools/quality_scenarios.py`
 
 ### Requirement verification
 
 | Requirement | Journeys | Scenarios | Outcome |
 | --- | --- | --- | --- |
-| `QC-QUALITY-POLICY` | `J-QUALITY-CHANGE` | `SC-POLICY-CONTRACT` (automated, `gate-contract`) | One current policy owns quality selection and traceability. |
+| `QC-QUALITY-POLICY` | `J-QUALITY-CHANGE` | `SC-POLICY-CONTRACT` (automated, `gate-contract`)<br>`SC-PROMOTION-CONTRACT` (automated, `gate-contract`) | One current policy owns quality selection and traceability. |
 | `QC-DOC-CONSISTENCY` | `J-DOCS-CONSISTENCY` | `SC-DOCS-CONTRACT` (automated, `static`) | Durable documentation and generated quality views stay synchronized. |
 
 ## `runtime`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	22
+policy	23
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -83,6 +83,8 @@ route	1000	scripts/quality-metrics	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_metrics.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-baseline	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_baseline.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-promote	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_promote.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-mutation	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_mutation.py	policy	safe	docs/specs/documentation.md
 route	1000	.github/workflows/quality-mutations.yml	policy	safe	docs/specs/documentation.md
@@ -207,7 +209,7 @@ capability	update	docs/specs/app.md	QC-APP-UPDATE	J-UPDATE-CHECK,J-UPDATE-APPLY
 capability	diagnostics	docs/specs/app.md	QC-APP-DOCTOR	J-DOCTOR-REPORT
 capability	installation	docs/specs/release.md	QC-RELEASE-INSTALL	J-INSTALL-CLEAN,J-INSTALL-REPAIR,J-INSTALL-UNINSTALL
 capability	publication	docs/specs/release.md	QC-RELEASE-PUBLISH	J-PUBLISH-ARTIFACTS
-journey	J-QUALITY-CHANGE	quality-system	QC-QUALITY-POLICY	SC-POLICY-CONTRACT	A policy change keeps local feedback focused and hosted evidence complete.
+journey	J-QUALITY-CHANGE	quality-system	QC-QUALITY-POLICY	SC-POLICY-CONTRACT,SC-PROMOTION-CONTRACT	A policy change keeps local feedback focused and hosted evidence complete.
 journey	J-DOCS-CONSISTENCY	documentation	QC-DOC-CONSISTENCY	SC-DOCS-CONTRACT	Documentation and executable contracts stay synchronized.
 journey	J-SESSION-CREATE	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP	SC-SESSION-CREATE-CODEX,SC-SESSION-CREATE-CLAUDE	A user creates a managed provider session.
 journey	J-SESSION-PERSIST	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-STORAGE	SC-SESSION-PERSIST-CODEX,SC-SESSION-PERSIST-CLAUDE	A live session remains available after the app exits.
@@ -236,6 +238,7 @@ journey	J-INSTALL-REPAIR	installation	QC-RELEASE-INSTALL	SC-INSTALL-REPAIR	Repai
 journey	J-INSTALL-UNINSTALL	installation	QC-RELEASE-INSTALL	SC-INSTALL-UNINSTALL	Uninstall removes only Detach-owned data selected by the user.
 journey	J-PUBLISH-ARTIFACTS	publication	QC-RELEASE-PUBLISH	SC-PUBLISH-CONTRACT	Publication exposes only verified allowlisted artifacts.
 scenario	SC-POLICY-CONTRACT	gate-contract	automated	tests/quality-policy.sh
+scenario	SC-PROMOTION-CONTRACT	gate-contract	automated	tests/quality-promote.sh
 scenario	SC-DOCS-CONTRACT	static	automated	tests/docs-contract.sh
 scenario	SC-SESSION-CREATE-CODEX	codex	instrumented	tests/run.sh
 scenario	SC-SESSION-CREATE-CLAUDE	claude	instrumented	tests/run-claude.sh

--- a/scripts/quality-promote
+++ b/scripts/quality-promote
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality-promote: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tools/quality_promote.py" "$@"

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -7,8 +7,10 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-quality-dashboard.XXXXXX")"
 RESULT_ROOT="$TMP_ROOT/results"
 RUN_DIR="$RESULT_ROOT/20260811T100000Z-1"
 OUTPUT="$TMP_ROOT/dashboard"
+PROMOTED_OUTPUT="$TMP_ROOT/promoted-dashboard"
 MUTATION_SUMMARY="$TMP_ROOT/mutation-summary.json"
 POLICY_VERSION="$("$ROOT/scripts/quality-policy" version)"
+MAIN_COMMIT=8989898989898989898989898989898989898989
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 
 fail() {
@@ -98,7 +100,7 @@ EOF
 PRIOR_RUN="$RESULT_ROOT/20260810T100000Z-1"
 mkdir -p "$PRIOR_RUN"
 awk -F '\t' -v OFS='\t' \
-  '$1 == "policy" {$2=21} $1 != "specs" {print}' \
+  '$1 == "policy" {$2=21} {print}' \
   "$RUN_DIR/manifest.tsv" >"$PRIOR_RUN/manifest.tsv"
 
 cat >"$MUTATION_SUMMARY" <<JSON
@@ -177,6 +179,57 @@ assert [journey["id"] for journey in data["journeys"]] == [
     "J-ONBOARD-FIRST-RUN", "J-ONBOARD-PROVIDER", "J-ONBOARD-APPROVAL"
 ]
 PY
+
+manifest_digest="$(shasum -a 256 "$RUN_DIR/manifest.tsv" | awk '{print $1}')"
+cat >"$RUN_DIR/promotion.tsv" <<EOF
+schema	1
+authority	ci-main
+result	passed
+repository	owner/repository
+main_commit	$MAIN_COMMIT
+main_tree	eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+base_commit	fedcba9876543210fedcba9876543210fedcba98
+head_commit	bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+tested_commit	0123456789abcdef0123456789abcdef01234567
+tested_tree	eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+pull_request	25
+merged_at	2026-08-11T10:00:30Z
+source_run	1
+source_run_attempt	1
+source_run_url	https://github.com/owner/repository/actions/runs/1
+source_artifact	quality-gate-evidence-1-1
+source_manifest_sha256	$manifest_digest
+EOF
+"$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+  --output "$PROMOTED_OUTPUT" \
+  --run-url 'https://github.com/owner/repository/actions/runs/2' \
+  --mutation-summary "$MUTATION_SUMMARY" >/dev/null
+grep -F "Tested merge <code>0123456789abcdef0123456789abcdef01234567</code>" \
+  "$PROMOTED_OUTPUT/index.html" >/dev/null || fail 'promotion provenance is missing'
+python3 - "$PROMOTED_OUTPUT/data.json" "$MAIN_COMMIT" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as source:
+    data = json.load(source)
+assert data["run"]["authority"] == "ci-main"
+assert data["run"]["commit"] == sys.argv[2]
+assert data["run"]["tested_commit"] == "0123456789abcdef0123456789abcdef01234567"
+assert data["run"]["promotion"]["source_run"] == "1"
+assert len(data["trends"]) == 2
+PY
+
+cp "$RUN_DIR/promotion.tsv" "$TMP_ROOT/promotion.tsv"
+sed 's/^tested_tree.*/tested_tree\t0000000000000000000000000000000000000000/' \
+  "$TMP_ROOT/promotion.tsv" >"$RUN_DIR/promotion.tsv"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/tampered-promotion" \
+    >"$TMP_ROOT/tampered-promotion.out" 2>&1; then
+  fail 'tampered promotion evidence was accepted'
+fi
+grep -F 'promotion evidence does not bind' \
+  "$TMP_ROOT/tampered-promotion.out" >/dev/null || \
+  fail 'tampered promotion failure is unclear'
+mv "$TMP_ROOT/promotion.tsv" "$RUN_DIR/promotion.tsv"
 
 cp "$RUN_DIR/manifest.tsv" "$TMP_ROOT/current-manifest.tsv"
 awk -F '\t' '$1 != "specs" {print}' "$TMP_ROOT/current-manifest.tsv" \

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -23,6 +23,14 @@ grep -F 'run: scripts/quality-gate --mode repository --base "$BASE_SHA" --keep-g
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-gate --mode repository --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Promote exact pull-request evidence' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F '  pull-requests: read' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'promotion_root="$(scripts/quality-promote 2>"$error_log")"' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "steps.promoted-main.outputs.promoted != 'true'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F -- '- "detach-release/**"' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 ! grep -E 'uses:[[:space:]]+[^[:space:]]+@v[0-9]' \

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -26,6 +26,10 @@ expect_route() {
 
 "$ROOT/scripts/quality-policy" validate >/dev/null
 "$ROOT/scripts/quality-policy" generate --check
+git -C "$ROOT" check-ignore --no-index -q -- presentations/internal.html || \
+  fail 'the internal presentations directory is a quality input'
+git -C "$ROOT" check-ignore --no-index -q -- docs/assets/internal.html || \
+  fail 'internal HTML presentation assets are quality inputs'
 python3 "$ROOT/tests/quality_policy_contract.py"
 policy_version="$("$ROOT/scripts/quality-policy" version)"
 [[ "$policy_version" =~ ^[1-9][0-9]*$ ]] || fail 'invalid policy version'
@@ -48,7 +52,7 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'capability inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" journeys | wc -l | tr -d ' ')" = 28 ] || \
   fail 'journey inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 39 ] || \
+[ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 40 ] || \
   fail 'scenario inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" coverage-exclusions | wc -l | tr -d ' ')" = 4 ] || \
   fail 'coverage exclusion inventory is incomplete'

--- a/tests/quality-promote.sh
+++ b/tests/quality-promote.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality promotion contracts: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tests/quality_promote_contract.py"

--- a/tests/quality_metrics_contract.py
+++ b/tests/quality_metrics_contract.py
@@ -24,6 +24,7 @@ from quality_policy import POLICY_FILE, Policy  # noqa: E402
 POLICY = Policy(POLICY_FILE)
 BASE_COMMIT = "a" * 40
 SOURCE_COMMIT = "b" * 40
+TESTED_COMMIT = "c" * 40
 
 
 def write_json(path: Path, value: Any) -> None:
@@ -81,6 +82,9 @@ def create_baseline(
     *,
     include_metrics: bool = True,
     manifest_policy: Optional[int] = None,
+    authority: str = "ci-main",
+    source_commit: str = BASE_COMMIT,
+    promotion_main: Optional[str] = None,
 ) -> Path:
     run_dir = root / "run"
     run_dir.mkdir(parents=True)
@@ -97,12 +101,35 @@ def create_baseline(
     (run_dir / "manifest.tsv").write_text(
         "schema\t4\n"
         f"policy\t{manifest_policy if manifest_policy is not None else POLICY.version}\n"
-        "authority\tci-main\n"
+        f"authority\t{authority}\n"
         "result\tpassed\n"
-        f"source_commit\t{BASE_COMMIT}\n"
+        f"source_commit\t{source_commit}\n"
+        f"base_commit\t{'d' * 40}\n"
         f"artifacts_sha256\t{digest(artifacts)}\n",
         encoding="utf-8",
     )
+    if promotion_main is not None:
+        manifest = run_dir / "manifest.tsv"
+        (run_dir / "promotion.tsv").write_text(
+            "schema\t1\n"
+            "authority\tci-main\n"
+            "result\tpassed\n"
+            "repository\towner/repository\n"
+            f"main_commit\t{promotion_main}\n"
+            f"main_tree\t{'e' * 40}\n"
+            f"base_commit\t{'d' * 40}\n"
+            f"head_commit\t{'f' * 40}\n"
+            f"tested_commit\t{source_commit}\n"
+            f"tested_tree\t{'e' * 40}\n"
+            "pull_request\t25\n"
+            "merged_at\t2026-08-12T12:00:00Z\n"
+            "source_run\t123\n"
+            "source_run_attempt\t1\n"
+            "source_run_url\thttps://github.com/owner/repository/actions/runs/123\n"
+            "source_artifact\tquality-gate-evidence-123-1\n"
+            f"source_manifest_sha256\t{digest(manifest)}\n",
+            encoding="utf-8",
+        )
     return run_dir
 
 
@@ -206,6 +233,72 @@ def main() -> None:
         assert document["suites"]["ui"]["line_coverage"]["percent"] == 90.0
         assert document["changed_lines"]["status"] == "passed"
         assert document["changed_lines"]["line_coverage"]["percent"] == 90.0
+
+        promoted_metrics = root / "promoted-metrics.json"
+        promoted_document = json.loads(baseline_metrics.read_text(encoding="utf-8"))
+        promoted_document["source_commit"] = TESTED_COMMIT
+        write_json(promoted_metrics, promoted_document)
+        promoted_root = root / "promoted-baseline"
+        promoted_run = create_baseline(
+            promoted_root,
+            promoted_metrics,
+            authority="ci-merge",
+            source_commit=TESTED_COMMIT,
+            promotion_main=BASE_COMMIT,
+        )
+        promoted_current = root / "promoted-current.json"
+        invoke(
+            evaluate_arguments(
+                coverage,
+                tests,
+                promoted_current,
+                changed,
+                baseline=promoted_root,
+                authority="ci-merge",
+            )
+        )
+        promoted_result = json.loads(promoted_current.read_text(encoding="utf-8"))
+        assert promoted_result["comparison"]["baseline_source_commit"] == BASE_COMMIT
+
+        missing_promotion_root = root / "missing-promotion"
+        create_baseline(
+            missing_promotion_root,
+            promoted_metrics,
+            authority="ci-merge",
+            source_commit=TESTED_COMMIT,
+        )
+        missing_promotion = invoke(
+            evaluate_arguments(
+                coverage,
+                tests,
+                root / "missing-promotion.json",
+                changed,
+                baseline=missing_promotion_root,
+                authority="ci-merge",
+            ),
+            expected=2,
+        )
+        require_text(missing_promotion, "no direct or promoted ci-main authority")
+
+        promotion_path = promoted_run / "promotion.tsv"
+        promotion_text = promotion_path.read_text(encoding="utf-8")
+        promotion_path.write_text(
+            promotion_text.replace(f"tested_tree\t{'e' * 40}", f"tested_tree\t{'0' * 40}"),
+            encoding="utf-8",
+        )
+        tampered_promotion = invoke(
+            evaluate_arguments(
+                coverage,
+                tests,
+                root / "tampered-promotion.json",
+                changed,
+                baseline=promoted_root,
+                authority="ci-merge",
+            ),
+            expected=2,
+        )
+        require_text(tampered_promotion, "does not bind the tested manifest")
+        promotion_path.write_text(promotion_text, encoding="utf-8")
 
         write_json(
             changed,

--- a/tests/quality_promote_contract.py
+++ b/tests/quality_promote_contract.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Deterministic contracts for exact pull-request evidence promotion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+from quality_policy import POLICY_FILE, Policy  # noqa: E402
+from quality_promote import PromotionError, read_tsv, validate_promotion  # noqa: E402
+
+
+POLICY = Policy(POLICY_FILE)
+BASE = "a" * 40
+HEAD = "b" * 40
+TESTED = "c" * 40
+MAIN = "d" * 40
+TREE = "e" * 40
+BASELINE = "f" * 40
+RUN_ID = 123
+ATTEMPT = 2
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def metrics_document() -> dict[str, object]:
+    return {
+        "schema": 1,
+        "policy": POLICY.version,
+        "source_commit": TESTED,
+        "suites": {
+            "business": {
+                "line_coverage": {"covered": 9, "percent": 90.0, "total": 10},
+                "test_count": 1,
+                "tests": ["DetachKitTests.Sample/testOne"],
+            },
+            "ui": {
+                "line_coverage": {"covered": 3, "percent": 30.0, "total": 10},
+                "test_count": 1,
+                "tests": ["DetachAppTests.Sample/testOne"],
+            },
+        },
+        "critical_files": [],
+        "changed_lines": {
+            "base_commit": BASE,
+            "files": [],
+            "line_coverage": {"covered": 0, "percent": 100.0, "total": 0},
+            "minimum_percent": 90,
+            "status": "not-applicable",
+        },
+        "comparison": {
+            "baseline_policy": max(1, (POLICY.version or 1) - 1),
+            "baseline_source_commit": BASELINE,
+            "mode": "green-main-artifact",
+            "regressions": [],
+            "status": "passed",
+        },
+    }
+
+
+def create_evidence(root: Path) -> Path:
+    run_dir = root / "20260812T120000Z-1"
+    run_dir.mkdir(parents=True)
+    summary_lines = [
+        "policy\tmode\tstage\tstatus\tduration_seconds\tlog\tlog_sha256\torigin_run"
+    ]
+    stages = [stage.name for stage in POLICY.stages if stage.name != "release-budget"]
+    for stage in stages:
+        log = run_dir / f"{stage}.log"
+        log.write_text(f"{stage} passed\n", encoding="utf-8")
+        summary_lines.append(
+            f"{POLICY.version}\trepository\t{stage}\tpassed\t1\t{stage}.log\t"
+            f"{digest(log)}\t-"
+        )
+    summary = run_dir / "summary.tsv"
+    summary.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    environment = run_dir / "environment.tsv"
+    environment.write_text("schema\t1\narchitecture\ttest\n", encoding="utf-8")
+    write_json(run_dir / "quality-metrics.json", metrics_document())
+    (run_dir / "scenarios.jsonl").write_text("{}\n", encoding="utf-8")
+    (run_dir / "scenarios.junit.xml").write_text(
+        '<testsuite name="quality" tests="0"/>\n', encoding="utf-8"
+    )
+    artifacts = run_dir / "artifacts.tsv"
+    artifacts.write_text(
+        "schema\t1\n"
+        + "".join(
+            f"file\t{name}\t{digest(run_dir / name)}\n"
+            for name in (
+                "quality-metrics.json",
+                "scenarios.jsonl",
+                "scenarios.junit.xml",
+            )
+        ),
+        encoding="utf-8",
+    )
+    manifest = run_dir / "manifest.tsv"
+    manifest.write_text(
+        "schema\t4\n"
+        f"policy\t{POLICY.version}\n"
+        "mode\trepository\n"
+        "authority\tci-merge\n"
+        f"source_commit\t{TESTED}\n"
+        f"base_commit\t{BASE}\n"
+        f"input_fingerprint\t{'1' * 64}\n"
+        f"fingerprint\t{'2' * 64}\n"
+        f"stages\t{','.join(stages)}\n"
+        f"specs\t{','.join(POLICY.specs)}\n"
+        f"capabilities\t{','.join(POLICY.capabilities)}\n"
+        f"journeys\t{','.join(POLICY.journeys)}\n"
+        "started_at\t2026-08-12T12:00:00Z\n"
+        "finished_at\t2026-08-12T12:03:00Z\n"
+        "duration_seconds\t180\n"
+        "timing_wall_seconds\t180\n"
+        "resumed_from_run\t\n"
+        "resumed_from_manifest_sha256\t\n"
+        f"environment_sha256\t{digest(environment)}\n"
+        f"artifacts_sha256\t{digest(artifacts)}\n"
+        f"summary_sha256\t{digest(summary)}\n"
+        "result\tpassed\n",
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def fake_tools(root: Path) -> tuple[Path, Path]:
+    fake_git = root / "fake-git"
+    fake_git.write_text(
+        f"""#!/usr/bin/env python3
+import os
+mode = os.environ.get("FAKE_PROMOTE_MODE", "success")
+parents = "{BASE} {HEAD}" if mode != "one-parent" else "{BASE}"
+print("{MAIN}")
+print("{TREE}")
+print(parents)
+""",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    fake_gh = root / "fake-gh"
+    fake_gh.write_text(
+        f"""#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+
+arguments = sys.argv[1:]
+mode = os.environ.get("FAKE_PROMOTE_MODE", "success")
+if arguments[0] == "api":
+    path = arguments[1]
+    if path.endswith("/commits/{MAIN}/pulls"):
+        records = [] if mode == "no-pr" else [{{
+            "number": 25,
+            "state": "closed",
+            "merged_at": "2026-08-12T12:04:00Z",
+            "merge_commit_sha": "{MAIN}",
+            "base": {{"sha": "{BASE}"}},
+            "head": {{"sha": "{HEAD}"}},
+        }}]
+        print(json.dumps(records))
+    elif "workflows/quality-gates.yml/runs" in path:
+        updated = "2026-08-12T12:05:00Z" if mode == "stale-run" else "2026-08-12T12:03:30Z"
+        print(json.dumps({{"workflow_runs": [{{
+            "id": {RUN_ID},
+            "run_attempt": {ATTEMPT},
+            "event": "pull_request",
+            "conclusion": "success",
+            "head_sha": "{HEAD}",
+            "updated_at": updated,
+            "html_url": "https://github.com/owner/repository/actions/runs/{RUN_ID}",
+        }}]}}))
+    elif path.endswith("/actions/runs/{RUN_ID}/artifacts"):
+        artifacts = [{{
+            "name": "quality-gate-evidence-{RUN_ID}-{ATTEMPT}",
+            "expired": False,
+        }}]
+        if mode == "duplicate-artifact": artifacts.append(artifacts[0])
+        print(json.dumps({{"artifacts": artifacts}}))
+    elif path.endswith("/git/commits/{TESTED}"):
+        tree = "{{}}".format("{'0' * 40}" if mode == "tree-mismatch" else "{TREE}")
+        head = "{'0' * 40}" if mode == "parent-mismatch" else "{HEAD}"
+        print(json.dumps({{
+            "sha": "{TESTED}",
+            "tree": {{"sha": tree}},
+            "parents": [{{"sha": "{BASE}"}}, {{"sha": head}}],
+        }}))
+    else:
+        raise SystemExit(3)
+elif arguments[:2] == ["run", "download"]:
+    destination = Path(arguments[arguments.index("--dir") + 1])
+    source = Path(os.environ["FAKE_PROMOTE_EVIDENCE"])
+    target = destination / source.name
+    shutil.copytree(source, target)
+    if mode == "symlinked-run":
+        shutil.rmtree(target)
+        target.symlink_to(source, target_is_directory=True)
+    if mode == "tampered-artifact":
+        with (target / "quality-metrics.json").open("a", encoding="utf-8") as stream:
+            stream.write(" ")
+else:
+    raise SystemExit(3)
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    return fake_gh, fake_git
+
+
+def invoke(
+    fake_gh: Path,
+    fake_git: Path,
+    evidence: Path,
+    output: Path,
+    *,
+    mode: str = "success",
+    expected: int = 0,
+    test_mode: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "DETACH_QUALITY_PROMOTE_GH": str(fake_gh),
+            "DETACH_QUALITY_PROMOTE_GIT": str(fake_git),
+            "FAKE_PROMOTE_EVIDENCE": str(evidence),
+            "FAKE_PROMOTE_MODE": mode,
+        }
+    )
+    if test_mode:
+        environment["DETACH_QUALITY_PROMOTE_TEST_MODE"] = "1"
+    else:
+        environment.pop("DETACH_QUALITY_PROMOTE_TEST_MODE", None)
+    result = subprocess.run(
+        [
+            str(ROOT / "scripts/quality-promote"),
+            "--repository", "owner/repository",
+            "--commit", MAIN,
+            "--output-root", str(output),
+        ],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != expected:
+        raise AssertionError(
+            f"promotion returned {result.returncode}, expected {expected}\n{result.stdout}"
+        )
+    return result
+
+
+def require(result: subprocess.CompletedProcess[str], text: str) -> None:
+    if text not in result.stdout:
+        raise AssertionError(f"missing diagnostic {text!r}:\n{result.stdout}")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="detach-quality-promote-contract.") as raw:
+        root = Path(raw)
+        evidence = create_evidence(root / "source")
+        fake_gh, fake_git = fake_tools(root)
+
+        first = root / "first"
+        result = invoke(fake_gh, fake_git, evidence, first)
+        if Path(result.stdout.strip()) != first:
+            raise AssertionError("promotion output root is not deterministic")
+        run_dir = next(path.parent for path in first.glob("*/manifest.tsv"))
+        manifest = read_tsv(run_dir / "manifest.tsv", "manifest")
+        promotion = validate_promotion(run_dir, manifest)
+        if promotion is None or promotion["main_commit"] != MAIN:
+            raise AssertionError("promotion does not bind the main commit")
+
+        second = root / "second"
+        invoke(fake_gh, fake_git, evidence, second)
+        second_run = next(path.parent for path in second.glob("*/manifest.tsv"))
+        if (run_dir / "promotion.tsv").read_bytes() != (second_run / "promotion.tsv").read_bytes():
+            raise AssertionError("promotion evidence is not deterministic")
+        if (run_dir / "promotion.md").read_bytes() != (second_run / "promotion.md").read_bytes():
+            raise AssertionError("promotion summary is not deterministic")
+
+        for mode, diagnostic in (
+            ("one-parent", "not an exact two-parent merge"),
+            ("no-pr", "no unique exact merged pull request"),
+            ("stale-run", "no successful pre-merge"),
+            ("duplicate-artifact", "no unique exact evidence artifact"),
+            ("tree-mismatch", "do not have the same tree and parents"),
+            ("parent-mismatch", "do not have the same tree and parents"),
+            ("tampered-artifact", "artifact digest does not match"),
+            ("symlinked-run", "evidence run directory is unsafe"),
+        ):
+            output = root / mode
+            failed = invoke(
+                fake_gh, fake_git, evidence, output, mode=mode, expected=2
+            )
+            require(failed, diagnostic)
+            if output.exists():
+                raise AssertionError(f"failed promotion retained output: {mode}")
+
+        promotion_path = run_dir / "promotion.tsv"
+        original = promotion_path.read_text(encoding="utf-8")
+        promotion_path.write_text(
+            original.replace(f"main_tree\t{TREE}", f"main_tree\t{'0' * 40}"),
+            encoding="utf-8",
+        )
+        try:
+            validate_promotion(run_dir, manifest)
+        except PromotionError as error:
+            if "does not bind" not in str(error):
+                raise
+        else:
+            raise AssertionError("tampered promotion evidence was accepted")
+
+        production = invoke(
+            fake_gh,
+            fake_git,
+            evidence,
+            root / "production",
+            expected=2,
+            test_mode=False,
+        )
+        require(production, "restricted to a GitHub main push")
+
+    print("Quality promotion contracts passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/shell-safety.sh
+++ b/tests/shell-safety.sh
@@ -16,7 +16,7 @@ failures=0
 while IFS= read -r -d '' file; do
   case "$file" in
     tests/shell-safety-contract.sh) continue ;;
-    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
+    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/quality-promote|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
     *) continue ;;
   esac
   [ -f "$ROOT/$file" ] || continue

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -17,6 +17,7 @@ from typing import Any, NoReturn, Optional
 
 from quality_metrics import MetricsError, validate_metrics
 from quality_mutation import MutationError, validate_summary
+from quality_promote import PromotionError, validate_promotion
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -84,9 +85,8 @@ def read_manifest(run_dir: Path) -> dict[str, str]:
         raise DashboardError("manifest schema is unsupported")
     if not values["policy"].isdigit():
         raise DashboardError("manifest policy is invalid")
-    if int(values["policy"]) >= 22 and not values.get("specs"):
+    if not values.get("specs"):
         raise DashboardError("manifest is missing: specs")
-    values.setdefault("specs", "")
     if values["authority"] not in ("local-diagnostic", "ci-merge", "ci-main", "release"):
         raise DashboardError("manifest authority is invalid")
     if values["result"] not in ("passed", "failed", "interrupted", "diagnostic"):
@@ -188,6 +188,18 @@ def split_csv(value: str) -> list[str]:
     return [item for item in value.split(",") if item]
 
 
+def effective_identity(
+    run_dir: Path, manifest: dict[str, str]
+) -> tuple[str, str, Optional[dict[str, str]]]:
+    try:
+        promotion = validate_promotion(run_dir, manifest)
+    except PromotionError as error:
+        raise DashboardError(str(error)) from error
+    if promotion is None:
+        return manifest["source_commit"], manifest["authority"], None
+    return promotion["main_commit"], promotion["authority"], promotion
+
+
 def percentile(values: list[int], percent: int) -> int:
     if not values:
         return 0
@@ -205,14 +217,15 @@ def collect_trends(result_root: Path, current: Path) -> list[dict[str, Any]]:
             continue
         try:
             manifest = read_manifest(candidate)
+            commit, authority, _ = effective_identity(candidate, manifest)
         except DashboardError:
             continue
         trends.append(
             {
                 "run": candidate.name,
                 "current": candidate.resolve() == current.resolve(),
-                "commit": manifest["source_commit"],
-                "authority": manifest["authority"],
+                "commit": commit,
+                "authority": authority,
                 "result": manifest["result"],
                 "finished_at": manifest["finished_at"],
                 "duration_seconds": int(manifest["duration_seconds"]),
@@ -241,6 +254,9 @@ def build_data(
     mutation_summary: Optional[Path] = None,
 ) -> dict[str, Any]:
     manifest = read_manifest(run_dir)
+    effective_commit, effective_authority, promotion = effective_identity(
+        run_dir, manifest
+    )
     stages = read_summary(run_dir, manifest)
     policy = read_policy()
     if int(manifest["policy"]) != policy["policy"]:
@@ -310,10 +326,11 @@ def build_data(
         "schema": 1,
         "run": {
             "id": run_dir.name,
-            "commit": manifest["source_commit"],
+            "commit": effective_commit,
+            "tested_commit": manifest["source_commit"],
             "fingerprint": manifest["fingerprint"],
             "policy": int(manifest["policy"]),
-            "authority": manifest["authority"],
+            "authority": effective_authority,
             "mode": manifest["mode"],
             "result": manifest["result"],
             "started_at": manifest["started_at"],
@@ -321,6 +338,7 @@ def build_data(
             "duration_seconds": int(manifest["duration_seconds"]),
             "wall_seconds": int(manifest["timing_wall_seconds"]),
             "url": run_url,
+            "promotion": promotion if promotion is not None else "not-promoted",
         },
         "specifications": impacted_specs,
         "capabilities": split_csv(manifest["capabilities"]),
@@ -401,6 +419,14 @@ def render_html(data: dict[str, Any]) -> str:
     specification_text = ", ".join(
         spec["id"] for spec in data["specifications"]
     ) or "none"
+    promotion = run["promotion"]
+    promotion_text = (
+        f'Tested merge <code>{html.escape(run["tested_commit"])}</code> · '
+        f'<a href="{html.escape(promotion["source_run_url"], quote=True)}">'
+        f'PR run {html.escape(promotion["source_run"])}</a>'
+        if isinstance(promotion, dict)
+        else "Direct evidence for this commit"
+    )
     coverage = quality["coverage"]
     if isinstance(coverage, dict):
         ui_coverage = coverage["suites"]["ui"]["line_coverage"]["percent"]
@@ -480,6 +506,7 @@ def render_html(data: dict[str, Any]) -> str:
       <div><span class="eyebrow">Fingerprint</span><br><code>{html.escape(run["fingerprint"])}</code></div>
       <div><span class="eyebrow">Specifications</span><br>{html.escape(specification_text)}</div>
       <div><span class="eyebrow">Capabilities</span><br>{html.escape(capability_text)}</div>
+      <div><span class="eyebrow">Evidence provenance</span><br>{promotion_text}</div>
       <div><span class="eyebrow">Freshness</span><br><span id="freshness" data-finished="{html.escape(run["finished_at"], quote=True)}">{html.escape(run["finished_at"])}</span></div>
     </div>
     <section><h2>Stages</h2><div class="table-wrap"><table><thead><tr><th>Stage</th><th>Status</th><th class="number">Seconds</th><th>Log</th></tr></thead><tbody>{stage_rows}</tbody></table></div></section>

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1660,6 +1660,7 @@ def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -
         "scripts/quality-metrics",
         "scripts/quality-mutation",
         "scripts/quality-baseline",
+        "scripts/quality-promote",
         "scripts/release-version",
         "scripts/release-impact",
         "scripts/release-lid-probe",
@@ -1743,6 +1744,12 @@ def run_gate_contract_stage(root: Path) -> int:
             [str(root / "tests/quality-baseline.sh")],
             {},
             "Quality baseline contracts passed",
+        ),
+        (
+            "quality-promote.log",
+            [str(root / "tests/quality-promote.sh")],
+            {},
+            "Quality promotion contracts passed",
         ),
         (
             "quality-mutation.log",

--- a/tools/quality_metrics.py
+++ b/tools/quality_metrics.py
@@ -14,6 +14,7 @@ import sys
 from typing import Any, NoReturn, Optional
 
 from quality_policy import POLICY_FILE, Policy, PolicyError, ROOT
+from quality_promote import PromotionError, validate_promotion
 
 
 HEX_COMMIT = re.compile(r"^[0-9a-f]{40}$")
@@ -275,7 +276,7 @@ def read_tsv_map(path: Path, label: str) -> dict[str, str]:
     return values
 
 
-def load_baseline_run(root: Path) -> tuple[Path, dict[str, str]]:
+def load_baseline_run(root: Path) -> tuple[Path, dict[str, str], str]:
     if not root.is_dir() or root.is_symlink():
         raise MetricsError(f"baseline root is missing or unsafe: {root}")
     manifests = sorted(root.glob("*/manifest.tsv"))
@@ -283,11 +284,7 @@ def load_baseline_run(root: Path) -> tuple[Path, dict[str, str]]:
         raise MetricsError("baseline root must contain exactly one quality run")
     run_dir = manifests[0].parent
     manifest = read_tsv_map(manifests[0], "baseline manifest")
-    required = {
-        "schema": "4",
-        "authority": "ci-main",
-        "result": "passed",
-    }
+    required = {"schema": "4", "result": "passed"}
     for key, expected in required.items():
         if manifest.get(key) != expected:
             raise MetricsError(f"baseline manifest {key} is not {expected}")
@@ -298,7 +295,19 @@ def load_baseline_run(root: Path) -> tuple[Path, dict[str, str]]:
     artifacts = safe_file(run_dir / "artifacts.tsv", "baseline artifact inventory")
     if sha256(artifacts) != manifest.get("artifacts_sha256"):
         raise MetricsError("baseline artifact inventory digest does not match its manifest")
-    return run_dir, manifest
+    try:
+        promotion = validate_promotion(run_dir, manifest)
+    except PromotionError as error:
+        raise MetricsError(str(error)) from error
+    if manifest.get("authority") == "ci-main":
+        if promotion is not None:
+            raise MetricsError("direct ci-main evidence cannot contain a promotion")
+        effective_source = manifest["source_commit"]
+    elif manifest.get("authority") == "ci-merge" and promotion is not None:
+        effective_source = promotion["main_commit"]
+    else:
+        raise MetricsError("baseline has no direct or promoted ci-main authority")
+    return run_dir, manifest, effective_source
 
 
 def artifact_digest(run_dir: Path, relative: str) -> Optional[str]:
@@ -470,7 +479,7 @@ def validate_metrics(document: Any, *, expected_policy: Optional[int] = None) ->
 def load_baseline(root: Optional[Path]) -> tuple[Optional[dict[str, Any]], str, str]:
     if root is None:
         return None, "none", ""
-    run_dir, manifest = load_baseline_run(root)
+    run_dir, manifest, effective_source = load_baseline_run(root)
     metrics_path = run_dir / "quality-metrics.json"
     digest = artifact_digest(run_dir, "quality-metrics.json")
     if metrics_path.exists() or digest is not None:
@@ -483,7 +492,8 @@ def load_baseline(root: Optional[Path]) -> tuple[Optional[dict[str, Any]], str, 
             raise MetricsError("baseline metrics source does not match its manifest")
         if document["policy"] != int(manifest["policy"]):
             raise MetricsError("baseline metrics policy does not match its manifest")
-        return document, "green-main-artifact", manifest["source_commit"]
+        effective_document = {**document, "source_commit": effective_source}
+        return effective_document, "green-main-artifact", effective_source
     raise MetricsError("last green main artifact has no quality metrics")
 
 

--- a/tools/quality_promote.py
+++ b/tools/quality_promote.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Promote exact successful pull-request evidence to a merged main commit."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, NoReturn
+
+from quality_policy import POLICY_FILE, Policy
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "app/build/quality-gates"
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"^[0-9a-f]{64}$")
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SUMMARY_HEADER = (
+    "policy\tmode\tstage\tstatus\tduration_seconds\tlog\tlog_sha256\torigin_run"
+)
+PROMOTION_FIELDS = (
+    "schema",
+    "authority",
+    "result",
+    "repository",
+    "main_commit",
+    "main_tree",
+    "base_commit",
+    "head_commit",
+    "tested_commit",
+    "tested_tree",
+    "pull_request",
+    "merged_at",
+    "source_run",
+    "source_run_attempt",
+    "source_run_url",
+    "source_artifact",
+    "source_manifest_sha256",
+)
+PROMOTION_KEYS = set(PROMOTION_FIELDS)
+
+
+class PromotionError(Exception):
+    """Evidence cannot be promoted without weakening provenance."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-promote: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def safe_file(path: Path, label: str) -> Path:
+    if not path.is_file() or path.is_symlink():
+        raise PromotionError(f"{label} is missing or unsafe")
+    return path
+
+
+def safe_relative_file(root: Path, relative: str, label: str) -> Path:
+    value = Path(relative)
+    if value.is_absolute() or ".." in value.parts or not relative:
+        raise PromotionError(f"{label} path is unsafe")
+    path = safe_file(root / value, label)
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as error:
+        raise PromotionError(f"{label} path escapes its evidence root") from error
+    return path
+
+
+def read_tsv(path: Path, label: str) -> dict[str, str]:
+    safe_file(path, label)
+    values: dict[str, str] = {}
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        fields = line.split("\t")
+        if len(fields) != 2 or not fields[0] or fields[0] in values:
+            raise PromotionError(f"{label} has a malformed record at line {number}")
+        values[fields[0]] = fields[1]
+    return values
+
+
+def parse_json(raw: str, label: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise PromotionError(f"{label} response is malformed: {error}") from error
+
+
+def command(executable: str, arguments: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            [executable, *arguments],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as error:
+        raise PromotionError(f"cannot start {executable}: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise PromotionError(f"{Path(executable).name} failed: {detail}")
+    return result.stdout
+
+
+def git_info(executable: str, commit: str) -> tuple[str, str, list[str]]:
+    lines = command(
+        executable,
+        ["show", "-s", "--format=%H%n%T%n%P", f"{commit}^{{commit}}"],
+    ).splitlines()
+    if (
+        len(lines) != 3
+        or not COMMIT.fullmatch(lines[0])
+        or not COMMIT.fullmatch(lines[1])
+    ):
+        raise PromotionError("main commit metadata is malformed")
+    parents = lines[2].split()
+    if any(not COMMIT.fullmatch(parent) for parent in parents):
+        raise PromotionError("main commit parents are malformed")
+    return lines[0], lines[1], parents
+
+
+def gh(executable: str, path: str) -> Any:
+    return parse_json(command(executable, ["api", path]), "GitHub API")
+
+
+def merged_pull_request(
+    executable: str, repository: str, main_commit: str, parents: list[str]
+) -> dict[str, Any]:
+    records = gh(executable, f"repos/{repository}/commits/{main_commit}/pulls")
+    if not isinstance(records, list):
+        raise PromotionError("associated pull-request response is malformed")
+    matches = [
+        record
+        for record in records
+        if isinstance(record, dict)
+        and record.get("state") == "closed"
+        and record.get("merge_commit_sha") == main_commit
+        and isinstance(record.get("merged_at"), str)
+        and isinstance(record.get("base"), dict)
+        and isinstance(record.get("head"), dict)
+        and record["base"].get("sha") == parents[0]
+        and record["head"].get("sha") == parents[1]
+    ]
+    if len(matches) != 1 or not isinstance(matches[0].get("number"), int):
+        raise PromotionError("main commit has no unique exact merged pull request")
+    return matches[0]
+
+
+def successful_run(
+    executable: str, repository: str, head_commit: str, merged_at: str
+) -> tuple[int, int, str]:
+    response = gh(
+        executable,
+        f"repos/{repository}/actions/workflows/quality-gates.yml/runs"
+        f"?event=pull_request&status=success&head_sha={head_commit}&per_page=20",
+    )
+    if not isinstance(response, dict) or not isinstance(response.get("workflow_runs"), list):
+        raise PromotionError("quality workflow response is malformed")
+    candidates: list[tuple[str, int, int, str]] = []
+    for run in response["workflow_runs"]:
+        if not isinstance(run, dict):
+            continue
+        run_id = run.get("id")
+        attempt = run.get("run_attempt")
+        updated_at = run.get("updated_at")
+        url = run.get("html_url")
+        if (
+            isinstance(run_id, int)
+            and run_id > 0
+            and isinstance(attempt, int)
+            and attempt > 0
+            and run.get("event") == "pull_request"
+            and run.get("conclusion") == "success"
+            and run.get("head_sha") == head_commit
+            and isinstance(updated_at, str)
+            and updated_at <= merged_at
+            and isinstance(url, str)
+        ):
+            candidates.append((updated_at, run_id, attempt, url))
+    if not candidates:
+        raise PromotionError("no successful pre-merge pull-request run is available")
+    _, run_id, attempt, url = max(candidates)
+    return run_id, attempt, url
+
+
+def artifact_name(executable: str, repository: str, run_id: int, attempt: int) -> str:
+    response = gh(executable, f"repos/{repository}/actions/runs/{run_id}/artifacts")
+    if not isinstance(response, dict) or not isinstance(response.get("artifacts"), list):
+        raise PromotionError("quality artifact response is malformed")
+    expected = f"quality-gate-evidence-{run_id}-{attempt}"
+    matches = [
+        artifact.get("name")
+        for artifact in response["artifacts"]
+        if isinstance(artifact, dict)
+        and artifact.get("name") == expected
+        and artifact.get("expired") is False
+    ]
+    if matches != [expected]:
+        raise PromotionError("pull-request run has no unique exact evidence artifact")
+    return expected
+
+
+def artifact_inventory(run_dir: Path, manifest: dict[str, str]) -> dict[str, str]:
+    inventory = safe_file(run_dir / "artifacts.tsv", "artifact inventory")
+    if sha256(inventory) != manifest.get("artifacts_sha256"):
+        raise PromotionError("artifact inventory digest does not match the manifest")
+    lines = inventory.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "schema\t1":
+        raise PromotionError("artifact inventory schema is invalid")
+    values: dict[str, str] = {}
+    for line in lines[1:]:
+        fields = line.split("\t")
+        if (
+            len(fields) != 3
+            or fields[0] != "file"
+            or not fields[1]
+            or fields[1] in values
+            or not DIGEST.fullmatch(fields[2])
+        ):
+            raise PromotionError("artifact inventory contains an invalid record")
+        artifact = safe_relative_file(run_dir, fields[1], "evidence artifact")
+        if sha256(artifact) != fields[2]:
+            raise PromotionError(f"evidence artifact digest does not match: {fields[1]}")
+        values[fields[1]] = fields[2]
+    for required in ("quality-metrics.json", "scenarios.jsonl", "scenarios.junit.xml"):
+        if required not in values:
+            raise PromotionError(f"required evidence artifact is missing: {required}")
+    return values
+
+
+def validate_summary(run_dir: Path, manifest: dict[str, str], policy: Policy) -> None:
+    summary = safe_file(run_dir / "summary.tsv", "quality summary")
+    if sha256(summary) != manifest.get("summary_sha256"):
+        raise PromotionError("quality summary digest does not match the manifest")
+    lines = summary.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != SUMMARY_HEADER:
+        raise PromotionError("quality summary schema is invalid")
+    expected_stages = [stage.name for stage in policy.stages if stage.name != "release-budget"]
+    seen: list[str] = []
+    for line in lines[1:]:
+        fields = line.split("\t")
+        if (
+            len(fields) != 8
+            or fields[0] != str(policy.version)
+            or fields[1] != "repository"
+            or fields[3] != "passed"
+            or not fields[4].isdigit()
+            or not DIGEST.fullmatch(fields[6])
+            or fields[7] != "-"
+        ):
+            raise PromotionError("quality summary contains non-passing or malformed evidence")
+        log = safe_relative_file(run_dir, fields[5], "stage log")
+        if sha256(log) != fields[6]:
+            raise PromotionError(f"stage log digest does not match: {fields[2]}")
+        seen.append(fields[2])
+    if seen != expected_stages:
+        raise PromotionError("quality summary is not the complete repository plan")
+
+
+def validate_evidence(
+    run_dir: Path, policy: Policy, base_commit: str
+) -> tuple[dict[str, str], str]:
+    manifest_path = safe_file(run_dir / "manifest.tsv", "quality manifest")
+    manifest = read_tsv(manifest_path, "quality manifest")
+    expected = {
+        "schema": "4",
+        "policy": str(policy.version),
+        "mode": "repository",
+        "authority": "ci-merge",
+        "result": "passed",
+        "base_commit": base_commit,
+        "stages": ",".join(
+            stage.name for stage in policy.stages if stage.name != "release-budget"
+        ),
+        "specs": ",".join(policy.specs),
+        "capabilities": ",".join(policy.capabilities),
+        "journeys": ",".join(policy.journeys),
+    }
+    for key, value in expected.items():
+        if manifest.get(key) != value:
+            raise PromotionError(f"quality manifest {key} is not exact")
+    tested_commit = manifest.get("source_commit", "")
+    if not COMMIT.fullmatch(tested_commit):
+        raise PromotionError("tested source commit is invalid")
+    for name in ("environment", "artifacts", "summary"):
+        evidence = safe_file(run_dir / f"{name}.tsv", f"{name} evidence")
+        if sha256(evidence) != manifest.get(f"{name}_sha256"):
+            raise PromotionError(f"{name} evidence digest does not match the manifest")
+    validate_summary(run_dir, manifest, policy)
+    artifact_inventory(run_dir, manifest)
+    from quality_metrics import read_json, validate_metrics
+
+    metrics = validate_metrics(
+        read_json(run_dir / "quality-metrics.json", "quality metrics"),
+        expected_policy=policy.version,
+    )
+    if metrics["source_commit"] != tested_commit or metrics["comparison"]["status"] != "passed":
+        raise PromotionError("quality metrics are not passing evidence for the tested commit")
+    return manifest, sha256(manifest_path)
+
+
+def github_commit(
+    executable: str, repository: str, commit: str
+) -> tuple[str, list[str]]:
+    value = gh(executable, f"repos/{repository}/git/commits/{commit}")
+    if not isinstance(value, dict) or value.get("sha") != commit:
+        raise PromotionError("tested commit response is malformed")
+    tree = value.get("tree")
+    parents = value.get("parents")
+    if (
+        not isinstance(tree, dict)
+        or not COMMIT.fullmatch(tree.get("sha", ""))
+        or not isinstance(parents, list)
+        or any(not isinstance(parent, dict) for parent in parents)
+    ):
+        raise PromotionError("tested commit provenance is malformed")
+    parent_ids = [parent.get("sha", "") for parent in parents]
+    if any(not COMMIT.fullmatch(parent) for parent in parent_ids):
+        raise PromotionError("tested commit parents are malformed")
+    return tree["sha"], parent_ids
+
+
+def write_promotion(run_dir: Path, values: dict[str, str]) -> None:
+    target = run_dir / "promotion.tsv"
+    temporary = run_dir / f".promotion.{os.getpid()}"
+    temporary.write_text(
+        "".join(f"{key}\t{values[key]}\n" for key in PROMOTION_FIELDS),
+        encoding="utf-8",
+    )
+    temporary.chmod(0o600)
+    os.replace(temporary, target)
+    markdown = run_dir / "promotion.md"
+    markdown.write_text(
+        "\n".join(
+            (
+                "# Promoted main evidence",
+                "",
+                f"- Main commit: `{values['main_commit']}`",
+                f"- Tested merge commit: `{values['tested_commit']}`",
+                f"- Pull request: `{values['pull_request']}`",
+                f"- Source run: [{values['source_run']}]({values['source_run_url']})",
+                "- Proof: the tested and merged commits have the same tree and parents.",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    markdown.chmod(0o600)
+
+
+def validate_promotion(run_dir: Path, manifest: dict[str, str]) -> dict[str, str] | None:
+    path = run_dir / "promotion.tsv"
+    if not path.exists():
+        return None
+    values = read_tsv(path, "promotion evidence")
+    if set(values) != PROMOTION_KEYS:
+        raise PromotionError("promotion evidence fields are malformed")
+    for key in (
+        "main_commit", "main_tree", "base_commit", "head_commit",
+        "tested_commit", "tested_tree",
+    ):
+        if not COMMIT.fullmatch(values[key]):
+            raise PromotionError(f"promotion {key} is invalid")
+    if (
+        values["schema"] != "1"
+        or values["authority"] != "ci-main"
+        or values["result"] != "passed"
+        or not REPOSITORY.fullmatch(values["repository"])
+        or not values["pull_request"].isdigit()
+        or int(values["pull_request"]) <= 0
+        or not values["source_run"].isdigit()
+        or int(values["source_run"]) <= 0
+        or not values["source_run_attempt"].isdigit()
+        or int(values["source_run_attempt"]) <= 0
+        or values["main_tree"] != values["tested_tree"]
+        or values["tested_commit"] != manifest.get("source_commit")
+        or values["base_commit"] != manifest.get("base_commit")
+        or manifest.get("authority") != "ci-merge"
+        or manifest.get("result") != "passed"
+        or not DIGEST.fullmatch(values["source_manifest_sha256"])
+        or sha256(run_dir / "manifest.tsv") != values["source_manifest_sha256"]
+    ):
+        raise PromotionError("promotion evidence does not bind the tested manifest")
+    expected_artifact = (
+        f"quality-gate-evidence-{values['source_run']}-{values['source_run_attempt']}"
+    )
+    expected_url = (
+        f"https://github.com/{values['repository']}/actions/runs/{values['source_run']}"
+    )
+    if values["source_artifact"] != expected_artifact or values["source_run_url"] != expected_url:
+        raise PromotionError("promotion source run identity is inconsistent")
+    try:
+        datetime.fromisoformat(values["merged_at"].replace("Z", "+00:00"))
+    except ValueError as error:
+        raise PromotionError("promotion merge timestamp is invalid") from error
+    return values
+
+
+def promote(
+    repository: str,
+    main_commit: str,
+    output_root: Path,
+    gh_executable: str,
+    git_executable: str,
+) -> Path:
+    if not REPOSITORY.fullmatch(repository):
+        raise PromotionError("repository must identify owner/repository")
+    resolved, main_tree, parents = git_info(git_executable, main_commit)
+    if resolved != main_commit or len(parents) != 2:
+        raise PromotionError("main commit is not an exact two-parent merge")
+    pull_request = merged_pull_request(gh_executable, repository, main_commit, parents)
+    merged_at = pull_request["merged_at"]
+    run_id, attempt, run_url = successful_run(
+        gh_executable, repository, parents[1], merged_at
+    )
+    artifact = artifact_name(gh_executable, repository, run_id, attempt)
+    if output_root.exists():
+        raise PromotionError("promotion output already exists")
+    output_root.mkdir(parents=True)
+    try:
+        command(
+            gh_executable,
+            [
+                "run", "download", str(run_id), "--repo", repository,
+                "--name", artifact, "--dir", str(output_root),
+            ],
+        )
+        manifests = [
+            path
+            for path in output_root.glob("*/manifest.tsv")
+            if path.is_file() and not path.is_symlink()
+        ]
+        if len(manifests) != 1:
+            raise PromotionError("downloaded evidence has no unique quality manifest")
+        run_dir = manifests[0].parent
+        if (
+            not run_dir.is_dir()
+            or run_dir.is_symlink()
+            or run_dir.resolve().parent != output_root.resolve()
+        ):
+            raise PromotionError("downloaded evidence run directory is unsafe")
+        policy = Policy(POLICY_FILE)
+        manifest, manifest_digest = validate_evidence(run_dir, policy, parents[0])
+        tested_commit = manifest["source_commit"]
+        tested_tree, tested_parents = github_commit(
+            gh_executable, repository, tested_commit
+        )
+        if tested_tree != main_tree or tested_parents != parents:
+            raise PromotionError("tested merge and main do not have the same tree and parents")
+        values = {
+            "schema": "1",
+            "authority": "ci-main",
+            "result": "passed",
+            "repository": repository,
+            "main_commit": main_commit,
+            "main_tree": main_tree,
+            "base_commit": parents[0],
+            "head_commit": parents[1],
+            "tested_commit": tested_commit,
+            "tested_tree": tested_tree,
+            "pull_request": str(pull_request["number"]),
+            "merged_at": merged_at,
+            "source_run": str(run_id),
+            "source_run_attempt": str(attempt),
+            "source_run_url": run_url,
+            "source_artifact": artifact,
+            "source_manifest_sha256": manifest_digest,
+        }
+        write_promotion(run_dir, values)
+        validate_promotion(run_dir, manifest)
+        return output_root
+    except Exception:
+        shutil.rmtree(output_root, ignore_errors=True)
+        raise
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    result.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
+    result.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path(os.environ.get("DETACH_QUALITY_PROMOTE_OUTPUT", DEFAULT_OUTPUT)),
+    )
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    test_mode = os.environ.get("DETACH_QUALITY_PROMOTE_TEST_MODE") == "1"
+    if not test_mode:
+        if (
+            os.environ.get("GITHUB_ACTIONS") != "true"
+            or os.environ.get("GITHUB_EVENT_NAME") != "push"
+            or os.environ.get("GITHUB_REF") != "refs/heads/main"
+        ):
+            raise PromotionError("promotion is restricted to a GitHub main push")
+        if arguments.output_root.resolve() != DEFAULT_OUTPUT.resolve():
+            raise PromotionError("promotion output must use app/build/quality-gates")
+    gh_executable = os.environ.get("DETACH_QUALITY_PROMOTE_GH", "gh") if test_mode else "gh"
+    git_executable = (
+        os.environ.get("DETACH_QUALITY_PROMOTE_GIT", "git") if test_mode else "git"
+    )
+    if not COMMIT.fullmatch(arguments.commit):
+        raise PromotionError("main commit is invalid")
+    output = promote(
+        arguments.repository,
+        arguments.commit,
+        arguments.output_root,
+        gh_executable,
+        git_executable,
+    )
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (PromotionError, OSError, UnicodeError) as error:
+        fail(str(error))


### PR DESCRIPTION
Promote digest-validated pull-request evidence when the final merge has the same tree and ordered parents. Fall back to the full main repository gate on any ambiguity. Keep the current-only quality policy, exclude internal presentation HTML from impact analysis, and show promotion provenance in metrics and the dashboard. No release, signing, publication, or physical power tests are part of this change.