### PR TITLE
Measure UI coverage from user journeys

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -630,11 +630,28 @@ enum UIE2ETestDriver {
                 frame: pageFrame,
                 name: "scroll toward \(name)",
                 owningWindow: measuredView.window)
-            try await waitUntil("visible \(name)", attempts: 10) {
-                measuredView.publishFrame()
-                guard let moved = UIE2EGeometryRegistry.frame(for: identifier)
-                else { return false }
-                return moved != current
+            do {
+                try await waitUntil("visible \(name)", attempts: 10) {
+                    measuredView.publishFrame()
+                    guard let moved = UIE2EGeometryRegistry.frame(for: identifier)
+                    else { return false }
+                    return moved != current
+                }
+            } catch {
+                // Overlay scrollers can expose page geometry while ignoring a
+                // synthesized click until a physical scroll makes the track
+                // visible. Reveal only the measured semantic control, then
+                // keep the actual action on the real button below.
+                measuredView.scrollToVisible(measuredView.bounds)
+                if let scrollView = measuredView.enclosingScrollView {
+                    scrollView.reflectScrolledClipView(scrollView.contentView)
+                }
+                try await waitUntil("fallback reveal for \(name)", attempts: 10) {
+                    measuredView.publishFrame()
+                    guard let moved = UIE2EGeometryRegistry.frame(for: identifier)
+                    else { return false }
+                    return moved != current
+                }
             }
         }
         measuredView.publishFrame()

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -83,7 +83,8 @@ The repository gate writes private evidence under
 `app/build/quality-gates/`. One run contains a schema-versioned TSV summary,
 gate and scenario JUnit, scenario JSONL, Markdown, stage logs, safe environment
 facts, a provenance manifest, and a digest inventory. Coverage runs also
-contain `quality-metrics.json`. A failed scenario adds a bounded
+contain `quality-metrics.json` and `coverage-opportunities.json`. A failed
+scenario adds a bounded
 `repair-bundle.json` with its requirement and journey links, exact rerun, and
 at most the last 100 log lines.
 
@@ -128,14 +129,19 @@ SLO is less than ten minutes.
 
 Static validation runs before the parallel self-contract workers. This keeps
 its two-second local signal free of scheduler contention. Coverage compilation
-and the app build then get exclusive SwiftPM access. Quality analysis reads the
-completed Swift log and coverage profile without another test run. The short
-packaged UI lane runs after the verified app and before the CPU-intensive
+and the app build then get exclusive SwiftPM access. The app stage verifies the
+normal bundle before it builds a coverage-enabled release executable for the
+private UI copy. The short packaged UI lane runs after the verified app and
+before the CPU-intensive
 provider, runtime, and gate-contract lanes. This prevents WindowServer event
 delivery from competing with those workers. Provider lanes then run in
 parallel. After they drain, the runtime and gate-contract lanes run in
 parallel. This admits at most two process-heavy top-level lanes. Independent
 distribution and release lanes overlap after both groups drain.
+
+Quality analysis runs after the UI lane. It merges the completed Swift profile
+with all passed packaged-app profiles. It reads the existing Swift log and does
+not run a test twice.
 
 The gate-contract stage keeps lightweight contracts concurrent. It admits at
 most two process-heavy orchestrator shards at one time. This limit prevents
@@ -183,6 +189,12 @@ Changed executable lines need at least 90 percent coverage. A new critical
 source needs 100 percent coverage for its first baseline. Missing, stale,
 unbound, unsafe, or malformed baseline evidence fails closed.
 
+The UI aggregate includes Swift tests and the bounded packaged-app journeys.
+The separate opportunity artifact ranks current uncovered UI sources. Its risk
+order comes from the current policy route, release impact, requirements, and
+user journeys. The next milestone is the next five-point boundary above the
+observed ratio. It is advisory and does not replace the last-green ratchet.
+
 A weekly and manual workflow runs each deterministic safety mutant in a
 separate bounded macOS job. The required mutation score is 100 percent. A
 survivor, timeout, or infrastructure-like failure is not a kill and fails the
@@ -208,13 +220,14 @@ run release tools.
 
 ## Dashboard
 
-The dashboard generator validates the current manifest, summary, metric and
-mutation digests. It also validates the care policy, source commit, schema, and
-input digests. It shows authority, result, exact commit, exact CI run,
-freshness, fingerprint, durations, coverage, affected journeys, scenario gaps,
-mutation score, workflow evals, feedback p95 and SLO, security state, and recent
-latency. Code review stays a read-only step in the active agent workflow. It is
-not a repository gate or a second merge authority.
+The dashboard generator validates the current manifest, summary, metric,
+coverage-opportunity, and mutation digests. It also validates the care policy,
+source commit, schema, and input digests. It shows authority, result, exact
+commit, exact CI run, freshness, fingerprint, durations, coverage, ranked UI
+opportunities, affected journeys, scenario gaps, mutation score, workflow
+evals, feedback p95 and SLO, security state, and recent latency. Code review
+stays a read-only step in the active agent workflow. It is not a repository
+gate or a second merge authority.
 
 The same artifact opens locally and deploys to GitHub Pages. Main and mutation
 workflows deploy only after a green `ci-main` gate or a green mutation score for

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -40,22 +40,24 @@ transient SMAppService Code=1 race. Do not replace a helper with active leases:
 defer the update. Report a normal reconciliation outcome and retry on a later
 app activation.
 
-Every readiness build has one unique `detach-app-build:<UUID>` in the main
-executable's `__TEXT,__detach_build` section and signed build marker. Both
-values must match. The packaged-app UI smoke uses a stripped private
-background copy under `/private/tmp/detach-ui-e2e.*`. Its identity has
-no production CLI payload, watchdog, helper, power or state executable, or
-tmux. All injected paths resolve below the private root. An escape, unsafe
-identity, build mismatch, or payload fails closed. The smoke proves startup
-does not take focus. It then
-activates the copy, posts AppKit mouse events to measured SwiftUI controls, and
-restores the prior application. Its locator bridge exposes semantics but has no
-actions. Each isolated launch has a driver deadline below its process
-deadline. A 40-second global deadline bounds the stage. It covers the
-dashboard, session actions, new-session sheet, empty and failure states,
-Settings, onboarding, and focus restoration. It disconnects Stop before it
-proves that the real control invokes the action. Onboarding fixture
-states are isolated; only a visible control completes first-run setup.
+Each readiness build stores one `detach-app-build:<UUID>` in its executable and
+signed marker. UI smoke uses a stripped private copy at
+`/private/tmp/detach-ui-e2e.*`. It excludes production CLI, watchdog, helper,
+power, state, and tmux payloads. Injections stay below its root. An escape,
+unsafe identity, build mismatch, or payload fails closed.
+
+The smoke keeps the prior app focused. It posts AppKit events to measured
+SwiftUI controls, then restores that app. Its semantic locator has no actions.
+Each launch ends before its process deadline; the stage deadline is 40 seconds.
+Journeys cover all main surfaces, Settings, onboarding, and focus. It
+disconnects Stop before it proves that the real control invokes the action.
+Only a visible control completes isolated onboarding.
+
+Coverage validates the normal bundle, puts a coverage-enabled release
+executable only in the stripped copy, and signs it. The executable and profiles
+stay ignored or private and never enter a verified bundle or public artifact.
+If an overlay scroller ignores a page event, the driver reveals the measured
+semantic control, then posts the action to it.
 
 The per-user watchdog has an additional launch-readiness rule. macOS can report
 an approved agent as enabled while no launchd job was loaded after the approval

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -87,6 +87,14 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   excluded. A test-only region in a product source has a policy-owned name,
   checked source markers, and automated scenario evidence. The region is
   omitted only from changed-line metrics, not aggregate coverage.
+- Authoritative UI coverage combines instrumented Swift tests with
+  packaged-app journeys. The app stage verifies the normal bundle, then builds
+  an instrumented release executable for the stripped private copy. The
+  metric stage merges profiles after UI without another test run.
+- `coverage-opportunities.json` is a separate digest-bound advisory artifact.
+  It ranks uncovered UI sources from policy routes, release impact,
+  requirements, and journeys. Its next milestone is the five-point boundary
+  above observed coverage. It does not set a floor or change gate status.
 - A scheduled, manually dispatchable mutation workflow checks a small
   deterministic safety corpus. It runs mutants in parallel, gives each test a
   240-second deadline, and requires a 100-percent score. Mutation work does not
@@ -107,8 +115,9 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   run. Bounded quality care can also deploy its validated result before it
   marks an attention run as failed. Care evidence binds the source commit and
   SHA-256 digests of its eval and history inputs. The dashboard shows measured
-  coverage, mutation score, workflow evals, feedback p95 and SLO, and security
-  state when they exist. The security state comes from a typed current-policy
+  coverage, ranked UI coverage opportunities, mutation score, workflow evals,
+  feedback p95 and SLO, and security state when they exist. The security state
+  comes from a typed current-policy
   artifact. It includes both CodeQL job results, the analyzed commit, an
   identity fingerprint, and the exact workflow link. A later main, care, or
   mutation deploy restores the newest valid current-policy security and care

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,9 +9,11 @@
   analysis; use it after a wider Swift edit when `critical` is too narrow.
 - `scripts/test coverage` — every coverage-enabled Swift test followed by
   automatic test-identity, aggregate, critical-source, and changed-line
-  metrics. Local use records diagnostic facts. Hosted CI compares them with
-  the last green `main` artifact. It deletes only the active SwiftPM build
-  path's prior profile, so stale build evidence cannot satisfy the command.
+  metrics. This fast local diagnostic is unit-only. An authoritative gate adds
+  the passed packaged-app profiles without another Swift test run. Hosted CI
+  compares the combined result with the last green `main` artifact. The local
+  command deletes only the active SwiftPM build path's prior profile, so stale
+  build evidence cannot satisfy the command.
 - `scripts/test smoke` — builds a fresh app, validates and runs the isolated
   packaged-app Accessibility flow, then verifies the bundled runtime. It needs
   a logged-in WindowServer session and an environment that permits the private
@@ -134,14 +136,18 @@
 - `cd app && swift test --enable-code-coverage --disable-sandbox`, followed by
   `tests/quality-contracts.sh` — unit tests plus measured UI and business test
   identities, aggregate coverage, and coverage for the 13 critical sources.
-  CI rejects a reduction from the last green `main` artifact. It also rejects
+  The authoritative gate also merges the release-configuration packaged-app
+  profiles after all UI journeys pass. CI rejects a reduction from the last
+  green `main` artifact. It also rejects
   changed executable Swift-line coverage below 90 percent. New critical
   sources start at 100 percent. The quality policy owns each coverage
   exclusion and links it to automated scenario evidence. Excluded sources do
   not enter aggregate or changed-line denominators. Named test-only regions in
   product files stay in aggregate coverage but use their automated scenario as
   changed-line evidence. `tests/quality-metrics.sh` covers missing, malformed,
-  removed-test, aggregate, critical-file, and changed-line regressions.
+  removed-test, aggregate, critical-file, changed-line, combined-profile, and
+  ranked-opportunity contracts. The opportunity artifact is advisory. It does
+  not set a coverage floor.
   `tests/release-budget-ratchet-contract.sh` protects timing.
 - `tests/quality-mutation.sh` checks source restoration, timeout handling,
   failure classification, score enforcement, remote evidence restore, and the

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -658,7 +658,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 40,
+  "policy": 41,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	40
+policy	41
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-contracts.sh
+++ b/tests/quality-contracts.sh
@@ -39,15 +39,28 @@ fi
 source_commit="${DETACH_QUALITY_SOURCE_COMMIT:-$(git -C "$ROOT" rev-parse HEAD)}"
 authority="${DETACH_QUALITY_AUTHORITY:-local-diagnostic}"
 output="${DETACH_QUALITY_METRICS_OUTPUT:-$ROOT/app/build/quality-metrics/quality-metrics.json}"
+opportunities="${DETACH_QUALITY_OPPORTUNITIES_OUTPUT:-$ROOT/app/build/quality-metrics/coverage-opportunities.json}"
 arguments=(
   evaluate
   --test-binary "$test_binary"
   --profile "$profdata"
   --tests "$tests"
   --output "$output"
+  --opportunities-output "$opportunities"
   --source-commit "$source_commit"
   --authority "$authority"
 )
+if { [ -n "${DETACH_UI_COVERAGE_BINARY:-}" ] && [ -z "${DETACH_UI_COVERAGE_PROFILE_DIR:-}" ]; } || \
+   { [ -z "${DETACH_UI_COVERAGE_BINARY:-}" ] && [ -n "${DETACH_UI_COVERAGE_PROFILE_DIR:-}" ]; }; then
+  printf 'quality contracts: UI coverage binary and profile directory must occur together\n' >&2
+  exit 2
+fi
+if [ -n "${DETACH_UI_COVERAGE_BINARY:-}" ]; then
+  arguments+=(
+    --additional-object "$DETACH_UI_COVERAGE_BINARY"
+    --additional-profile-directory "$DETACH_UI_COVERAGE_PROFILE_DIR"
+  )
+fi
 [ -z "${RESOLVED_BASE:-}" ] || arguments+=(--base-commit "$RESOLVED_BASE")
 [ -z "${DETACH_QUALITY_BASELINE_ROOT:-}" ] || \
   arguments+=(--baseline-root "$DETACH_QUALITY_BASELINE_ROOT")

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -73,8 +73,35 @@ cat >"$RUN_DIR/quality-metrics.json" <<JSON
   }
 }
 JSON
+cat >"$RUN_DIR/coverage-opportunities.json" <<JSON
+{
+  "lines_to_milestone": 5,
+  "next_milestone_percent": 35,
+  "observed": {"covered": 30, "percent": 30.0, "total": 100},
+  "opportunities": [
+    {
+      "capabilities": ["onboarding"],
+      "journeys": ["J-ONBOARD-APPROVAL", "J-ONBOARD-FIRST-RUN", "J-ONBOARD-PROVIDER"],
+      "line_coverage": {"covered": 30, "percent": 30.0, "total": 100},
+      "path": "app/Sources/DetachApp/RootView.swift",
+      "rank": 1,
+      "recommended_evidence": "packaged-user-journey",
+      "requirements": ["QC-APP-ONBOARDING"],
+      "risk": "installation-sensitive",
+      "risk_tier": 3,
+      "uncovered": 70
+    }
+  ],
+  "policy": $POLICY_VERSION,
+  "schema": 1,
+  "source_commit": "0123456789abcdef0123456789abcdef01234567",
+  "suite": "ui"
+}
+JSON
 metrics_digest="$(shasum -a 256 "$RUN_DIR/quality-metrics.json" | awk '{print $1}')"
-printf 'schema\t1\nfile\tquality-metrics.json\t%s\n' "$metrics_digest" \
+opportunities_digest="$(shasum -a 256 "$RUN_DIR/coverage-opportunities.json" | awk '{print $1}')"
+printf 'schema\t1\nfile\tcoverage-opportunities.json\t%s\nfile\tquality-metrics.json\t%s\n' \
+  "$opportunities_digest" "$metrics_digest" \
   >"$RUN_DIR/artifacts.tsv"
 artifacts_digest="$(shasum -a 256 "$RUN_DIR/artifacts.tsv" | awk '{print $1}')"
 cat >"$RUN_DIR/manifest.tsv" <<EOF
@@ -216,6 +243,12 @@ grep -F 'Planned gaps</span><strong>0' "$OUTPUT/index.html" >/dev/null || \
   fail 'closed scenario set still reports a planned gap'
 grep -F 'changed lines 90.00%' "$OUTPUT/index.html" >/dev/null || \
   fail 'measured changed-line coverage is missing'
+grep -F 'UI coverage opportunities' "$OUTPUT/index.html" >/dev/null || \
+  fail 'coverage opportunity table is missing'
+grep -F 'Next automatic milestone: 35% (5 executable lines).' \
+  "$OUTPUT/index.html" >/dev/null || fail 'automatic coverage milestone is missing'
+grep -F 'app/Sources/DetachApp/RootView.swift' "$OUTPUT/index.html" >/dev/null || \
+  fail 'ranked coverage source is missing'
 grep -F '100% · 1/1 killed · passed' "$OUTPUT/index.html" >/dev/null || \
   fail 'mutation score is missing'
 grep -F '8/8 passed · passed · 1 repaired failure retained · source' "$OUTPUT/index.html" >/dev/null || \
@@ -233,12 +266,16 @@ import json
 import sys
 with open(sys.argv[1], encoding="utf-8") as source:
     data = json.load(source)
-assert data["schema"] == 2
+assert data["schema"] == 3
 assert data["run"]["authority"] == "ci-merge"
 assert data["run"]["result"] == "passed"
 assert [spec["id"] for spec in data["specifications"]] == ["app"]
 assert data["quality"]["planned_scenarios"] == 0
 assert data["quality"]["coverage"]["comparison"]["mode"] == "green-main-artifact"
+assert data["quality"]["coverage_opportunities"]["next_milestone_percent"] == 35
+assert data["quality"]["coverage_opportunities"]["opportunities"][0]["path"].endswith(
+    "RootView.swift"
+)
 assert data["quality"]["mutation"]["score_percent"] == 100
 assert data["quality"]["merge"] == "not-yet-emitted"
 with open(sys.argv[2], encoding="utf-8") as source:

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -434,9 +434,11 @@ resumed_run="$(find "$RESULT_ROOT" -mindepth 1 -maxdepth 1 -type d -print | LC_A
 grep -F 'reusing static from matching evidence' "$REPO/resume-second.out" >/dev/null
 grep -F 'reusing gate-contract from matching evidence' "$REPO/resume-second.out" >/dev/null
 grep -R $'static\treused' "$RESULT_ROOT" >/dev/null
-[ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 14 ]
+[ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 15 ]
+[ "$(awk '$0 == "ui-e2e" { count += 1 } END { print count + 0 }' \
+    "$ACTION_LOG")" = 2 ]
 grep -F $'result\tpassed' "$RESULT_ROOT"/*/manifest.tsv >/dev/null
-grep -F '<testsuite name="detach-quality-gate" tests="14" failures="0" skipped="11">' "$RESULT_ROOT"/*/junit.xml >/dev/null
+grep -F '<testsuite name="detach-quality-gate" tests="14" failures="0" skipped="10">' "$RESULT_ROOT"/*/junit.xml >/dev/null
 grep -F $'resumed_from_run\t'"$(basename "$resume_dir")" "$resumed_run/manifest.tsv" >/dev/null
 expected_parent_digest="$(shasum -a 256 "$resume_dir/manifest.tsv" | awk '{print $1}')"
 grep -F $'resumed_from_manifest_sha256\t'"$expected_parent_digest" "$resumed_run/manifest.tsv" >/dev/null
@@ -644,11 +646,12 @@ if FAIL_STAGES=app gate --mode repository --keep-going >"$REPO/dependency.out" 2
   printf 'quality gate unexpectedly passed a failed prerequisite\n' >&2
   exit 1
 fi
-[ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 9 ]
+[ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 8 ]
 grep -F $'codex\tblocked' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 grep -F $'tmux-runtime\tblocked' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 grep -F $'ui-e2e\tblocked' "$RESULT_ROOT"/*/summary.tsv >/dev/null
-grep -F '<testsuite name="detach-quality-gate" tests="14" failures="1" skipped="5">' "$RESULT_ROOT"/*/junit.xml >/dev/null
+grep -F $'quality-contracts\tblocked' "$RESULT_ROOT"/*/summary.tsv >/dev/null
+grep -F '<testsuite name="detach-quality-gate" tests="14" failures="1" skipped="6">' "$RESULT_ROOT"/*/junit.xml >/dev/null
 
 setup_fixture parallel-lanes
 PARALLEL_ROOT="$REPO/parallel"
@@ -694,6 +697,7 @@ cat >"$REPO/tests/quality-gate-fixtures/quality-contracts" <<'SH'
 #!/bin/bash
 set -eu
 [ -f "${GATE_ORDER_ROOT:?}/swift" ]
+[ -f "${GATE_ORDER_ROOT:?}/ui-e2e" ]
 sleep 1
 printf '{}\n' >"${DETACH_QUALITY_METRICS_OUTPUT:?}"
 : >"$GATE_ORDER_ROOT/quality-contracts"

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -50,7 +50,13 @@ class QualityGateContract(unittest.TestCase):
     def test_execution_prerequisites_reference_policy_stages(self) -> None:
         stages = set(Policy(POLICY_FILE).stages_by_name)
         self.assertLessEqual(set(EXECUTION_PREREQUISITES), stages)
-        self.assertLessEqual(set(EXECUTION_PREREQUISITES.values()), stages)
+        self.assertTrue(all(EXECUTION_PREREQUISITES.values()))
+        prerequisites = {
+            prerequisite
+            for values in EXECUTION_PREREQUISITES.values()
+            for prerequisite in values
+        }
+        self.assertLessEqual(prerequisites, stages)
 
     def test_local_change_contracts_skip_repository_orchestrator_shards(self) -> None:
         all_contracts = gate_contract_definitions(ROOT, include_orchestrators=True)

--- a/tests/quality_metrics_contract.py
+++ b/tests/quality_metrics_contract.py
@@ -12,11 +12,13 @@ import subprocess
 import sys
 import tempfile
 from typing import Any, Optional, Tuple
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "tools"))
 
+import quality_metrics  # noqa: E402
 from quality_metrics import build_metrics, collect_coverage  # noqa: E402
 from quality_policy import POLICY_FILE, Policy  # noqa: E402
 
@@ -164,6 +166,7 @@ def evaluate_arguments(
     baseline: Optional[Path] = None,
     authority: str = "local-diagnostic",
     source_commit: str = SOURCE_COMMIT,
+    opportunities: Optional[Path] = None,
 ) -> list[str]:
     arguments = [
         "evaluate",
@@ -182,6 +185,8 @@ def evaluate_arguments(
     ]
     if baseline is not None:
         arguments.extend(("--baseline-root", str(baseline)))
+    if opportunities is not None:
+        arguments.extend(("--opportunities-output", str(opportunities)))
     return arguments
 
 
@@ -201,6 +206,45 @@ def main() -> None:
         baseline_metrics = root / "baseline-metrics.json"
         baseline_root = root / "baseline"
 
+        test_binary = root / "tests-binary"
+        unit_profile = root / "unit.profdata"
+        app_binary = root / "app-binary"
+        profile_directory = root / "ui-profiles"
+        profile_directory.mkdir()
+        for fixture in (test_binary, unit_profile, app_binary):
+            fixture.write_bytes(b"fixture")
+        (profile_directory / "ui.profraw").write_bytes(b"fixture")
+        coverage_export = json.dumps(coverage_document()).encode("utf-8")
+        coverage_commands: list[list[str]] = []
+
+        def fake_coverage_run(
+            command: list[str], *, text: bool = True
+        ) -> subprocess.CompletedProcess[Any]:
+            coverage_commands.append(command)
+            if "llvm-profdata" in command:
+                Path(command[-1]).write_bytes(b"combined")
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(
+                command, 0, stdout=coverage_export, stderr=b""
+            )
+
+        with patch.object(quality_metrics, "run", side_effect=fake_coverage_run):
+            merged_export = quality_metrics.export_coverage(
+                test_binary,
+                unit_profile,
+                [app_binary],
+                profile_directory,
+            )
+        assert merged_export == coverage_document()
+        assert len(coverage_commands) == 2
+        assert "llvm-profdata" in coverage_commands[0]
+        assert str(unit_profile) in coverage_commands[0]
+        assert str(profile_directory / "ui.profraw") in coverage_commands[0]
+        assert "llvm-cov" in coverage_commands[1]
+        assert coverage_commands[1][coverage_commands[1].index("-object") + 1] == str(
+            app_binary
+        )
+
         write_json(coverage, coverage_document())
         tests.write_text("\n".join(test_lines()) + "\n", encoding="utf-8")
         write_json(changed, {})
@@ -218,6 +262,7 @@ def main() -> None:
 
         write_json(changed, {"app/Sources/DetachApp/Synthetic.swift": list(range(1, 11))})
         current = root / "current.json"
+        current_opportunities = root / "current-opportunities.json"
         invoke(
             evaluate_arguments(
                 coverage,
@@ -226,6 +271,7 @@ def main() -> None:
                 changed,
                 baseline=baseline_root,
                 authority="ci-merge",
+                opportunities=current_opportunities,
             )
         )
         document = json.loads(current.read_text(encoding="utf-8"))
@@ -233,6 +279,52 @@ def main() -> None:
         assert document["suites"]["ui"]["line_coverage"]["percent"] == 90.0
         assert document["changed_lines"]["status"] == "passed"
         assert document["changed_lines"]["line_coverage"]["percent"] == 90.0
+        invoke(["validate-opportunities", str(current_opportunities)])
+        opportunity_document = json.loads(
+            current_opportunities.read_text(encoding="utf-8")
+        )
+        assert opportunity_document["observed"]["percent"] == 90.0
+        assert opportunity_document["next_milestone_percent"] == 95
+        assert opportunity_document["lines_to_milestone"] == 1
+        assert opportunity_document["opportunities"][0]["path"] == (
+            "app/Sources/DetachApp/Synthetic.swift"
+        )
+        assert opportunity_document["opportunities"][0]["uncovered"] == 1
+
+        malformed_opportunities = json.loads(
+            current_opportunities.read_text(encoding="utf-8")
+        )
+        malformed_opportunities["opportunities"][0]["uncovered"] = 2
+        malformed_opportunities_path = root / "malformed-opportunities.json"
+        write_json(malformed_opportunities_path, malformed_opportunities)
+        malformed_opportunities_result = invoke(
+            ["validate-opportunities", str(malformed_opportunities_path)],
+            expected=2,
+        )
+        require_text(
+            malformed_opportunities_result,
+            "uncovered count is inconsistent",
+        )
+
+        extra_coverage_input = invoke(
+            [
+                *evaluate_arguments(
+                    coverage,
+                    tests,
+                    root / "extra-coverage-input.json",
+                    changed,
+                ),
+                "--additional-object",
+                str(coverage),
+                "--additional-profile-directory",
+                str(root),
+            ],
+            expected=2,
+        )
+        require_text(
+            extra_coverage_input,
+            "additional coverage inputs require a test binary",
+        )
 
         promoted_metrics = root / "promoted-metrics.json"
         promoted_document = json.loads(baseline_metrics.read_text(encoding="utf-8"))

--- a/tests/quality_promote_contract.py
+++ b/tests/quality_promote_contract.py
@@ -73,6 +73,32 @@ def metrics_document() -> dict[str, object]:
     }
 
 
+def opportunities_document() -> dict[str, object]:
+    return {
+        "schema": 1,
+        "policy": POLICY.version,
+        "source_commit": TESTED,
+        "suite": "ui",
+        "observed": {"covered": 3, "percent": 30.0, "total": 10},
+        "next_milestone_percent": 35,
+        "lines_to_milestone": 1,
+        "opportunities": [
+            {
+                "rank": 1,
+                "path": "app/Sources/DetachApp/Synthetic.swift",
+                "risk": "user-journey",
+                "risk_tier": 1,
+                "line_coverage": {"covered": 3, "percent": 30.0, "total": 10},
+                "uncovered": 7,
+                "capabilities": [],
+                "requirements": [],
+                "journeys": [],
+                "recommended_evidence": "behavioral-unit-test",
+            }
+        ],
+    }
+
+
 def create_evidence(root: Path) -> Path:
     run_dir = root / "20260812T120000Z-1"
     run_dir.mkdir(parents=True)
@@ -92,6 +118,7 @@ def create_evidence(root: Path) -> Path:
     environment = run_dir / "environment.tsv"
     environment.write_text("schema\t1\narchitecture\ttest\n", encoding="utf-8")
     write_json(run_dir / "quality-metrics.json", metrics_document())
+    write_json(run_dir / "coverage-opportunities.json", opportunities_document())
     (run_dir / "scenarios.jsonl").write_text("{}\n", encoding="utf-8")
     (run_dir / "scenarios.junit.xml").write_text(
         '<testsuite name="quality" tests="0"/>\n', encoding="utf-8"
@@ -102,6 +129,7 @@ def create_evidence(root: Path) -> Path:
         + "".join(
             f"file\t{name}\t{digest(run_dir / name)}\n"
             for name in (
+                "coverage-opportunities.json",
                 "quality-metrics.json",
                 "scenarios.jsonl",
                 "scenarios.junit.xml",

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -23,6 +23,24 @@ run_validation() {
 
 run_validation "$APP"
 
+if DETACH_TEST_APP="$APP" DETACH_UI_E2E_VALIDATE_ONLY=1 \
+    DETACH_UI_E2E_COVERAGE_BINARY="$TMP_ROOT/missing-coverage-binary" \
+    "$ROOT/tests/ui-e2e.sh" >"$TMP_ROOT/missing-coverage.log" 2>&1; then
+  printf 'UI e2e accepted a missing coverage executable\n' >&2
+  exit 1
+fi
+grep -F 'coverage executable is missing or unsafe' \
+  "$TMP_ROOT/missing-coverage.log" >/dev/null
+
+if DETACH_TEST_APP="$APP" DETACH_UI_E2E_VALIDATE_ONLY=1 \
+    DETACH_UI_E2E_COVERAGE_BINARY="$APP/Contents/MacOS/Detach" \
+    "$ROOT/tests/ui-e2e.sh" >"$TMP_ROOT/uninstrumented-coverage.log" 2>&1; then
+  printf 'UI e2e accepted an uninstrumented coverage executable\n' >&2
+  exit 1
+fi
+grep -F 'coverage executable has no coverage map' \
+  "$TMP_ROOT/uninstrumented-coverage.log" >/dev/null
+
 for invocation in \
   'list --json' \
   'codex logs --ansi detach-codex-ui-running' \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -7,6 +7,7 @@ SOURCE_APP="${DETACH_TEST_APP:-$ROOT/app/build/Detach.app}"
 VALIDATE_ONLY="${DETACH_UI_E2E_VALIDATE_ONLY:-0}"
 KEEP="${DETACH_UI_E2E_KEEP:-0}"
 ARTIFACT_DIR="${DETACH_UI_E2E_ARTIFACT_DIR:-}"
+COVERAGE_BINARY="${DETACH_UI_E2E_COVERAGE_BINARY:-}"
 TEST_ROOT=""
 APP_PID=""
 
@@ -105,6 +106,22 @@ case "$VALIDATE_ONLY:$KEEP" in 0:0|0:1|1:0|1:1) ;;
   *) printf 'invalid UI e2e boolean option\n' >&2; exit 2 ;;
 esac
 validate_fresh_app "$SOURCE_APP"
+if [ -n "$COVERAGE_BINARY" ]; then
+  [ -f "$COVERAGE_BINARY" ] && [ ! -L "$COVERAGE_BINARY" ] && \
+    [ -x "$COVERAGE_BINARY" ] || {
+    printf 'UI e2e: coverage executable is missing or unsafe\n' >&2
+    exit 2
+  }
+  [ "$(lipo -archs "$COVERAGE_BINARY")" = arm64 ] || {
+    printf 'UI e2e: coverage executable must be arm64-only\n' >&2
+    exit 2
+  }
+  otool -l "$COVERAGE_BINARY" | grep -F '__llvm_covmap' >/dev/null || {
+    printf 'UI e2e: coverage executable has no coverage map\n' >&2
+    exit 2
+  }
+fi
+
 [ "$VALIDATE_ONLY" = 0 ] || exit 0
 
 TEST_ROOT="$(mktemp -d /private/tmp/detach-ui-e2e.XXXXXX)"
@@ -122,6 +139,19 @@ UI_E2E_DEADLINE=$((SECONDS + 38))
 mkdir -p "$TEST_HOME/.local/bin" "$TEST_HOME/Library/Preferences" \
   "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
 ditto "$SOURCE_APP" "$TEST_APP"
+
+if [ -n "$COVERAGE_BINARY" ]; then
+  install -m 0755 "$COVERAGE_BINARY" "$TEST_APP/Contents/MacOS/Detach"
+  if ! otool -l "$TEST_APP/Contents/MacOS/Detach" | awk '
+      $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+      in_rpath && $1 == "path" && $2 == "@executable_path/../Frameworks" { found = 1 }
+      in_rpath && $1 == "path" { in_rpath = 0 }
+      END { exit found ? 0 : 1 }
+    '; then
+    install_name_tool -add_rpath '@executable_path/../Frameworks' \
+      "$TEST_APP/Contents/MacOS/Detach"
+  fi
+fi
 
 # The test copy cannot install, repair, unregister, power-protect, or invoke a
 # bundled runtime even if the app regresses. Only the main UI executable and

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -22,7 +22,7 @@ from quality_care import (
     validate_input_bindings as validate_care_inputs,
     validate_summary as validate_care_summary,
 )
-from quality_metrics import MetricsError, validate_metrics
+from quality_metrics import MetricsError, validate_metrics, validate_opportunities
 from quality_mutation import MutationError, validate_summary
 from quality_promote import PromotionError, validate_promotion
 from quality_security import SecurityError, validate_summary as validate_security_summary
@@ -173,6 +173,47 @@ def read_metrics(run_dir: Path, manifest: dict[str, str]) -> Optional[dict[str, 
     if metrics["source_commit"] != manifest["source_commit"]:
         raise DashboardError("quality metrics source does not match the run")
     return metrics
+
+
+def read_coverage_opportunities(
+    run_dir: Path, manifest: dict[str, str], metrics: Optional[dict[str, Any]]
+) -> Optional[dict[str, Any]]:
+    if metrics is None:
+        return None
+    opportunities_path = safe_file(
+        run_dir / "coverage-opportunities.json", "coverage opportunities"
+    )
+    artifacts_path = safe_file(run_dir / "artifacts.tsv", "artifact inventory")
+    if hashlib.sha256(artifacts_path.read_bytes()).hexdigest() != manifest["artifacts_sha256"]:
+        raise DashboardError("artifact inventory digest does not match the manifest")
+    expected_digests: list[str] = []
+    for line_number, line in enumerate(
+        artifacts_path.read_text(encoding="utf-8").splitlines(), 1
+    ):
+        fields = line.split("\t")
+        if fields == ["schema", "1"]:
+            continue
+        if len(fields) != 3 or fields[0] != "file":
+            raise DashboardError(f"artifact inventory line {line_number} is malformed")
+        if fields[1] == "coverage-opportunities.json":
+            expected_digests.append(fields[2])
+    if len(expected_digests) != 1:
+        raise DashboardError("coverage opportunities digest is missing or duplicated")
+    if hashlib.sha256(opportunities_path.read_bytes()).hexdigest() != expected_digests[0]:
+        raise DashboardError("coverage opportunities digest does not match the inventory")
+    try:
+        opportunities = validate_opportunities(
+            json.loads(opportunities_path.read_text(encoding="utf-8"))
+        )
+    except (MetricsError, json.JSONDecodeError, UnicodeError) as error:
+        raise DashboardError(f"coverage opportunities are invalid: {error}") from error
+    if opportunities["policy"] != int(manifest["policy"]):
+        raise DashboardError("coverage opportunities policy does not match the run")
+    if opportunities["source_commit"] != manifest["source_commit"]:
+        raise DashboardError("coverage opportunities source does not match the run")
+    if opportunities["observed"] != metrics["suites"]["ui"]["line_coverage"]:
+        raise DashboardError("coverage opportunities do not match UI metrics")
+    return opportunities
 
 
 def read_policy() -> dict[str, Any]:
@@ -434,6 +475,9 @@ def build_data(
     trend_walls = [trend["wall_seconds"] for trend in trends]
     slowest = max(stages, key=lambda stage: stage["duration_seconds"], default=None)
     metrics = read_metrics(run_dir, manifest)
+    coverage_opportunities = read_coverage_opportunities(
+        run_dir, manifest, metrics
+    )
     mutation = read_mutation_summary(mutation_summary, int(manifest["policy"]))
     care = read_care_summary(
         care_summary,
@@ -444,7 +488,7 @@ def build_data(
         security_summary, int(manifest["policy"])
     )
     return {
-        "schema": 2,
+        "schema": 3,
         "run": {
             "id": run_dir.name,
             "commit": effective_commit,
@@ -478,6 +522,11 @@ def build_data(
             "run_wall_p50_seconds": percentile(trend_walls, 50),
             "run_wall_p95_seconds": percentile(trend_walls, 95),
             "coverage": metrics if metrics is not None else "not-yet-emitted",
+            "coverage_opportunities": (
+                coverage_opportunities
+                if coverage_opportunities is not None
+                else "not-yet-emitted"
+            ),
             "mutation": mutation if mutation is not None else "not-yet-emitted",
             "care": care if care is not None else "not-yet-emitted",
             "merge": merge_evidence(
@@ -564,6 +613,27 @@ def render_html(data: dict[str, Any]) -> str:
         )
     else:
         coverage_text = str(coverage)
+    opportunities = quality["coverage_opportunities"]
+    if isinstance(opportunities, dict):
+        opportunity_rows = "\n".join(
+            f'<tr><td class="number">{entry["rank"]}</td>'
+            f'<td><code>{html.escape(entry["path"])}</code></td>'
+            f'<td>{html.escape(entry["risk"])}</td>'
+            f'<td class="number">{entry["line_coverage"]["percent"]:.2f}%</td>'
+            f'<td class="number">{entry["uncovered"]}</td>'
+            f'<td>{html.escape(entry["recommended_evidence"])}</td>'
+            f'<td>{html.escape(", ".join(entry["journeys"]))}</td></tr>'
+            for entry in opportunities["opportunities"][:10]
+        ) or '<tr><td colspan="7">No uncovered UI source remains.</td></tr>'
+        opportunity_summary = (
+            f'Observed {opportunities["observed"]["percent"]:.2f}%. '
+            f'Next automatic milestone: {opportunities["next_milestone_percent"]}% '
+            f'({opportunities["lines_to_milestone"]} executable lines).'
+        )
+        opportunity_section = f'''
+    <section><h2>UI coverage opportunities</h2><p class="section-note">{html.escape(opportunity_summary)}</p><div class="table-wrap"><table><thead><tr><th class="number">Rank</th><th>Source</th><th>Risk</th><th class="number">Covered</th><th class="number">Missed</th><th>Evidence</th><th>User journeys</th></tr></thead><tbody>{opportunity_rows}</tbody></table></div></section>'''
+    else:
+        opportunity_section = ""
     mutation = quality["mutation"]
     if isinstance(mutation, dict):
         mutation_text = (
@@ -655,6 +725,7 @@ def render_html(data: dict[str, Any]) -> str:
     .journey li {{ display:flex; justify-content:space-between; gap:12px; padding:7px 0; border-bottom:1px solid var(--line); }} .journey li:last-child {{ border:0; }}
     .gaps {{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:1px; background:var(--line); border:1px solid var(--line); }} .gap {{ padding:14px; background:var(--panel); }}
     .empty {{ padding:20px; border:1px dashed var(--line); }}
+    .section-note {{ margin:-8px 0 12px; color:var(--muted); }}
     footer {{ padding:20px 0 36px; border-top:1px solid var(--line); color:var(--muted); }}
     #freshness.stale {{ color:var(--bad); font-weight:700; }}
     @media (max-width:850px) {{ .metrics {{ grid-template-columns:repeat(2,1fr); }} .metric {{ border-bottom:1px solid var(--line); }} .journeys {{ grid-template-columns:1fr; }} .gaps {{ grid-template-columns:repeat(2,1fr); }} }}
@@ -693,6 +764,7 @@ def render_html(data: dict[str, Any]) -> str:
       <div class="gap"><span class="eyebrow">Bounded merge</span><p>{html.escape(merge_text)}</p></div>
       <div class="gap"><span class="eyebrow">Security</span><p>{security_html}</p></div>
     </div></section>
+    {opportunity_section}
     <section><h2>Recent runs</h2><div class="table-wrap"><table><thead><tr><th>Commit</th><th>Authority</th><th>Result</th><th class="number">Wall</th><th>Finished</th></tr></thead><tbody>{trend_rows}</tbody></table></div></section>
   </main>
   <footer>Generated from digest-bound quality evidence. No result is inferred from terminal text.</footer>

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -51,11 +51,11 @@ DIGEST = re.compile(r"^[0-9a-f]{64}$")
 POSITIVE_INTEGER = re.compile(r"^[1-9][0-9]*$")
 NONNEGATIVE_INTEGER = re.compile(r"^[0-9]+$")
 EXECUTION_PREREQUISITES = {
-    "quality-contracts": "swift",
-    "ui-e2e": "app",
-    "codex": "app",
-    "claude": "app",
-    "tmux-runtime": "app",
+    "quality-contracts": ("swift", "ui-e2e"),
+    "ui-e2e": ("app",),
+    "codex": ("app",),
+    "claude": ("app",),
+    "tmux-runtime": ("app",),
 }
 PROVIDER_WAVE = (
     "codex",
@@ -659,9 +659,10 @@ class QualityGate:
 
     def artifact_inventory(self) -> None:
         files: list[Path] = []
-        metrics = self.run_dir / "quality-metrics.json"
-        if metrics.exists():
-            files.append(metrics)
+        for name in ("quality-metrics.json", "coverage-opportunities.json"):
+            evidence = self.run_dir / name
+            if evidence.exists():
+                files.append(evidence)
         for name in ("scenarios.jsonl", "scenarios.junit.xml", "repair-bundle.json"):
             path = self.run_dir / name
             if path.exists():
@@ -899,6 +900,7 @@ class QualityGate:
                 raise GateError("resume artifact inventory path is unsafe")
             if not (
                 relative == "quality-metrics.json"
+                or relative == "coverage-opportunities.json"
                 or relative == "scenarios.jsonl"
                 or relative == "scenarios.junit.xml"
                 or relative == "repair-bundle.json"
@@ -1026,19 +1028,26 @@ class QualityGate:
 
     def reusable(self, stage: str) -> bool:
         result = self.prior_results.get(stage)
+        if stage == "ui-e2e" and "quality-contracts" in self.selected:
+            metrics = self.prior_results.get("quality-contracts")
+            if metrics is None or metrics.status not in ("passed", "reused"):
+                return False
         return result is not None and result.status in ("passed", "reused")
 
     def prerequisite_failed(self, stage: str) -> bool:
-        prerequisite = EXECUTION_PREREQUISITES.get(stage)
-        if prerequisite is None:
+        prerequisites = EXECUTION_PREREQUISITES.get(stage)
+        if prerequisites is None:
             return False
-        result = self.results.get(prerequisite)
-        return result is not None and result.status in (
-            "failed",
-            "environment-failed",
-            "timeout",
-            "interrupted",
-            "blocked",
+        return any(
+            self.results.get(prerequisite) is not None
+            and self.results[prerequisite].status in (
+                "failed",
+                "environment-failed",
+                "timeout",
+                "interrupted",
+                "blocked",
+            )
+            for prerequisite in prerequisites
         )
 
     def timeout_for_stage(self, stage: str) -> int:
@@ -1084,6 +1093,7 @@ class QualityGate:
                 "DETACH_QUALITY_GATE_RESOLVED_BASE": self.resolved_base,
                 "DETACH_QUALITY_GATE_MODE": self.options.mode,
                 "DETACH_QUALITY_GATE_DIAGNOSTIC_STAGE": self.options.stage,
+                "DETACH_QUALITY_GATE_SELECTED_STAGES": ",".join(self.selected),
                 "DETACH_QUALITY_GATE_TEST_MODE": str(int(self.test_mode)),
                 "DETACH_QUALITY_GATE_TEST_REAL_STATIC": str(
                     int(self.test_real_static)
@@ -1119,6 +1129,15 @@ class QualityGate:
                     )
                 shutil.copyfile(metrics, self.run_dir / "quality-metrics.json")
                 (self.run_dir / "quality-metrics.json").chmod(0o600)
+                opportunities = self.resume_dir / "coverage-opportunities.json"
+                if not opportunities.is_file() or opportunities.is_symlink():
+                    raise GateError(
+                        "reused quality-contracts evidence has no safe coverage opportunities"
+                    )
+                shutil.copyfile(
+                    opportunities, self.run_dir / "coverage-opportunities.json"
+                )
+                (self.run_dir / "coverage-opportunities.json").chmod(0o600)
             self.record_result(
                 stage,
                 StageResult("reused", prior.duration, reused_log, 0, origin),
@@ -1581,11 +1600,11 @@ class QualityGate:
             self.wait_for(("static",))
             self.launch("swift")
             self.wait_for(("swift",))
-            self.launch("quality-contracts")
             self.launch("app")
             self.wait_for(("app",))
             self.launch("ui-e2e")
             self.wait_for(("ui-e2e",))
+            self.launch("quality-contracts")
             self.wait_for(("quality-contracts",))
             for stage in PROVIDER_WAVE:
                 self.launch(stage)
@@ -1975,6 +1994,9 @@ def run_stage_worker(stage: str) -> int:
                     "DETACH_QUALITY_METRICS_OUTPUT": str(
                         run_dir / "quality-metrics.json"
                     ),
+                    "DETACH_QUALITY_OPPORTUNITIES_OUTPUT": str(
+                        run_dir / "coverage-opportunities.json"
+                    ),
                     "DETACH_QUALITY_SOURCE_COMMIT": source_commit,
                     "DETACH_QUALITY_AUTHORITY": authority,
                 }
@@ -1988,6 +2010,10 @@ def run_stage_worker(stage: str) -> int:
         for scenario_id in instrumented:
             record_scenario_event("begin", scenario_id)
         status = child_run([str(fixture)], cwd=root, env=environment)
+        if status == 0 and stage == "quality-contracts":
+            opportunities = run_dir / "coverage-opportunities.json"
+            if not opportunities.exists():
+                write_private(opportunities, "{}\n")
         if status == 0:
             for scenario_id in instrumented:
                 record_scenario_event("pass", scenario_id)
@@ -2029,20 +2055,94 @@ def run_stage_worker(stage: str) -> int:
             {
                 "DETACH_SWIFT_TEST_LOG": str(run_dir / "swift.log"),
                 "DETACH_QUALITY_METRICS_OUTPUT": str(run_dir / "quality-metrics.json"),
+                "DETACH_QUALITY_OPPORTUNITIES_OUTPUT": str(
+                    run_dir / "coverage-opportunities.json"
+                ),
                 "DETACH_QUALITY_SOURCE_COMMIT": source_commit,
                 "DETACH_QUALITY_AUTHORITY": authority,
             }
         )
-        return child_run([str(root / "tests/quality-contracts.sh")], env=environment)
+        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+        if "ui-e2e" in selected:
+            profile_directory = (
+                root / "app/build/quality-ui-coverage" / run_dir.name
+            )
+            environment.update(
+                {
+                    "DETACH_UI_COVERAGE_BINARY": str(
+                        root / "app/.build/arm64-apple-macosx/release/DetachApp"
+                    ),
+                    "DETACH_UI_COVERAGE_PROFILE_DIR": str(profile_directory),
+                }
+            )
+        status = child_run([str(root / "tests/quality-contracts.sh")], env=environment)
+        if "ui-e2e" in selected:
+            if profile_directory.is_symlink():
+                print(
+                    "quality-gate: refusing unsafe UI coverage cleanup",
+                    file=sys.stderr,
+                )
+                return status or 2
+            shutil.rmtree(profile_directory, ignore_errors=True)
+        return status
     if stage == "app":
-        return child_run([str(root / "app/scripts/make-app.sh")])
+        status = child_run([str(root / "app/scripts/make-app.sh")])
+        if status:
+            return status
+        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+        if "quality-contracts" not in selected:
+            return 0
+        return child_run(
+            [
+                "swift",
+                "build",
+                "--enable-code-coverage",
+                "--disable-sandbox",
+                "--disable-automatic-resolution",
+                "-c",
+                "release",
+                "--triple",
+                "arm64-apple-macosx26.0",
+                "--scratch-path",
+                ".build",
+                "--product",
+                "DetachApp",
+            ],
+            cwd=root / "app",
+        )
     if stage == "ui-e2e":
         status = child_run([str(root / "tests/ui-e2e-contract.sh")])
         if status:
             return status
         environment = os.environ.copy()
         environment["DETACH_UI_E2E_ARTIFACT_DIR"] = str(run_dir / "ui-e2e-artifacts")
-        return child_run([str(root / "tests/ui-e2e.sh")], env=environment)
+        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+        coverage_dir = root / "app/build/quality-ui-coverage" / run_dir.name
+        if "quality-contracts" in selected:
+            coverage_binary = (
+                root / "app/.build/arm64-apple-macosx/release/DetachApp"
+            )
+            if not coverage_binary.is_file() or coverage_binary.is_symlink():
+                print(
+                    "quality-gate: app stage emitted no safe coverage executable",
+                    file=sys.stderr,
+                )
+                return 2
+            coverage_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+            environment["LLVM_PROFILE_FILE"] = str(
+                coverage_dir / "%p-%m.profraw"
+            )
+            environment["DETACH_UI_E2E_COVERAGE_BINARY"] = str(coverage_binary)
+        status = child_run([str(root / "tests/ui-e2e.sh")], env=environment)
+        if status == 0 and "quality-contracts" in selected:
+            profiles = [
+                path for path in coverage_dir.glob("*.profraw")
+                if path.is_file() and not path.is_symlink()
+            ]
+            if not profiles:
+                print("quality-gate: UI e2e emitted no coverage profile", file=sys.stderr)
+                return 2
+        return status
     payload = root / "app/build/Detach.app/Contents/Resources/DetachCLI"
     tmux = payload / "tmux"
     state = payload / "detach-state"

--- a/tools/quality_metrics.py
+++ b/tools/quality_metrics.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 from pathlib import Path
 import re
 import subprocess
 import sys
+import tempfile
 from typing import Any, NoReturn, Optional
 
 from quality_policy import POLICY_FILE, Policy, PolicyError, ROOT
@@ -179,6 +181,210 @@ def collect_coverage(document: Any) -> dict[str, dict[str, Any]]:
     if not files:
         raise MetricsError("LLVM coverage contains no Detach sources")
     return files
+
+
+def references(value: str) -> list[str]:
+    return [] if value in ("", "-") else value.split(",")
+
+
+def opportunity_risk(
+    path: str, policy: Policy, release_domain: str
+) -> tuple[int, str]:
+    if any(source == path for source, _ in policy.critical):
+        return 5, "critical"
+    return {
+        "both": (4, "power-and-installation"),
+        "install": (3, "installation-sensitive"),
+        "unknown": (2, "unclassified"),
+        "safe": (1, "user-journey"),
+    }[release_domain]
+
+
+def next_coverage_milestone(current_percent: float) -> int:
+    if current_percent >= 100:
+        return 100
+    milestone = min(100, int(math.ceil(current_percent / 5.0) * 5))
+    return min(100, milestone + 5) if milestone <= current_percent else milestone
+
+
+def build_opportunities(
+    coverage: dict[str, dict[str, Any]],
+    metrics: dict[str, Any],
+    policy: Policy,
+    source_commit: str,
+) -> dict[str, Any]:
+    observed = metrics["suites"]["ui"]["line_coverage"]
+    current_percent = observed["percent"]
+    milestone = next_coverage_milestone(current_percent)
+    lines_to_milestone = max(
+        0,
+        math.ceil(milestone * observed["total"] / 100) - observed["covered"],
+    )
+    entries: list[dict[str, Any]] = []
+    for path, value in coverage.items():
+        if group_for_source(path, policy) != "ui":
+            continue
+        uncovered = value["total"] - value["covered"]
+        if uncovered == 0:
+            continue
+        classification = policy.classify(path)
+        capabilities = sorted(references(classification.capabilities))
+        journeys = sorted(references(classification.journeys))
+        requirements = sorted(
+            {
+                requirement
+                for capability in capabilities
+                for requirement in references(policy.capabilities[capability][1])
+            }
+            | {
+                requirement
+                for journey in journeys
+                for requirement in references(policy.journeys[journey][1])
+            }
+        )
+        scenario_stages = {
+            policy.scenarios[scenario][0]
+            for journey in journeys
+            for scenario in references(policy.journeys[journey][2])
+            if policy.scenarios[scenario][1] not in ("planned", "manual-release")
+        }
+        risk_tier, risk = opportunity_risk(
+            path, policy, classification.release_domain
+        )
+        entries.append(
+            {
+                "path": path,
+                "risk": risk,
+                "risk_tier": risk_tier,
+                "line_coverage": coverage_value(value["covered"], value["total"]),
+                "uncovered": uncovered,
+                "capabilities": capabilities,
+                "requirements": requirements,
+                "journeys": journeys,
+                "recommended_evidence": (
+                    "packaged-user-journey"
+                    if "ui-e2e" in scenario_stages
+                    else "behavioral-unit-test"
+                ),
+            }
+        )
+    entries.sort(
+        key=lambda item: (
+            -item["risk_tier"],
+            -len(item["requirements"]),
+            -len(item["journeys"]),
+            -item["uncovered"],
+            item["path"],
+        )
+    )
+    for rank, entry in enumerate(entries, 1):
+        entry["rank"] = rank
+    return {
+        "schema": 1,
+        "policy": policy.version,
+        "source_commit": source_commit,
+        "suite": "ui",
+        "observed": observed,
+        "next_milestone_percent": milestone,
+        "lines_to_milestone": lines_to_milestone,
+        "opportunities": entries,
+    }
+
+
+def validate_opportunities(
+    document: Any, *, expected_policy: Optional[int] = None
+) -> dict[str, Any]:
+    required = {
+        "schema",
+        "policy",
+        "source_commit",
+        "suite",
+        "observed",
+        "next_milestone_percent",
+        "lines_to_milestone",
+        "opportunities",
+    }
+    if (
+        not isinstance(document, dict)
+        or set(document) != required
+        or document.get("schema") != 1
+        or document.get("suite") != "ui"
+    ):
+        raise MetricsError("coverage opportunities schema is unsupported")
+    policy_version = document.get("policy")
+    if not isinstance(policy_version, int) or policy_version <= 0:
+        raise MetricsError("coverage opportunities policy is invalid")
+    if expected_policy is not None and policy_version != expected_policy:
+        raise MetricsError("coverage opportunities use another policy")
+    if not HEX_COMMIT.fullmatch(document.get("source_commit", "")):
+        raise MetricsError("coverage opportunities source commit is invalid")
+    covered, total = validate_coverage(document.get("observed"), "opportunity observed")
+    milestone = document.get("next_milestone_percent")
+    if not isinstance(milestone, int) or not 1 <= milestone <= 100:
+        raise MetricsError("coverage opportunity milestone is invalid")
+    if milestone != next_coverage_milestone(document["observed"]["percent"]):
+        raise MetricsError("coverage opportunity milestone is inconsistent")
+    expected_lines = max(0, math.ceil(milestone * total / 100) - covered)
+    if integer(document.get("lines_to_milestone"), "lines to milestone") != expected_lines:
+        raise MetricsError("coverage opportunity milestone line count is inconsistent")
+    entries = document.get("opportunities")
+    if not isinstance(entries, list):
+        raise MetricsError("coverage opportunities are malformed")
+    paths: set[str] = set()
+    fields = {
+        "rank",
+        "path",
+        "risk",
+        "risk_tier",
+        "line_coverage",
+        "uncovered",
+        "capabilities",
+        "requirements",
+        "journeys",
+        "recommended_evidence",
+    }
+    risk_names = {
+        1: "user-journey",
+        2: "unclassified",
+        3: "installation-sensitive",
+        4: "power-and-installation",
+        5: "critical",
+    }
+    for expected_rank, entry in enumerate(entries, 1):
+        if not isinstance(entry, dict) or set(entry) != fields:
+            raise MetricsError("coverage opportunity record is malformed")
+        path = entry.get("path")
+        risk_tier = entry.get("risk_tier")
+        if (
+            entry.get("rank") != expected_rank
+            or not isinstance(path, str)
+            or not path.startswith(UI_PREFIX)
+            or path in paths
+            or risk_tier not in risk_names
+            or entry.get("risk") != risk_names[risk_tier]
+            or entry.get("recommended_evidence")
+            not in ("packaged-user-journey", "behavioral-unit-test")
+        ):
+            raise MetricsError("coverage opportunity identity is invalid")
+        paths.add(path)
+        entry_covered, entry_total = validate_coverage(
+            entry.get("line_coverage"), path
+        )
+        if (
+            integer(entry.get("uncovered"), f"{path} uncovered")
+            != entry_total - entry_covered
+            or entry_covered == entry_total
+        ):
+            raise MetricsError("coverage opportunity uncovered count is inconsistent")
+        for key in ("capabilities", "requirements", "journeys"):
+            values = entry.get(key)
+            if (
+                not isinstance(values, list)
+                or values != sorted(set(values))
+                or any(not isinstance(value, str) or not value for value in values)
+            ):
+                raise MetricsError(f"coverage opportunity {key} are malformed")
+    return document
 
 
 def collect_tests(path: Path) -> set[str]:
@@ -674,24 +880,54 @@ def build_metrics(
     }
 
 
-def export_coverage(binary: Path, profile: Path) -> Any:
+def export_coverage(
+    binary: Path,
+    profile: Path,
+    additional_objects: list[Path],
+    additional_profile_directory: Optional[Path],
+) -> Any:
     safe_file(binary, "Swift test binary")
     safe_file(profile, "Swift coverage profile")
-    result = run(
-        [
-            "xcrun",
-            "llvm-cov",
-            "export",
-            str(binary),
-            "-instr-profile",
-            str(profile),
-        ],
-        text=False,
-    )
-    try:
-        return json.loads(result.stdout.decode("utf-8"))
-    except (UnicodeError, json.JSONDecodeError) as error:
-        raise MetricsError(f"LLVM coverage export is malformed: {error}") from error
+    for additional in additional_objects:
+        safe_file(additional, "additional coverage object")
+    with tempfile.TemporaryDirectory(prefix="detach-quality-coverage.") as temporary:
+        export_profile = profile
+        if additional_profile_directory is not None:
+            if (
+                not additional_profile_directory.is_dir()
+                or additional_profile_directory.is_symlink()
+            ):
+                raise MetricsError("additional coverage profile directory is missing or unsafe")
+            additional_profiles = sorted(
+                additional_profile_directory.glob("*.profraw")
+            )
+            if not additional_profiles:
+                raise MetricsError("additional coverage profile directory is empty")
+            for additional_profile in additional_profiles:
+                safe_file(additional_profile, "additional coverage profile")
+            export_profile = Path(temporary) / "combined.profdata"
+            run(
+                [
+                    "xcrun",
+                    "llvm-profdata",
+                    "merge",
+                    "-sparse",
+                    str(profile),
+                    *(str(path) for path in additional_profiles),
+                    "-o",
+                    str(export_profile),
+                ]
+            )
+            safe_file(export_profile, "combined coverage profile")
+        arguments = ["xcrun", "llvm-cov", "export", str(binary)]
+        for additional in additional_objects:
+            arguments.extend(("-object", str(additional)))
+        arguments.extend(("-instr-profile", str(export_profile)))
+        result = run(arguments, text=False)
+        try:
+            return json.loads(result.stdout.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as error:
+            raise MetricsError(f"LLVM coverage export is malformed: {error}") from error
 
 
 def evaluate(arguments: argparse.Namespace) -> int:
@@ -702,11 +938,28 @@ def evaluate(arguments: argparse.Namespace) -> int:
     if arguments.test_changed_lines and test_mode != "1":
         raise MetricsError("test changed-line evidence is test-only")
     if arguments.coverage_json:
+        if arguments.additional_object or arguments.additional_profile_directory:
+            raise MetricsError("additional coverage inputs require a test binary")
         coverage_document = read_json(Path(arguments.coverage_json), "LLVM coverage")
     else:
         if not arguments.test_binary or not arguments.profile:
             raise MetricsError("test binary and profile are required")
-        coverage_document = export_coverage(Path(arguments.test_binary), Path(arguments.profile))
+        additional_objects = [Path(path) for path in arguments.additional_object]
+        profile_directory = (
+            Path(arguments.additional_profile_directory)
+            if arguments.additional_profile_directory
+            else None
+        )
+        if bool(additional_objects) != bool(profile_directory):
+            raise MetricsError(
+                "additional coverage objects and profile directory must occur together"
+            )
+        coverage_document = export_coverage(
+            Path(arguments.test_binary),
+            Path(arguments.profile),
+            additional_objects,
+            profile_directory,
+        )
     coverage = collect_coverage(coverage_document)
     tests = collect_tests(Path(arguments.tests))
     baseline_root = Path(arguments.baseline_root) if arguments.baseline_root else None
@@ -743,6 +996,12 @@ def evaluate(arguments: argparse.Namespace) -> int:
     )
     validate_metrics(document, expected_policy=policy.version)
     write_json(Path(arguments.output), document)
+    if arguments.opportunities_output:
+        opportunities = build_opportunities(
+            coverage, document, policy, arguments.source_commit
+        )
+        validate_opportunities(opportunities, expected_policy=policy.version)
+        write_json(Path(arguments.opportunities_output), opportunities)
     suites = document["suites"]
     changed = document["changed_lines"]
     print(
@@ -769,8 +1028,11 @@ def parser() -> argparse.ArgumentParser:
     source.add_argument("--coverage-json")
     source.add_argument("--test-binary")
     evaluate_parser.add_argument("--profile")
+    evaluate_parser.add_argument("--additional-object", action="append", default=[])
+    evaluate_parser.add_argument("--additional-profile-directory", default="")
     evaluate_parser.add_argument("--tests", required=True)
     evaluate_parser.add_argument("--output", required=True)
+    evaluate_parser.add_argument("--opportunities-output", default="")
     evaluate_parser.add_argument("--source-commit", required=True)
     evaluate_parser.add_argument("--base-commit", default="")
     evaluate_parser.add_argument("--baseline-root", default="")
@@ -782,6 +1044,8 @@ def parser() -> argparse.ArgumentParser:
     evaluate_parser.add_argument("--test-changed-lines", default="", help=argparse.SUPPRESS)
     validate_parser = subcommands.add_parser("validate")
     validate_parser.add_argument("path")
+    validate_opportunities_parser = subcommands.add_parser("validate-opportunities")
+    validate_opportunities_parser.add_argument("path")
     return result
 
 
@@ -793,6 +1057,15 @@ def main(arguments: list[str]) -> int:
         document = validate_metrics(read_json(Path(parsed.path), "quality metrics"))
         print(
             f"Quality metrics are valid: policy={document['policy']} "
+            f"source={document['source_commit']}"
+        )
+        return 0
+    if parsed.command == "validate-opportunities":
+        document = validate_opportunities(
+            read_json(Path(parsed.path), "coverage opportunities")
+        )
+        print(
+            f"Coverage opportunities are valid: policy={document['policy']} "
             f"source={document['source_commit']}"
         )
         return 0

--- a/tools/quality_promote.py
+++ b/tools/quality_promote.py
@@ -252,7 +252,12 @@ def artifact_inventory(run_dir: Path, manifest: dict[str, str]) -> dict[str, str
         if sha256(artifact) != fields[2]:
             raise PromotionError(f"evidence artifact digest does not match: {fields[1]}")
         values[fields[1]] = fields[2]
-    for required in ("quality-metrics.json", "scenarios.jsonl", "scenarios.junit.xml"):
+    for required in (
+        "coverage-opportunities.json",
+        "quality-metrics.json",
+        "scenarios.jsonl",
+        "scenarios.junit.xml",
+    ):
         if required not in values:
             raise PromotionError(f"required evidence artifact is missing: {required}")
     return values
@@ -318,7 +323,7 @@ def validate_evidence(
             raise PromotionError(f"{name} evidence digest does not match the manifest")
     validate_summary(run_dir, manifest, policy)
     artifact_inventory(run_dir, manifest)
-    from quality_metrics import read_json, validate_metrics
+    from quality_metrics import read_json, validate_metrics, validate_opportunities
 
     metrics = validate_metrics(
         read_json(run_dir / "quality-metrics.json", "quality metrics"),
@@ -326,6 +331,19 @@ def validate_evidence(
     )
     if metrics["source_commit"] != tested_commit or metrics["comparison"]["status"] != "passed":
         raise PromotionError("quality metrics are not passing evidence for the tested commit")
+    opportunities = validate_opportunities(
+        read_json(
+            run_dir / "coverage-opportunities.json", "coverage opportunities"
+        ),
+        expected_policy=policy.version,
+    )
+    if (
+        opportunities["source_commit"] != tested_commit
+        or opportunities["observed"] != metrics["suites"]["ui"]["line_coverage"]
+    ):
+        raise PromotionError(
+            "coverage opportunities do not match the tested UI metrics"
+        )
     return manifest, sha256(manifest_path)
 
 


### PR DESCRIPTION
Summary:
- merge Swift-test coverage with passed packaged-app user journeys
- publish a digest-bound, risk-ranked UI coverage opportunity report and dashboard section
- keep the normal app bundle public-safe and use an instrumented executable only in the stripped private UI copy
- preserve current time budgets and the last-green-main ratchet; add no manual coverage floor

Focused diagnostics:
- UI journey coverage: 66.94% (7,085/10,584); business coverage: 94.94%
- real instrumented packaged-app smoke: 12/12 scenarios passed
- quality metrics, dashboard, promotion, UI harness, gate selection/execution/resume contracts passed
- focused Swift UI event resolver tests passed
- static diagnostic passed

Not run: release, signing, notarization, publication, real power or closed-lid tests.