### PR TITLE
Bind dashboard security cadence to workflow

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -267,9 +267,10 @@ disabled because CodeQL does not use them. The workflow does not repeat SwiftPM
 preparation in a matrix. The Swift job has a 30-minute deadline. Dependency
 network, repeated package planning, and process oversubscription cannot consume
 the complete security workflow budget. A 25-minute successful hosted run makes
-this workflow too expensive for each merge. The dashboard keeps the latest
-current security state between weekly runs. These care jobs do not extend
-pull-request feedback and cannot run release commands.
+this workflow too expensive for each merge. The dashboard reads and shows the
+configured CodeQL languages and cadence. Generation fails if the workflow no
+longer uses weekly and explicit runs. These care jobs do not extend pull-request
+feedback and cannot run release commands.
 
 Release readiness also requires the tracked reference-Mac time budgets and the
 release-only gates below. Ordinary implementation must not run them.

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -139,7 +139,8 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   repeat package preparation in a matrix. The Swift job has a 30-minute
   deadline. The workflow runs each week and on explicit request. It does not
   run after each merge, add work to pull-request feedback, or enter a release
-  path. The dashboard keeps the latest current security state between runs.
+  path. The dashboard reads the workflow and shows its configured languages
+  and cadence. It fails if these values do not match the security contract.
 - By default, put a ready task-scoped change on a topic branch. Review the
   staged public diff, commit it, and push it. Open a pull request, then give its
   number, exact head, and current repair attempt to `scripts/quality-merge`.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -658,7 +658,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 37,
+  "policy": 38,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	37
+policy	38
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -210,6 +210,8 @@ grep -F '8/8 passed · passed · 1 repaired failure retained · source' "$OUTPUT
   fail 'workflow-eval summary is missing'
 grep -F 'p95 285s · alert 480s · SLO 600s · healthy' "$OUTPUT/index.html" >/dev/null || \
   fail 'feedback latency summary is missing'
+grep -F 'CodeQL actions + swift · weekly-and-manual · outside PR feedback' \
+  "$OUTPUT/index.html" >/dev/null || fail 'security cadence is stale'
 ! grep -F '<svg' "$OUTPUT/index.html" >/dev/null || fail 'dashboard contains hand-drawn SVG'
 
 python3 - "$OUTPUT/data.json" <<'PY'
@@ -226,7 +228,7 @@ assert data["quality"]["coverage"]["comparison"]["mode"] == "green-main-artifact
 assert data["quality"]["mutation"]["score_percent"] == 100
 assert data["quality"]["merge"] == "not-yet-emitted"
 assert data["quality"]["security"] == {
-    "cadence": "main-and-weekly",
+    "cadence": "weekly-and-manual",
     "codeql_languages": ["actions", "swift"],
     "pull_request_feedback": "not-selected",
     "status": "configured",

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -31,6 +31,7 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_RESULT_ROOT = ROOT / "app/build/quality-gates"
 DEFAULT_OUTPUT = ROOT / "app/build/quality-dashboard"
 POLICY_JSON = ROOT / "quality/generated/policy.json"
+SECURITY_WORKFLOW = ROOT / ".github/workflows/security.yml"
 MANIFEST_SCHEMA = "4"
 SUMMARY_HEADER = [
     "policy",
@@ -314,10 +315,27 @@ def merge_evidence(commit: str, policy: int, maximum_repairs: int) -> Any:
 
 
 def security_automation() -> dict[str, Any]:
+    workflow = safe_file(SECURITY_WORKFLOW, "security workflow").read_text(
+        encoding="utf-8"
+    )
+    try:
+        trigger_block = workflow[workflow.index("on:\n"):workflow.index("\npermissions:")]
+    except ValueError as error:
+        raise DashboardError("security workflow triggers are invalid") from error
+    if (
+        "workflow_dispatch:" not in trigger_block
+        or "schedule:" not in trigger_block
+        or "push:" in trigger_block
+        or "pull_request:" in trigger_block
+    ):
+        raise DashboardError("security workflow cadence is not weekly and manual")
+    languages = sorted(set(re.findall(r"(?m)^\s+languages:\s+([a-z]+)$", workflow)))
+    if languages != ["actions", "swift"]:
+        raise DashboardError("security workflow CodeQL languages are invalid")
     return {
         "status": "configured",
-        "codeql_languages": ["actions", "swift"],
-        "cadence": "main-and-weekly",
+        "codeql_languages": languages,
+        "cadence": "weekly-and-manual",
         "pull_request_feedback": "not-selected",
     }
 


### PR DESCRIPTION
The published policy-37 dashboard retained a stale main-and-weekly security label after the workflow moved to weekly and manual runs. Read the workflow during deterministic dashboard generation, fail closed on cadence or CodeQL-language drift, and render the current cadence. Focused local static and gate-contract diagnostics passed in seven seconds.