### PR TITLE
Add bounded quality care evals

### DIFF
--- a/.github/workflows/documentation-care.yml
+++ b/.github/workflows/documentation-care.yml
@@ -1,0 +1,78 @@
+name: Documentation care
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "13 6 * * 3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: documentation-care-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generated-context:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+      - name: Regenerate deterministic documentation
+        run: |
+          scripts/quality-policy generate
+          scripts/quality-care validate
+          tests/docs-contract.sh
+      - id: generated-diff
+        name: Restrict automatic edits to generated context
+        run: |
+          changed="$(git diff --name-only)"
+          if [ -z "$changed" ]; then
+            printf 'changed=false\n' >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          unexpected="$(printf '%s\n' "$changed" | grep -Ev '^quality/generated/(policy\.json|spec-traceability\.md)$' || true)"
+          [ -z "$unexpected" ] || {
+            printf 'documentation-care: unexpected generated path: %s\n' "$unexpected" >&2
+            exit 1
+          }
+          printf 'changed=true\n' >>"$GITHUB_OUTPUT"
+      - name: Open deterministic documentation repair pull request
+        if: steps.generated-diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch=quality/documentation-care
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout -B "$branch"
+          git add quality/generated/policy.json quality/generated/spec-traceability.md
+          git commit -m 'Regenerate quality context'
+          remote_sha="$(timeout 20s git ls-remote --heads origin "refs/heads/$branch" | awk '{print $1}')"
+          if [ -n "$remote_sha" ]; then
+            timeout 30s git push \
+              --force-with-lease="refs/heads/$branch:$remote_sha" \
+              origin "HEAD:refs/heads/$branch"
+          else
+            timeout 30s git push origin "HEAD:refs/heads/$branch"
+          fi
+          existing="$(timeout 20s gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$branch" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -z "$existing" ]; then
+            timeout 20s gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$branch" \
+              --title 'Regenerate quality context' \
+              --body 'Automated bounded documentation-care repair. Only deterministic generated quality context changed.'
+          fi

--- a/.github/workflows/quality-care.yml
+++ b/.github/workflows/quality-care.yml
@@ -1,0 +1,109 @@
+name: Quality care
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "41 4 * * 2,5"
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: quality-care-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  care:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Evaluate workflow corpus
+        run: >-
+          scripts/quality-care evaluate
+          --output app/build/quality-care/evals.json
+      - name: Collect recent bounded gate history
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          raw="$RUNNER_TEMP/quality-care-raw"
+          history="app/build/quality-care/history"
+          since="$(date -u -d '13 days ago' +%Y-%m-%d)"
+          mkdir -p "$raw" "$history"
+          timeout 30s gh run list \
+            --workflow quality-gates.yml \
+            --branch main \
+            --created ">=$since" \
+            --limit 10 \
+            --json databaseId \
+            --jq '.[].databaseId' >"$raw/run-ids"
+          download_failures=0
+          while IFS= read -r run_id; do
+            [ -n "$run_id" ] || continue
+            if ! timeout 20s gh run download "$run_id" \
+              --pattern 'quality-gate-evidence-*' \
+              --dir "$raw/$run_id"; then
+              download_failures=$((download_failures + 1))
+            fi
+          done <"$raw/run-ids"
+          [ "$download_failures" -eq 0 ] || {
+            printf 'quality-care: %s gate artifact downloads failed\n' "$download_failures" >&2
+            exit 1
+          }
+          count=0
+          while IFS= read -r manifest; do
+            count=$((count + 1))
+            cp -R "$(dirname "$manifest")" "$history/run-$count"
+          done < <(find "$raw" -type f -name manifest.tsv | LC_ALL=C sort)
+          [ "$count" -gt 0 ] || {
+            printf 'quality-care: no gate evidence was downloaded\n' >&2
+            exit 1
+          }
+          scripts/quality-history --format json "$history" \
+            >app/build/quality-care/history.json
+      - name: Assess eval and latency regressions
+        if: always()
+        run: >-
+          scripts/quality-care assess
+          --eval-summary app/build/quality-care/evals.json
+          --history-summary app/build/quality-care/history.json
+          --output app/build/quality-care/summary.json
+      - name: Upload quality-care evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: quality-care-${{ github.run_id }}-${{ github.run_attempt }}
+          path: app/build/quality-care
+          if-no-files-found: error
+          retention-days: 30
+
+  attention:
+    if: failure()
+    needs: care
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open one bounded quality-care issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title='[quality-care] Scheduled control loop needs attention'
+          existing="$(timeout 20s gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$title in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -z "$existing" ]; then
+            timeout 20s gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --body "The bounded quality-care workflow found an eval, evidence, or latency regression. Inspect $RUN_URL."
+          fi

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -107,8 +107,10 @@ enum UIE2ETestDriver {
             let confirmDelete = try await sheetButton(
                 label: "Delete")
             try requireSemanticControl(confirmDelete, name: "delete confirmation")
-            try await click(confirmDelete, name: "delete confirmation")
-            try await waitUntil("fake CLI records delete action") {
+            try await clickUntil(
+                confirmDelete,
+                name: "delete confirmation",
+                outcome: "fake CLI records delete action") {
                 let actions = try? String(
                     contentsOf: configuration.root
                         .appendingPathComponent("fake/actions.log"),

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -31,8 +31,12 @@ the only ordinary merge authority. Unknown paths select the full plan.
   an instrumented scenario, or its direct policy command otherwise. The owning
   stage process deadline bounds both forms. The helper has 30 seconds for
   evidence finalization and process-group cleanup.
-- `scripts/quality-history [RESULT_ROOT]` reports run and failure counts plus
-  p50 and p95 wall and stage durations. It cannot produce readiness evidence.
+- `scripts/quality-history [--format tsv|json] [RESULT_ROOT]` validates retained
+  current-schema summaries and reports run and failure counts plus p50 and p95
+  wall and stage durations. It cannot produce readiness evidence.
+- `scripts/quality-care validate` checks the versioned workflow eval corpus.
+  `scripts/quality-care evaluate` grades diff impact and private-scope cases.
+  `scripts/quality-care assess` compares the results with retained run latency.
 - `scripts/quality-policy specs` lists current durable specs.
   `scripts/quality-policy render-specs` prints their requirement, journey, and
   scenario links.
@@ -168,6 +172,23 @@ A weekly and manual workflow runs each deterministic safety mutant in a
 separate bounded macOS job. The required mutation score is 100 percent. A
 survivor, timeout, or infrastructure-like failure is not a kill and fails the
 workflow.
+
+## Continuous care
+
+`quality/evals.json` contains stable expected outcomes for representative
+historical tasks, escaped defects, policy mutations, and repository-scope
+violations. Impact cases assert the complete stage, specification, capability,
+user-journey, and release-gate plan after dependency closure. Scope cases assert
+that internal presentations, work plans, and credential paths stay ignored.
+
+The quality-care workflow has a five-minute deadline. It reads up to 10 gate
+artifacts from the last 13 days. Each download has a 20-second deadline. A
+missing artifact fails the care run. The workflow creates one open issue for an eval
+regression, failed or invalid evidence, an environment failure, or wall p95 at
+or above 480 seconds. The documentation-care workflow has the same overall
+deadline. It can create one repair pull request only when deterministic
+generated policy views drift. Both workflows cancel superseded runs and never
+run release tools.
 
 ## Dashboard
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -54,6 +54,11 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   match the policy.
 - Retained gate results contain execution history for timing and quality
   trends. They are not policy history and cannot restore an old policy state.
+- `quality/evals.json` keeps current expected outcomes for historical changes,
+  escaped defects, policy mutations, and scope violations. Its stable graders
+  compare selected stages, specifications, capabilities, user journeys,
+  release gates, and ignored private paths. A policy change must update an
+  expectation only when the intended observable outcome changes.
 - Instrumented user scenarios emit addressable begin and pass events. Gate
   evidence records their requirement and journey links, duration, result, and
   bounded rerun command. A passed stage with missing scenario events fails.
@@ -76,6 +81,14 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   deterministic safety corpus. It runs mutants in parallel, gives each test a
   240-second deadline, and requires a 100-percent score. Mutation work does not
   extend pull-request feedback time.
+- A bounded quality-care workflow evaluates the workflow corpus and recent
+  current-schema gate evidence twice each week. It opens one issue when an eval
+  changes, evidence is invalid, or pull-request wall p95 reaches 80 percent of
+  the ten-minute SLO. A separate bounded documentation-care workflow can open
+  a pull request only for deterministic files under `quality/generated/`.
+  Neither workflow can enter a release path. Care evidence reports agent review
+  as not configured until an independent provider binds a review to the exact
+  commit.
 - A deterministic static dashboard reads only validated gate evidence. The
   same artifact opens locally and deploys to GitHub Pages only after a green
   `main` run with direct or promoted evidence, or a green scheduled mutation

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,8 +38,14 @@
   granularity until it gets scenario markers.
 - `scripts/quality-history [RESULT_ROOT]` reports p50/p95 wall and stage timing,
   ordinary failures, and execution-environment failures across retained local
-  or downloaded gate evidence. It is run telemetry, not policy history or
-  readiness evidence.
+  or downloaded current-schema gate evidence. Add `--format json` for care
+  automation. It is run telemetry, not policy history or readiness evidence.
+- `scripts/quality-care validate` checks the four required eval categories.
+  `scripts/quality-care evaluate --output <json>` grades exact diff impact and
+  private-scope outcomes. `scripts/quality-care assess` fails before the
+  pull-request wall p95 reaches the ten-minute SLO. Scheduled quality care opens
+  one scoped issue. Scheduled documentation care can open a pull request only
+  for deterministic files under `quality/generated/`.
 - `scripts/quality-policy generate --check` checks both generated policy JSON
   and the readable current-spec traceability table.
 - `scripts/quality-promote` is the hosted post-merge path. It downloads the

--- a/quality/evals.json
+++ b/quality/evals.json
@@ -1,0 +1,297 @@
+{
+  "schema": 1,
+  "cases": [
+    {
+      "id": "historical-quality-tool",
+      "category": "historical-task",
+      "grader": "impact",
+      "paths": [
+        "tools/quality_gate.py"
+      ],
+      "expected": {
+        "status": "known",
+        "stages": [
+          "static",
+          "gate-contract"
+        ],
+        "specs": [
+          "documentation"
+        ],
+        "capabilities": [
+          "quality-system"
+        ],
+        "journeys": [
+          "J-QUALITY-CHANGE"
+        ],
+        "release_gates": [],
+        "unknown": false
+      }
+    },
+    {
+      "id": "historical-provider-cli",
+      "category": "historical-task",
+      "grader": "impact",
+      "paths": [
+        "bin/detach-core"
+      ],
+      "expected": {
+        "status": "known",
+        "stages": [
+          "static",
+          "app",
+          "ui-e2e",
+          "codex",
+          "claude",
+          "distribution",
+          "tmux-runtime",
+          "release-budget"
+        ],
+        "specs": [
+          "runtime"
+        ],
+        "capabilities": [
+          "session-lifecycle"
+        ],
+        "journeys": [
+          "J-SESSION-CREATE",
+          "J-SESSION-PERSIST",
+          "J-SESSION-RECOVER",
+          "J-SESSION-STOP",
+          "J-SESSION-DELETE"
+        ],
+        "release_gates": [
+          "lid"
+        ],
+        "unknown": false
+      }
+    },
+    {
+      "id": "escaped-session-controls",
+      "category": "escaped-defect",
+      "grader": "impact",
+      "paths": [
+        "app/Sources/DetachApp/SessionDetailView.swift"
+      ],
+      "expected": {
+        "status": "known",
+        "stages": [
+          "static",
+          "swift",
+          "quality-contracts",
+          "app",
+          "ui-e2e",
+          "release-budget"
+        ],
+        "specs": [
+          "app"
+        ],
+        "capabilities": [
+          "session-lifecycle",
+          "app-experience"
+        ],
+        "journeys": [
+          "J-SESSION-CREATE",
+          "J-SESSION-PERSIST",
+          "J-SESSION-RECOVER",
+          "J-SESSION-STOP",
+          "J-SESSION-DELETE",
+          "J-APP-DASHBOARD",
+          "J-APP-DETAIL",
+          "J-APP-EMPTY",
+          "J-APP-FAILURE",
+          "J-APP-FOCUS",
+          "J-APP-NEW-SESSION"
+        ],
+        "release_gates": [],
+        "unknown": false
+      }
+    },
+    {
+      "id": "escaped-power-process",
+      "category": "escaped-defect",
+      "grader": "impact",
+      "paths": [
+        "app/Sources/DetachKit/ClamshellLockRunner.swift"
+      ],
+      "expected": {
+        "status": "known",
+        "stages": [
+          "static",
+          "swift",
+          "quality-contracts",
+          "app",
+          "ui-e2e",
+          "distribution",
+          "tmux-runtime",
+          "release-budget"
+        ],
+        "specs": [
+          "power"
+        ],
+        "capabilities": [
+          "power-protection"
+        ],
+        "journeys": [
+          "J-POWER-ENABLE",
+          "J-POWER-LOW-BATTERY",
+          "J-POWER-HELPER-LEASE",
+          "J-POWER-CLOSED-LID"
+        ],
+        "release_gates": [
+          "install",
+          "lid"
+        ],
+        "unknown": false
+      }
+    },
+    {
+      "id": "policy-mixed-docs-power",
+      "category": "policy-mutant",
+      "grader": "impact",
+      "paths": [
+        "README.md",
+        "app/Sources/DetachPower/main.swift"
+      ],
+      "expected": {
+        "status": "known",
+        "stages": [
+          "static",
+          "swift",
+          "quality-contracts",
+          "app",
+          "ui-e2e",
+          "distribution",
+          "tmux-runtime",
+          "release-budget"
+        ],
+        "specs": [
+          "documentation",
+          "power"
+        ],
+        "capabilities": [
+          "documentation",
+          "power-protection"
+        ],
+        "journeys": [
+          "J-DOCS-CONSISTENCY",
+          "J-POWER-ENABLE",
+          "J-POWER-LOW-BATTERY",
+          "J-POWER-HELPER-LEASE",
+          "J-POWER-CLOSED-LID"
+        ],
+        "release_gates": [
+          "install",
+          "lid"
+        ],
+        "unknown": false
+      }
+    },
+    {
+      "id": "policy-unmapped-fail-safe",
+      "category": "policy-mutant",
+      "grader": "impact",
+      "paths": [
+        "unmapped/new-tool.xyz"
+      ],
+      "expected": {
+        "status": "unknown",
+        "stages": [
+          "static",
+          "gate-contract",
+          "swift",
+          "quality-contracts",
+          "app",
+          "ui-e2e",
+          "codex",
+          "claude",
+          "distribution",
+          "tmux-runtime",
+          "release-preflight",
+          "publish-preflight",
+          "release-workflow",
+          "release-budget"
+        ],
+        "specs": [
+          "documentation",
+          "runtime",
+          "power",
+          "app",
+          "release"
+        ],
+        "capabilities": [
+          "quality-system",
+          "documentation",
+          "session-lifecycle",
+          "power-protection",
+          "app-experience",
+          "onboarding",
+          "settings",
+          "update",
+          "diagnostics",
+          "installation",
+          "publication"
+        ],
+        "journeys": [
+          "J-QUALITY-CHANGE",
+          "J-DOCS-CONSISTENCY",
+          "J-SESSION-CREATE",
+          "J-SESSION-PERSIST",
+          "J-SESSION-RECOVER",
+          "J-SESSION-STOP",
+          "J-SESSION-DELETE",
+          "J-POWER-ENABLE",
+          "J-POWER-LOW-BATTERY",
+          "J-POWER-HELPER-LEASE",
+          "J-POWER-CLOSED-LID",
+          "J-APP-DASHBOARD",
+          "J-APP-DETAIL",
+          "J-APP-EMPTY",
+          "J-APP-FAILURE",
+          "J-APP-FOCUS",
+          "J-APP-NEW-SESSION",
+          "J-ONBOARD-FIRST-RUN",
+          "J-ONBOARD-PROVIDER",
+          "J-ONBOARD-APPROVAL",
+          "J-SETTINGS-CHANGE",
+          "J-UPDATE-CHECK",
+          "J-UPDATE-APPLY",
+          "J-DOCTOR-REPORT",
+          "J-INSTALL-CLEAN",
+          "J-INSTALL-REPAIR",
+          "J-INSTALL-UNINSTALL",
+          "J-PUBLISH-ARTIFACTS"
+        ],
+        "release_gates": [
+          "install",
+          "lid"
+        ],
+        "unknown": true
+      }
+    },
+    {
+      "id": "scope-internal-presentations",
+      "category": "scope-violation",
+      "grader": "ignored",
+      "paths": [
+        "presentations/internal.html",
+        "docs/assets/internal.html"
+      ],
+      "expected": {
+        "ignored": true
+      }
+    },
+    {
+      "id": "scope-private-work",
+      "category": "scope-violation",
+      "grader": "ignored",
+      "paths": [
+        "docs/work/quality-plan.md",
+        ".env",
+        ".secrets/provider-token"
+      ],
+      "expected": {
+        "ignored": true
+      }
+    }
+  ]
+}

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -619,7 +619,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 23,
+  "policy": 24,
   "release_domains": [
     {
       "gates": "-",
@@ -908,6 +908,20 @@
       "test_domain": "policy"
     },
     {
+      "pattern": ".github/workflows/quality-care.yml",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": ".github/workflows/documentation-care.yml",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
       "pattern": "scripts/quality-dashboard",
       "priority": 1000,
       "release_domain": "safe",
@@ -923,6 +937,27 @@
     },
     {
       "pattern": "scripts/quality-history",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_history.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-care",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_care.py",
       "priority": 1000,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -1937,6 +1972,8 @@
         "*.sh",
         ".gitattributes",
         ".github/*",
+        ".github/workflows/documentation-care.yml",
+        ".github/workflows/quality-care.yml",
         ".github/workflows/quality-gates.yml",
         ".github/workflows/quality-mutations.yml",
         ".gitignore",
@@ -1950,6 +1987,7 @@
         "quality/*",
         "scripts/*",
         "scripts/quality-baseline",
+        "scripts/quality-care",
         "scripts/quality-dashboard",
         "scripts/quality-gate",
         "scripts/quality-history",
@@ -1967,8 +2005,10 @@
         "tests/shell-safety*",
         "tests/test-suite-contract.sh",
         "tools/quality_baseline.py",
+        "tools/quality_care.py",
         "tools/quality_dashboard.py",
         "tools/quality_gate.py",
+        "tools/quality_history.py",
         "tools/quality_metrics.py",
         "tools/quality_mutation.py",
         "tools/quality_policy.py",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -15,6 +15,8 @@ It lists current specification ownership and verification links.
 - `*.sh`
 - `.gitattributes`
 - `.github/*`
+- `.github/workflows/documentation-care.yml`
+- `.github/workflows/quality-care.yml`
 - `.github/workflows/quality-gates.yml`
 - `.github/workflows/quality-mutations.yml`
 - `.gitignore`
@@ -28,6 +30,7 @@ It lists current specification ownership and verification links.
 - `quality/*`
 - `scripts/*`
 - `scripts/quality-baseline`
+- `scripts/quality-care`
 - `scripts/quality-dashboard`
 - `scripts/quality-gate`
 - `scripts/quality-history`
@@ -45,8 +48,10 @@ It lists current specification ownership and verification links.
 - `tests/shell-safety*`
 - `tests/test-suite-contract.sh`
 - `tools/quality_baseline.py`
+- `tools/quality_care.py`
 - `tools/quality_dashboard.py`
 - `tools/quality_gate.py`
+- `tools/quality_history.py`
 - `tools/quality_metrics.py`
 - `tools/quality_mutation.py`
 - `tools/quality_policy.py`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	23
+policy	24
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -88,9 +88,14 @@ route	1000	tools/quality_promote.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-mutation	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_mutation.py	policy	safe	docs/specs/documentation.md
 route	1000	.github/workflows/quality-mutations.yml	policy	safe	docs/specs/documentation.md
+route	1000	.github/workflows/quality-care.yml	policy	safe	docs/specs/documentation.md
+route	1000	.github/workflows/documentation-care.yml	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-dashboard	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_dashboard.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-history	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_history.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-care	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_care.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/test	policy	safe	docs/specs/documentation.md
 route	1000	tests/quality-*	policy	safe	docs/specs/documentation.md
 route	1000	tests/quality_*	policy	safe	docs/specs/documentation.md

--- a/scripts/quality-care
+++ b/scripts/quality-care
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 command -v python3 >/dev/null 2>&1 || {
-  printf 'quality-history: python3 is required\n' >&2
+  printf 'quality-care: python3 is required\n' >&2
   exit 2
 }
-exec python3 "$ROOT/tools/quality_history.py" "$@"
+exec python3 "$ROOT/tools/quality_care.py" "$@"

--- a/tests/quality-care.sh
+++ b/tests/quality-care.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+PYTHONDONTWRITEBYTECODE=1 python3 "$ROOT/tests/quality_care_contract.py"

--- a/tests/quality-history-contract.sh
+++ b/tests/quality-history-contract.sh
@@ -4,32 +4,52 @@ set -euo pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-quality-history-contract.XXXXXX")"
-
-cleanup() {
-  rm -rf "$TMP_ROOT"
-}
-trap cleanup EXIT
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 
 write_run() {
   local name="$1" result="$2" wall="$3" static_status="$4" static_duration="$5"
-  mkdir -p "$TMP_ROOT/$name"
-  printf 'schema\t3\ntiming_wall_seconds\t%s\nresult\t%s\n' "$wall" "$result" \
-    >"$TMP_ROOT/$name/manifest.tsv"
+  local run="$TMP_ROOT/$name" summary_digest
+  mkdir -p "$run"
   printf 'policy\tmode\tstage\tstatus\tduration_seconds\tlog\tlog_sha256\torigin_run\n' \
-    >"$TMP_ROOT/$name/summary.tsv"
-  printf '8\trepository\tstatic\t%s\t%s\tstatic.log\tdigest\t-\n' \
-    "$static_status" "$static_duration" >>"$TMP_ROOT/$name/summary.tsv"
+    >"$run/summary.tsv"
+  printf '23\trepository\tstatic\t%s\t%s\tstatic.log\t%s\t-\n' \
+    "$static_status" "$static_duration" "$(printf digest | shasum -a 256 | awk '{print $1}')" \
+    >>"$run/summary.tsv"
+  summary_digest="$(shasum -a 256 "$run/summary.tsv" | awk '{print $1}')"
+  cat >"$run/manifest.tsv" <<EOF
+schema	4
+policy	23
+mode	repository
+authority	ci-main
+source_commit	0123456789abcdef0123456789abcdef01234567
+fingerprint	0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+stages	static
+specs	documentation
+capabilities	quality-system
+journeys	J-QUALITY-CHANGE
+started_at	2026-08-12T10:00:00Z
+finished_at	2026-08-12T10:00:01Z
+duration_seconds	$wall
+timing_wall_seconds	$wall
+summary_sha256	$summary_digest
+result	$result
+EOF
 }
 
 write_run one passed 100 passed 1
 write_run two failed 180 environment-failed 3
 write_run three passed 120 passed 2
+mkdir -p "$TMP_ROOT/invalid"
+printf 'schema\t3\nresult\tpassed\n' >"$TMP_ROOT/invalid/manifest.tsv"
 
 "$ROOT/scripts/quality-history" "$TMP_ROOT" >"$TMP_ROOT/report.tsv"
 grep -F $'runs\t3' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'passed\t2' "$TMP_ROOT/report.tsv" >/dev/null
+grep -F $'invalid_evidence\t1' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'wall_p50_seconds\t120' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'wall_p95_seconds\t180' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'static\t3\t1\t1\t2\t3' "$TMP_ROOT/report.tsv" >/dev/null
+"$ROOT/scripts/quality-history" --format json "$TMP_ROOT" \
+  | python3 -c 'import json,sys; value=json.load(sys.stdin); assert value["schema"] == 1 and value["runs"] == 3'
 
 printf 'Quality history contract tests passed\n'

--- a/tests/quality_care_contract.py
+++ b/tests/quality_care_contract.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Contract tests for quality-cycle evals and scheduled care."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts/quality-care"
+CORPUS = ROOT / "quality/evals.json"
+CARE_WORKFLOW = ROOT / ".github/workflows/quality-care.yml"
+DOC_WORKFLOW = ROOT / ".github/workflows/documentation-care.yml"
+
+
+def invoke(
+    arguments: list[str], *, expected: int = 0
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(SCRIPT), *arguments],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if result.returncode != expected:
+        raise AssertionError(
+            f"unexpected exit {result.returncode}, expected {expected}: "
+            f"{' '.join(arguments)}\n{result.stdout}"
+        )
+    return result
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def assert_workflows() -> None:
+    care = CARE_WORKFLOW.read_text(encoding="utf-8")
+    docs = DOC_WORKFLOW.read_text(encoding="utf-8")
+    for required in (
+        "schedule:",
+        "timeout-minutes: 5",
+        "scripts/quality-care evaluate",
+        "scripts/quality-history --format json",
+        "scripts/quality-care assess",
+        "cancel-in-progress: true",
+        "--created \">=$since\"",
+        "timeout 20s gh run download",
+        "timeout 20s gh issue create",
+        "issues: write",
+    ):
+        if required not in care:
+            raise AssertionError(f"quality-care workflow is missing: {required}")
+    for required in (
+        "schedule:",
+        "timeout-minutes: 5",
+        "scripts/quality-policy generate",
+        "scripts/quality-care validate",
+        "pull-requests: write",
+        "--force-with-lease=",
+        "timeout 20s git ls-remote",
+        "timeout 20s gh pr create",
+        "quality/generated/(policy\\.json|spec-traceability\\.md)",
+    ):
+        if required not in docs:
+            raise AssertionError(f"documentation-care workflow is missing: {required}")
+    for workflow in (care, docs):
+        if re.search(r"uses:\s+\S+@v[0-9]", workflow):
+            raise AssertionError("care workflow contains a mutable Action tag")
+        if re.search(r"release-version|notary|tag |upload release", workflow, re.IGNORECASE):
+            raise AssertionError("care workflow can enter a release path")
+
+
+def history(wall_p95: int) -> dict[str, object]:
+    return {
+        "schema": 1,
+        "runs": 4,
+        "passed": 4,
+        "failed_or_interrupted": 0,
+        "invalid_evidence": 0,
+        "wall": {"samples": 4, "p50_seconds": 300, "p95_seconds": wall_p95},
+        "stages": [
+            {
+                "stage": "codex",
+                "samples": 4,
+                "failures": 0,
+                "environment_failures": 0,
+                "p50_seconds": 120,
+                "p95_seconds": 150,
+            }
+        ],
+    }
+
+
+def main() -> int:
+    assert_workflows()
+    invoke(["validate"])
+    result = json.loads(invoke(["evaluate", "--json"]).stdout)
+    assert result["schema"] == 1
+    assert result["status"] == "passed"
+    assert result["passed"] == result["total"] == 8
+    assert set(result["categories"]) == {
+        "escaped-defect", "historical-task", "policy-mutant", "scope-violation"
+    }
+
+    with tempfile.TemporaryDirectory(prefix="detach-quality-care-") as raw:
+        root = Path(raw)
+        corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
+
+        wrong_impact = json.loads(json.dumps(corpus))
+        wrong_impact["cases"][0]["expected"]["stages"].remove("gate-contract")
+        wrong_impact_path = root / "wrong-impact.json"
+        write_json(wrong_impact_path, wrong_impact)
+        failed = json.loads(
+            invoke(
+                ["--corpus", str(wrong_impact_path), "evaluate", "--json"],
+                expected=1,
+            ).stdout
+        )
+        assert failed["status"] == "failed"
+        assert failed["results"][0]["id"] == "historical-quality-tool"
+
+        scope_escape = json.loads(json.dumps(corpus))
+        scope_escape["cases"][-1]["paths"] = ["public/not-ignored.txt"]
+        scope_escape_path = root / "scope-escape.json"
+        write_json(scope_escape_path, scope_escape)
+        escaped = json.loads(
+            invoke(
+                ["--corpus", str(scope_escape_path), "evaluate", "--json"],
+                expected=1,
+            ).stdout
+        )
+        assert escaped["results"][-1]["actual"] == {"ignored": False}
+
+        missing_category = json.loads(json.dumps(corpus))
+        missing_category["cases"] = [
+            case for case in missing_category["cases"]
+            if case["category"] != "escaped-defect"
+        ]
+        missing_path = root / "missing-category.json"
+        write_json(missing_path, missing_category)
+        output = invoke(
+            ["--corpus", str(missing_path), "validate"], expected=2
+        ).stdout
+        assert "missing category: escaped-defect" in output
+
+        eval_path = root / "evals.json"
+        write_json(eval_path, result)
+        healthy_history = root / "healthy-history.json"
+        write_json(healthy_history, history(420))
+        healthy_summary = root / "healthy-summary.json"
+        invoke(
+            [
+                "assess", "--eval-summary", str(eval_path),
+                "--history-summary", str(healthy_history),
+                "--output", str(healthy_summary),
+            ]
+        )
+        healthy = json.loads(healthy_summary.read_text(encoding="utf-8"))
+        assert healthy["status"] == "passed"
+        assert healthy["latency"]["alert_seconds"] == 480
+
+        slow_history = root / "slow-history.json"
+        write_json(slow_history, history(481))
+        slow_summary = root / "slow-summary.json"
+        invoke(
+            [
+                "assess", "--eval-summary", str(eval_path),
+                "--history-summary", str(slow_history),
+                "--output", str(slow_summary),
+            ],
+            expected=1,
+        )
+        slow = json.loads(slow_summary.read_text(encoding="utf-8"))
+        assert slow["status"] == "attention"
+        assert slow["latency"]["status"] == "attention"
+
+        failed_history_value = history(420)
+        failed_history_value["passed"] = 3
+        failed_history_value["failed_or_interrupted"] = 1
+        failed_history = root / "failed-history.json"
+        write_json(failed_history, failed_history_value)
+        failed_summary = root / "failed-summary.json"
+        invoke(
+            [
+                "assess", "--eval-summary", str(eval_path),
+                "--history-summary", str(failed_history),
+                "--output", str(failed_summary),
+            ],
+            expected=1,
+        )
+        failed_care = json.loads(failed_summary.read_text(encoding="utf-8"))
+        assert "a retained gate run failed or was interrupted" in failed_care["reasons"]
+
+    print("Quality care contracts passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/shell-safety.sh
+++ b/tests/shell-safety.sh
@@ -16,7 +16,7 @@ failures=0
 while IFS= read -r -d '' file; do
   case "$file" in
     tests/shell-safety-contract.sh) continue ;;
-    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/quality-promote|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
+    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/quality-promote|scripts/quality-history|scripts/quality-care|scripts/release-version|scripts/release-impact|scripts/release-lid-probe) ;;
     *) continue ;;
   esac
   [ -f "$ROOT/$file" ] || continue

--- a/tools/quality_care.py
+++ b/tools/quality_care.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""Evaluate versioned quality-cycle cases with stable deterministic graders."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+from typing import Any, NoReturn
+
+from quality_policy import POLICY_FILE, Policy, PolicyError
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CORPUS = ROOT / "quality/evals.json"
+CASE_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+CATEGORIES = {
+    "escaped-defect",
+    "historical-task",
+    "policy-mutant",
+    "scope-violation",
+}
+IMPACT_KEYS = {
+    "status",
+    "stages",
+    "specs",
+    "capabilities",
+    "journeys",
+    "release_gates",
+    "unknown",
+}
+
+
+class CareError(Exception):
+    """The quality-care corpus or its outcome is invalid."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-care: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def read_json(path: Path, label: str) -> Any:
+    if not path.is_file() or path.is_symlink():
+        raise CareError(f"{label} is missing or unsafe: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeError, OSError) as error:
+        raise CareError(f"{label} is invalid: {error}") from error
+
+
+def valid_path(value: Any) -> bool:
+    if not isinstance(value, str) or not value or "\t" in value or "\n" in value:
+        return False
+    path = PurePosixPath(value)
+    return not path.is_absolute() and ".." not in path.parts and str(path) == value
+
+
+def validate_impact(value: Any, case_id: str) -> None:
+    if not isinstance(value, dict) or set(value) != IMPACT_KEYS:
+        raise CareError(f"case {case_id} has an invalid impact expectation")
+    if value["status"] not in ("known", "unknown") or not isinstance(value["unknown"], bool):
+        raise CareError(f"case {case_id} has an invalid impact status")
+    if value["unknown"] != (value["status"] == "unknown"):
+        raise CareError(f"case {case_id} has inconsistent unknown impact")
+    for key in IMPACT_KEYS - {"status", "unknown"}:
+        values = value[key]
+        if (
+            not isinstance(values, list)
+            or any(not isinstance(item, str) or not item for item in values)
+            or len(values) != len(set(values))
+        ):
+            raise CareError(f"case {case_id} has an invalid {key} expectation")
+
+
+def load_corpus(path: Path) -> list[dict[str, Any]]:
+    value = read_json(path, "eval corpus")
+    if not isinstance(value, dict) or set(value) != {"schema", "cases"}:
+        raise CareError("eval corpus schema is invalid")
+    if value["schema"] != 1 or not isinstance(value["cases"], list) or not value["cases"]:
+        raise CareError("eval corpus must contain schema 1 cases")
+    cases: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    seen_categories: set[str] = set()
+    for raw_case in value["cases"]:
+        if not isinstance(raw_case, dict) or set(raw_case) != {
+            "id", "category", "grader", "paths", "expected"
+        }:
+            raise CareError("eval case schema is invalid")
+        case_id = raw_case["id"]
+        category = raw_case["category"]
+        grader = raw_case["grader"]
+        paths = raw_case["paths"]
+        if not isinstance(case_id, str) or not CASE_ID.fullmatch(case_id) or case_id in seen:
+            raise CareError(f"eval case id is invalid or duplicate: {case_id}")
+        if category not in CATEGORIES:
+            raise CareError(f"case {case_id} has an invalid category")
+        if grader not in ("impact", "ignored"):
+            raise CareError(f"case {case_id} has an invalid grader")
+        if category == "scope-violation" and grader != "ignored":
+            raise CareError(f"scope case {case_id} must use the ignored grader")
+        if category != "scope-violation" and grader != "impact":
+            raise CareError(f"impact case {case_id} must use the impact grader")
+        if (
+            not isinstance(paths, list)
+            or not paths
+            or any(not valid_path(item) for item in paths)
+            or len(paths) != len(set(paths))
+        ):
+            raise CareError(f"case {case_id} has invalid paths")
+        if grader == "impact":
+            validate_impact(raw_case["expected"], case_id)
+        elif raw_case["expected"] != {"ignored": True}:
+            raise CareError(f"case {case_id} must expect ignored paths")
+        seen.add(case_id)
+        seen_categories.add(category)
+        cases.append(raw_case)
+    missing = CATEGORIES - seen_categories
+    if missing:
+        raise CareError(f"eval corpus is missing category: {sorted(missing)[0]}")
+    return cases
+
+
+def in_policy_order(values: set[str], order: list[str]) -> list[str]:
+    return [value for value in order if value in values]
+
+
+def impact(policy: Policy, paths: list[str]) -> dict[str, Any]:
+    classifications = [policy.classify(path) for path in paths]
+    unknown = any(classification.status == "unknown" for classification in classifications)
+    if unknown:
+        return {
+            "status": "unknown",
+            "stages": [stage.name for stage in policy.stages],
+            "specs": list(policy.specs),
+            "capabilities": list(policy.capabilities),
+            "journeys": list(policy.journeys),
+            "release_gates": ["install", "lid"],
+            "unknown": True,
+        }
+    stages = {
+        stage
+        for classification in classifications
+        for stage in classification.stages.split(",")
+    }
+    changed = True
+    while changed:
+        changed = False
+        for prerequisite, dependent in policy.dependencies:
+            if prerequisite in stages and dependent not in stages:
+                stages.add(dependent)
+                changed = True
+    spec_paths = {classification.spec for classification in classifications}
+    capabilities = {
+        capability
+        for classification in classifications
+        for capability in classification.capabilities.split(",")
+    }
+    journeys = {
+        journey
+        for classification in classifications
+        for journey in classification.journeys.split(",")
+    }
+    gates = {
+        gate
+        for classification in classifications
+        for gate in classification.release_gates.split(",")
+        if gate != "-"
+    }
+    return {
+        "status": "known",
+        "stages": [stage.name for stage in policy.stages if stage.name in stages],
+        "specs": [identifier for identifier, (path, _) in policy.specs.items() if path in spec_paths],
+        "capabilities": in_policy_order(capabilities, list(policy.capabilities)),
+        "journeys": in_policy_order(journeys, list(policy.journeys)),
+        "release_gates": in_policy_order(gates, ["install", "lid"]),
+        "unknown": False,
+    }
+
+
+def ignored(paths: list[str]) -> dict[str, bool]:
+    results = []
+    for path in paths:
+        try:
+            result = subprocess.run(
+                ("git", "-C", str(ROOT), "check-ignore", "--quiet", "--no-index", "--", path),
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as error:
+            raise CareError(f"cannot inspect ignored paths: {error}") from error
+        if result.returncode not in (0, 1):
+            raise CareError(f"cannot inspect ignored path: {path}")
+        results.append(result.returncode == 0)
+    return {"ignored": all(results)}
+
+
+def evaluate(cases: list[dict[str, Any]], policy: Policy) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        actual = (
+            impact(policy, case["paths"])
+            if case["grader"] == "impact"
+            else ignored(case["paths"])
+        )
+        passed = actual == case["expected"]
+        results.append(
+            {
+                "id": case["id"],
+                "category": case["category"],
+                "grader": case["grader"],
+                "passed": passed,
+                "expected": case["expected"],
+                "actual": actual,
+            }
+        )
+    passed_count = sum(result["passed"] for result in results)
+    return {
+        "schema": 1,
+        "policy": policy.version,
+        "status": "passed" if passed_count == len(results) else "failed",
+        "passed": passed_count,
+        "total": len(results),
+        "categories": {
+            category: sum(
+                result["passed"]
+                for result in results
+                if result["category"] == category
+            )
+            for category in sorted(CATEGORIES)
+        },
+        "results": results,
+    }
+
+
+def assess(eval_path: Path, history_path: Path, policy: Policy) -> dict[str, Any]:
+    eval_summary = read_json(eval_path, "eval summary")
+    history = read_json(history_path, "history summary")
+    if (
+        not isinstance(eval_summary, dict)
+        or set(eval_summary) != {
+            "schema", "policy", "status", "passed", "total", "categories", "results"
+        }
+        or eval_summary.get("schema") != 1
+        or eval_summary.get("policy") != policy.version
+        or eval_summary.get("status") not in ("passed", "failed")
+        or not isinstance(eval_summary.get("passed"), int)
+        or not isinstance(eval_summary.get("total"), int)
+        or not isinstance(eval_summary.get("categories"), dict)
+        or not isinstance(eval_summary.get("results"), list)
+    ):
+        raise CareError("eval summary schema or policy is invalid")
+    if (
+        eval_summary["passed"] < 0
+        or eval_summary["total"] < 1
+        or eval_summary["passed"] > eval_summary["total"]
+        or len(eval_summary["results"]) != eval_summary["total"]
+        or set(eval_summary["categories"]) != CATEGORIES
+        or any(
+            not isinstance(value, int) or value < 0
+            for value in eval_summary["categories"].values()
+        )
+    ):
+        raise CareError("eval summary counts are invalid")
+    if (
+        not isinstance(history, dict)
+        or set(history) != {
+            "schema", "runs", "passed", "failed_or_interrupted",
+            "invalid_evidence", "wall", "stages"
+        }
+        or history.get("schema") != 1
+        or not isinstance(history.get("wall"), dict)
+        or set(history["wall"]) != {"samples", "p50_seconds", "p95_seconds"}
+        or not isinstance(history["wall"].get("p95_seconds"), int)
+        or not isinstance(history.get("invalid_evidence"), int)
+        or not isinstance(history.get("stages"), list)
+    ):
+        raise CareError("history summary schema is invalid")
+    for key in ("runs", "passed", "failed_or_interrupted", "invalid_evidence"):
+        if not isinstance(history[key], int) or history[key] < 0:
+            raise CareError("history summary counts are invalid")
+    for key in ("samples", "p50_seconds", "p95_seconds"):
+        if not isinstance(history["wall"][key], int) or history["wall"][key] < 0:
+            raise CareError("history summary timing is invalid")
+    if (
+        history["passed"] + history["failed_or_interrupted"] != history["runs"]
+        or history["wall"]["samples"] != history["runs"]
+        or history["wall"]["p50_seconds"] > history["wall"]["p95_seconds"]
+    ):
+        raise CareError("history summary totals are inconsistent")
+    stage_keys = {
+        "stage", "samples", "failures", "environment_failures",
+        "p50_seconds", "p95_seconds"
+    }
+    for stage in history["stages"]:
+        if (
+            not isinstance(stage, dict)
+            or set(stage) != stage_keys
+            or not isinstance(stage["stage"], str)
+            or any(
+                not isinstance(stage[key], int) or stage[key] < 0
+                for key in stage_keys - {"stage"}
+            )
+        ):
+            raise CareError("history stage summary is invalid")
+        if (
+            stage["failures"] > stage["samples"]
+            or stage["environment_failures"] > stage["failures"]
+            or stage["p50_seconds"] > stage["p95_seconds"]
+        ):
+            raise CareError("history stage totals are inconsistent")
+    slo = policy.limits["pr_feedback_seconds"]
+    alert = slo * 80 // 100
+    p95 = history["wall"]["p95_seconds"]
+    if p95 >= slo:
+        latency_status = "breached"
+    elif p95 >= alert:
+        latency_status = "attention"
+    else:
+        latency_status = "healthy"
+    environment_failures = sum(
+        stage.get("environment_failures", 0)
+        for stage in history["stages"]
+        if isinstance(stage, dict)
+    )
+    status = "passed"
+    reasons: list[str] = []
+    if eval_summary["status"] != "passed":
+        status = "attention"
+        reasons.append("workflow eval regression")
+    if latency_status != "healthy":
+        status = "attention"
+        reasons.append(f"pull-request wall p95 is {latency_status}")
+    if history["invalid_evidence"]:
+        status = "attention"
+        reasons.append("invalid current-schema evidence was skipped")
+    if history["failed_or_interrupted"]:
+        status = "attention"
+        reasons.append("a retained gate run failed or was interrupted")
+    if environment_failures:
+        status = "attention"
+        reasons.append("a retained stage had an environment failure")
+    return {
+        "schema": 1,
+        "policy": policy.version,
+        "status": status,
+        "reasons": reasons,
+        "evals": {
+            "passed": eval_summary.get("passed", 0),
+            "total": eval_summary.get("total", 0),
+            "categories": eval_summary.get("categories", {}),
+        },
+        "latency": {
+            "status": latency_status,
+            "wall_p95_seconds": p95,
+            "alert_seconds": alert,
+            "slo_seconds": slo,
+        },
+        "runs": {
+            "total": history.get("runs", 0),
+            "failed_or_interrupted": history.get("failed_or_interrupted", 0),
+            "environment_failures": environment_failures,
+            "invalid_evidence": history["invalid_evidence"],
+        },
+        "autonomy": {
+            "review": "not-configured",
+            "repair_loops": "not-yet-emitted",
+        },
+    }
+
+
+def atomic_write(path: Path, value: dict[str, Any]) -> None:
+    if path.exists() and path.is_symlink():
+        raise CareError(f"output target is a symlink: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(prog="scripts/quality-care")
+    result.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS)
+    commands = result.add_subparsers(dest="command", required=True)
+    commands.add_parser("validate")
+    evaluate_parser = commands.add_parser("evaluate")
+    evaluate_parser.add_argument("--output", type=Path)
+    evaluate_parser.add_argument("--json", action="store_true")
+    assess_parser = commands.add_parser("assess")
+    assess_parser.add_argument("--eval-summary", type=Path, required=True)
+    assess_parser.add_argument("--history-summary", type=Path, required=True)
+    assess_parser.add_argument("--output", type=Path, required=True)
+    assess_parser.add_argument("--json", action="store_true")
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    policy = Policy(POLICY_FILE)
+    if arguments.command == "assess":
+        document = assess(
+            arguments.eval_summary.resolve(), arguments.history_summary.resolve(), policy
+        )
+        atomic_write(arguments.output.resolve(), document)
+        if arguments.json:
+            print(json.dumps(document, indent=2, sort_keys=True))
+        else:
+            print(
+                f"quality-care: {document['status']} policy={document['policy']} "
+                f"wall-p95={document['latency']['wall_p95_seconds']}s"
+            )
+        return 0 if document["status"] == "passed" else 1
+    cases = load_corpus(arguments.corpus.resolve())
+    if arguments.command == "validate":
+        print(f"quality-care: valid corpus with {len(cases)} cases")
+        return 0
+    document = evaluate(cases, policy)
+    if arguments.output:
+        atomic_write(arguments.output.resolve(), document)
+    if arguments.json:
+        print(json.dumps(document, indent=2, sort_keys=True))
+    else:
+        print(
+            f"quality-care: {document['status']} policy={document['policy']} "
+            f"cases={document['passed']}/{document['total']}"
+        )
+        for result in document["results"]:
+            if not result["passed"]:
+                print(f"quality-care: failed case {result['id']}", file=sys.stderr)
+    return 0 if document["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (CareError, PolicyError) as error:
+        fail(str(error))

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1661,6 +1661,8 @@ def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -
         "scripts/quality-mutation",
         "scripts/quality-baseline",
         "scripts/quality-promote",
+        "scripts/quality-history",
+        "scripts/quality-care",
         "scripts/release-version",
         "scripts/release-impact",
         "scripts/release-lid-probe",
@@ -1774,6 +1776,12 @@ def run_gate_contract_stage(root: Path) -> int:
             [str(root / "tests/quality-history-contract.sh")],
             {},
             "Quality history contract tests passed",
+        ),
+        (
+            "quality-care.log",
+            [str(root / "tests/quality-care.sh")],
+            {},
+            "Quality care contracts passed",
         ),
         (
             "quality-gate-python.log",

--- a/tools/quality_history.py
+++ b/tools/quality_history.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Report timing and failure telemetry from current-schema quality evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, NoReturn
+
+from quality_dashboard import DashboardError, read_manifest, read_summary
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RESULT_ROOT = ROOT / "app/build/quality-gates"
+FAILURES = {"failed", "environment-failed", "timeout", "interrupted"}
+
+
+class HistoryError(Exception):
+    """Retained evidence cannot produce trustworthy run telemetry."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-history: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def percentile(values: list[int], percent: int) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    index = (len(ordered) * percent + 99) // 100
+    return ordered[max(0, index - 1)]
+
+
+def collect(result_root: Path) -> dict[str, Any]:
+    if not result_root.is_dir() or result_root.is_symlink():
+        raise HistoryError("result root is missing or unsafe")
+    walls: list[int] = []
+    stage_values: dict[str, list[tuple[int, str]]] = {}
+    runs = 0
+    passed = 0
+    invalid = 0
+    for run_dir in sorted(result_root.iterdir()):
+        if not run_dir.is_dir() or run_dir.is_symlink():
+            continue
+        try:
+            manifest = read_manifest(run_dir)
+            stages = read_summary(run_dir, manifest)
+        except DashboardError:
+            invalid += 1
+            continue
+        if manifest["result"] not in ("passed", "failed", "interrupted"):
+            continue
+        runs += 1
+        passed += int(manifest["result"] == "passed")
+        walls.append(int(manifest["timing_wall_seconds"]))
+        for stage in stages:
+            if stage["status"] in ("reused", "blocked"):
+                continue
+            stage_values.setdefault(stage["stage"], []).append(
+                (stage["duration_seconds"], stage["status"])
+            )
+    if not runs:
+        raise HistoryError("no valid completed current-schema evidence found")
+    stages = []
+    for name, records in sorted(stage_values.items()):
+        durations = [duration for duration, _ in records]
+        stages.append(
+            {
+                "environment_failures": sum(
+                    status == "environment-failed" for _, status in records
+                ),
+                "failures": sum(status in FAILURES for _, status in records),
+                "p50_seconds": percentile(durations, 50),
+                "p95_seconds": percentile(durations, 95),
+                "samples": len(records),
+                "stage": name,
+            }
+        )
+    return {
+        "schema": 1,
+        "runs": runs,
+        "passed": passed,
+        "failed_or_interrupted": runs - passed,
+        "invalid_evidence": invalid,
+        "wall": {
+            "samples": len(walls),
+            "p50_seconds": percentile(walls, 50),
+            "p95_seconds": percentile(walls, 95),
+        },
+        "stages": stages,
+    }
+
+
+def render_tsv(document: dict[str, Any]) -> str:
+    lines = [
+        f"runs\t{document['runs']}",
+        f"passed\t{document['passed']}",
+        f"failed_or_interrupted\t{document['failed_or_interrupted']}",
+        f"invalid_evidence\t{document['invalid_evidence']}",
+        f"wall_p50_seconds\t{document['wall']['p50_seconds']}",
+        f"wall_p95_seconds\t{document['wall']['p95_seconds']}",
+        "",
+        "stage\tsamples\tfailures\tenvironment_failures\tp50_seconds\tp95_seconds",
+    ]
+    lines.extend(
+        "\t".join(
+            str(stage[key])
+            for key in (
+                "stage",
+                "samples",
+                "failures",
+                "environment_failures",
+                "p50_seconds",
+                "p95_seconds",
+            )
+        )
+        for stage in document["stages"]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("result_root", nargs="?", type=Path, default=DEFAULT_RESULT_ROOT)
+    result.add_argument("--format", choices=("tsv", "json"), default="tsv")
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    document = collect(arguments.result_root.resolve())
+    if arguments.format == "json":
+        print(json.dumps(document, indent=2, sort_keys=True))
+    else:
+        print(render_tsv(document), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (HistoryError, OSError, UnicodeError) as error:
+        fail(str(error))


### PR DESCRIPTION
## Outcome
- move quality-history parsing into stdlib Python with a thin shell wrapper
- grade exact stages, specs, capabilities, user journeys, release impact, and ignored private scope
- add bounded scheduled quality and documentation care with latency alerts and scoped issue/PR repair

## Local evidence
- policy 24 focused diagnostic PASS: static 1s, gate-contract 70s
- quality-care, quality-history, documentation, policy, and shell-safety contracts PASS
- no product matrix, release command, signing, publication, or physical power test was run