### PR TITLE
test: cover installation recovery paths

### DIFF
--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -7,6 +7,37 @@ enum InstallationContextOperation: Equatable, Sendable {
     case repair
 }
 
+@MainActor
+protocol InstallationWatchdogServicing: AnyObject {
+    var status: WatchdogStatus { get }
+    func reconcileAfterAppUpdate(forceReplacement: Bool) async throws
+    func enable() async throws
+    func disable() async throws
+    func openLoginItemsSettings()
+}
+
+extension WatchdogService: InstallationWatchdogServicing {}
+
+@MainActor
+protocol InstallationPowerHelperServicing: AnyObject {
+    var status: PowerHelperRegistrationStatus { get }
+    func reconcileAfterAppUpdate() async throws
+        -> PowerHelperReconciliationOutcome
+    func enable() async throws
+    func disable() async throws
+    func openApprovalSettings()
+}
+
+extension PowerHelperService: InstallationPowerHelperServicing {}
+
+@MainActor
+protocol InstallationDistributionServicing {
+    func synchronize(repair: Bool) async throws -> String
+    func doctor() async throws -> DoctorReport
+}
+
+extension DistributionClient: InstallationDistributionServicing {}
+
 @Observable @MainActor
 final class InstallationStore {
     private struct BundledMetadata {
@@ -45,8 +76,8 @@ final class InstallationStore {
 
     private static let onboardingCompletedKey = "onboardingCompleted"
     private let detachPath: String
-    private let watchdog = WatchdogService()
-    private let powerHelper = PowerHelperService()
+    private let watchdog: any InstallationWatchdogServicing
+    private let powerHelper: any InstallationPowerHelperServicing
     private let payloadDirectory: URL?
     private let bundleURL: URL
     private let bundledMetadata: BundledMetadata?
@@ -55,6 +86,10 @@ final class InstallationStore {
     private let defaults: UserDefaults
     private let contextOperationOverride:
         (@MainActor (InstallationContextOperation) async -> Void)?
+    private let applicationLocationValidator: @MainActor (URL) -> Bool
+    private let distributionClientFactory:
+        @MainActor (URL, URL, URL, URL) -> any InstallationDistributionServicing
+    private let cliFactory: @MainActor (URL) -> any DetachCLIRunning
     private var contextOperationRunning = false
     @ObservationIgnored private var currentContextOperation:
         InstallationContextOperation?
@@ -70,9 +105,28 @@ final class InstallationStore {
         defaults: UserDefaults = .standard,
         uiE2EScenario: String? = AppSettings.uiE2E?.scenario,
         contextOperationOverride:
-            (@MainActor (InstallationContextOperation) async -> Void)? = nil
+            (@MainActor (InstallationContextOperation) async -> Void)? = nil,
+        watchdog: (any InstallationWatchdogServicing)? = nil,
+        powerHelper: (any InstallationPowerHelperServicing)? = nil,
+        applicationLocationValidator: @escaping @MainActor (URL) -> Bool = {
+            UpdateConfiguration.isStableApplicationLocation($0)
+        },
+        distributionClientFactory: @escaping @MainActor
+            (URL, URL, URL, URL) -> any InstallationDistributionServicing = {
+                installerURL, cliURL, payloadDirectory, versionURL in
+                DistributionClient(
+                    installer: ProcessDetachCLI(executable: installerURL),
+                    cli: ProcessDetachCLI(executable: cliURL),
+                    payloadDirectory: payloadDirectory,
+                    versionFile: versionURL)
+            },
+        cliFactory: @escaping @MainActor (URL) -> any DetachCLIRunning = {
+            ProcessDetachCLI(executable: $0)
+        }
     ) {
         self.detachPath = detachPath
+        self.watchdog = watchdog ?? WatchdogService()
+        self.powerHelper = powerHelper ?? PowerHelperService()
         self.powerStateRoot = powerStateRoot ?? Self.defaultPowerStateRoot
         let heartbeatReader = PowerHeartbeatReader(
             statusURL: self.powerStateRoot
@@ -83,6 +137,9 @@ final class InstallationStore {
         onboardingEverCompleted = defaults.bool(
             forKey: Self.onboardingCompletedKey)
         self.contextOperationOverride = contextOperationOverride
+        self.applicationLocationValidator = applicationLocationValidator
+        self.distributionClientFactory = distributionClientFactory
+        self.cliFactory = cliFactory
         switch uiE2EScenario {
         case "onboarding-first-run": uiE2EOnboardingStep = .done
         case "onboarding-provider": uiE2EOnboardingStep = .provider
@@ -111,7 +168,7 @@ final class InstallationStore {
     var presentsUIE2EOnboarding: Bool { uiE2EOnboardingStep != nil }
     var isStableApplicationLocation: Bool {
         guard hasDistributionPayload else { return true }
-        return UpdateConfiguration.isStableApplicationLocation(bundleURL)
+        return applicationLocationValidator(bundleURL)
     }
     var isBusy: Bool { phase == .syncing || contextOperationRunning }
 
@@ -499,8 +556,8 @@ final class InstallationStore {
         do {
             try await watchdog.disable()
             try await powerHelper.disable()
-            let installer = ProcessDetachCLI(
-                executable: payloadDirectory.appendingPathComponent("detach-install"))
+            let installer = cliFactory(
+                payloadDirectory.appendingPathComponent("detach-install"))
             let result = try await installer.run(
                 arguments: ["uninstall", purgeState ? "--purge-state" : "--keep-state"],
                 timeout: 30)
@@ -537,11 +594,8 @@ final class InstallationStore {
         let installerURL = payloadDirectory.appendingPathComponent("detach-install")
         let versionURL = payloadDirectory.appendingPathComponent("VERSION")
         let cliURL = URL(fileURLWithPath: detachPath)
-        let client = DistributionClient(
-            installer: ProcessDetachCLI(executable: installerURL),
-            cli: ProcessDetachCLI(executable: cliURL),
-            payloadDirectory: payloadDirectory,
-            versionFile: versionURL)
+        let client = distributionClientFactory(
+            installerURL, cliURL, payloadDirectory, versionURL)
         do {
             lastInstallMessage = try await client.synchronize(repair: repair)
             report = try await client.doctor()
@@ -626,11 +680,11 @@ final class InstallationStore {
         powerHelperUpdateDeferred: Bool = false
     ) async {
         guard let payloadDirectory else { phase = .ready; return }
-        let client = DistributionClient(
-            installer: ProcessDetachCLI(executable: payloadDirectory.appendingPathComponent("detach-install")),
-            cli: ProcessDetachCLI(executable: URL(fileURLWithPath: detachPath)),
-            payloadDirectory: payloadDirectory,
-            versionFile: payloadDirectory.appendingPathComponent("VERSION"))
+        let client = distributionClientFactory(
+            payloadDirectory.appendingPathComponent("detach-install"),
+            URL(fileURLWithPath: detachPath),
+            payloadDirectory,
+            payloadDirectory.appendingPathComponent("VERSION"))
         do {
             report = try await client.doctor()
             if let bundledMetadata, let report {
@@ -641,6 +695,7 @@ final class InstallationStore {
                     payloadID: bundledMetadata.payloadID)
             }
             guard distributionMatchesBundle else {
+                powerHelperReadinessConfirmed = false
                 phase = .failed(L10n.string(
                     "The CLI is missing or belongs to another build; run Repair from the intended app version"))
                 return
@@ -656,6 +711,7 @@ final class InstallationStore {
                 updatePhase()
             }
         } catch {
+            powerHelperReadinessConfirmed = false
             phase = powerHelperUpdateDeferred && onboardingEverCompleted
                 ? .updateDeferred : .failed(error.localizedDescription)
         }

--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -111,18 +111,9 @@ final class InstallationStore {
         applicationLocationValidator: @escaping @MainActor (URL) -> Bool = {
             UpdateConfiguration.isStableApplicationLocation($0)
         },
-        distributionClientFactory: @escaping @MainActor
-            (URL, URL, URL, URL) -> any InstallationDistributionServicing = {
-                installerURL, cliURL, payloadDirectory, versionURL in
-                DistributionClient(
-                    installer: ProcessDetachCLI(executable: installerURL),
-                    cli: ProcessDetachCLI(executable: cliURL),
-                    payloadDirectory: payloadDirectory,
-                    versionFile: versionURL)
-            },
-        cliFactory: @escaping @MainActor (URL) -> any DetachCLIRunning = {
-            ProcessDetachCLI(executable: $0)
-        }
+        distributionClientFactory: (@MainActor
+            (URL, URL, URL, URL) -> any InstallationDistributionServicing)? = nil,
+        cliFactory: (@MainActor (URL) -> any DetachCLIRunning)? = nil
     ) {
         self.detachPath = detachPath
         self.watchdog = watchdog ?? WatchdogService()
@@ -139,7 +130,8 @@ final class InstallationStore {
         self.contextOperationOverride = contextOperationOverride
         self.applicationLocationValidator = applicationLocationValidator
         self.distributionClientFactory = distributionClientFactory
-        self.cliFactory = cliFactory
+            ?? Self.makeDistributionClient
+        self.cliFactory = cliFactory ?? Self.makeCLI
         switch uiE2EScenario {
         case "onboarding-first-run": uiE2EOnboardingStep = .done
         case "onboarding-provider": uiE2EOnboardingStep = .provider
@@ -162,6 +154,23 @@ final class InstallationStore {
             bundledMetadata = nil
         }
         powerProtectionState = watchdogHeartbeat.effectivePowerState
+    }
+
+    static func makeDistributionClient(
+        installerURL: URL,
+        cliURL: URL,
+        payloadDirectory: URL,
+        versionURL: URL
+    ) -> any InstallationDistributionServicing {
+        DistributionClient(
+            installer: ProcessDetachCLI(executable: installerURL),
+            cli: ProcessDetachCLI(executable: cliURL),
+            payloadDirectory: payloadDirectory,
+            versionFile: versionURL)
+    }
+
+    static func makeCLI(executable: URL) -> any DetachCLIRunning {
+        ProcessDetachCLI(executable: executable)
     }
 
     var hasDistributionPayload: Bool { payloadDirectory != nil }

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -37,6 +37,23 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertFalse(store.presentsUIE2EOnboarding)
     }
 
+    func testProductionFactoriesConstructRealProcessBoundaries() {
+        let installerURL = URL(fileURLWithPath: "/tmp/detach-install")
+        let cliURL = URL(fileURLWithPath: "/tmp/detach")
+        let payloadURL = URL(fileURLWithPath: "/tmp/payload")
+        let versionURL = payloadURL.appendingPathComponent("VERSION")
+
+        let distribution = InstallationStore.makeDistributionClient(
+            installerURL: installerURL,
+            cliURL: cliURL,
+            payloadDirectory: payloadURL,
+            versionURL: versionURL)
+        let cli = InstallationStore.makeCLI(executable: cliURL)
+
+        XCTAssertTrue(distribution is DistributionClient)
+        XCTAssertEqual((cli as? ProcessDetachCLI)?.executable, cliURL)
+    }
+
     func testUIE2EOnboardingFixturesExposeOnlyTheirRequestedStep() {
         let fixtures: [(String, OnboardingStep)] = [
             ("onboarding-first-run", .done),

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -512,6 +512,394 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertFalse(store.isBusy)
     }
 
+    func testPackagedBootstrapReconcilesServicesAndPublishesReadyState()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed payload")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+
+        await fixture.store.bootstrap()
+
+        XCTAssertEqual(fixture.store.phase, .ready)
+        XCTAssertTrue(fixture.store.distributionMatchesBundle)
+        XCTAssertTrue(fixture.store.powerHelperReadinessConfirmed)
+        XCTAssertEqual(fixture.store.lastInstallMessage, "installed payload")
+        XCTAssertEqual(distribution.repairs, [false])
+        XCTAssertEqual(distribution.doctorCallCount, 2)
+        XCTAssertEqual(powerHelper.reconcileCallCount, 1)
+        XCTAssertEqual(watchdog.forceReplacementRequests, [true])
+        let checks = Dictionary(uniqueKeysWithValues:
+            fixture.store.appContextChecks.map { ($0.id, $0) })
+        XCTAssertEqual(checks["app_cli_match"]?.status, .ok)
+        XCTAssertEqual(checks["app_power_helper"]?.status, .ok)
+        XCTAssertEqual(checks["app_watchdog"]?.status, .ok)
+        XCTAssertEqual(checks["watchdog_heartbeat"]?.status, .warning)
+    }
+
+    func testDeferredExistingInstallRetriesAutomaticallyAndRecovers()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [
+                .success("first install"), .success("recovered install"),
+            ],
+            doctorResults: [
+                .success(installedRuntimeReport(build: "other")),
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            completedOnboarding: true,
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+
+        await fixture.store.bootstrap()
+
+        XCTAssertEqual(fixture.store.phase, .updateDeferred)
+        XCTAssertFalse(fixture.store.distributionMatchesBundle)
+        XCTAssertEqual(powerHelper.reconcileCallCount, 0)
+        XCTAssertTrue(watchdog.forceReplacementRequests.isEmpty)
+
+        let refreshed = await fixture.store.refreshContext()
+        XCTAssertTrue(refreshed)
+
+        XCTAssertEqual(fixture.store.phase, .ready)
+        XCTAssertTrue(fixture.store.distributionMatchesBundle)
+        XCTAssertEqual(fixture.store.lastInstallMessage, "recovered install")
+        XCTAssertEqual(distribution.repairs, [false, false])
+        XCTAssertEqual(powerHelper.reconcileCallCount, 1)
+        XCTAssertEqual(watchdog.forceReplacementRequests, [false])
+    }
+
+    func testRepairDefersHelperReplacementWhileActiveLeasesRemain()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("repaired")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(
+            status: .enabled,
+            reconcileResult: .success(.deferredForActiveLeases))
+        let fixture = try makePackagedInstallationFixture(
+            completedOnboarding: true,
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+
+        await fixture.store.repair()
+
+        XCTAssertEqual(fixture.store.phase, .updateDeferred)
+        XCTAssertEqual(fixture.store.onboardingStep, .mainApp)
+        XCTAssertTrue(fixture.store.powerHelperReadinessConfirmed)
+        XCTAssertEqual(distribution.repairs, [true])
+        XCTAssertEqual(watchdog.forceReplacementRequests, [true])
+    }
+
+    func testRefreshWithdrawsReadinessWhenServiceReconciliationFails()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+        await fixture.store.bootstrap()
+        XCTAssertEqual(fixture.store.phase, .ready)
+
+        watchdog.status = .notRegistered
+        watchdog.reconcileResult = .failure(InstallationProbeError.watchdog)
+        powerHelper.reconcileResult = .failure(
+            InstallationProbeError.powerHelper)
+
+        let refreshed = await fixture.store.refreshContext()
+        XCTAssertTrue(refreshed)
+
+        XCTAssertEqual(fixture.store.phase, .actionRequired)
+        XCTAssertFalse(fixture.store.powerHelperReadinessConfirmed)
+        XCTAssertEqual(
+            fixture.store.powerHelperError, "power helper probe failed")
+        XCTAssertEqual(fixture.store.watchdogError, "watchdog probe failed")
+        XCTAssertEqual(watchdog.forceReplacementRequests, [true, false])
+        let checks = Dictionary(uniqueKeysWithValues:
+            fixture.store.appContextChecks.map { ($0.id, $0) })
+        XCTAssertEqual(checks["app_power_helper"]?.status, .error)
+        XCTAssertEqual(checks["app_watchdog"]?.status, .error)
+    }
+
+    func testRefreshRejectsRuntimeIdentityDrift() async throws {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport(build: "replaced")),
+            ])
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: InstallationWatchdogProbe(status: .enabled),
+            powerHelper: InstallationPowerHelperProbe(status: .enabled))
+        defer { fixture.cleanup() }
+        await fixture.store.bootstrap()
+
+        let refreshed = await fixture.store.refreshContext()
+        XCTAssertTrue(refreshed)
+
+        XCTAssertEqual(
+            fixture.store.phase,
+            .failed("The CLI is missing or belongs to another build; run Repair from the intended app version"))
+        XCTAssertFalse(fixture.store.distributionMatchesBundle)
+        XCTAssertFalse(fixture.store.powerHelperReadinessConfirmed)
+    }
+
+    func testPostRegistrationDoctorFailureCannotPublishStaleReadiness()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .failure(InstallationProbeError.doctor),
+            ])
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: InstallationWatchdogProbe(status: .enabled),
+            powerHelper: InstallationPowerHelperProbe(status: .enabled))
+        defer { fixture.cleanup() }
+
+        await fixture.store.bootstrap()
+
+        XCTAssertEqual(fixture.store.phase, .failed("doctor probe failed"))
+        XCTAssertFalse(fixture.store.powerHelperReadinessConfirmed)
+    }
+
+    func testRegistrationPollingPublishesEveryActionableStatus() throws {
+        let watchdog = InstallationWatchdogProbe(status: .requiresApproval)
+        let powerHelper = InstallationPowerHelperProbe(
+            status: .requiresApproval)
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+
+        store.refreshRegistrationStatusesOnly()
+        var checks = Dictionary(uniqueKeysWithValues:
+            store.appContextChecks.map { ($0.id, $0) })
+        XCTAssertEqual(checks["app_power_helper"]?.status, .warning)
+        XCTAssertEqual(checks["app_watchdog"]?.status, .error)
+
+        watchdog.status = .notRegistered
+        powerHelper.status = .notRegistered
+        store.refreshRegistrationStatusesOnly()
+        checks = Dictionary(uniqueKeysWithValues:
+            store.appContextChecks.map { ($0.id, $0) })
+        XCTAssertEqual(checks["app_power_helper"]?.status, .warning)
+        XCTAssertEqual(checks["app_watchdog"]?.status, .error)
+
+        watchdog.status = .enabled
+        powerHelper.status = .enabled
+        store.refreshRegistrationStatusesOnly()
+        checks = Dictionary(uniqueKeysWithValues:
+            store.appContextChecks.map { ($0.id, $0) })
+        XCTAssertEqual(checks["app_power_helper"]?.status, .warning)
+        XCTAssertEqual(checks["app_watchdog"]?.status, .ok)
+
+        store.openLoginItemsSettings()
+        store.openPowerHelperApprovalSettings()
+        XCTAssertEqual(watchdog.openSettingsCallCount, 1)
+        XCTAssertEqual(powerHelper.openSettingsCallCount, 1)
+    }
+
+    func testUninstallRemovesServicesBeforeDistribution() async throws {
+        let cli = InstallationCLIProbe(result: .success(CLIResult(
+            exitCode: 0,
+            stdout: "removed\n",
+            stderr: "",
+            timedOut: false)))
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            distribution: InstallationDistributionProbe(),
+            watchdog: watchdog,
+            powerHelper: powerHelper,
+            cli: cli)
+        defer { fixture.cleanup() }
+
+        await fixture.store.uninstall(purgeState: true)
+
+        XCTAssertEqual(fixture.store.phase, .actionRequired)
+        XCTAssertEqual(fixture.store.lastInstallMessage, "removed")
+        XCTAssertFalse(fixture.store.distributionMatchesBundle)
+        XCTAssertEqual(watchdog.disableCallCount, 1)
+        XCTAssertEqual(powerHelper.disableCallCount, 1)
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls.map(\.arguments), [["uninstall", "--purge-state"]])
+        XCTAssertEqual(calls.map(\.timeout), [30])
+    }
+
+    func testFailedUninstallRestoresPreviouslyEnabledServices()
+        async throws
+    {
+        let cli = InstallationCLIProbe(result: .success(CLIResult(
+            exitCode: 17,
+            stdout: "",
+            stderr: "cannot remove runtime\n",
+            timedOut: false)))
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            distribution: InstallationDistributionProbe(),
+            watchdog: watchdog,
+            powerHelper: powerHelper,
+            cli: cli)
+        defer { fixture.cleanup() }
+
+        await fixture.store.uninstall(purgeState: false)
+
+        XCTAssertEqual(
+            fixture.store.phase,
+            .failed("Could not remove components: cannot remove runtime"))
+        XCTAssertEqual(watchdog.enableCallCount, 1)
+        XCTAssertEqual(powerHelper.enableCallCount, 1)
+        XCTAssertEqual(watchdog.status, .enabled)
+        XCTAssertEqual(powerHelper.status, .enabled)
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls.map(\.arguments), [["uninstall", "--keep-state"]])
+    }
+
+    func testIdleRefreshBootstrapsPackagedPayload() async throws {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed from refresh")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: InstallationWatchdogProbe(status: .enabled),
+            powerHelper: InstallationPowerHelperProbe(status: .enabled))
+        defer { fixture.cleanup() }
+
+        let refreshed = await fixture.store.refreshContext()
+
+        XCTAssertTrue(refreshed)
+        XCTAssertEqual(fixture.store.phase, .ready)
+        XCTAssertEqual(distribution.repairs, [false])
+    }
+
+    func testRefreshDefersHelperReplacementWhileActiveLeasesRemain()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            completedOnboarding: true,
+            distribution: distribution,
+            watchdog: InstallationWatchdogProbe(status: .enabled),
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+        await fixture.store.bootstrap()
+        powerHelper.reconcileResult = .success(.deferredForActiveLeases)
+
+        let refreshed = await fixture.store.refreshContext()
+
+        XCTAssertTrue(refreshed)
+        XCTAssertEqual(fixture.store.phase, .updateDeferred)
+        XCTAssertEqual(fixture.store.onboardingStep, .mainApp)
+    }
+
+    func testDeferredRefreshDoctorFailureWithdrawsStaleReadiness()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+                .failure(InstallationProbeError.doctor),
+            ])
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            completedOnboarding: true,
+            distribution: distribution,
+            watchdog: InstallationWatchdogProbe(status: .enabled),
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+        await fixture.store.bootstrap()
+        XCTAssertTrue(fixture.store.powerHelperReadinessConfirmed)
+        powerHelper.reconcileResult = .success(.deferredForActiveLeases)
+
+        let refreshed = await fixture.store.refreshContext()
+
+        XCTAssertTrue(refreshed)
+        XCTAssertEqual(fixture.store.phase, .updateDeferred)
+        XCTAssertFalse(fixture.store.powerHelperReadinessConfirmed)
+    }
+
+    func testBootstrapPublishesBothServiceReconciliationFailures()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(
+            status: .notRegistered,
+            reconcileResult: .failure(InstallationProbeError.watchdog))
+        let powerHelper = InstallationPowerHelperProbe(
+            status: .enabled,
+            reconcileResult: .failure(InstallationProbeError.powerHelper))
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+
+        await fixture.store.bootstrap()
+
+        XCTAssertEqual(fixture.store.phase, .actionRequired)
+        XCTAssertEqual(
+            fixture.store.powerHelperError, "power helper probe failed")
+        XCTAssertEqual(fixture.store.watchdogError, "watchdog probe failed")
+        XCTAssertFalse(fixture.store.powerHelperReadinessConfirmed)
+    }
+
     private func makeStateRoot() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -569,15 +957,15 @@ final class InstallationStorePowerStateTests: XCTestCase {
                 summary: "power helper")])
     }
 
-    private func installedRuntimeReport() -> DoctorReport {
+    private func installedRuntimeReport(build: String = "17") -> DoctorReport {
         let ids = [
             "integrity", "cli", "manifest", "tmux", "state_helper",
-            "power_runtime",
+            "power_runtime", "power_helper", "provider",
         ]
         return DoctorReport(
             schema: 1,
             version: "0.2.7",
-            build: "17",
+            build: build,
             payloadID: "payload",
             ok: true,
             checks: ids.map { id in
@@ -590,6 +978,38 @@ final class InstallationStorePowerStateTests: XCTestCase {
                     path: "/tmp/\(id)",
                     summary: "ok")
             })
+    }
+
+    private func makePackagedInstallationFixture(
+        completedOnboarding: Bool = false,
+        distribution: InstallationDistributionProbe,
+        watchdog: InstallationWatchdogProbe,
+        powerHelper: InstallationPowerHelperProbe,
+        cli: InstallationCLIProbe = InstallationCLIProbe(result: .success(
+            CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)))
+    ) throws -> PackagedInstallationFixture {
+        let bundleRoot = try makeTestAppBundle()
+        let stateRoot = try makeStateRoot()
+        let bundle = try XCTUnwrap(Bundle(path: bundleRoot.path))
+        let suite = "InstallationStorePowerStateTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defaults.set(completedOnboarding, forKey: "onboardingCompleted")
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            bundle: bundle,
+            powerStateRoot: stateRoot,
+            defaults: defaults,
+            watchdog: watchdog,
+            powerHelper: powerHelper,
+            applicationLocationValidator: { _ in true },
+            distributionClientFactory: { _, _, _, _ in distribution },
+            cliFactory: { _ in cli })
+        return PackagedInstallationFixture(
+            store: store,
+            bundleRoot: bundleRoot,
+            stateRoot: stateRoot,
+            defaults: defaults,
+            suite: suite)
     }
 
     private func makeCompletedOnboardingStore(
@@ -659,5 +1079,166 @@ private final class InstallationContextOperationProbe {
 
     func releaseNext() {
         continuations.removeFirst().resume()
+    }
+}
+
+private enum InstallationProbeError: LocalizedError {
+    case watchdog
+    case powerHelper
+    case doctor
+
+    var errorDescription: String? {
+        switch self {
+        case .watchdog: "watchdog probe failed"
+        case .powerHelper: "power helper probe failed"
+        case .doctor: "doctor probe failed"
+        }
+    }
+}
+
+@MainActor
+private final class InstallationWatchdogProbe:
+    InstallationWatchdogServicing
+{
+    var status: WatchdogStatus
+    var reconcileResult: Result<Void, Error>
+    private(set) var forceReplacementRequests: [Bool] = []
+    private(set) var enableCallCount = 0
+    private(set) var disableCallCount = 0
+    private(set) var openSettingsCallCount = 0
+
+    init(
+        status: WatchdogStatus,
+        reconcileResult: Result<Void, Error> = .success(())
+    ) {
+        self.status = status
+        self.reconcileResult = reconcileResult
+    }
+
+    func reconcileAfterAppUpdate(forceReplacement: Bool) async throws {
+        forceReplacementRequests.append(forceReplacement)
+        try reconcileResult.get()
+    }
+
+    func enable() async throws {
+        enableCallCount += 1
+        status = .enabled
+    }
+
+    func disable() async throws {
+        disableCallCount += 1
+        status = .notRegistered
+    }
+
+    func openLoginItemsSettings() {
+        openSettingsCallCount += 1
+    }
+}
+
+@MainActor
+private final class InstallationPowerHelperProbe:
+    InstallationPowerHelperServicing
+{
+    var status: PowerHelperRegistrationStatus
+    var reconcileResult: Result<PowerHelperReconciliationOutcome, Error>
+    private(set) var reconcileCallCount = 0
+    private(set) var enableCallCount = 0
+    private(set) var disableCallCount = 0
+    private(set) var openSettingsCallCount = 0
+
+    init(
+        status: PowerHelperRegistrationStatus,
+        reconcileResult: Result<PowerHelperReconciliationOutcome, Error> =
+            .success(.complete)
+    ) {
+        self.status = status
+        self.reconcileResult = reconcileResult
+    }
+
+    func reconcileAfterAppUpdate() async throws
+        -> PowerHelperReconciliationOutcome
+    {
+        reconcileCallCount += 1
+        return try reconcileResult.get()
+    }
+
+    func enable() async throws {
+        enableCallCount += 1
+        status = .enabled
+    }
+
+    func disable() async throws {
+        disableCallCount += 1
+        status = .notRegistered
+    }
+
+    func openApprovalSettings() {
+        openSettingsCallCount += 1
+    }
+}
+
+@MainActor
+private final class InstallationDistributionProbe:
+    InstallationDistributionServicing
+{
+    var synchronizeResults: [Result<String, Error>]
+    var doctorResults: [Result<DoctorReport, Error>]
+    private(set) var repairs: [Bool] = []
+    private(set) var doctorCallCount = 0
+
+    init(
+        synchronizeResults: [Result<String, Error>] = [],
+        doctorResults: [Result<DoctorReport, Error>] = []
+    ) {
+        self.synchronizeResults = synchronizeResults
+        self.doctorResults = doctorResults
+    }
+
+    func synchronize(repair: Bool) async throws -> String {
+        repairs.append(repair)
+        return try synchronizeResults.removeFirst().get()
+    }
+
+    func doctor() async throws -> DoctorReport {
+        doctorCallCount += 1
+        return try doctorResults.removeFirst().get()
+    }
+}
+
+private actor InstallationCLIProbe: DetachCLIRunning {
+    struct Call: Sendable {
+        let arguments: [String]
+        let timeout: TimeInterval
+    }
+
+    let result: Result<CLIResult, Error>
+    private var calls: [Call] = []
+
+    init(result: Result<CLIResult, Error>) {
+        self.result = result
+    }
+
+    func run(arguments: [String], timeout: TimeInterval) async throws
+        -> CLIResult
+    {
+        calls.append(Call(arguments: arguments, timeout: timeout))
+        return try result.get()
+    }
+
+    func recordedCalls() -> [Call] { calls }
+}
+
+@MainActor
+private struct PackagedInstallationFixture {
+    let store: InstallationStore
+    let bundleRoot: URL
+    let stateRoot: URL
+    let defaults: UserDefaults
+    let suite: String
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suite)
+        try? FileManager.default.removeItem(at: bundleRoot)
+        try? FileManager.default.removeItem(at: stateRoot)
     }
 }

--- a/app/Tests/DetachAppTests/PowerHelperHandoffStoreTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperHandoffStoreTests.swift
@@ -80,6 +80,189 @@ final class PowerHelperHandoffStoreTests: XCTestCase {
         withExtendedLifetime(laterLock) {}
     }
 
+    func testRejectsOversizedJournalBeforeDecoding() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        try writeJournal(
+            Data(
+                repeating: 0,
+                count: FilePowerHelperHandoffStore.maximumBytes + 1),
+            fixture: fixture)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case PowerHelperHandoffStoreError.stateTooLarge = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsInvalidPersistedTransaction() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let invalid = PowerHelperHandoffTransaction(
+            phase: .registering,
+            goal: .install,
+            targetDigest: nil,
+            bootSessionIdentifier:
+                "00000000-0000-0000-0000-000000000001")
+        try writeJournal(
+            try JSONEncoder().encode(invalid),
+            fixture: fixture)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case PowerHelperHandoffStoreError.invalidState = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsJournalReadableByOtherUsers() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let transaction = PowerHelperHandoffTransaction(
+            phase: .removed,
+            goal: .install,
+            targetDigest: "digest",
+            bootSessionIdentifier:
+                "00000000-0000-0000-0000-000000000001")
+        try writeJournal(
+            try JSONEncoder().encode(transaction),
+            fixture: fixture,
+            permissions: 0o644)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case PowerHelperHandoffStoreError.insecurePath = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testTransactionValidationRejectsInvalidIdentityAndRemovalTarget() {
+        let invalidIdentity = PowerHelperHandoffTransaction(
+            phase: .registering,
+            goal: .install,
+            targetDigest: "digest",
+            bootSessionIdentifier: "NOT-A-BOOT-UUID")
+        let removalWithTarget = PowerHelperHandoffTransaction(
+            phase: .removed,
+            goal: .remove,
+            targetDigest: "digest",
+            bootSessionIdentifier:
+                "00000000-0000-0000-0000-000000000001")
+
+        XCTAssertFalse(invalidIdentity.isValid)
+        XCTAssertFalse(removalWithTarget.isValid)
+    }
+
+    func testStoreErrorsHaveActionableDescriptions() {
+        let cases: [(PowerHelperHandoffStoreError, String)] = [
+            (.insecurePath,
+             "The power helper handoff journal has an insecure path."),
+            (.stateTooLarge,
+             "The power helper handoff journal is unexpectedly large."),
+            (.invalidState,
+             "The power helper handoff journal is invalid."),
+            (.transactionBusy,
+             "Another Detach process is already updating the power helper."),
+            (.fileSystem(operation: "read", code: EIO),
+             "Could not read the power helper handoff journal (errno \(EIO))."),
+        ]
+
+        for (error, description) in cases {
+            XCTAssertEqual(error.errorDescription, description)
+        }
+    }
+
+    func testClearIsIdempotentBeforeJournalDirectoryExists() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        try fixture.store.clear()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.root.path))
+    }
+
+    func testRejectsNonDirectoryJournalParent() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let parent = fixture.fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: parent.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data().write(to: parent)
+        let transaction = PowerHelperHandoffTransaction(
+            phase: .removed,
+            goal: .install,
+            targetDigest: "digest",
+            bootSessionIdentifier:
+                "00000000-0000-0000-0000-000000000001")
+
+        XCTAssertThrowsError(try fixture.store.save(transaction)) { error in
+            guard case PowerHelperHandoffStoreError.insecurePath = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsSymlinkTransactionLock() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let directory = fixture.fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let target = fixture.root.appendingPathComponent("lock-target")
+        try Data().write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: directory.appendingPathComponent(
+                "power-helper-handoff.lock"),
+            withDestinationURL: target)
+
+        XCTAssertThrowsError(try fixture.store.acquireTransactionLock()) {
+            error in
+            guard case let PowerHelperHandoffStoreError.fileSystem(
+                operation, _) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(operation, "open transaction lock")
+        }
+    }
+
+    func testRejectsOversizedSerializedTransactionBeforeWriting() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let transaction = PowerHelperHandoffTransaction(
+            phase: .removed,
+            goal: .install,
+            targetDigest: String(
+                repeating: "x",
+                count: FilePowerHelperHandoffStore.maximumBytes),
+            bootSessionIdentifier:
+                "00000000-0000-0000-0000-000000000001")
+
+        XCTAssertThrowsError(try fixture.store.save(transaction)) { error in
+            guard case PowerHelperHandoffStoreError.stateTooLarge = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    private func writeJournal(
+        _ data: Data,
+        fixture: StoreFixture,
+        permissions: Int = 0o600
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: fixture.fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        try data.write(to: fixture.fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: permissions],
+            ofItemAtPath: fixture.fileURL.path)
+    }
+
     private func makeFixture() throws -> StoreFixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(

--- a/app/Tests/DetachAppTests/WatchdogHandoffStoreTests.swift
+++ b/app/Tests/DetachAppTests/WatchdogHandoffStoreTests.swift
@@ -127,6 +127,210 @@ final class WatchdogHandoffStoreTests: XCTestCase {
             "power-watchdog-handoff.json")
     }
 
+    func testRejectsOversizedJournalBeforeDecoding() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        try writeJournal(
+            Data(repeating: 0, count: FileWatchdogHandoffStore.maximumBytes + 1),
+            fixture: fixture)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case WatchdogHandoffStoreError.stateTooLarge = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsInvalidPersistedTransaction() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        let invalid = WatchdogHandoffTransaction(
+            phase: .registering,
+            targetDigest: nil)
+        try writeJournal(
+            try JSONEncoder().encode(invalid),
+            fixture: fixture)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case WatchdogHandoffStoreError.invalidState = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsJournalReadableByOtherUsers() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        let transaction = WatchdogHandoffTransaction(
+            phase: .removed,
+            targetDigest: "digest")
+        try writeJournal(
+            try JSONEncoder().encode(transaction),
+            fixture: fixture,
+            permissions: 0o644)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case WatchdogHandoffStoreError.insecurePath = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsSymlinkJournalWithoutFollowingIt() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        try FileManager.default.createDirectory(
+            at: fixture.fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let target = fixture.root.appendingPathComponent("target.json")
+        try Data("{}".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.fileURL,
+            withDestinationURL: target)
+
+        XCTAssertThrowsError(try fixture.store.load()) { error in
+            guard case let WatchdogHandoffStoreError.fileSystem(operation, _) =
+                    error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(operation, "open")
+        }
+    }
+
+    func testStoreErrorsHaveActionableDescriptions() {
+        let cases: [(WatchdogHandoffStoreError, String)] = [
+            (.insecurePath,
+             "The watchdog handoff journal has an insecure path."),
+            (.stateTooLarge,
+             "The watchdog handoff journal is unexpectedly large."),
+            (.invalidState,
+             "The watchdog handoff journal is invalid."),
+            (.transactionBusy,
+             "Another Detach process is already updating the watchdog."),
+            (.fileSystem(operation: "read", code: EIO),
+             "Could not read the watchdog handoff journal (errno \(EIO))."),
+        ]
+
+        for (error, description) in cases {
+            XCTAssertEqual(error.errorDescription, description)
+        }
+    }
+
+    func testClearIsIdempotentBeforeJournalDirectoryExists() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+
+        try fixture.store.clear()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.root.path))
+    }
+
+    func testRejectsNonDirectoryJournalParent() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        let parent = fixture.fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: parent.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data().write(to: parent)
+        let transaction = WatchdogHandoffTransaction(
+            phase: .removed,
+            targetDigest: "digest")
+
+        XCTAssertThrowsError(try fixture.store.save(transaction)) { error in
+            guard case WatchdogHandoffStoreError.insecurePath = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testRejectsSymlinkTransactionLock() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        let directory = fixture.fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let target = fixture.root.appendingPathComponent("lock-target")
+        try Data().write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: directory.appendingPathComponent(
+                "power-watchdog-handoff.lock"),
+            withDestinationURL: target)
+
+        XCTAssertThrowsError(try fixture.store.acquireTransactionLock()) {
+            error in
+            guard case let WatchdogHandoffStoreError.fileSystem(operation, _) =
+                    error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(operation, "open transaction lock")
+        }
+    }
+
+    func testRejectsOversizedSerializedTransactionBeforeWriting() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        let transaction = WatchdogHandoffTransaction(
+            phase: .removed,
+            targetDigest: String(
+                repeating: "x",
+                count: FileWatchdogHandoffStore.maximumBytes))
+
+        XCTAssertThrowsError(try fixture.store.save(transaction)) { error in
+            guard case WatchdogHandoffStoreError.stateTooLarge = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testLifetimeBarrierReportsMissingAndRejectsInsecureFile() throws {
+        let fixture = makeFixture()
+        defer { fixture.cleanup() }
+        let lifetimeURL = fixture.root.appendingPathComponent("lifetime.lock")
+        let barrier = WatchdogLifetimeBarrier(
+            fileURL: lifetimeURL,
+            expectedOwner: geteuid())
+
+        XCTAssertEqual(try barrier.status(), .missing)
+
+        try FileManager.default.createDirectory(
+            at: fixture.root,
+            withIntermediateDirectories: true)
+        try Data().write(to: lifetimeURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644],
+            ofItemAtPath: lifetimeURL.path)
+        XCTAssertThrowsError(try barrier.status()) { error in
+            guard case WatchdogHandoffStoreError.insecurePath = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testDefaultLifetimeBarrierUsesWatchdogLockName() {
+        XCTAssertEqual(
+            WatchdogLifetimeBarrier.defaultFileURL.lastPathComponent,
+            "watchdog-lifetime.lock")
+    }
+
+    private func writeJournal(
+        _ data: Data,
+        fixture: WatchdogStoreFixture,
+        permissions: Int = 0o600
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: fixture.fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        try data.write(to: fixture.fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: permissions],
+            ofItemAtPath: fixture.fileURL.path)
+    }
+
     private func makeFixture() -> WatchdogStoreFixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -15,17 +15,18 @@ against `ANSIParser.terminalBackground`, which is also the `LogTextView`
 background; do not duplicate that canvas color. Font-size scaling may replace
 only the font attribute and must preserve every ANSI-derived attribute.
 
-Onboarding is a card assistant driven by the pure step reducer in
-`SetupGuidance.step(for:)`; a setup failure outranks provider discovery. A bare
-`SMAppService.status == .enabled` read never completes the permissions step:
-the live poller reads statuses without side effects and runs one coordinated
-reconciliation on the enable transition, and only confirmed readiness (helper
-journal finished, root gate reopened) advances the step. Registration may
-truthfully remain in `requiresApproval`; never treat it as enabled before macOS
-does. The success card waits for the first fresh watchdog heartbeat; its
-dashboard action remains disabled until then, and after a long wait it offers
-an explicit monitor retry instead of a bypass. Completion is guarded again in
-the store and is recorded only by that explicit action, exactly once.
+Onboarding uses the pure reducer in `SetupGuidance.step(for:)`; a setup failure
+outranks provider discovery. A bare
+`SMAppService.status == .enabled` read never completes the permissions step.
+The live poller reads status without side effects and reconciles once when it
+becomes enabled. Only confirmed readiness (a
+finished helper journal and an open root gate) advances the step. Registration
+can stay in `requiresApproval`; do not treat it as enabled before macOS does.
+The success card waits for a fresh watchdog heartbeat. Its dashboard action
+stays disabled until then. After a long wait, it offers a monitor retry, not a
+bypass. The store records completion only after that action, exactly once.
+If a doctor refresh fails or detects another runtime identity, the app
+withdraws the earlier helper-readiness confirmation.
 
 After onboarding completes, `.idle`, `.syncing`, `.updateDeferred`, and
 `.ready` present `.mainApp`. Bootstrap, refresh, and an update held by active

--- a/tests/quality_security_contract.py
+++ b/tests/quality_security_contract.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import subprocess
 import sys
 import tempfile
-import time
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -23,7 +22,11 @@ COMMIT = "0123456789abcdef0123456789abcdef01234567"
 RUN_URL = "https://github.com/owner/repository/actions/runs/901"
 
 
-def invoke(*arguments: str, environment: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+def invoke(
+    *arguments: str,
+    environment: dict[str, str] | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(ROOT / "scripts/quality-security"), *arguments],
         cwd=ROOT,
@@ -32,6 +35,7 @@ def invoke(*arguments: str, environment: dict[str, str] | None = None) -> subpro
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        timeout=timeout,
     )
 
 
@@ -79,6 +83,9 @@ import os,pathlib,shutil,sys,time
 args=sys.argv[1:]
 if os.environ.get('FAKE_SECURITY_SLEEP'):
     time.sleep(float(os.environ['FAKE_SECURITY_SLEEP']))
+    marker=os.environ.get('FAKE_SECURITY_COMPLETION_MARKER')
+    if marker:
+        pathlib.Path(marker).write_text('completed', encoding='utf-8')
 if args[:1] == ['api'] and '/artifacts' not in args[1]:
     print('901')
 elif args[:1] == ['api']:
@@ -109,20 +116,22 @@ else:
         assert restored_path.is_file()
         assert json.loads(restored_path.read_text(encoding="utf-8")) == passed
 
+        completion_marker = root / "slow-gh-completed"
         slow_environment = {
             **environment,
             "DETACH_QUALITY_SECURITY_LATEST_SECONDS": "1",
             "FAKE_SECURITY_SLEEP": "2",
+            "FAKE_SECURITY_COMPLETION_MARKER": str(completion_marker),
         }
-        started = time.monotonic()
         timed = invoke(
             "latest",
             "--repository", "owner/repository",
             "--output-root", str(root / "timed"),
             environment=slow_environment,
+            timeout=5,
         )
         assert timed.returncode == 2
-        assert time.monotonic() - started < 1.8
+        assert not completion_marker.exists()
         assert "bounded security restore deadline" in timed.stderr
 
     print("Quality security evidence contracts passed")


### PR DESCRIPTION
## Summary
- cover packaged installation, repair, refresh, uninstall, and service failure scenarios
- cover handoff journal size, permissions, symlink, and recovery boundaries
- withdraw stale helper readiness after doctor failure or runtime identity drift

## Local evidence
- 67 focused tests passed in 0.14 seconds
- InstallationStore.swift: 649/686 lines (94.61%)
- WatchdogHandoffStore.swift: 297/324 lines (91.67%)
- PowerHelperHandoffStore.swift: 246/267 lines (92.13%)
- documentation contract and git diff check passed
- projected combined UI coverage is at least 70.06%; hosted quality-gates computes the authoritative unit plus packaged-journey union

No release, signing, real power, or closed-lid checks were run.