### PR TITLE
Integrate quality care into dashboard

### DIFF
--- a/.github/workflows/quality-care.yml
+++ b/.github/workflows/quality-care.yml
@@ -18,9 +18,12 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      attention: ${{ steps.assess.outputs.attention }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Evaluate workflow corpus
+        continue-on-error: true
         run: >-
           scripts/quality-care evaluate
           --output app/build/quality-care/evals.json
@@ -64,13 +67,22 @@ jobs:
           }
           scripts/quality-history --format json "$history" \
             >app/build/quality-care/history.json
-      - name: Assess eval and latency regressions
+      - id: assess
+        name: Assess eval and latency regressions
         if: always()
-        run: >-
-          scripts/quality-care assess
-          --eval-summary app/build/quality-care/evals.json
-          --history-summary app/build/quality-care/history.json
-          --output app/build/quality-care/summary.json
+        run: |
+          set +e
+          scripts/quality-care assess \
+            --eval-summary app/build/quality-care/evals.json \
+            --history-summary app/build/quality-care/history.json \
+            --output app/build/quality-care/summary.json
+          status=$?
+          set -e
+          case "$status" in
+            0) printf 'attention=false\n' >>"$GITHUB_OUTPUT" ;;
+            1) printf 'attention=true\n' >>"$GITHUB_OUTPUT" ;;
+            *) exit "$status" ;;
+          esac
       - name: Upload quality-care evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -80,8 +92,64 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  quality-dashboard:
+    needs: care
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Download current care evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: quality-care-${{ github.run_id }}-${{ github.run_attempt }}
+          path: app/build/quality-care
+      - id: main-evidence
+        name: Restore last green main quality evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          baseline_root="$(scripts/quality-baseline)"
+          printf 'root=%s\n' "$baseline_root" >>"$GITHUB_OUTPUT"
+          printf 'run_id=%s\n' "${baseline_root##*/}" >>"$GITHUB_OUTPUT"
+      - id: mutation-evidence
+        name: Restore latest mutation score when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-mutation latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - name: Generate dashboard with care evidence
+        run: |
+          mutation_args=()
+          if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
+            mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          fi
+          scripts/quality-dashboard generate \
+            --result-root "${{ steps.main-evidence.outputs.root }}" \
+            --output app/build/quality-dashboard \
+            --care-summary app/build/quality-care/summary.json \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
+            "${mutation_args[@]}"
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: app/build/quality-dashboard
+      - name: Deploy quality dashboard
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
   attention:
-    if: failure()
+    if: always() && (needs.care.result == 'failure' || needs.care.outputs.attention == 'true')
     needs: care
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -107,3 +175,16 @@ jobs:
               --title "$title" \
               --body "The bounded quality-care workflow found an eval, evidence, or latency regression. Inspect $RUN_URL."
           fi
+
+  enforce-attention:
+    if: needs.care.outputs.attention == 'true'
+    needs:
+      - care
+      - quality-dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Keep attention visible in workflow status
+        run: |
+          printf 'quality-care: attention evidence was published and requires repair\n' >&2
+          exit 1

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -145,17 +145,29 @@ jobs:
         run: |
           summary="$(scripts/quality-mutation latest --optional)"
           printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - id: care-evidence
+        name: Restore latest quality-care summary when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-care latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
       - name: Generate quality dashboard
         run: |
           mutation_args=()
+          care_args=()
           if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
             mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          fi
+          if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
+            care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
           fi
           scripts/quality-dashboard generate \
             --result-root app/build/quality-gates \
             --output app/build/quality-dashboard \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            "${mutation_args[@]}"
+            "${mutation_args[@]}" \
+            "${care_args[@]}"
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload Pages artifact

--- a/.github/workflows/quality-mutations.yml
+++ b/.github/workflows/quality-mutations.yml
@@ -96,13 +96,25 @@ jobs:
           baseline_root="$(scripts/quality-baseline)"
           printf 'root=%s\n' "$baseline_root" >>"$GITHUB_OUTPUT"
           printf 'run_id=%s\n' "${baseline_root##*/}" >>"$GITHUB_OUTPUT"
+      - id: care-evidence
+        name: Restore latest quality-care summary when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-care latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
       - name: Generate dashboard with mutation score
-        run: >-
-          scripts/quality-dashboard generate
-          --result-root "${{ steps.main-evidence.outputs.root }}"
-          --output app/build/quality-dashboard
-          --mutation-summary app/build/quality-mutations/summary.json
-          --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}"
+        run: |
+          care_args=()
+          if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
+            care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
+          fi
+          scripts/quality-dashboard generate \
+            --result-root "${{ steps.main-evidence.outputs.root }}" \
+            --output app/build/quality-dashboard \
+            --mutation-summary app/build/quality-mutations/summary.json \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
+            "${care_args[@]}"
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload Pages artifact

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -37,6 +37,9 @@ the only ordinary merge authority. Unknown paths select the full plan.
 - `scripts/quality-care validate` checks the versioned workflow eval corpus.
   `scripts/quality-care evaluate` grades diff impact and private-scope cases.
   `scripts/quality-care assess` compares the results with retained run latency.
+  `scripts/quality-care latest --optional` inspects at most five completed
+  runs within one 60-second deadline. It restores the newest valid
+  current-policy care artifact for a dashboard deploy.
 - `scripts/quality-policy specs` lists current durable specs.
   `scripts/quality-policy render-specs` prints their requirement, journey, and
   scenario links.
@@ -126,6 +129,10 @@ delivery from competing with those workers. Provider lanes then run in
 parallel. Independent distribution and release lanes overlap after provider
 work drains.
 
+The gate-contract stage keeps lightweight contracts concurrent. It admits at
+most two process-heavy orchestrator shards at one time. This limit prevents
+process oversubscription without increasing the stage budget.
+
 Swift and Clang caches stay under `app/.build`. The packaged UI test uses a
 stripped process-private app, fake CLI, and private state. Provider tests use
 private state and socket roots plus the newly bundled `tmux` and
@@ -193,13 +200,18 @@ run release tools.
 ## Dashboard
 
 The dashboard generator validates the current manifest, summary, metric and
-mutation digests. It shows authority, result, exact commit, exact CI run,
+mutation digests. It also validates the care policy, source commit, schema, and
+input digests. It shows authority, result, exact commit, exact CI run,
 freshness, fingerprint, durations, coverage, affected journeys, scenario gaps,
-mutation score, and recent latency.
+mutation score, workflow evals, feedback p95 and SLO, review state, security
+state, and recent latency.
 
-The same artifact opens locally and deploys to GitHub Pages. Pages deploys only
-after a green `ci-main` gate or a green mutation score for that policy. The
-workflow does not publish pull request or local evidence.
+The same artifact opens locally and deploys to GitHub Pages. Main and mutation
+workflows deploy only after a green `ci-main` gate or a green mutation score for
+that policy. The bounded care workflow can publish a validated attention
+result, then marks its run failed and opens one issue. A later deploy restores
+the newest valid care artifact for the current policy. No workflow publishes
+pull request or local gate evidence.
 
 ## Definition of done
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -68,6 +68,9 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - Pull-request CI runs every functional check once and the timing-policy
   ratchets. It does not enforce reference-machine wall or per-stage timing
   ceilings. The workflow has a ten-minute overall deadline.
+- The gate-contract runner admits at most two process-heavy orchestrator shards
+  at one time. Lightweight contracts stay concurrent. The runner does not
+  increase a timing budget to hide process oversubscription.
 - CI gets quality metrics from the last green `main` artifact. Test identities,
   aggregate coverage, and critical-source coverage cannot decrease. Changed
   executable Swift lines need at least 90 percent coverage. A person does not
@@ -92,8 +95,13 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - A deterministic static dashboard reads only validated gate evidence. The
   same artifact opens locally and deploys to GitHub Pages only after a green
   `main` run with direct or promoted evidence, or a green scheduled mutation
-  run. It shows measured coverage and the latest valid mutation score when
-  they exist. Only deploy jobs have Pages write permission.
+  run. Bounded quality care can also deploy its validated result before it
+  marks an attention run as failed. Care evidence binds the source commit and
+  SHA-256 digests of its eval and history inputs. The dashboard shows measured
+  coverage, mutation score, workflow evals, feedback p95 and SLO, review state,
+  and security state when they exist. A later main or mutation deploy restores
+  the newest valid current-policy care artifact. Only deploy jobs have Pages
+  write permission.
 - An ordinary merged pull request does not repeat the full functional matrix
   on `main`. The main workflow promotes the successful pull-request artifact
   only when the tested merge and final merge have the same tree and ordered

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,8 +44,11 @@
   `scripts/quality-care evaluate --output <json>` grades exact diff impact and
   private-scope outcomes. `scripts/quality-care assess` fails before the
   pull-request wall p95 reaches the ten-minute SLO. Scheduled quality care opens
-  one scoped issue. Scheduled documentation care can open a pull request only
-  for deterministic files under `quality/generated/`.
+  one scoped issue. Its summary binds the source commit and both input digests.
+  `scripts/quality-care latest --optional` inspects at most five completed runs
+  inside one 60-second deadline. It supplies only a valid current-policy
+  artifact to later dashboard deploys. Scheduled documentation care can open a
+  pull request only for deterministic files under `quality/generated/`.
 - `scripts/quality-policy generate --check` checks both generated policy JSON
   and the readable current-spec traceability table.
 - `scripts/quality-promote` is the hosted post-merge path. It downloads the
@@ -56,7 +59,10 @@
   `app/build/quality-dashboard/{index.html,data.json}` from the newest schema-4
   evidence. `scripts/quality-dashboard serve --seconds 300` serves it only on
   loopback and stops at the deadline. A green `main` workflow publishes the
-  same static files to `https://iltsarev.github.io/detach/`.
+  same static files to `https://iltsarev.github.io/detach/`. Add
+  `--care-summary <json>` to show validated eval, latency, run-health, and
+  autonomy facts. Scheduled care can publish an attention result before the
+  workflow records FAIL and opens its issue.
 - `scripts/quality-mutation validate` checks the deterministic safety corpus.
   `scripts/quality-mutation run --id <id> --output <json> --log <log>` runs one
   mutant and restores its source. The weekly hosted workflow runs all mutants

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -619,7 +619,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 24,
+  "policy": 25,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	24
+policy	25
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -9,7 +9,11 @@ RUN_DIR="$RESULT_ROOT/20260811T100000Z-1"
 OUTPUT="$TMP_ROOT/dashboard"
 PROMOTED_OUTPUT="$TMP_ROOT/promoted-dashboard"
 MUTATION_SUMMARY="$TMP_ROOT/mutation-summary.json"
+CARE_SUMMARY="$TMP_ROOT/care-summary.json"
+CARE_EVALS="$TMP_ROOT/evals.json"
+CARE_HISTORY="$TMP_ROOT/history.json"
 POLICY_VERSION="$("$ROOT/scripts/quality-policy" version)"
+SOURCE_COMMIT="$(git -C "$ROOT" rev-parse HEAD)"
 MAIN_COMMIT=8989898989898989898989898989898989898989
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 
@@ -130,16 +134,60 @@ cat >"$MUTATION_SUMMARY" <<JSON
 }
 JSON
 
+printf '{"schema":1,"status":"passed"}\n' >"$CARE_EVALS"
+printf '{"schema":1,"runs":4}\n' >"$CARE_HISTORY"
+CARE_EVAL_DIGEST="$(shasum -a 256 "$CARE_EVALS" | awk '{print $1}')"
+CARE_HISTORY_DIGEST="$(shasum -a 256 "$CARE_HISTORY" | awk '{print $1}')"
+cat >"$CARE_SUMMARY" <<JSON
+{
+  "schema": 1,
+  "policy": $POLICY_VERSION,
+  "source_commit": "$SOURCE_COMMIT",
+  "status": "passed",
+  "reasons": [],
+  "inputs": {
+    "eval_sha256": "$CARE_EVAL_DIGEST",
+    "history_sha256": "$CARE_HISTORY_DIGEST"
+  },
+  "evals": {
+    "passed": 8,
+    "total": 8,
+    "categories": {
+      "escaped-defect": 2,
+      "historical-task": 2,
+      "policy-mutant": 2,
+      "scope-violation": 2
+    }
+  },
+  "latency": {
+    "status": "healthy",
+    "wall_p95_seconds": 285,
+    "alert_seconds": 480,
+    "slo_seconds": 600
+  },
+  "runs": {
+    "total": 4,
+    "failed_or_interrupted": 0,
+    "environment_failures": 0,
+    "invalid_evidence": 0
+  },
+  "autonomy": {
+    "review": "not-configured",
+    "repair_loops": "not-yet-emitted"
+  }
+}
+JSON
+
 "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
   --output "$OUTPUT" --run-url 'https://github.example/actions/runs/1' \
-  --mutation-summary "$MUTATION_SUMMARY" >/dev/null
+  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" >/dev/null
 [ -f "$OUTPUT/index.html" ] && [ -f "$OUTPUT/data.json" ] || \
   fail 'dashboard artifacts are missing'
 first_html="$(shasum -a 256 "$OUTPUT/index.html" | awk '{print $1}')"
 first_data="$(shasum -a 256 "$OUTPUT/data.json" | awk '{print $1}')"
 "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
   --output "$OUTPUT" --run-url 'https://github.example/actions/runs/1' \
-  --mutation-summary "$MUTATION_SUMMARY" >/dev/null
+  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" >/dev/null
 [ "$first_html" = "$(shasum -a 256 "$OUTPUT/index.html" | awk '{print $1}')" ] || \
   fail 'HTML generation is not deterministic'
 [ "$first_data" = "$(shasum -a 256 "$OUTPUT/data.json" | awk '{print $1}')" ] || \
@@ -160,6 +208,10 @@ grep -F 'changed lines 90.00%' "$OUTPUT/index.html" >/dev/null || \
   fail 'measured changed-line coverage is missing'
 grep -F '100% · 1/1 killed · passed' "$OUTPUT/index.html" >/dev/null || \
   fail 'mutation score is missing'
+grep -F '8/8 passed · passed · source' "$OUTPUT/index.html" >/dev/null || \
+  fail 'workflow-eval summary is missing'
+grep -F 'p95 285s · alert 480s · SLO 600s · healthy' "$OUTPUT/index.html" >/dev/null || \
+  fail 'feedback latency summary is missing'
 ! grep -F '<svg' "$OUTPUT/index.html" >/dev/null || fail 'dashboard contains hand-drawn SVG'
 
 python3 - "$OUTPUT/data.json" <<'PY'
@@ -174,6 +226,15 @@ assert [spec["id"] for spec in data["specifications"]] == ["app"]
 assert data["quality"]["planned_scenarios"] == 3
 assert data["quality"]["coverage"]["comparison"]["mode"] == "green-main-artifact"
 assert data["quality"]["mutation"]["score_percent"] == 100
+assert data["quality"]["care"]["evals"] == {
+    "categories": {
+        "escaped-defect": 2, "historical-task": 2,
+        "policy-mutant": 2, "scope-violation": 2,
+    },
+    "passed": 8,
+    "total": 8,
+}
+assert data["quality"]["review"] == "not-configured"
 assert len(data["trends"]) == 2
 assert [journey["id"] for journey in data["journeys"]] == [
     "J-ONBOARD-FIRST-RUN", "J-ONBOARD-PROVIDER", "J-ONBOARD-APPROVAL"
@@ -203,7 +264,7 @@ EOF
 "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
   --output "$PROMOTED_OUTPUT" \
   --run-url 'https://github.com/owner/repository/actions/runs/2' \
-  --mutation-summary "$MUTATION_SUMMARY" >/dev/null
+  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" >/dev/null
 grep -F "Tested merge <code>0123456789abcdef0123456789abcdef01234567</code>" \
   "$PROMOTED_OUTPUT/index.html" >/dev/null || fail 'promotion provenance is missing'
 python3 - "$PROMOTED_OUTPUT/data.json" "$MAIN_COMMIT" <<'PY'
@@ -230,6 +291,36 @@ grep -F 'promotion evidence does not bind' \
   "$TMP_ROOT/tampered-promotion.out" >/dev/null || \
   fail 'tampered promotion failure is unclear'
 mv "$TMP_ROOT/promotion.tsv" "$RUN_DIR/promotion.tsv"
+
+cp "$CARE_SUMMARY" "$TMP_ROOT/care-summary.backup.json"
+python3 - "$CARE_SUMMARY" <<'PY'
+import json,sys
+path=sys.argv[1]
+value=json.load(open(path,encoding="utf-8"))
+value["policy"] += 1
+with open(path,"w",encoding="utf-8") as target:
+    json.dump(value,target)
+PY
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/stale-care" --care-summary "$CARE_SUMMARY" \
+    >"$TMP_ROOT/stale-care.out" 2>&1; then
+  fail 'care evidence from another policy was accepted'
+fi
+grep -F 'care summary is invalid' "$TMP_ROOT/stale-care.out" >/dev/null || \
+  fail 'stale care failure is unclear'
+mv "$TMP_ROOT/care-summary.backup.json" "$CARE_SUMMARY"
+
+cp "$CARE_EVALS" "$TMP_ROOT/evals.backup.json"
+printf 'tampered\n' >>"$CARE_EVALS"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/tampered-care-input" --care-summary "$CARE_SUMMARY" \
+    >"$TMP_ROOT/tampered-care-input.out" 2>&1; then
+  fail 'tampered care input was accepted'
+fi
+grep -F 'care input digest does not match: evals.json' \
+  "$TMP_ROOT/tampered-care-input.out" >/dev/null || \
+  fail 'tampered care input failure is unclear'
+mv "$TMP_ROOT/evals.backup.json" "$CARE_EVALS"
 
 cp "$RUN_DIR/manifest.tsv" "$TMP_ROOT/current-manifest.tsv"
 awk -F '\t' '$1 != "specs" {print}' "$TMP_ROOT/current-manifest.tsv" \

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -44,6 +44,10 @@ grep -F "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" \
 grep -F 'pages: write' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'scripts/quality-dashboard generate' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'scripts/quality-care latest --optional' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'care_args+=(--care-summary' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 
 prepare_template() {
   local stage

--- a/tests/quality_care_contract.py
+++ b/tests/quality_care_contract.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 from pathlib import Path
 import re
 import subprocess
@@ -18,11 +20,16 @@ DOC_WORKFLOW = ROOT / ".github/workflows/documentation-care.yml"
 
 
 def invoke(
-    arguments: list[str], *, expected: int = 0
+    arguments: list[str], *, expected: int = 0,
+    extra_environment: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    if extra_environment:
+        environment.update(extra_environment)
     result = subprocess.run(
         [str(SCRIPT), *arguments],
         cwd=ROOT,
+        env=environment,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -49,6 +56,9 @@ def assert_workflows() -> None:
         "scripts/quality-care evaluate",
         "scripts/quality-history --format json",
         "scripts/quality-care assess",
+        "--care-summary app/build/quality-care/summary.json",
+        "enforce-attention:",
+        "pages: write",
         "cancel-in-progress: true",
         "--created \">=$since\"",
         "timeout 20s gh run download",
@@ -152,7 +162,7 @@ def main() -> int:
 
         eval_path = root / "evals.json"
         write_json(eval_path, result)
-        healthy_history = root / "healthy-history.json"
+        healthy_history = root / "history.json"
         write_json(healthy_history, history(420))
         healthy_summary = root / "healthy-summary.json"
         invoke(
@@ -165,6 +175,11 @@ def main() -> int:
         healthy = json.loads(healthy_summary.read_text(encoding="utf-8"))
         assert healthy["status"] == "passed"
         assert healthy["latency"]["alert_seconds"] == 480
+        assert len(healthy["source_commit"]) == 40
+        assert healthy["inputs"] == {
+            "eval_sha256": hashlib.sha256(eval_path.read_bytes()).hexdigest(),
+            "history_sha256": hashlib.sha256(healthy_history.read_bytes()).hexdigest(),
+        }
 
         slow_history = root / "slow-history.json"
         write_json(slow_history, history(481))
@@ -197,6 +212,105 @@ def main() -> int:
         )
         failed_care = json.loads(failed_summary.read_text(encoding="utf-8"))
         assert "a retained gate run failed or was interrupted" in failed_care["reasons"]
+
+        fake_gh = root / "fake-gh.py"
+        fake_gh.write_text(
+            """#!/usr/bin/env python3
+import os
+from pathlib import Path
+import shutil
+import sys
+import time
+args=sys.argv[1:]
+if os.environ.get("CARE_GH_SLEEP"):
+    time.sleep(float(os.environ["CARE_GH_SLEEP"]))
+if args[0] == "api" and "workflows/quality-care.yml/runs" in args[1]:
+    print("778\\n777")
+elif args[0] == "api" and args[1].endswith("/runs/778/artifacts"):
+    print("missing")
+elif args[0] == "api" and args[1].endswith("/runs/777/artifacts"):
+    print("quality-care-777-1")
+elif args[:2] == ["run", "download"]:
+    destination=Path(args[args.index("--dir") + 1])
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(os.environ["CARE_FIXTURE"], destination / "summary.json")
+    shutil.copyfile(os.environ["CARE_EVAL_FIXTURE"], destination / "evals.json")
+    shutil.copyfile(os.environ["CARE_HISTORY_FIXTURE"], destination / "history.json")
+else:
+    raise SystemExit(3)
+""",
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+        latest_root = root / "latest"
+        latest = invoke(
+            [
+                "latest", "--repository", "owner/repository",
+                "--output-root", str(latest_root),
+            ],
+            extra_environment={
+                "DETACH_QUALITY_CARE_TEST_MODE": "1",
+                "DETACH_QUALITY_CARE_GH": str(fake_gh),
+                "CARE_FIXTURE": str(healthy_summary),
+                "CARE_EVAL_FIXTURE": str(eval_path),
+                "CARE_HISTORY_FIXTURE": str(healthy_history),
+            },
+        ).stdout.strip()
+        assert Path(latest) == latest_root / "777/summary.json"
+
+        stale_value = json.loads(healthy_summary.read_text(encoding="utf-8"))
+        stale_value["policy"] -= 1
+        stale_fixture = root / "stale-care.json"
+        write_json(stale_fixture, stale_value)
+        optional = invoke(
+            [
+                "latest", "--repository", "owner/repository",
+                "--output-root", str(root / "stale-latest"), "--optional",
+            ],
+            extra_environment={
+                "DETACH_QUALITY_CARE_TEST_MODE": "1",
+                "DETACH_QUALITY_CARE_GH": str(fake_gh),
+                "CARE_FIXTURE": str(stale_fixture),
+                "CARE_EVAL_FIXTURE": str(eval_path),
+                "CARE_HISTORY_FIXTURE": str(healthy_history),
+            },
+        )
+        assert optional.stdout == ""
+
+        false_pass_value = json.loads(healthy_summary.read_text(encoding="utf-8"))
+        false_pass_value["latency"]["wall_p95_seconds"] = 481
+        false_pass_fixture = root / "false-pass-care.json"
+        write_json(false_pass_fixture, false_pass_value)
+        false_pass = invoke(
+            [
+                "latest", "--repository", "owner/repository",
+                "--output-root", str(root / "false-pass-latest"),
+            ],
+            expected=2,
+            extra_environment={
+                "DETACH_QUALITY_CARE_TEST_MODE": "1",
+                "DETACH_QUALITY_CARE_GH": str(fake_gh),
+                "CARE_FIXTURE": str(false_pass_fixture),
+                "CARE_EVAL_FIXTURE": str(eval_path),
+                "CARE_HISTORY_FIXTURE": str(healthy_history),
+            },
+        )
+        assert "care summary latency status is inconsistent" in false_pass.stdout
+
+        timed_out = invoke(
+            [
+                "latest", "--repository", "owner/repository",
+                "--output-root", str(root / "timed-out-latest"),
+            ],
+            expected=2,
+            extra_environment={
+                "DETACH_QUALITY_CARE_TEST_MODE": "1",
+                "DETACH_QUALITY_CARE_GH": str(fake_gh),
+                "DETACH_QUALITY_CARE_LATEST_SECONDS": "1",
+                "CARE_GH_SLEEP": "2",
+            },
+        )
+        assert "deadline" in timed_out.stdout
 
     print("Quality care contracts passed")
     return 0

--- a/tests/quality_mutation_contract.py
+++ b/tests/quality_mutation_contract.py
@@ -104,6 +104,8 @@ def main() -> int:
         "scripts/quality-mutation summarize",
         "fail-fast: false",
         "if: github.ref == 'refs/heads/main'",
+        "scripts/quality-care latest --optional",
+        "care_args+=(--care-summary",
     ):
         if required not in workflow:
             fail(f"mutation workflow is missing: {required}")

--- a/tools/quality_care.py
+++ b/tools/quality_care.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 from pathlib import Path, PurePosixPath
 import re
 import subprocess
 import sys
+import time
 from typing import Any, NoReturn
 
 from quality_policy import POLICY_FILE, Policy, PolicyError
@@ -16,7 +19,14 @@ from quality_policy import POLICY_FILE, Policy, PolicyError
 
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CORPUS = ROOT / "quality/evals.json"
+DEFAULT_BASELINE = ROOT / "app/build/quality-care-baseline"
+LATEST_RUN_LIMIT = 5
+GH_TIMEOUT_SECONDS = 20
+LATEST_DEADLINE_SECONDS = 60
 CASE_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"^[0-9a-f]{64}$")
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 CATEGORIES = {
     "escaped-defect",
     "historical-task",
@@ -50,6 +60,27 @@ def read_json(path: Path, label: str) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, UnicodeError, OSError) as error:
         raise CareError(f"{label} is invalid: {error}") from error
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def git_source_commit() -> str:
+    try:
+        result = subprocess.run(
+            ("git", "-C", str(ROOT), "rev-parse", "HEAD"),
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        raise CareError(f"cannot inspect source commit: {error}") from error
+    value = result.stdout.strip()
+    if result.returncode or not COMMIT.fullmatch(value):
+        raise CareError("cannot resolve the quality-care source commit")
+    return value
 
 
 def valid_path(value: Any) -> bool:
@@ -347,8 +378,13 @@ def assess(eval_path: Path, history_path: Path, policy: Policy) -> dict[str, Any
     return {
         "schema": 1,
         "policy": policy.version,
+        "source_commit": git_source_commit(),
         "status": status,
         "reasons": reasons,
+        "inputs": {
+            "eval_sha256": sha256_file(eval_path),
+            "history_sha256": sha256_file(history_path),
+        },
         "evals": {
             "passed": eval_summary.get("passed", 0),
             "total": eval_summary.get("total", 0),
@@ -373,6 +409,252 @@ def assess(eval_path: Path, history_path: Path, policy: Policy) -> dict[str, Any
     }
 
 
+def valid_count(value: Any) -> bool:
+    return type(value) is int and value >= 0
+
+
+def validate_summary(
+    value: Any, expected_policy: int, expected_slo_seconds: int
+) -> dict[str, Any]:
+    keys = {
+        "schema", "policy", "source_commit", "status", "reasons", "inputs",
+        "evals", "latency", "runs", "autonomy"
+    }
+    if not isinstance(value, dict) or set(value) != keys:
+        raise CareError("care summary schema is invalid")
+    if (
+        value["schema"] != 1
+        or value["policy"] != expected_policy
+        or not isinstance(value["source_commit"], str)
+        or not COMMIT.fullmatch(value["source_commit"])
+        or value["status"] not in ("passed", "attention")
+        or not isinstance(value["reasons"], list)
+        or any(not isinstance(reason, str) or not reason for reason in value["reasons"])
+    ):
+        raise CareError("care summary identity is invalid")
+    inputs = value["inputs"]
+    if (
+        not isinstance(inputs, dict)
+        or set(inputs) != {"eval_sha256", "history_sha256"}
+        or any(not isinstance(digest, str) or not DIGEST.fullmatch(digest) for digest in inputs.values())
+    ):
+        raise CareError("care summary input digests are invalid")
+    evals = value["evals"]
+    if (
+        not isinstance(evals, dict)
+        or set(evals) != {"passed", "total", "categories"}
+        or not valid_count(evals["passed"])
+        or not valid_count(evals["total"])
+        or evals["total"] < 1
+        or evals["passed"] > evals["total"]
+        or not isinstance(evals["categories"], dict)
+        or set(evals["categories"]) != CATEGORIES
+        or any(not valid_count(count) for count in evals["categories"].values())
+        or sum(evals["categories"].values()) != evals["passed"]
+    ):
+        raise CareError("care summary evals are invalid")
+    latency = value["latency"]
+    if (
+        not isinstance(latency, dict)
+        or set(latency) != {
+            "status", "wall_p95_seconds", "alert_seconds", "slo_seconds"
+        }
+        or latency["status"] not in ("healthy", "attention", "breached")
+        or any(
+            not valid_count(latency[key])
+            for key in ("wall_p95_seconds", "alert_seconds", "slo_seconds")
+        )
+        or latency["slo_seconds"] != expected_slo_seconds
+        or latency["alert_seconds"] != expected_slo_seconds * 80 // 100
+        or latency["alert_seconds"] >= latency["slo_seconds"]
+    ):
+        raise CareError("care summary latency is invalid")
+    runs = value["runs"]
+    if (
+        not isinstance(runs, dict)
+        or set(runs) != {
+            "total", "failed_or_interrupted", "environment_failures", "invalid_evidence"
+        }
+        or any(not valid_count(count) for count in runs.values())
+        or runs["failed_or_interrupted"] > runs["total"]
+    ):
+        raise CareError("care summary run counts are invalid")
+    autonomy = value["autonomy"]
+    if (
+        not isinstance(autonomy, dict)
+        or set(autonomy) != {"review", "repair_loops"}
+        or autonomy["review"] not in ("not-configured", "passed", "failed")
+        or not (
+            autonomy["repair_loops"] == "not-yet-emitted"
+            or valid_count(autonomy["repair_loops"])
+        )
+    ):
+        raise CareError("care summary autonomy is invalid")
+    p95 = latency["wall_p95_seconds"]
+    expected_latency = (
+        "breached" if p95 >= latency["slo_seconds"]
+        else "attention" if p95 >= latency["alert_seconds"]
+        else "healthy"
+    )
+    if latency["status"] != expected_latency:
+        raise CareError("care summary latency status is inconsistent")
+    needs_attention = (
+        evals["passed"] != evals["total"]
+        or latency["status"] != "healthy"
+        or any(runs[key] for key in (
+            "failed_or_interrupted", "environment_failures", "invalid_evidence"
+        ))
+    )
+    if (
+        (value["status"] == "attention") != needs_attention
+        or (value["status"] == "attention") != bool(value["reasons"])
+    ):
+        raise CareError("care summary status is inconsistent")
+    return value
+
+
+def validate_input_bindings(path: Path, summary: dict[str, Any]) -> None:
+    for filename, key in (
+        ("evals.json", "eval_sha256"),
+        ("history.json", "history_sha256"),
+    ):
+        candidate = path.parent / filename
+        if not candidate.is_file() or candidate.is_symlink():
+            raise CareError(f"care input is missing or unsafe: {filename}")
+        if sha256_file(candidate) != summary["inputs"][key]:
+            raise CareError(f"care input digest does not match: {filename}")
+
+
+def gh_output(
+    executable: str, arguments: list[str], *, deadline: float | None = None
+) -> str:
+    timeout = GH_TIMEOUT_SECONDS
+    if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise CareError(
+                f"care restore exceeded its {LATEST_DEADLINE_SECONDS}-second deadline"
+            )
+        timeout = min(timeout, remaining)
+    try:
+        result = subprocess.run(
+            [executable, *arguments],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        if deadline is not None:
+            raise CareError("gh did not finish before the bounded care restore deadline") from error
+        raise CareError(f"gh exceeded its {GH_TIMEOUT_SECONDS}-second deadline") from error
+    except OSError as error:
+        raise CareError(f"cannot start gh: {error}") from error
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise CareError(f"gh failed: {detail}")
+    return result.stdout.strip()
+
+
+def latest_summary(
+    repository: str,
+    output_root: Path,
+    optional: bool,
+    policy: Policy,
+    test_mode: bool,
+) -> Path | None:
+    if not REPOSITORY.fullmatch(repository):
+        if optional and not repository:
+            return None
+        raise CareError("repository must identify owner/repository")
+    if not test_mode and output_root.resolve() != DEFAULT_BASELINE.resolve():
+        raise CareError("care baseline output must use app/build/quality-care-baseline")
+    if output_root.exists() and (not output_root.is_dir() or output_root.is_symlink()):
+        raise CareError("care baseline output is unsafe")
+    output_root.mkdir(parents=True, exist_ok=True)
+    executable = os.environ.get("DETACH_QUALITY_CARE_GH", "gh") if test_mode else "gh"
+    deadline_seconds = LATEST_DEADLINE_SECONDS
+    if test_mode and os.environ.get("DETACH_QUALITY_CARE_LATEST_SECONDS"):
+        raw_deadline = os.environ["DETACH_QUALITY_CARE_LATEST_SECONDS"]
+        if not raw_deadline.isdigit() or int(raw_deadline) < 1:
+            raise CareError("test care restore deadline must be a positive integer")
+        deadline_seconds = int(raw_deadline)
+    deadline = time.monotonic() + deadline_seconds
+    run_output = gh_output(
+        executable,
+        [
+            "api",
+            f"repos/{repository}/actions/workflows/quality-care.yml/runs"
+            f"?branch=main&status=completed&per_page={LATEST_RUN_LIMIT}",
+            "--jq",
+            ".workflow_runs[].id",
+        ],
+        deadline=deadline,
+    )
+    run_ids = run_output.splitlines()
+    if not run_ids:
+        if optional:
+            return None
+        raise CareError("no completed main quality-care run is available")
+    if len(run_ids) > LATEST_RUN_LIMIT or any(
+        not re.fullmatch(r"[1-9][0-9]*", run_id) for run_id in run_ids
+    ):
+        raise CareError("quality-care run list is invalid")
+    for run_id in run_ids:
+        artifact_name = gh_output(
+            executable,
+            [
+                "api",
+                f"repos/{repository}/actions/runs/{run_id}/artifacts",
+                "--jq",
+                ".artifacts | map(select(.expired == false and "
+                "(.name | startswith(\"quality-care-\")))) | "
+                "if length == 0 then \"missing\" elif length == 1 then "
+                ".[0].name else \"ambiguous\" end",
+            ],
+            deadline=deadline,
+        )
+        if artifact_name == "missing":
+            continue
+        if artifact_name == "ambiguous" or not artifact_name.startswith("quality-care-"):
+            raise CareError(f"quality-care run {run_id} has ambiguous artifacts")
+        destination = output_root / run_id
+        if destination.exists():
+            raise CareError(f"care baseline destination already exists: {destination}")
+        destination.mkdir()
+        gh_output(
+            executable,
+            [
+                "run", "download", run_id, "--repo", repository,
+                "--name", artifact_name, "--dir", str(destination),
+            ],
+            deadline=deadline,
+        )
+        candidates = [
+            path for path in destination.rglob("summary.json")
+            if path.is_file() and not path.is_symlink()
+        ]
+        if len(candidates) != 1:
+            raise CareError("downloaded care evidence has no unique summary")
+        document = read_json(candidates[0], "care summary")
+        if isinstance(document, dict) and document.get("policy") != policy.version:
+            continue
+        summary = validate_summary(
+            document, policy.version, policy.limits["pr_feedback_seconds"]
+        )
+        validate_input_bindings(candidates[0], summary)
+        print(candidates[0])
+        return candidates[0]
+    if optional:
+        return None
+    raise CareError(
+        f"no valid policy {policy.version} care artifact exists in the latest "
+        f"{LATEST_RUN_LIMIT} completed runs"
+    )
+
+
 def atomic_write(path: Path, value: dict[str, Any]) -> None:
     if path.exists() and path.is_symlink():
         raise CareError(f"output target is a symlink: {path}")
@@ -395,15 +677,32 @@ def parser() -> argparse.ArgumentParser:
     assess_parser.add_argument("--history-summary", type=Path, required=True)
     assess_parser.add_argument("--output", type=Path, required=True)
     assess_parser.add_argument("--json", action="store_true")
+    latest_parser = commands.add_parser("latest")
+    latest_parser.add_argument(
+        "--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    latest_parser.add_argument("--output-root", type=Path, default=DEFAULT_BASELINE)
+    latest_parser.add_argument("--optional", action="store_true")
     return result
 
 
 def main() -> int:
     arguments = parser().parse_args()
     policy = Policy(POLICY_FILE)
+    if arguments.command == "latest":
+        latest_summary(
+            arguments.repository,
+            arguments.output_root,
+            arguments.optional,
+            policy,
+            os.environ.get("DETACH_QUALITY_CARE_TEST_MODE") == "1",
+        )
+        return 0
     if arguments.command == "assess":
         document = assess(
             arguments.eval_summary.resolve(), arguments.history_summary.resolve(), policy
+        )
+        validate_summary(
+            document, policy.version, policy.limits["pr_feedback_seconds"]
         )
         atomic_write(arguments.output.resolve(), document)
         if arguments.json:

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -15,6 +15,11 @@ import sys
 import threading
 from typing import Any, NoReturn, Optional
 
+from quality_care import (
+    CareError,
+    validate_input_bindings as validate_care_inputs,
+    validate_summary as validate_care_summary,
+)
 from quality_metrics import MetricsError, validate_metrics
 from quality_mutation import MutationError, validate_summary
 from quality_promote import PromotionError, validate_promotion
@@ -184,6 +189,23 @@ def read_mutation_summary(
         raise DashboardError(f"mutation summary is invalid: {error}") from error
 
 
+def read_care_summary(
+    path: Optional[Path], expected_policy: int, expected_slo_seconds: int
+) -> Optional[dict[str, Any]]:
+    if path is None:
+        return None
+    try:
+        care_path = safe_file(path, "care summary")
+        document = json.loads(care_path.read_text(encoding="utf-8"))
+        summary = validate_care_summary(
+            document, expected_policy, expected_slo_seconds
+        )
+        validate_care_inputs(care_path, summary)
+        return summary
+    except (CareError, json.JSONDecodeError, UnicodeError) as error:
+        raise DashboardError(f"care summary is invalid: {error}") from error
+
+
 def split_csv(value: str) -> list[str]:
     return [item for item in value.split(",") if item]
 
@@ -252,6 +274,7 @@ def build_data(
     result_root: Path,
     run_url: str,
     mutation_summary: Optional[Path] = None,
+    care_summary: Optional[Path] = None,
 ) -> dict[str, Any]:
     manifest = read_manifest(run_dir)
     effective_commit, effective_authority, promotion = effective_identity(
@@ -322,6 +345,11 @@ def build_data(
     slowest = max(stages, key=lambda stage: stage["duration_seconds"], default=None)
     metrics = read_metrics(run_dir, manifest)
     mutation = read_mutation_summary(mutation_summary, int(manifest["policy"]))
+    care = read_care_summary(
+        care_summary,
+        int(manifest["policy"]),
+        int(policy["limits"]["pr_feedback_seconds"]),
+    )
     return {
         "schema": 1,
         "run": {
@@ -358,7 +386,8 @@ def build_data(
             "run_wall_p95_seconds": percentile(trend_walls, 95),
             "coverage": metrics if metrics is not None else "not-yet-emitted",
             "mutation": mutation if mutation is not None else "not-yet-emitted",
-            "review": "not-yet-emitted",
+            "care": care if care is not None else "not-yet-emitted",
+            "review": care["autonomy"]["review"] if care is not None else "not-yet-emitted",
             "security": "not-yet-emitted",
         },
         "trends": trends,
@@ -446,6 +475,20 @@ def render_html(data: dict[str, Any]) -> str:
         )
     else:
         mutation_text = str(mutation)
+    care = quality["care"]
+    if isinstance(care, dict):
+        eval_text = (
+            f'{care["evals"]["passed"]}/{care["evals"]["total"]} passed · '
+            f'{care["status"]} · source {care["source_commit"][:10]}'
+        )
+        latency_text = (
+            f'p95 {care["latency"]["wall_p95_seconds"]}s · '
+            f'alert {care["latency"]["alert_seconds"]}s · '
+            f'SLO {care["latency"]["slo_seconds"]}s · '
+            f'{care["latency"]["status"]}'
+        )
+    else:
+        eval_text = latency_text = str(care)
     return f'''<!doctype html>
 <html lang="en">
 <head>
@@ -479,7 +522,7 @@ def render_html(data: dict[str, Any]) -> str:
     .journey {{ display:grid; grid-template-columns:1fr auto; gap:16px; padding:17px; background:var(--panel); border:1px solid var(--line); border-top:3px solid var(--accent); }}
     .journey ul {{ grid-column:1/-1; list-style:none; margin:4px 0 0; padding:0; border-top:1px solid var(--line); }}
     .journey li {{ display:flex; justify-content:space-between; gap:12px; padding:7px 0; border-bottom:1px solid var(--line); }} .journey li:last-child {{ border:0; }}
-    .gaps {{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:1px; background:var(--line); border:1px solid var(--line); }} .gap {{ padding:14px; background:var(--panel); }}
+    .gaps {{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:1px; background:var(--line); border:1px solid var(--line); }} .gap {{ padding:14px; background:var(--panel); }}
     .empty {{ padding:20px; border:1px dashed var(--line); }}
     footer {{ padding:20px 0 36px; border-top:1px solid var(--line); color:var(--muted); }}
     #freshness.stale {{ color:var(--bad); font-weight:700; }}
@@ -514,8 +557,10 @@ def render_html(data: dict[str, Any]) -> str:
     <section><h2>Quality signals</h2><div class="gaps">
       <div class="gap"><span class="eyebrow">Coverage</span><p>{html.escape(coverage_text)}</p></div>
       <div class="gap"><span class="eyebrow">Mutation</span><p>{html.escape(mutation_text)}</p></div>
-      <div class="gap"><span class="eyebrow">Agent review</span><p>{quality["review"]}</p></div>
-      <div class="gap"><span class="eyebrow">Security</span><p>{quality["security"]}</p></div>
+      <div class="gap"><span class="eyebrow">Workflow evals</span><p>{html.escape(eval_text)}</p></div>
+      <div class="gap"><span class="eyebrow">Feedback latency</span><p>{html.escape(latency_text)}</p></div>
+      <div class="gap"><span class="eyebrow">Agent review</span><p>{html.escape(str(quality["review"]))}</p></div>
+      <div class="gap"><span class="eyebrow">Security</span><p>{html.escape(str(quality["security"]))}</p></div>
     </div></section>
     <section><h2>Recent runs</h2><div class="table-wrap"><table><thead><tr><th>Commit</th><th>Authority</th><th>Result</th><th class="number">Wall</th><th>Finished</th></tr></thead><tbody>{trend_rows}</tbody></table></div></section>
   </main>
@@ -544,7 +589,10 @@ def generate(arguments: argparse.Namespace) -> int:
     if run_dir.parent != result_root:
         raise DashboardError("run must be directly under the selected result root")
     mutation_summary = arguments.mutation_summary.resolve() if arguments.mutation_summary else None
-    data = build_data(run_dir, result_root, arguments.run_url, mutation_summary)
+    care_summary = arguments.care_summary.resolve() if arguments.care_summary else None
+    data = build_data(
+        run_dir, result_root, arguments.run_url, mutation_summary, care_summary
+    )
     output = arguments.output.resolve()
     if output == Path("/") or output == ROOT:
         raise DashboardError("dashboard output path is too broad")
@@ -589,6 +637,7 @@ def parser() -> argparse.ArgumentParser:
     generate_parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     generate_parser.add_argument("--run-url", default="")
     generate_parser.add_argument("--mutation-summary", type=Path)
+    generate_parser.add_argument("--care-summary", type=Path)
     generate_parser.set_defaults(function=generate)
     serve_parser = commands.add_parser("serve", help="serve a generated dashboard for a bounded time")
     serve_parser.add_argument("--directory", type=Path, default=DEFAULT_OUTPUT)

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1698,6 +1698,7 @@ def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -
 
 
 def run_gate_contract_stage(root: Path) -> int:
+    orchestrator_limit = 2
     contracts = [
         (
             "orchestrator-selection.log",
@@ -1811,24 +1812,33 @@ def run_gate_contract_stage(root: Path) -> int:
     contract_root = Path(tempfile.mkdtemp(prefix="detach-gate-contract."))
     processes: list[tuple[Path, subprocess.Popen[bytes], TextIO, str, float]] = []
     try:
-        for filename, command, additions, expected in contracts:
-            path = contract_root / filename
-            output = path.open("w", encoding="utf-8")
-            environment = os.environ.copy()
-            environment.update(additions)
-            process = subprocess.Popen(
-                command,
-                cwd=root,
-                env=environment,
-                stdout=output,
-                stderr=subprocess.STDOUT,
-            )
-            processes.append((path, process, output, expected, time.monotonic()))
         failed = False
         durations: dict[Path, int] = {}
-        pending = set(range(len(processes)))
-        while pending:
-            for index in list(pending):
+        waiting = list(contracts)
+        running: set[int] = set()
+        running_orchestrators = 0
+        while waiting or running:
+            for contract in list(waiting):
+                filename, command, additions, expected = contract
+                is_orchestrator = filename.startswith("orchestrator-")
+                if is_orchestrator and running_orchestrators >= orchestrator_limit:
+                    continue
+                path = contract_root / filename
+                output = path.open("w", encoding="utf-8")
+                environment = os.environ.copy()
+                environment.update(additions)
+                process = subprocess.Popen(
+                    command,
+                    cwd=root,
+                    env=environment,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                )
+                processes.append((path, process, output, expected, time.monotonic()))
+                running.add(len(processes) - 1)
+                running_orchestrators += int(is_orchestrator)
+                waiting.remove(contract)
+            for index in list(running):
                 path, process, output, _, started = processes[index]
                 status = process.poll()
                 if status is None:
@@ -1837,8 +1847,10 @@ def run_gate_contract_stage(root: Path) -> int:
                     failed = True
                 durations[path] = max(0, round(time.monotonic() - started))
                 output.close()
-                pending.remove(index)
-            if pending:
+                running.remove(index)
+                if path.name.startswith("orchestrator-"):
+                    running_orchestrators -= 1
+            if running:
                 time.sleep(0.05)
         for path, _, _, expected, _ in sorted(processes, key=lambda item: item[0].name):
             content = path.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## Outcome

- publish validated workflow-eval and feedback-latency facts on the quality dashboard
- bind care summaries to their source commit and input digests
- restore current-policy care evidence within a 60-second deadline
- limit process-heavy gate-contract shards to prevent oversubscription without raising budgets

## Local diagnostics

- quality-care contracts passed
- quality-dashboard contracts passed
- gate-contract passed in 80s after the scheduler repair, below its unchanged 100s budget
- static passed in 2s
- generated policy check and diff check passed

Hosted pull-request quality-gates remains the merge-readiness authority. No release, signing, notarization, upload, or physical power test was run.