### PR TITLE
Keep quality history policy-agnostic

### DIFF
--- a/.github/workflows/quality-care.yml
+++ b/.github/workflows/quality-care.yml
@@ -188,3 +188,31 @@ jobs:
         run: |
           printf 'quality-care: attention evidence was published and requires repair\n' >&2
           exit 1
+
+  resolved:
+    if: needs.care.result == 'success' && needs.care.outputs.attention == 'false'
+    needs:
+      - care
+      - quality-dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Close the resolved quality-care issue when it exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title='[quality-care] Scheduled control loop needs attention'
+          existing="$(timeout 20s gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "$title in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            timeout 20s gh issue close "$existing" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment 'The bounded quality-care control loop is healthy again.'
+          fi

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -33,7 +33,11 @@ the only ordinary merge authority. Unknown paths select the full plan.
   evidence finalization and process-group cleanup.
 - `scripts/quality-history [--format tsv|json] [RESULT_ROOT]` validates retained
   current-schema summaries and reports run and failure counts plus p50 and p95
-  wall and stage durations. It cannot produce readiness evidence.
+  wall and stage durations. A declared unsupported schema is outside the
+  sample. Current-schema timing can span earlier policy identifiers and does
+  not require dashboard-only manifest fields. Malformed telemetry evidence
+  stays invalid. The tool cannot produce readiness evidence or decode an old
+  layout.
 - `scripts/quality-care validate` checks the versioned workflow eval corpus.
   `scripts/quality-care evaluate` grades diff impact and private-scope cases.
   `scripts/quality-care assess` compares the results with retained run latency.
@@ -210,8 +214,9 @@ The same artifact opens locally and deploys to GitHub Pages. Main and mutation
 workflows deploy only after a green `ci-main` gate or a green mutation score for
 that policy. The bounded care workflow can publish a validated attention
 result, then marks its run failed and opens one issue. A later deploy restores
-the newest valid care artifact for the current policy. No workflow publishes
-pull request or local gate evidence.
+the newest valid care artifact for the current policy. The next healthy care
+run closes the issue. No workflow publishes pull request or local gate
+evidence.
 
 ## Definition of done
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -54,6 +54,10 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   match the policy.
 - Retained gate results contain execution history for timing and quality
   trends. They are not policy history and cannot restore an old policy state.
+  A declared unsupported evidence schema is outside the current telemetry
+  sample. Current-schema telemetry can span earlier policy identifiers without
+  requiring dashboard-only fields. Malformed telemetry evidence remains an
+  attention signal.
 - `quality/evals.json` keeps current expected outcomes for historical changes,
   escaped defects, policy mutations, and scope violations. Its stable graders
   compare selected stages, specifications, capabilities, user journeys,
@@ -101,7 +105,7 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   coverage, mutation score, workflow evals, feedback p95 and SLO, review state,
   and security state when they exist. A later main or mutation deploy restores
   the newest valid current-policy care artifact. Only deploy jobs have Pages
-  write permission.
+  write permission. A healthy care run closes the prior scoped attention issue.
 - An ordinary merged pull request does not repeat the full functional matrix
   on `main`. The main workflow promotes the successful pull-request artifact
   only when the tested merge and final merge have the same tree and ordered

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,8 +38,10 @@
   granularity until it gets scenario markers.
 - `scripts/quality-history [RESULT_ROOT]` reports p50/p95 wall and stage timing,
   ordinary failures, and execution-environment failures across retained local
-  or downloaded current-schema gate evidence. Add `--format json` for care
-  automation. It is run telemetry, not policy history or readiness evidence.
+  or downloaded current-schema gate evidence. A declared unsupported schema is
+  outside the sample. Current-schema timing can span earlier policy identifiers
+  without dashboard-only fields. Add `--format json` for care automation. It is
+  run telemetry, not policy history or readiness evidence.
 - `scripts/quality-care validate` checks the four required eval categories.
   `scripts/quality-care evaluate --output <json>` grades exact diff impact and
   private-scope outcomes. `scripts/quality-care assess` fails before the

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -619,7 +619,7 @@
     "pr_feedback_seconds": 600,
     "review_seconds": 180
   },
-  "policy": 25,
+  "policy": 26,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	25
+policy	26
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-history-contract.sh
+++ b/tests/quality-history-contract.sh
@@ -39,13 +39,26 @@ EOF
 write_run one passed 100 passed 1
 write_run two failed 180 environment-failed 3
 write_run three passed 120 passed 2
-mkdir -p "$TMP_ROOT/invalid"
-printf 'schema\t3\nresult\tpassed\n' >"$TMP_ROOT/invalid/manifest.tsv"
+awk -F '\t' '$1 != "specs" {print}' "$TMP_ROOT/three/manifest.tsv" \
+  >"$TMP_ROOT/three/manifest-without-dashboard-fields.tsv"
+mv "$TMP_ROOT/three/manifest-without-dashboard-fields.tsv" \
+  "$TMP_ROOT/three/manifest.tsv"
+mkdir -p "$TMP_ROOT/unsupported"
+printf 'schema\t3\nresult\tpassed\n' >"$TMP_ROOT/unsupported/manifest.tsv"
+
+"$ROOT/scripts/quality-history" "$TMP_ROOT" >"$TMP_ROOT/unsupported-report.tsv"
+grep -F $'runs\t3' "$TMP_ROOT/unsupported-report.tsv" >/dev/null
+grep -F $'invalid_evidence\t0' "$TMP_ROOT/unsupported-report.tsv" >/dev/null
+
+mkdir -p "$TMP_ROOT/invalid-current"
+printf 'schema\t4\nresult\tpassed\n' >"$TMP_ROOT/invalid-current/manifest.tsv"
+mkdir -p "$TMP_ROOT/invalid-encoding"
+printf '\377' >"$TMP_ROOT/invalid-encoding/manifest.tsv"
 
 "$ROOT/scripts/quality-history" "$TMP_ROOT" >"$TMP_ROOT/report.tsv"
 grep -F $'runs\t3' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'passed\t2' "$TMP_ROOT/report.tsv" >/dev/null
-grep -F $'invalid_evidence\t1' "$TMP_ROOT/report.tsv" >/dev/null
+grep -F $'invalid_evidence\t2' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'wall_p50_seconds\t120' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'wall_p95_seconds\t180' "$TMP_ROOT/report.tsv" >/dev/null
 grep -F $'static\t3\t1\t1\t2\t3' "$TMP_ROOT/report.tsv" >/dev/null

--- a/tests/quality_care_contract.py
+++ b/tests/quality_care_contract.py
@@ -58,6 +58,8 @@ def assert_workflows() -> None:
         "scripts/quality-care assess",
         "--care-summary app/build/quality-care/summary.json",
         "enforce-attention:",
+        "resolved:",
+        "timeout 20s gh issue close",
         "pages: write",
         "cancel-in-progress: true",
         "--created \">=$since\"",

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -29,6 +29,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_RESULT_ROOT = ROOT / "app/build/quality-gates"
 DEFAULT_OUTPUT = ROOT / "app/build/quality-dashboard"
 POLICY_JSON = ROOT / "quality/generated/policy.json"
+MANIFEST_SCHEMA = "4"
 SUMMARY_HEADER = [
     "policy",
     "mode",
@@ -58,7 +59,9 @@ def safe_file(path: Path, label: str) -> Path:
     return path
 
 
-def read_manifest(run_dir: Path) -> dict[str, str]:
+def read_manifest(
+    run_dir: Path, *, require_dashboard_fields: bool = True
+) -> dict[str, str]:
     manifest_path = safe_file(run_dir / "manifest.tsv", "manifest")
     values: dict[str, str] = {}
     for line_number, line in enumerate(manifest_path.read_text(encoding="utf-8").splitlines(), 1):
@@ -86,11 +89,11 @@ def read_manifest(run_dir: Path) -> dict[str, str]:
     missing = required - values.keys()
     if missing:
         raise DashboardError(f"manifest is missing: {sorted(missing)[0]}")
-    if values["schema"] != "4":
+    if values["schema"] != MANIFEST_SCHEMA:
         raise DashboardError("manifest schema is unsupported")
     if not values["policy"].isdigit():
         raise DashboardError("manifest policy is invalid")
-    if not values.get("specs"):
+    if require_dashboard_fields and not values.get("specs"):
         raise DashboardError("manifest is missing: specs")
     if values["authority"] not in ("local-diagnostic", "ci-merge", "ci-main", "release"):
         raise DashboardError("manifest authority is invalid")

--- a/tools/quality_history.py
+++ b/tools/quality_history.py
@@ -9,7 +9,12 @@ from pathlib import Path
 import sys
 from typing import Any, NoReturn
 
-from quality_dashboard import DashboardError, read_manifest, read_summary
+from quality_dashboard import (
+    DashboardError,
+    MANIFEST_SCHEMA,
+    read_manifest,
+    read_summary,
+)
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -34,6 +39,25 @@ def percentile(values: list[int], percent: int) -> int:
     return ordered[max(0, index - 1)]
 
 
+def uses_unsupported_schema(run_dir: Path) -> bool:
+    manifest = run_dir / "manifest.tsv"
+    if not manifest.is_file() or manifest.is_symlink():
+        return False
+    try:
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return False
+    if not lines:
+        return False
+    fields = lines[0].split("\t")
+    return (
+        len(fields) == 2
+        and fields[0] == "schema"
+        and fields[1].isdigit()
+        and fields[1] != MANIFEST_SCHEMA
+    )
+
+
 def collect(result_root: Path) -> dict[str, Any]:
     if not result_root.is_dir() or result_root.is_symlink():
         raise HistoryError("result root is missing or unsafe")
@@ -45,10 +69,12 @@ def collect(result_root: Path) -> dict[str, Any]:
     for run_dir in sorted(result_root.iterdir()):
         if not run_dir.is_dir() or run_dir.is_symlink():
             continue
+        if uses_unsupported_schema(run_dir):
+            continue
         try:
-            manifest = read_manifest(run_dir)
+            manifest = read_manifest(run_dir, require_dashboard_fields=False)
             stages = read_summary(run_dir, manifest)
-        except DashboardError:
+        except (DashboardError, OSError, UnicodeError):
             invalid += 1
             continue
         if manifest["result"] not in ("passed", "failed", "interrupted"):


### PR DESCRIPTION
## Outcome

- accept digest-valid schema-4 timing evidence across earlier policy identifiers
- keep the full dashboard manifest validator strict
- ignore declared unsupported evidence schemas without decoding them
- retain malformed current telemetry as attention
- close the scoped quality-care issue after the next healthy run

## Evidence

- the same ten downloaded main artifacts now produce 10 valid runs, 0 invalid evidence, 0 failures, and p95 394s
- focused policy-26 diagnostic passed: static 1s, gate-contract 79s
- history, care, dashboard, docs, shell-safety, generated-policy, YAML, and malformed-input contracts passed

Hosted pull-request quality-gates remains the merge-readiness authority. No release or physical power test was run.