### PR TITLE
Retry transient GitHub quality reads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,11 @@ updates:
       day: monday
       time: "05:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: swift
     directory: /app
     schedule:
@@ -15,4 +19,8 @@ updates:
       day: monday
       time: "05:30"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
+    groups:
+      swift-packages:
+        patterns:
+          - "*"

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -249,9 +249,11 @@ rejects a changed head, a weaker ruleset, and an attempt above
 ## Security care
 
 Dependabot checks immutable GitHub Actions pins and Swift package pins each
-week. The bounded security workflow scans both GitHub Actions source and arm64
-Swift source with CodeQL after a `main` change and on a weekly schedule. The
-Swift scan uses an explicit build. These care jobs do not extend pull-request
+week. It groups each ecosystem into at most one open update pull request. This
+keeps update traffic from exhausting the pull-request feedback queue. The
+bounded security workflow scans both GitHub Actions source and arm64 Swift
+source with CodeQL after a `main` change and on a weekly schedule. The Swift
+scan uses an explicit build. These care jobs do not extend pull-request
 feedback and cannot run release commands.
 
 Release readiness also requires the tracked reference-Mac time budgets and the

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -121,10 +121,12 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   at most the merge deadline. It disables auto-merge on timeout. The command
   rejects a changed head, an invalid ruleset, and a repair attempt above the
   policy maximum. It writes current-policy evidence under `app/build/`.
-- Dependabot checks pinned GitHub Actions and Swift packages each week. A
-  bounded CodeQL workflow scans GitHub Actions source on Linux and explicitly
-  built arm64 Swift source on macOS. It runs after `main` changes and each week.
-  It does not add work to pull-request feedback or enter a release path.
+- Dependabot checks pinned GitHub Actions and Swift packages each week. It
+  groups each ecosystem into at most one open update pull request so update
+  traffic cannot exhaust the feedback queue. A bounded CodeQL workflow scans
+  GitHub Actions source on Linux and explicitly built arm64 Swift source on
+  macOS. It runs after `main` changes and each week. It does not add work to
+  pull-request feedback or enter a release path.
 - By default, put a ready task-scoped change on a topic branch. Review the
   staged public diff, commit it, and push it. Open a pull request, then give its
   number, exact head, and current repair attempt to `scripts/quality-merge`.

--- a/tests/quality_merge_contract.py
+++ b/tests/quality_merge_contract.py
@@ -29,6 +29,15 @@ state = Path(os.environ["MERGE_STATE"])
 state.mkdir(parents=True, exist_ok=True)
 (state / "calls.log").open("a", encoding="utf-8").write(json.dumps(arguments) + "\\n")
 
+if (
+    mode == "transient-api"
+    and arguments[:1] == ["api"]
+    and not (state / "transient").exists()
+):
+    (state / "transient").write_text("yes")
+    print("unexpected end of JSON input", file=sys.stderr)
+    raise SystemExit(1)
+
 rules = [
     {{"type": "deletion"}},
     {{"type": "non_fast_forward"}},
@@ -175,6 +184,13 @@ def main() -> None:
         assert summary["repair_attempt"] == 0
         assert summary["gate_run"] == 123
         assert summary["ruleset"] == 77
+
+        transient = invoke(root, fake, "transient-api")
+        assert transient.returncode == 0, transient.stdout
+        transient_summary = json.loads(
+            (root / "transient-api-0.json").read_text(encoding="utf-8")
+        )
+        assert transient_summary["status"] == "passed"
 
         require_failure(invoke(root, fake, "unprotected"), "one exact active PR-only")
         require_failure(invoke(root, fake, "review-required"), "one exact active PR-only")

--- a/tests/security_contract.py
+++ b/tests/security_contract.py
@@ -42,6 +42,12 @@ def main() -> None:
     require("directory: /app" in dependabot, "Swift package directory is wrong")
     require(dependabot.count("interval: weekly") == 2,
             "dependency updates must use one bounded weekly cadence")
+    require(dependabot.count("open-pull-requests-limit: 1") == 2,
+            "each dependency ecosystem must allow only one open update pull request")
+    require("actions:" in dependabot and "swift-packages:" in dependabot,
+            "dependency updates must be grouped by ecosystem")
+    require(dependabot.count('          - "*"') == 2,
+            "each dependency group must cover its complete ecosystem")
     print("Security automation contracts passed")
 
 

--- a/tools/quality_merge.py
+++ b/tools/quality_merge.py
@@ -23,6 +23,8 @@ DEFAULT_OUTPUT = ROOT / "app/build/quality-merge.json"
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
 REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 GH_CALL_SECONDS = 20
+GH_API_ATTEMPTS = 3
+GH_API_RETRY_SECONDS = 1
 POLL_SECONDS = 5
 QUALITY_CHECK = "quality-gates"
 GITHUB_ACTIONS_INTEGRATION_ID = 15368
@@ -71,7 +73,16 @@ class GitHub:
         return result.stdout.strip()
 
     def api(self, path: str) -> Any:
-        return parse_json(self.command(["api", path]), "GitHub API")
+        last_error: MergeError | None = None
+        for attempt in range(1, GH_API_ATTEMPTS + 1):
+            try:
+                return parse_json(self.command(["api", path]), "GitHub API")
+            except MergeError as error:
+                last_error = error
+                if attempt < GH_API_ATTEMPTS:
+                    time.sleep(GH_API_RETRY_SECONDS * attempt)
+        assert last_error is not None
+        raise last_error
 
     def enable_auto_merge(
         self,


### PR DESCRIPTION
Repair attempt 1 of 2 for the automated quality cycle. The first exact-head gate passed and PR 31 merged, but two read-only GitHub API responses returned HTTP 503 or truncated JSON while the client observed the run. This adds three bounded retries only to read-only API operations and a deterministic regression contract. Merge mutations remain single-shot and match-head protected. No release action is involved.