### PR TITLE
Bind metadata snapshots to owned session root

### DIFF
--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -643,13 +643,12 @@ public enum DetachStateCommand {
         }
         defer { close(checkpoint) }
         var openedCheckpoint = stat()
-        guard fstat(checkpoint, &openedCheckpoint) == 0,
-              isDirectory(openedCheckpoint),
-              openedCheckpoint.st_uid == geteuid(),
-              openedCheckpoint.st_dev == checkpointMetadata.st_dev,
-              openedCheckpoint.st_ino == checkpointMetadata.st_ino else {
-            throw DetachStateCommandError.invalidArguments
-        }
+        let checkpointMatches = fstat(checkpoint, &openedCheckpoint) == 0
+            && isDirectory(openedCheckpoint)
+            && openedCheckpoint.st_uid == geteuid()
+            && openedCheckpoint.st_dev == checkpointMetadata.st_dev
+            && openedCheckpoint.st_ino == checkpointMetadata.st_ino
+        guard checkpointMatches else { throw DetachStateCommandError.invalidArguments }
         if let data = readOwnedMetadataFile(in: checkpoint, name: "meta.json") {
             if let values = try? SessionMetadataDocument.usableScalars(
                 in: data,
@@ -681,18 +680,14 @@ public enum DetachStateCommand {
         }
         defer { close(rootDescriptor) }
         var rootMetadata = stat()
-        guard fstat(rootDescriptor, &rootMetadata) == 0,
-              isDirectory(rootMetadata),
-              rootMetadata.st_uid == geteuid() else {
-            throw DetachStateCommandError.invalidArguments
-        }
+        let rootIsOwnedDirectory = fstat(rootDescriptor, &rootMetadata) == 0
+            && isDirectory(rootMetadata)
+            && rootMetadata.st_uid == geteuid()
+        guard rootIsOwnedDirectory else { throw DetachStateCommandError.invalidArguments }
         let enumerationDescriptor = dup(rootDescriptor)
-        guard enumerationDescriptor >= 0 else {
-            throw DetachStateCommandError.invalidArguments
-        }
+        guard enumerationDescriptor >= 0 else { throw DetachStateCommandError.invalidArguments }
         guard let directory = fdopendir(enumerationDescriptor) else {
-            close(enumerationDescriptor)
-            throw DetachStateCommandError.invalidArguments
+            close(enumerationDescriptor); throw DetachStateCommandError.invalidArguments
         }
         defer { closedir(directory) }
         var names: [String] = []
@@ -708,9 +703,7 @@ public enum DetachStateCommand {
         for name in names.sorted() {
             var item = stat()
             if fstatat(rootDescriptor, name, &item, AT_SYMLINK_NOFOLLOW) != 0 {
-                guard errno == ENOENT else {
-                    throw DetachStateCommandError.invalidArguments
-                }
+                guard errno == ENOENT else { throw DetachStateCommandError.invalidArguments }
                 continue
             }
             if isSymbolicLink(item) {
@@ -727,13 +720,13 @@ public enum DetachStateCommand {
                 throw DetachStateCommandError.invalidArguments
             }
             var opened = stat()
-            guard fstat(session, &opened) == 0,
-                  isDirectory(opened),
-                  opened.st_uid == geteuid(),
-                  opened.st_dev == item.st_dev,
-                  opened.st_ino == item.st_ino else {
-                close(session)
-                throw DetachStateCommandError.invalidArguments
+            let sessionMatches = fstat(session, &opened) == 0
+                && isDirectory(opened)
+                && opened.st_uid == geteuid()
+                && opened.st_dev == item.st_dev
+                && opened.st_ino == item.st_ino
+            guard sessionMatches else {
+                close(session); throw DetachStateCommandError.invalidArguments
             }
             let values: [DetachStateScalar?]?
             do {
@@ -770,10 +763,7 @@ public enum DetachStateCommand {
             while offset < buffer.count {
                 let count = Darwin.read(
                     descriptor, base.advanced(by: offset), buffer.count - offset)
-                if count < 0 {
-                    if errno == EINTR { continue }
-                    return false
-                }
+                if count < 0 { if errno == EINTR { continue }; return false }
                 if count == 0 { return false }
                 offset += count
             }

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 public enum DetachStateCommandError: Error, Equatable, Sendable {
@@ -587,59 +588,23 @@ public enum DetachStateCommand {
         return output
     }
 
-    /// Reads primary/checkpoint metadata pairs in one process. Input and output
-    /// use NUL delimiters so metadata values can contain tabs and newlines. An
-    /// empty-session completion record detects an interrupted shell producer.
+    /// Enumerates one validated sessions root in one process. Output uses NUL
+    /// delimiters so metadata values can contain tabs and newlines.
     private static func metaSnapshots(
         _ arguments: [String],
-        standardInput: Data?
+        standardInput _: Data?
     ) throws -> Data {
         guard arguments.count == 1 else {
             throw DetachStateCommandError.invalidArguments
         }
-        let input = try inputData(
-            atPath: arguments[0],
-            standardInput: standardInput)
-        let components = input.split(separator: 0, omittingEmptySubsequences: false)
-        guard components.last?.isEmpty == true else {
-            throw DetachStateCommandError.invalidArguments
-        }
-        let request = components.dropLast()
-        var index = request.startIndex
-        var complete = false
+        let sessions = try metadataSnapshots(at: arguments[0])
         var output = Data()
-        while index < request.endIndex {
-            guard let session = String(data: Data(request[index]), encoding: .utf8) else {
-                throw DetachStateCommandError.invalidArguments
-            }
-            index = request.index(after: index)
-            if session.isEmpty {
-                guard index < request.endIndex,
-                      String(data: Data(request[index]), encoding: .utf8) == "true",
-                      request.index(after: index) == request.endIndex else {
-                    throw DetachStateCommandError.invalidArguments
-                }
-                complete = true
-                break
-            }
-            guard request.distance(from: index, to: request.endIndex) >= 2,
-                  let primary = String(data: Data(request[index]), encoding: .utf8),
-                  let checkpoint = String(
-                    data: Data(request[request.index(after: index)]),
-                    encoding: .utf8) else {
-                throw DetachStateCommandError.invalidArguments
-            }
-            index = request.index(index, offsetBy: 2)
-            let values = metadataSnapshotValues(at: primary, session: session)
-                ?? metadataSnapshotValues(at: checkpoint, session: session)
+        for (session, values) in sessions {
             appendNULTerminated(session, to: &output)
             appendNULTerminated(values == nil ? "false" : "true", to: &output)
             for value in values ?? Array(repeating: nil, count: metadataSnapshotFields.count) {
                 appendNULTerminated(value.map(render) ?? "", to: &output)
             }
-        }
-        guard complete else {
-            throw DetachStateCommandError.invalidArguments
         }
         appendNULTerminated("", to: &output)
         appendNULTerminated("true", to: &output)
@@ -647,14 +612,206 @@ public enum DetachStateCommand {
     }
 
     private static func metadataSnapshotValues(
-        at path: String,
+        in directory: Int32,
         session: String
-    ) -> [DetachStateScalar?]? {
-        guard let data = try? Data(contentsOf: fileURL(path)) else { return nil }
-        return try? SessionMetadataDocument.usableScalars(
+    ) throws -> [DetachStateScalar?]? {
+        if let data = readOwnedMetadataFile(in: directory, name: "meta.json"),
+           let values = try? SessionMetadataDocument.usableScalars(
             in: data,
             expectedSessionName: session,
-            pathGroups: metadataSnapshotFields.map(\.1))
+            pathGroups: metadataSnapshotFields.map(\.1)) {
+            return values
+        }
+        var checkpointMetadata = stat()
+        let checkpointStatus = fstatat(
+            directory, "checkpoint", &checkpointMetadata, AT_SYMLINK_NOFOLLOW)
+        if checkpointStatus != 0 {
+            guard errno == ENOENT else {
+                throw DetachStateCommandError.invalidArguments
+            }
+            return nil
+        }
+        guard isDirectory(checkpointMetadata),
+              !isSymbolicLink(checkpointMetadata),
+              checkpointMetadata.st_uid == geteuid() else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let checkpoint = openat(
+            directory, "checkpoint", O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard checkpoint >= 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        defer { close(checkpoint) }
+        var openedCheckpoint = stat()
+        guard fstat(checkpoint, &openedCheckpoint) == 0,
+              isDirectory(openedCheckpoint),
+              openedCheckpoint.st_uid == geteuid(),
+              openedCheckpoint.st_dev == checkpointMetadata.st_dev,
+              openedCheckpoint.st_ino == checkpointMetadata.st_ino else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        if let data = readOwnedMetadataFile(in: checkpoint, name: "meta.json") {
+            if let values = try? SessionMetadataDocument.usableScalars(
+                in: data,
+                expectedSessionName: session,
+                pathGroups: metadataSnapshotFields.map(\.1)) {
+                return values
+            }
+        }
+        return nil
+    }
+
+    private static func metadataSnapshots(
+        at root: String
+    ) throws -> [(String, [DetachStateScalar?]?)] {
+        let components = root.split(separator: "/", omittingEmptySubsequences: false)
+        guard root.hasPrefix("/"),
+              root != "/",
+              !root.hasSuffix("/"),
+              !root.contains("\n"),
+              !root.contains("\r"),
+              !components.contains("."),
+              !components.contains("..") else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let rootDescriptor = open(
+            root, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard rootDescriptor >= 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        defer { close(rootDescriptor) }
+        var rootMetadata = stat()
+        guard fstat(rootDescriptor, &rootMetadata) == 0,
+              isDirectory(rootMetadata),
+              rootMetadata.st_uid == geteuid() else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let enumerationDescriptor = dup(rootDescriptor)
+        guard enumerationDescriptor >= 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        guard let directory = fdopendir(enumerationDescriptor) else {
+            close(enumerationDescriptor)
+            throw DetachStateCommandError.invalidArguments
+        }
+        defer { closedir(directory) }
+        var names: [String] = []
+        while let entry = readdir(directory) {
+            let name = withUnsafePointer(to: &entry.pointee.d_name) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: Int(NAME_MAX) + 1) {
+                    String(cString: $0)
+                }
+            }
+            if name != "." && name != ".." { names.append(name) }
+        }
+        var sessions: [(String, [DetachStateScalar?]?)] = []
+        for name in names.sorted() {
+            var item = stat()
+            if fstatat(rootDescriptor, name, &item, AT_SYMLINK_NOFOLLOW) != 0 {
+                guard errno == ENOENT else {
+                    throw DetachStateCommandError.invalidArguments
+                }
+                continue
+            }
+            if isSymbolicLink(item) {
+                throw DetachStateCommandError.invalidArguments
+            }
+            guard isDirectory(item) else { continue }
+            guard item.st_uid == geteuid(), validSessionIdentifier(name) else {
+                throw DetachStateCommandError.invalidArguments
+            }
+            let session = openat(
+                rootDescriptor, name,
+                O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+            guard session >= 0 else {
+                throw DetachStateCommandError.invalidArguments
+            }
+            var opened = stat()
+            guard fstat(session, &opened) == 0,
+                  isDirectory(opened),
+                  opened.st_uid == geteuid(),
+                  opened.st_dev == item.st_dev,
+                  opened.st_ino == item.st_ino else {
+                close(session)
+                throw DetachStateCommandError.invalidArguments
+            }
+            let values: [DetachStateScalar?]?
+            do {
+                values = try metadataSnapshotValues(in: session, session: name)
+            } catch {
+                close(session)
+                throw error
+            }
+            close(session)
+            sessions.append((name, values))
+        }
+        return sessions
+    }
+
+    private static func readOwnedMetadataFile(
+        in directory: Int32,
+        name: String
+    ) -> Data? {
+        let descriptor = openat(
+            directory, name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else { return nil }
+        defer { close(descriptor) }
+        var item = stat()
+        let maximumBytes: off_t = 1_048_576
+        guard fstat(descriptor, &item) == 0,
+              isRegularFile(item),
+              item.st_uid == geteuid(),
+              item.st_size >= 0,
+              item.st_size <= maximumBytes else { return nil }
+        var data = Data(count: Int(item.st_size))
+        let complete = data.withUnsafeMutableBytes { buffer -> Bool in
+            guard let base = buffer.baseAddress else { return item.st_size == 0 }
+            var offset = 0
+            while offset < buffer.count {
+                let count = Darwin.read(
+                    descriptor, base.advanced(by: offset), buffer.count - offset)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    return false
+                }
+                if count == 0 { return false }
+                offset += count
+            }
+            return true
+        }
+        return complete ? data : nil
+    }
+
+    private static func isDirectory(_ item: stat) -> Bool {
+        item.st_mode & S_IFMT == S_IFDIR
+    }
+
+    private static func isRegularFile(_ item: stat) -> Bool {
+        item.st_mode & S_IFMT == S_IFREG
+    }
+
+    private static func isSymbolicLink(_ item: stat) -> Bool {
+        item.st_mode & S_IFMT == S_IFLNK
+    }
+
+    private static func validSessionIdentifier(_ value: String) -> Bool {
+        guard value.hasPrefix("detach-codex-") || value.hasPrefix("detach-claude-") else {
+            return false
+        }
+        let prefix = value.hasPrefix("detach-codex-") ? "detach-codex-" : "detach-claude-"
+        let suffix = value.dropFirst(prefix.count)
+        guard (1...48).contains(suffix.utf8.count),
+              let first = suffix.utf8.first,
+              asciiAlphanumeric(first) else { return false }
+        return suffix.utf8.dropFirst().allSatisfy {
+            asciiAlphanumeric($0) || $0 == 0x5F || $0 == 0x2D
+        }
+    }
+
+    private static func asciiAlphanumeric(_ value: UInt8) -> Bool {
+        (0x30...0x39).contains(value)
+            || (0x41...0x5A).contains(value)
+            || (0x61...0x7A).contains(value)
     }
 
     private static func metaUsable(

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -351,10 +351,11 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
-    func testMetaSnapshotsEnumeratesSafeRootAndRejectsSymlinks() throws {
+    func testMetaSnapshotsBatchesFallbacksAndRejectsIncompleteInput() throws {
         let root = temporaryDirectory.appendingPathComponent("sessions", isDirectory: true)
         let first = root.appendingPathComponent("detach-codex-one", isDirectory: true)
         let second = root.appendingPathComponent("detach-codex-two", isDirectory: true)
+        let third = root.appendingPathComponent("detach-claude-three", isDirectory: true)
         let checkpointDirectory = first.appendingPathComponent("checkpoint", isDirectory: true)
         let invalid = first.appendingPathComponent("meta.json")
         let checkpoint = checkpointDirectory.appendingPathComponent("meta.json")
@@ -362,7 +363,10 @@ final class DetachStateCommandTests: XCTestCase {
             at: checkpointDirectory, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(
             at: second, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: third, withIntermediateDirectories: true)
         try Data("not-json".utf8).write(to: invalid)
+        try Data(count: 1_048_577).write(to: second.appendingPathComponent("meta.json"))
         let project = "/tmp/project\twith\ncontrols"
         try JSONSerialization.data(withJSONObject: [
             "schema": 1,
@@ -370,6 +374,13 @@ final class DetachStateCommandTests: XCTestCase {
             "project_dir": project,
             "status": "stopped",
         ]).write(to: checkpoint)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-claude-three",
+            "project_dir": "/tmp/primary",
+            "status": "running",
+        ]).write(to: third.appendingPathComponent("meta.json"))
+        try Data("ignored".utf8).write(to: root.appendingPathComponent("regular-file"))
 
         let output = try DetachStateCommand.run(arguments: [
             "meta", "snapshots", root.path,
@@ -378,15 +389,44 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
         let recordSize = 19
-        XCTAssertEqual(values.count, recordSize * 2 + 2)
-        XCTAssertEqual(values[0], "detach-codex-one")
+        XCTAssertEqual(values.count, recordSize * 3 + 2)
+        XCTAssertEqual(values[0], "detach-claude-three")
         XCTAssertEqual(values[1], "true")
-        XCTAssertEqual(values[2], "stopped")
-        XCTAssertEqual(values[4], project)
-        XCTAssertEqual(values[recordSize], "detach-codex-two")
-        XCTAssertEqual(values[recordSize + 1], "false")
-        XCTAssertTrue(values[(recordSize + 2)..<(recordSize * 2)].allSatisfy(\.isEmpty))
+        XCTAssertEqual(values[2], "running")
+        XCTAssertEqual(values[4], "/tmp/primary")
+        XCTAssertEqual(values[recordSize], "detach-codex-one")
+        XCTAssertEqual(values[recordSize + 1], "true")
+        XCTAssertEqual(values[recordSize + 2], "stopped")
+        XCTAssertEqual(values[recordSize + 4], project)
+        XCTAssertEqual(values[recordSize * 2], "detach-codex-two")
+        XCTAssertEqual(values[recordSize * 2 + 1], "false")
+        XCTAssertTrue(values[(recordSize * 2 + 2)..<(recordSize * 3)].allSatisfy(\.isEmpty))
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
+        let repeatedSeparatorRoot = root.path.replacingOccurrences(
+            of: "/sessions", with: "//sessions")
+        XCTAssertEqual(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", repeatedSeparatorRoot,
+        ]), output)
+
+        for invalidRoot in [
+            "relative/sessions", root.path + "/", root.path + "/../sessions",
+            root.path + "\n",
+        ] {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", invalidRoot,
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+            }
+        }
+
+        let invalidSession = root.appendingPathComponent("unsafe name", isDirectory: true)
+        try FileManager.default.createDirectory(at: invalidSession, withIntermediateDirectories: true)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+        try FileManager.default.removeItem(at: invalidSession)
 
         let unsafeRoot = temporaryDirectory.appendingPathComponent("unsafe-sessions")
         try FileManager.default.createSymbolicLink(at: unsafeRoot, withDestinationURL: root)
@@ -411,6 +451,71 @@ final class DetachStateCommandTests: XCTestCase {
             withDestinationURL: external)
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
             "meta", "snapshots", checkpointRoot.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+
+        let invalidCheckpointRoot = temporaryDirectory.appendingPathComponent(
+            "invalid-checkpoint-sessions", isDirectory: true)
+        let invalidCheckpointSession = invalidCheckpointRoot.appendingPathComponent(
+            "detach-codex-invalid-checkpoint", isDirectory: true)
+        let invalidCheckpointDirectory = invalidCheckpointSession.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: invalidCheckpointDirectory, withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(
+            to: invalidCheckpointDirectory.appendingPathComponent("meta.json"))
+        let invalidCheckpointOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", invalidCheckpointRoot.path,
+        ])
+        let invalidCheckpointValues = invalidCheckpointOutput.split(
+            separator: 0, omittingEmptySubsequences: false)
+        XCTAssertEqual(String(decoding: invalidCheckpointValues[0], as: UTF8.self),
+                       "detach-codex-invalid-checkpoint")
+        XCTAssertEqual(String(decoding: invalidCheckpointValues[1], as: UTF8.self), "false")
+
+        let unreadableRoot = temporaryDirectory.appendingPathComponent(
+            "unreadable-sessions", isDirectory: true)
+        let unreadableSession = unreadableRoot.appendingPathComponent(
+            "detach-codex-unreadable", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: unreadableSession, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o100], ofItemAtPath: unreadableSession.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: unreadableSession.path)
+        }
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", unreadableRoot.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o400], ofItemAtPath: unreadableSession.path)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", unreadableRoot.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+
+        let unreadableCheckpointRoot = temporaryDirectory.appendingPathComponent(
+            "unreadable-checkpoint-sessions", isDirectory: true)
+        let unreadableCheckpointSession = unreadableCheckpointRoot.appendingPathComponent(
+            "detach-codex-unreadable-checkpoint", isDirectory: true)
+        let unreadableCheckpoint = unreadableCheckpointSession.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: unreadableCheckpoint, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o100], ofItemAtPath: unreadableCheckpoint.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: unreadableCheckpoint.path)
+        }
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", unreadableCheckpointRoot.path,
         ])) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
         }

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -351,10 +351,17 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
-    func testMetaSnapshotsBatchesFallbacksAndRejectsIncompleteInput() throws {
-        let invalid = temporaryDirectory.appendingPathComponent("invalid-primary.json")
-        let checkpoint = temporaryDirectory.appendingPathComponent("checkpoint.json")
-        let missing = temporaryDirectory.appendingPathComponent("missing.json")
+    func testMetaSnapshotsEnumeratesSafeRootAndRejectsSymlinks() throws {
+        let root = temporaryDirectory.appendingPathComponent("sessions", isDirectory: true)
+        let first = root.appendingPathComponent("detach-codex-one", isDirectory: true)
+        let second = root.appendingPathComponent("detach-codex-two", isDirectory: true)
+        let checkpointDirectory = first.appendingPathComponent("checkpoint", isDirectory: true)
+        let invalid = first.appendingPathComponent("meta.json")
+        let checkpoint = checkpointDirectory.appendingPathComponent("meta.json")
+        try FileManager.default.createDirectory(
+            at: checkpointDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: second, withIntermediateDirectories: true)
         try Data("not-json".utf8).write(to: invalid)
         let project = "/tmp/project\twith\ncontrols"
         try JSONSerialization.data(withJSONObject: [
@@ -364,18 +371,9 @@ final class DetachStateCommandTests: XCTestCase {
             "status": "stopped",
         ]).write(to: checkpoint)
 
-        var input = Data()
-        for value in [
-            "detach-codex-one", invalid.path, checkpoint.path,
-            "detach-codex-two", missing.path, missing.path,
-            "", "true",
-        ] {
-            input.append(Data(value.utf8))
-            input.append(0)
-        }
-        let output = try DetachStateCommand.run(
-            arguments: ["meta", "snapshots", "-"],
-            standardInput: input)
+        let output = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path,
+        ])
         let values = output.split(separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
@@ -390,21 +388,39 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertTrue(values[(recordSize + 2)..<(recordSize * 2)].allSatisfy(\.isEmpty))
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
 
-        let malformed = [
-            Data("record-without-nul".utf8),
-            Data([0xFF, 0x00]),
-            Data("\0false\0".utf8),
-            Data("session\0only-primary\0".utf8),
-            Data([0x73, 0x00, 0xFF, 0x00, 0x63, 0x00]),
-            Data("session\0primary\0checkpoint\0".utf8),
-        ]
-        for payload in malformed {
-            XCTAssertThrowsError(try DetachStateCommand.run(
-                arguments: ["meta", "snapshots", "-"],
-                standardInput: payload
-            )) { error in
-                XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
-            }
+        let unsafeRoot = temporaryDirectory.appendingPathComponent("unsafe-sessions")
+        try FileManager.default.createSymbolicLink(at: unsafeRoot, withDestinationURL: root)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", unsafeRoot.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+
+        let external = temporaryDirectory.appendingPathComponent("external", isDirectory: true)
+        try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+        let checkpointRoot = temporaryDirectory.appendingPathComponent(
+            "checkpoint-sessions", isDirectory: true)
+        let checkpointSession = checkpointRoot.appendingPathComponent(
+            "detach-codex-checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: checkpointSession, withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(
+            to: checkpointSession.appendingPathComponent("meta.json"))
+        try FileManager.default.createSymbolicLink(
+            at: checkpointSession.appendingPathComponent("checkpoint"),
+            withDestinationURL: external)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", checkpointRoot.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+
+        let linked = root.appendingPathComponent("detach-codex-linked")
+        try FileManager.default.createSymbolicLink(at: linked, withDestinationURL: external)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
         }
     }
 

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -4115,21 +4115,8 @@ prepare_list_json_args() {
   LIST_JSON_ARGS=( "${session_args[@]}" )
 }
 
-list_meta_snapshot_requests() {
-  local dir
-  local session
-
-  for dir in "$SESSIONS_ROOT"/*; do
-    [ -d "$dir" ] || continue
-    session="$(basename "$dir")"
-    printf '%s\0%s\0%s\0' \
-      "$session" "$dir/meta.json" "$dir/checkpoint/meta.json"
-  done
-  printf '\0true\0'
-}
-
 list_meta_snapshots() {
-  list_meta_snapshot_requests | "$STATE_BIN" meta snapshots /dev/stdin
+  "$STATE_BIN" meta snapshots "$SESSIONS_ROOT"
 }
 
 list_session_records() {

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -54,25 +54,25 @@ keep the lock around the whole child process and preserve that lock order.
 
 ### Typed state boundary
 
-`detach-state` is the JSON boundary; do not restore jq or shell JSON
-editing. Its typed commands cover guarded metadata mutation and batch reads,
-JSONL validation/summary, health/reconcile, emission, and storage plans.
-Out-of-range integer conversion must never trap. Storage reports allocated and
-logical bytes, exclude provider storage, never follow symlinks, and authorize
-cleanup only after a complete scan with explicit `cleanup_eligible: true`.
+`detach-state` is the JSON boundary. Do not edit JSON in shell. It owns typed
+metadata, JSONL, health, reconcile, storage, and emit operations.
+`meta snapshots` enumerates one owned sessions root through anchored directory
+descriptors. It accepts no path stream. It rejects unsafe session or checkpoint
+directories and opens only owned regular files of at most 1 MiB with
+`O_NOFOLLOW`.
+Integer conversion must not trap. Storage reports allocated and logical bytes,
+excludes provider storage, does not follow symlinks, and authorizes cleanup
+only after a complete scan with explicit `cleanup_eligible: true`.
 
-Per-session `meta.json` uses schema 1, an internal `session_name`, an optional
-human-facing `display_name`, and a `run_token`. Older schema-1 documents without
-`display_name` remain valid. A stale worker or checkpoint loop must not
-overwrite metadata belonging to a replacement run.
-New runs also publish `health_schema=1`, the exact worker/provider PIDs, worker
-heartbeat time, and checkpoint epoch. Health is a typed state machine over
-managed tmux/pane state, the matching run token, PID ownership and ancestry,
-metadata validity, and heartbeat/checkpoint freshness. Stale freshness alone
-must never classify a proven live provider as hung. A live recorded runtime
-without managed tmux authorizes no signal, replacement start, recovery, or
-deletion; wait for the exact processes to disappear rather than touching a
-possibly foreign process.
+Per-session `meta.json` uses schema 1, internal `session_name`, optional
+`display_name`, and a `run_token`. Older documents without `display_name`
+remain valid. A stale worker or checkpoint loop must not overwrite replacement
+run metadata. New runs publish `health_schema=1`, exact worker/provider PIDs,
+worker heartbeat time, and checkpoint epoch. Health combines managed tmux/pane
+state, run token, PID ownership and ancestry, valid metadata, heartbeat, and
+checkpoint freshness. Stale data alone cannot classify a proven live provider
+as hung. A recorded live runtime without managed tmux permits no signal,
+replacement, recovery, or deletion. Wait for the exact processes to exit.
 Anything restored into provider storage must pass canonical path, symlink,
 session-ID, and JSONL validation, be written to a temporary file, validated
 again, and only then be moved into place.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -658,7 +658,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 39,
+  "policy": 40,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	39
+policy	40
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.


### PR DESCRIPTION
Closes the CodeQL swift/path-injection data path in the batched metadata reader. The typed helper enumerates one owned sessions root through descriptor-anchored traversal, rejects unsafe session/checkpoint directories, and reads only owned bounded regular files with O_NOFOLLOW. Keeps one batch process and preserves legacy path formatting. No release path is invoked.