### PR TITLE
Expose bounded CodeQL evidence in quality dashboard

### DIFF
--- a/.github/workflows/quality-care.yml
+++ b/.github/workflows/quality-care.yml
@@ -126,18 +126,30 @@ jobs:
         run: |
           summary="$(scripts/quality-mutation latest --optional)"
           printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - id: security-evidence
+        name: Restore latest security result when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-security latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
       - name: Generate dashboard with care evidence
         run: |
           mutation_args=()
+          security_args=()
           if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
             mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          fi
+          if [ -n "${{ steps.security-evidence.outputs.summary }}" ]; then
+            security_args+=(--security-summary "${{ steps.security-evidence.outputs.summary }}")
           fi
           scripts/quality-dashboard generate \
             --result-root "${{ steps.main-evidence.outputs.root }}" \
             --output app/build/quality-dashboard \
             --care-summary app/build/quality-care/summary.json \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
-            "${mutation_args[@]}"
+            "${mutation_args[@]}" \
+            "${security_args[@]}"
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload Pages artifact

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -146,22 +146,34 @@ jobs:
         run: |
           summary="$(scripts/quality-care latest --optional)"
           printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - id: security-evidence
+        name: Restore latest security result when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-security latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
       - name: Generate quality dashboard
         run: |
           mutation_args=()
           care_args=()
+          security_args=()
           if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
             mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
           fi
           if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
             care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
           fi
+          if [ -n "${{ steps.security-evidence.outputs.summary }}" ]; then
+            security_args+=(--security-summary "${{ steps.security-evidence.outputs.summary }}")
+          fi
           scripts/quality-dashboard generate \
             --result-root app/build/quality-gates \
             --output app/build/quality-dashboard \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             "${mutation_args[@]}" \
-            "${care_args[@]}"
+            "${care_args[@]}" \
+            "${security_args[@]}"
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload Pages artifact

--- a/.github/workflows/quality-mutations.yml
+++ b/.github/workflows/quality-mutations.yml
@@ -103,18 +103,30 @@ jobs:
         run: |
           summary="$(scripts/quality-care latest --optional)"
           printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - id: security-evidence
+        name: Restore latest security result when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-security latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
       - name: Generate dashboard with mutation score
         run: |
           care_args=()
+          security_args=()
           if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
             care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
+          fi
+          if [ -n "${{ steps.security-evidence.outputs.summary }}" ]; then
+            security_args+=(--security-summary "${{ steps.security-evidence.outputs.summary }}")
           fi
           scripts/quality-dashboard generate \
             --result-root "${{ steps.main-evidence.outputs.root }}" \
             --output app/build/quality-dashboard \
             --mutation-summary app/build/quality-mutations/summary.json \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
-            "${care_args[@]}"
+            "${care_args[@]}" \
+            "${security_args[@]}"
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload Pages artifact

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -81,3 +81,106 @@ jobs:
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: /language:swift
+
+  security-evidence:
+    if: always()
+    needs:
+      - actions
+      - swift
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Create exact security result
+        run: >-
+          scripts/quality-security create
+          --source-commit "${{ github.sha }}"
+          --run-id "${{ github.run_id }}"
+          --run-attempt "${{ github.run_attempt }}"
+          --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --actions-result "${{ needs.actions.result }}"
+          --swift-result "${{ needs.swift.result }}"
+          --output app/build/quality-security/summary.json
+      - name: Upload security result
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: quality-security-${{ github.run_id }}-${{ github.run_attempt }}
+          path: app/build/quality-security
+          if-no-files-found: error
+          retention-days: 30
+      - name: Enforce successful analysis
+        run: >-
+          scripts/quality-security validate
+          app/build/quality-security/summary.json
+          --require-pass
+
+  quality-dashboard:
+    if: always() && github.ref == 'refs/heads/main'
+    needs: security-evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      actions: read
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Download current security result
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: quality-security-${{ github.run_id }}-${{ github.run_attempt }}
+          path: app/build/quality-security
+      - id: main-evidence
+        name: Restore last green main quality evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          baseline_root="$(scripts/quality-baseline)"
+          printf 'root=%s\n' "$baseline_root" >>"$GITHUB_OUTPUT"
+          printf 'run_id=%s\n' "${baseline_root##*/}" >>"$GITHUB_OUTPUT"
+      - id: mutation-evidence
+        name: Restore latest mutation score when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-mutation latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - id: care-evidence
+        name: Restore latest quality-care summary when available
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          summary="$(scripts/quality-care latest --optional)"
+          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+      - name: Generate dashboard with security result
+        run: |
+          mutation_args=()
+          care_args=()
+          if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
+            mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          fi
+          if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
+            care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
+          fi
+          scripts/quality-dashboard generate \
+            --result-root "${{ steps.main-evidence.outputs.root }}" \
+            --output app/build/quality-dashboard \
+            --security-summary app/build/quality-security/summary.json \
+            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
+            "${mutation_args[@]}" \
+            "${care_args[@]}"
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: app/build/quality-dashboard
+      - name: Deploy quality dashboard
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -108,9 +108,15 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   marks an attention run as failed. Care evidence binds the source commit and
   SHA-256 digests of its eval and history inputs. The dashboard shows measured
   coverage, mutation score, workflow evals, feedback p95 and SLO, and security
-  state when they exist. A later main or mutation deploy restores
-  the newest valid current-policy care artifact. Only deploy jobs have Pages
-  write permission. A healthy care run closes the prior scoped attention issue.
+  state when they exist. The security state comes from a typed current-policy
+  artifact. It includes both CodeQL job results, the analyzed commit, an
+  identity fingerprint, and the exact workflow link. A later main, care, or
+  mutation deploy restores the newest valid current-policy security and care
+  artifacts. Each restore checks at most five completed runs and has a
+  60-second deadline. Only deploy jobs have Pages write permission. A
+  main-branch Security run can deploy its passed or failed CodeQL result over
+  the last green main evidence. A healthy care run closes the prior scoped
+  attention issue.
 - An ordinary merged pull request does not repeat the full functional matrix
   on `main`. The main workflow promotes the successful pull-request artifact
   only when the tested merge and final merge have the same tree and ordered
@@ -139,8 +145,11 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   repeat package preparation in a matrix. The Swift job has a 30-minute
   deadline. The workflow runs each week and on explicit request. It does not
   run after each merge, add work to pull-request feedback, or enter a release
-  path. The dashboard reads the workflow and shows its configured languages
-  and cadence. It fails if these values do not match the security contract.
+  path. The workflow uploads its result before it enforces success. This keeps
+  failed analysis visible. The dashboard reads the workflow and the validated
+  result artifact. It shows the configured languages, cadence, job results,
+  analyzed commit, and exact run link. It fails if the configuration, result,
+  or result fingerprint does not match the security contract.
 - By default, put a ready task-scoped change on a topic branch. Review the
   staged public diff, commit it, and push it. Open a pull request, then give its
   number, exact head, and current repair attempt to `scripts/quality-merge`.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -658,7 +658,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 38,
+  "policy": 39,
   "release_domains": [
     {
       "gates": "-",
@@ -1002,6 +1002,20 @@
     },
     {
       "pattern": "tools/quality_dashboard.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-security",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_security.py",
       "priority": 1000,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -2165,6 +2179,7 @@
         "scripts/quality-policy",
         "scripts/quality-promote",
         "scripts/quality-scenarios",
+        "scripts/quality-security",
         "scripts/test",
         "tests/*",
         "tests/docs-contract.sh",
@@ -2185,7 +2200,8 @@
         "tools/quality_mutation.py",
         "tools/quality_policy.py",
         "tools/quality_promote.py",
-        "tools/quality_scenarios.py"
+        "tools/quality_scenarios.py",
+        "tools/quality_security.py"
       ],
       "path": "docs/specs/documentation.md",
       "requirements": [

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -42,6 +42,7 @@ It lists current specification ownership and verification links.
 - `scripts/quality-policy`
 - `scripts/quality-promote`
 - `scripts/quality-scenarios`
+- `scripts/quality-security`
 - `scripts/test`
 - `tests/*`
 - `tests/docs-contract.sh`
@@ -63,6 +64,7 @@ It lists current specification ownership and verification links.
 - `tools/quality_policy.py`
 - `tools/quality_promote.py`
 - `tools/quality_scenarios.py`
+- `tools/quality_security.py`
 
 ### Requirement verification
 

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	38
+policy	39
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -98,6 +98,8 @@ route	1000	.github/workflows/quality-care.yml	policy	safe	docs/specs/documentati
 route	1000	.github/workflows/documentation-care.yml	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-dashboard	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_dashboard.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-security	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_security.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-history	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_history.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-care	policy	safe	docs/specs/documentation.md

--- a/scripts/quality-security
+++ b/scripts/quality-security
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality-security: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tools/quality_security.py" "$@"

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -10,6 +10,7 @@ OUTPUT="$TMP_ROOT/dashboard"
 PROMOTED_OUTPUT="$TMP_ROOT/promoted-dashboard"
 MUTATION_SUMMARY="$TMP_ROOT/mutation-summary.json"
 CARE_SUMMARY="$TMP_ROOT/care-summary.json"
+SECURITY_SUMMARY="$TMP_ROOT/security-summary.json"
 CARE_EVALS="$TMP_ROOT/evals.json"
 CARE_HISTORY="$TMP_ROOT/history.json"
 POLICY_VERSION="$("$ROOT/scripts/quality-policy" version)"
@@ -175,16 +176,27 @@ cat >"$CARE_SUMMARY" <<JSON
 }
 JSON
 
+"$ROOT/scripts/quality-security" create \
+  --source-commit "$SOURCE_COMMIT" \
+  --run-id 901 \
+  --run-attempt 2 \
+  --run-url 'https://github.com/owner/repository/actions/runs/901' \
+  --actions-result success \
+  --swift-result success \
+  --output "$SECURITY_SUMMARY" >/dev/null
+
 "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
   --output "$OUTPUT" --run-url 'https://github.example/actions/runs/1' \
-  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" >/dev/null
+  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" \
+  --security-summary "$SECURITY_SUMMARY" >/dev/null
 [ -f "$OUTPUT/index.html" ] && [ -f "$OUTPUT/data.json" ] || \
   fail 'dashboard artifacts are missing'
 first_html="$(shasum -a 256 "$OUTPUT/index.html" | awk '{print $1}')"
 first_data="$(shasum -a 256 "$OUTPUT/data.json" | awk '{print $1}')"
 "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
   --output "$OUTPUT" --run-url 'https://github.example/actions/runs/1' \
-  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" >/dev/null
+  --mutation-summary "$MUTATION_SUMMARY" --care-summary "$CARE_SUMMARY" \
+  --security-summary "$SECURITY_SUMMARY" >/dev/null
 [ "$first_html" = "$(shasum -a 256 "$OUTPUT/index.html" | awk '{print $1}')" ] || \
   fail 'HTML generation is not deterministic'
 [ "$first_data" = "$(shasum -a 256 "$OUTPUT/data.json" | awk '{print $1}')" ] || \
@@ -210,11 +222,13 @@ grep -F '8/8 passed · passed · 1 repaired failure retained · source' "$OUTPUT
   fail 'workflow-eval summary is missing'
 grep -F 'p95 285s · alert 480s · SLO 600s · healthy' "$OUTPUT/index.html" >/dev/null || \
   fail 'feedback latency summary is missing'
-grep -F 'CodeQL actions + swift · weekly-and-manual · outside PR feedback' \
-  "$OUTPUT/index.html" >/dev/null || fail 'security cadence is stale'
+grep -F "CodeQL actions passed + swift passed · passed · weekly-and-manual · source ${SOURCE_COMMIT:0:10} · " \
+  "$OUTPUT/index.html" >/dev/null || fail 'security result is missing'
+grep -F 'href="https://github.com/owner/repository/actions/runs/901">run 901</a>' \
+  "$OUTPUT/index.html" >/dev/null || fail 'security run link is missing'
 ! grep -F '<svg' "$OUTPUT/index.html" >/dev/null || fail 'dashboard contains hand-drawn SVG'
 
-python3 - "$OUTPUT/data.json" <<'PY'
+python3 - "$OUTPUT/data.json" "$SECURITY_SUMMARY" <<'PY'
 import json
 import sys
 with open(sys.argv[1], encoding="utf-8") as source:
@@ -227,11 +241,13 @@ assert data["quality"]["planned_scenarios"] == 0
 assert data["quality"]["coverage"]["comparison"]["mode"] == "green-main-artifact"
 assert data["quality"]["mutation"]["score_percent"] == 100
 assert data["quality"]["merge"] == "not-yet-emitted"
+with open(sys.argv[2], encoding="utf-8") as source:
+    security = json.load(source)
 assert data["quality"]["security"] == {
     "cadence": "weekly-and-manual",
     "codeql_languages": ["actions", "swift"],
     "pull_request_feedback": "not-selected",
-    "status": "configured",
+    **security,
 }
 assert data["quality"]["care"]["evals"] == {
     "categories": {
@@ -334,6 +350,24 @@ fi
 grep -F 'care summary is invalid' "$TMP_ROOT/stale-care.out" >/dev/null || \
   fail 'stale care failure is unclear'
 mv "$TMP_ROOT/care-summary.backup.json" "$CARE_SUMMARY"
+
+cp "$SECURITY_SUMMARY" "$TMP_ROOT/security-summary.backup.json"
+python3 - "$SECURITY_SUMMARY" <<'PY'
+import json,sys
+path=sys.argv[1]
+value=json.load(open(path,encoding="utf-8"))
+value["policy"] += 1
+with open(path,"w",encoding="utf-8") as target:
+    json.dump(value,target)
+PY
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/stale-security" --security-summary "$SECURITY_SUMMARY" \
+    >"$TMP_ROOT/stale-security.out" 2>&1; then
+  fail 'security evidence from another policy was accepted'
+fi
+grep -F 'security summary is invalid' "$TMP_ROOT/stale-security.out" >/dev/null || \
+  fail 'stale security failure is unclear'
+mv "$TMP_ROOT/security-summary.backup.json" "$SECURITY_SUMMARY"
 
 cp "$CARE_EVALS" "$TMP_ROOT/evals.backup.json"
 printf 'tampered\n' >>"$CARE_EVALS"

--- a/tests/quality_security_contract.py
+++ b/tests/quality_security_contract.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Contracts for typed and bounded CodeQL result evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+from quality_policy import POLICY_FILE, Policy  # noqa: E402
+from quality_security import SecurityError, create_summary, validate_summary  # noqa: E402
+
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+RUN_URL = "https://github.com/owner/repository/actions/runs/901"
+
+
+def invoke(*arguments: str, environment: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(ROOT / "scripts/quality-security"), *arguments],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def main() -> None:
+    policy = Policy(POLICY_FILE)
+    passed = create_summary(policy, COMMIT, 901, 2, RUN_URL, "success", "success")
+    assert validate_summary(passed, policy.version) == passed
+    assert passed["status"] == "passed"
+    failed = create_summary(policy, COMMIT, 901, 2, RUN_URL, "failure", "cancelled")
+    assert failed["status"] == "failed"
+    inconsistent = {**passed, "status": "failed"}
+    try:
+        validate_summary(inconsistent, policy.version)
+    except SecurityError:
+        pass
+    else:
+        raise AssertionError("security evidence accepted an inconsistent result")
+
+    with tempfile.TemporaryDirectory(prefix="detach-quality-security.") as directory:
+        root = Path(directory)
+        summary = root / "summary.json"
+        created = invoke(
+            "create",
+            "--source-commit", COMMIT,
+            "--run-id", "901",
+            "--run-attempt", "2",
+            "--run-url", RUN_URL,
+            "--actions-result", "success",
+            "--swift-result", "success",
+            "--output", str(summary),
+        )
+        assert created.returncode == 0, created.stderr
+        assert json.loads(summary.read_text(encoding="utf-8")) == passed
+        assert invoke("validate", str(summary), "--require-pass").returncode == 0
+
+        summary.write_text(json.dumps(failed), encoding="utf-8")
+        assert invoke("validate", str(summary), "--require-pass").returncode == 1
+
+        fixture = root / "fixture.json"
+        fixture.write_text(json.dumps(passed), encoding="utf-8")
+        fake_gh = root / "fake-gh"
+        fake_gh.write_text(
+            """#!/usr/bin/env python3
+import os,pathlib,shutil,sys,time
+args=sys.argv[1:]
+if os.environ.get('FAKE_SECURITY_SLEEP'):
+    time.sleep(float(os.environ['FAKE_SECURITY_SLEEP']))
+if args[:1] == ['api'] and '/artifacts' not in args[1]:
+    print('901')
+elif args[:1] == ['api']:
+    print('quality-security-901-2')
+elif args[:2] == ['run', 'download']:
+    destination=pathlib.Path(args[args.index('--dir') + 1])
+    shutil.copyfile(os.environ['FAKE_SECURITY_FIXTURE'], destination / 'summary.json')
+else:
+    raise SystemExit(3)
+""",
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+        environment = {
+            **os.environ,
+            "DETACH_QUALITY_SECURITY_TEST_MODE": "1",
+            "DETACH_QUALITY_SECURITY_GH": str(fake_gh),
+            "FAKE_SECURITY_FIXTURE": str(fixture),
+        }
+        restored = invoke(
+            "latest",
+            "--repository", "owner/repository",
+            "--output-root", str(root / "baseline"),
+            environment=environment,
+        )
+        assert restored.returncode == 0, restored.stderr
+        restored_path = Path(restored.stdout.strip())
+        assert restored_path.is_file()
+        assert json.loads(restored_path.read_text(encoding="utf-8")) == passed
+
+        slow_environment = {
+            **environment,
+            "DETACH_QUALITY_SECURITY_LATEST_SECONDS": "1",
+            "FAKE_SECURITY_SLEEP": "2",
+        }
+        started = time.monotonic()
+        timed = invoke(
+            "latest",
+            "--repository", "owner/repository",
+            "--output-root", str(root / "timed"),
+            environment=slow_environment,
+        )
+        assert timed.returncode == 2
+        assert time.monotonic() - started < 1.8
+        assert "bounded security restore deadline" in timed.stderr
+
+    print("Quality security evidence contracts passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/security-contract.sh
+++ b/tests/security-contract.sh
@@ -7,4 +7,5 @@ command -v python3 >/dev/null 2>&1 || {
   printf 'security automation contracts: python3 is required\n' >&2
   exit 2
 }
+PYTHONDONTWRITEBYTECODE=1 python3 "$ROOT/tests/quality_security_contract.py"
 exec python3 "$ROOT/tests/security_contract.py"

--- a/tests/security_contract.py
+++ b/tests/security_contract.py
@@ -11,6 +11,11 @@ ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = ROOT / ".github/workflows/security.yml"
 DEPENDABOT = ROOT / ".github/dependabot.yml"
 PACKAGE = ROOT / "app/Package.swift"
+PAGES_WORKFLOWS = (
+    ROOT / ".github/workflows/quality-gates.yml",
+    ROOT / ".github/workflows/quality-care.yml",
+    ROOT / ".github/workflows/quality-mutations.yml",
+)
 PINNED_ACTION = re.compile(r"(?:-\s+)?uses:\s+[^\s@]+@[0-9a-f]{40}(?:\s+#\s+v[0-9]+)?$")
 
 
@@ -84,6 +89,38 @@ def main() -> None:
             "25-minute security care must not run after every merge")
     require("workflow_dispatch:" in workflow and "schedule:" in workflow,
             "security care must support weekly and explicit runs")
+    evidence = workflow.index("  security-evidence:")
+    dashboard = workflow.index("  quality-dashboard:")
+    require(swift_analyze < evidence < dashboard,
+            "security evidence and dashboard jobs are out of order")
+    evidence_zone = workflow[evidence:dashboard]
+    require("if: always()" in evidence_zone
+            and "- actions" in evidence_zone and "- swift" in evidence_zone,
+            "security evidence must record both completed analysis jobs")
+    require("scripts/quality-security create" in evidence_zone,
+            "security evidence must use the typed Python boundary")
+    require("${{ needs.actions.result }}" in evidence_zone
+            and "${{ needs.swift.result }}" in evidence_zone,
+            "security evidence does not bind exact job results")
+    require("quality-security-${{ github.run_id }}-${{ github.run_attempt }}" in evidence_zone,
+            "security evidence artifact identity is not exact")
+    upload = evidence_zone.index("Upload security result")
+    enforce = evidence_zone.index("Enforce successful analysis")
+    require(upload < enforce and "--require-pass" in evidence_zone[enforce:],
+            "failed security results must upload before enforcement")
+    dashboard_zone = workflow[dashboard:]
+    require("github.ref == 'refs/heads/main'" in dashboard_zone,
+            "security evidence from a topic branch can replace the main dashboard")
+    require("--security-summary app/build/quality-security/summary.json" in dashboard_zone,
+            "the security dashboard does not consume the exact current artifact")
+    require("timeout-minutes: 3" in dashboard_zone,
+            "security dashboard deadline is missing")
+    for path in PAGES_WORKFLOWS:
+        pages_workflow = path.read_text(encoding="utf-8")
+        require("scripts/quality-security latest --optional" in pages_workflow,
+                f"{path.name} does not preserve the latest security result")
+        require("--security-summary" in pages_workflow,
+                f"{path.name} does not pass security evidence to the dashboard")
     require("release-version" not in workflow and "notary" not in workflow,
             "security care can enter a release path")
     require("version: 2" in dependabot, "Dependabot schema is missing")

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -25,6 +25,7 @@ from quality_care import (
 from quality_metrics import MetricsError, validate_metrics
 from quality_mutation import MutationError, validate_summary
 from quality_promote import PromotionError, validate_promotion
+from quality_security import SecurityError, validate_summary as validate_security_summary
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -214,6 +215,20 @@ def read_care_summary(
         raise DashboardError(f"care summary is invalid: {error}") from error
 
 
+def read_security_summary(
+    path: Optional[Path], expected_policy: int
+) -> Optional[dict[str, Any]]:
+    if path is None:
+        return None
+    try:
+        document = json.loads(
+            safe_file(path, "security summary").read_text(encoding="utf-8")
+        )
+        return validate_security_summary(document, expected_policy)
+    except (SecurityError, json.JSONDecodeError, UnicodeError) as error:
+        raise DashboardError(f"security summary is invalid: {error}") from error
+
+
 def split_csv(value: str) -> list[str]:
     return [item for item in value.split(",") if item]
 
@@ -314,7 +329,7 @@ def merge_evidence(commit: str, policy: int, maximum_repairs: int) -> Any:
     return parse_merge_evidence(result.stdout, policy, maximum_repairs)
 
 
-def security_automation() -> dict[str, Any]:
+def security_automation(summary: Optional[dict[str, Any]]) -> dict[str, Any]:
     workflow = safe_file(SECURITY_WORKFLOW, "security workflow").read_text(
         encoding="utf-8"
     )
@@ -332,12 +347,15 @@ def security_automation() -> dict[str, Any]:
     languages = sorted(set(re.findall(r"(?m)^\s+languages:\s+([a-z]+)$", workflow)))
     if languages != ["actions", "swift"]:
         raise DashboardError("security workflow CodeQL languages are invalid")
-    return {
-        "status": "configured",
+    configuration: dict[str, Any] = {
+        "status": "not-yet-emitted",
         "codeql_languages": languages,
         "cadence": "weekly-and-manual",
         "pull_request_feedback": "not-selected",
     }
+    if summary is not None:
+        configuration.update(summary)
+    return configuration
 
 
 def build_data(
@@ -346,6 +364,7 @@ def build_data(
     run_url: str,
     mutation_summary: Optional[Path] = None,
     care_summary: Optional[Path] = None,
+    security_summary: Optional[Path] = None,
 ) -> dict[str, Any]:
     manifest = read_manifest(run_dir)
     effective_commit, effective_authority, promotion = effective_identity(
@@ -421,6 +440,9 @@ def build_data(
         int(manifest["policy"]),
         int(policy["limits"]["pr_feedback_seconds"]),
     )
+    security = read_security_summary(
+        security_summary, int(manifest["policy"])
+    )
     return {
         "schema": 2,
         "run": {
@@ -463,7 +485,7 @@ def build_data(
                 int(manifest["policy"]),
                 int(policy["limits"]["max_repair_loops"]),
             ),
-            "security": security_automation(),
+            "security": security_automation(security),
         },
         "trends": trends,
     }
@@ -579,10 +601,25 @@ def render_html(data: dict[str, Any]) -> str:
         else str(merge)
     )
     security = quality["security"]
-    security_text = (
-        f'CodeQL {" + ".join(security["codeql_languages"])} · '
-        f'{security["cadence"]} · outside PR feedback'
-    )
+    if isinstance(security.get("jobs"), dict):
+        job_text = " + ".join(
+            f'{language} {security["jobs"][language]}'
+            for language in security["codeql_languages"]
+        )
+        security_text = (
+            f'CodeQL {job_text} · {security["status"]} · '
+            f'{security["cadence"]} · source {security["source_commit"][:10]} · '
+        )
+        security_html = (
+            html.escape(security_text)
+            + f'<a href="{html.escape(security["run_url"], quote=True)}">'
+            + f'run {security["run_id"]}</a>'
+        )
+    else:
+        security_html = html.escape(
+            f'CodeQL {" + ".join(security["codeql_languages"])} · '
+            f'{security["status"]} · {security["cadence"]} · outside PR feedback'
+        )
     return f'''<!doctype html>
 <html lang="en">
 <head>
@@ -654,7 +691,7 @@ def render_html(data: dict[str, Any]) -> str:
       <div class="gap"><span class="eyebrow">Workflow evals</span><p>{html.escape(eval_text)}</p></div>
       <div class="gap"><span class="eyebrow">Feedback latency</span><p>{html.escape(latency_text)}</p></div>
       <div class="gap"><span class="eyebrow">Bounded merge</span><p>{html.escape(merge_text)}</p></div>
-      <div class="gap"><span class="eyebrow">Security</span><p>{html.escape(security_text)}</p></div>
+      <div class="gap"><span class="eyebrow">Security</span><p>{security_html}</p></div>
     </div></section>
     <section><h2>Recent runs</h2><div class="table-wrap"><table><thead><tr><th>Commit</th><th>Authority</th><th>Result</th><th class="number">Wall</th><th>Finished</th></tr></thead><tbody>{trend_rows}</tbody></table></div></section>
   </main>
@@ -684,8 +721,10 @@ def generate(arguments: argparse.Namespace) -> int:
         raise DashboardError("run must be directly under the selected result root")
     mutation_summary = arguments.mutation_summary.resolve() if arguments.mutation_summary else None
     care_summary = arguments.care_summary.resolve() if arguments.care_summary else None
+    security_summary = arguments.security_summary.resolve() if arguments.security_summary else None
     data = build_data(
-        run_dir, result_root, arguments.run_url, mutation_summary, care_summary
+        run_dir, result_root, arguments.run_url, mutation_summary, care_summary,
+        security_summary
     )
     output = arguments.output.resolve()
     if output == Path("/") or output == ROOT:
@@ -732,6 +771,7 @@ def parser() -> argparse.ArgumentParser:
     generate_parser.add_argument("--run-url", default="")
     generate_parser.add_argument("--mutation-summary", type=Path)
     generate_parser.add_argument("--care-summary", type=Path)
+    generate_parser.add_argument("--security-summary", type=Path)
     generate_parser.set_defaults(function=generate)
     serve_parser = commands.add_parser("serve", help="serve a generated dashboard for a bounded time")
     serve_parser.add_argument("--directory", type=Path, default=DEFAULT_OUTPUT)

--- a/tools/quality_security.py
+++ b/tools/quality_security.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Create, validate, and restore bounded CodeQL result evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any, NoReturn
+
+from quality_policy import POLICY_FILE, Policy, PolicyError
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASELINE = ROOT / "app/build/quality-security-baseline"
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+RUN_URL = re.compile(
+    r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/actions/runs/[1-9][0-9]*$"
+)
+JOB_RESULTS = {"success", "failure", "cancelled", "skipped"}
+RESULT_STATUS = {
+    "success": "passed",
+    "failure": "failed",
+    "cancelled": "cancelled",
+    "skipped": "skipped",
+}
+LATEST_RUN_LIMIT = 5
+GH_TIMEOUT_SECONDS = 20
+LATEST_DEADLINE_SECONDS = 60
+
+
+class SecurityError(Exception):
+    """Security result evidence is invalid or unavailable."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-security: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def positive_integer(value: Any) -> bool:
+    return type(value) is int and value > 0
+
+
+def evidence_fingerprint(value: dict[str, Any]) -> str:
+    identity = {
+        key: value[key]
+        for key in (
+            "schema", "policy", "source_commit", "run_id", "run_attempt",
+            "run_url", "status", "jobs"
+        )
+    }
+    payload = json.dumps(
+        identity, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def create_summary(
+    policy: Policy,
+    source_commit: str,
+    run_id: int,
+    run_attempt: int,
+    run_url: str,
+    actions_result: str,
+    swift_result: str,
+) -> dict[str, Any]:
+    jobs = {
+        "actions": RESULT_STATUS.get(actions_result),
+        "swift": RESULT_STATUS.get(swift_result),
+    }
+    if (
+        not COMMIT.fullmatch(source_commit)
+        or not positive_integer(run_id)
+        or not positive_integer(run_attempt)
+        or not RUN_URL.fullmatch(run_url)
+        or actions_result not in JOB_RESULTS
+        or swift_result not in JOB_RESULTS
+    ):
+        raise SecurityError("security result identity is invalid")
+    summary = {
+        "schema": 1,
+        "policy": policy.version,
+        "source_commit": source_commit,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "run_url": run_url,
+        "status": "passed" if set(jobs.values()) == {"passed"} else "failed",
+        "jobs": jobs,
+    }
+    summary["fingerprint"] = evidence_fingerprint(summary)
+    return summary
+
+
+def validate_summary(value: Any, expected_policy: int) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "schema", "policy", "source_commit", "run_id", "run_attempt",
+        "run_url", "status", "jobs", "fingerprint"
+    }:
+        raise SecurityError("security summary schema is invalid")
+    jobs = value["jobs"]
+    if (
+        value["schema"] != 1
+        or value["policy"] != expected_policy
+        or not isinstance(value["source_commit"], str)
+        or not COMMIT.fullmatch(value["source_commit"])
+        or not positive_integer(value["run_id"])
+        or not positive_integer(value["run_attempt"])
+        or not isinstance(value["run_url"], str)
+        or not RUN_URL.fullmatch(value["run_url"])
+        or value["run_url"].rsplit("/", 1)[-1] != str(value["run_id"])
+        or value["status"] not in ("passed", "failed")
+        or not isinstance(value["fingerprint"], str)
+        or not re.fullmatch(r"[0-9a-f]{64}", value["fingerprint"])
+        or not isinstance(jobs, dict)
+        or set(jobs) != {"actions", "swift"}
+        or any(result not in RESULT_STATUS.values() for result in jobs.values())
+    ):
+        raise SecurityError("security summary identity is invalid")
+    expected_status = "passed" if set(jobs.values()) == {"passed"} else "failed"
+    if value["status"] != expected_status:
+        raise SecurityError("security summary status is inconsistent")
+    if value["fingerprint"] != evidence_fingerprint(value):
+        raise SecurityError("security summary fingerprint is invalid")
+    return value
+
+
+def read_summary(path: Path, expected_policy: int) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise SecurityError(f"security summary is missing or unsafe: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeError, OSError) as error:
+        raise SecurityError(f"security summary is invalid: {error}") from error
+    return validate_summary(value, expected_policy)
+
+
+def atomic_write(path: Path, value: dict[str, Any]) -> None:
+    if path.exists() and path.is_symlink():
+        raise SecurityError(f"output target is a symlink: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    temporary.replace(path)
+
+
+def gh_output(executable: str, arguments: list[str], deadline: float) -> str:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise SecurityError(
+            f"security restore exceeded its {LATEST_DEADLINE_SECONDS}-second deadline"
+        )
+    try:
+        result = subprocess.run(
+            [executable, *arguments],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=min(GH_TIMEOUT_SECONDS, remaining),
+        )
+    except subprocess.TimeoutExpired as error:
+        raise SecurityError(
+            "gh did not finish before the bounded security restore deadline"
+        ) from error
+    except OSError as error:
+        raise SecurityError(f"cannot start gh: {error}") from error
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise SecurityError(f"gh failed: {detail}")
+    return result.stdout.strip()
+
+
+def latest_summary(
+    repository: str,
+    output_root: Path,
+    optional: bool,
+    policy: Policy,
+    test_mode: bool,
+) -> Path | None:
+    if not REPOSITORY.fullmatch(repository):
+        if optional and not repository:
+            return None
+        raise SecurityError("repository must identify owner/repository")
+    if not test_mode and output_root.resolve() != DEFAULT_BASELINE.resolve():
+        raise SecurityError(
+            "security baseline output must use app/build/quality-security-baseline"
+        )
+    if output_root.exists() and (not output_root.is_dir() or output_root.is_symlink()):
+        raise SecurityError("security baseline output is unsafe")
+    output_root.mkdir(parents=True, exist_ok=True)
+    executable = os.environ.get("DETACH_QUALITY_SECURITY_GH", "gh") if test_mode else "gh"
+    deadline_seconds = LATEST_DEADLINE_SECONDS
+    if test_mode and os.environ.get("DETACH_QUALITY_SECURITY_LATEST_SECONDS"):
+        raw_deadline = os.environ["DETACH_QUALITY_SECURITY_LATEST_SECONDS"]
+        if not raw_deadline.isdigit() or int(raw_deadline) < 1:
+            raise SecurityError("test security restore deadline must be a positive integer")
+        deadline_seconds = int(raw_deadline)
+    deadline = time.monotonic() + deadline_seconds
+    run_output = gh_output(
+        executable,
+        [
+            "api",
+            f"repos/{repository}/actions/workflows/security.yml/runs"
+            f"?branch=main&status=completed&per_page={LATEST_RUN_LIMIT}",
+            "--jq",
+            ".workflow_runs[].id",
+        ],
+        deadline,
+    )
+    run_ids = run_output.splitlines()
+    if not run_ids:
+        if optional:
+            return None
+        raise SecurityError("no completed main security run is available")
+    if len(run_ids) > LATEST_RUN_LIMIT or any(
+        not re.fullmatch(r"[1-9][0-9]*", run_id) for run_id in run_ids
+    ):
+        raise SecurityError("security run list is invalid")
+    for run_id in run_ids:
+        artifact_name = gh_output(
+            executable,
+            [
+                "api",
+                f"repos/{repository}/actions/runs/{run_id}/artifacts",
+                "--jq",
+                ".artifacts | map(select(.expired == false and "
+                "(.name | startswith(\"quality-security-\")))) | "
+                "if length == 0 then \"missing\" elif length == 1 then "
+                ".[0].name else \"ambiguous\" end",
+            ],
+            deadline,
+        )
+        if artifact_name == "missing":
+            continue
+        if (
+            artifact_name == "ambiguous"
+            or not re.fullmatch(rf"quality-security-{run_id}-[1-9][0-9]*", artifact_name)
+        ):
+            raise SecurityError(f"security run {run_id} has ambiguous artifacts")
+        destination = output_root / run_id
+        if destination.exists():
+            raise SecurityError(f"security baseline destination already exists: {destination}")
+        destination.mkdir()
+        gh_output(
+            executable,
+            [
+                "run", "download", run_id, "--repo", repository,
+                "--name", artifact_name, "--dir", str(destination),
+            ],
+            deadline,
+        )
+        candidates = [
+            path for path in destination.rglob("summary.json")
+            if path.is_file() and not path.is_symlink()
+        ]
+        if len(candidates) != 1:
+            raise SecurityError("downloaded security evidence has no unique summary")
+        try:
+            value = json.loads(candidates[0].read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeError, OSError) as error:
+            raise SecurityError(f"security summary is invalid: {error}") from error
+        if isinstance(value, dict) and value.get("policy") != policy.version:
+            continue
+        validate_summary(value, policy.version)
+        print(candidates[0])
+        return candidates[0]
+    if optional:
+        return None
+    raise SecurityError(
+        f"no valid policy {policy.version} security artifact exists in the latest "
+        f"{LATEST_RUN_LIMIT} completed runs"
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(prog="scripts/quality-security")
+    commands = result.add_subparsers(dest="command", required=True)
+    create = commands.add_parser("create")
+    create.add_argument("--source-commit", required=True)
+    create.add_argument("--run-id", required=True, type=int)
+    create.add_argument("--run-attempt", required=True, type=int)
+    create.add_argument("--run-url", required=True)
+    create.add_argument("--actions-result", required=True)
+    create.add_argument("--swift-result", required=True)
+    create.add_argument("--output", required=True, type=Path)
+    validate = commands.add_parser("validate")
+    validate.add_argument("summary", type=Path)
+    validate.add_argument("--require-pass", action="store_true")
+    latest = commands.add_parser("latest")
+    latest.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    latest.add_argument("--output-root", type=Path, default=DEFAULT_BASELINE)
+    latest.add_argument("--optional", action="store_true")
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    policy = Policy(POLICY_FILE)
+    if arguments.command == "create":
+        summary = create_summary(
+            policy,
+            arguments.source_commit,
+            arguments.run_id,
+            arguments.run_attempt,
+            arguments.run_url,
+            arguments.actions_result,
+            arguments.swift_result,
+        )
+        validate_summary(summary, policy.version)
+        atomic_write(arguments.output.resolve(), summary)
+        print(
+            f"quality-security: {summary['status']} policy={policy.version} "
+            f"run={summary['run_id']}"
+        )
+        return 0
+    if arguments.command == "validate":
+        summary = read_summary(arguments.summary.resolve(), policy.version)
+        print(
+            f"quality-security: {summary['status']} policy={policy.version} "
+            f"run={summary['run_id']}"
+        )
+        return 1 if arguments.require_pass and summary["status"] != "passed" else 0
+    latest_summary(
+        arguments.repository,
+        arguments.output_root,
+        arguments.optional,
+        policy,
+        os.environ.get("DETACH_QUALITY_SECURITY_TEST_MODE") == "1",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (PolicyError, SecurityError) as error:
+        fail(str(error))


### PR DESCRIPTION
Adds typed current-policy CodeQL result evidence and displays the exact Security run on the shared quality dashboard. Keeps Security weekly/manual and outside PR feedback. Restores the latest bounded result across main, care, and mutation Pages deployments. No release path is invoked.