### PR TITLE
docs: add contract delta workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Contract delta
+
+<!--
+State the safe current-to-target behavior change. List each affected README or
+durable spec and its ADDED, MODIFIED, or REMOVED requirements. If behavior and
+invariants do not change, write "No contract change" and explain why.
+Do not copy private ExecPlan content, private names, or machine-specific data.
+-->
+
+## Durable decisions
+
+<!-- Record only decisions and rationale that future maintainers need. -->
+
+## Acceptance evidence
+
+<!-- List each requirement, its test or manual gate, and the observed result. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,41 +10,41 @@ the providers separately.
 1. Inspect the working tree; preserve unrelated user changes.
 2. Use the context map below to read the one relevant specification. Read a
    second spec only when the change genuinely crosses that boundary.
-3. For a small, obvious change, edit directly. For a cross-subsystem change,
-   risky migration, or work with unresolved requirements, create an ignored
-   ExecPlan under `docs/work/` from `docs/exec-plan-template.md` and keep it current.
+3. Edit a small, obvious change directly. For cross-subsystem work, a risky
+   migration, or unresolved requirements, create an ignored ExecPlan under
+   `docs/work/`. Before implementation, write and review its current-to-target
+   contract delta. Ask the owner only about material choices the task does not fix.
 4. During implementation, run the narrow checks named by the selected specs.
    Before handoff, inspect `scripts/quality-gate --plan --explain` and run the
    focused local diagnostics once. Use `--resume latest` after a compatible
    interrupted or failed run. Hosted pull-request CI is readiness authority.
 5. Review the final diff and evidence. Update the user contract or durable spec
    in the same change whenever behavior or an invariant changes.
-6. Unless the owner explicitly asks to keep work local, ordinary changes use a
-   topic branch: stage only task-scoped files, inspect the staged public diff,
-   commit after local diagnostics pass, push, and merge only through a PR whose
-   required authoritative `quality-gates` job passed. Verify final `main` upstream parity.
+6. Unless the owner asks to keep work local, use a topic branch. Stage only
+   task-scoped files, inspect the staged public diff, and summarize the safe
+   contract delta, durable decisions, and evidence in the PR. Merge only after
+   its authoritative `quality-gates` job passes. Verify final `main` upstream parity.
    Release metadata uses a PR. `scripts/release-version` is the sole entry.
 
 `README.md` is the user-facing contract. `docs/specs/` contains durable
 current-state engineering contracts. Tests and gates are executable evidence;
 they do not make stale prose correct.
 
-Use [ASD-STE100 Issue 9](https://www.asd-ste100.org/) for new or changed
-English text in `README.md` and `docs/`. Use short, direct sentences and one
-term for each meaning. Treat product names, paths, commands, and identifiers as
-project technical terms. Do not claim verified STE compliance without a review
-against the official standard.
+Use [ASD-STE100 Issue 9](https://www.asd-ste100.org/) for changed English in
+`README.md` and `docs/`. Use short, direct sentences and one term per meaning.
+Product names, paths, commands, and identifiers are technical terms. Do not
+claim verified compliance without review against the official standard.
 
 ## Context and specification policy
 
-- Keep this file under 200 lines and limited to rules needed on most tasks.
-- Do not add architecture tutorials or file-by-file inventories here. Put a
+- Keep this file under 200 lines and limited to common rules.
+- Do not add architecture tutorials or file inventories here. Put a
   durable invariant in the narrowest file under `docs/specs/`; put a
   temporary task plan under ignored `docs/work/`.
 - `CLAUDE.md` must contain only `@AGENTS.md`. Never copy this content
   into it or create a second lowercase agent-instruction file.
-- Do not import the detailed specs from this file: imports are eager context in
-  Claude Code. Follow the small context map below instead.
+- Do not import detailed specs: Claude loads imports eagerly. Use the context
+  map below.
 - Specs state observable outcomes, non-goals, invariants, owning paths, and
   verification. Avoid implementation narration that code already makes clear.
 - Complex plans are living, self-contained handoff artifacts. Record decisions,

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -17,10 +17,11 @@ final class PowerHelperPlatformTests: XCTestCase {
             timeout: 0.05, terminationGrace: 0.05)
 
         XCTAssertThrowsError(try runner.run(RootCommand(
-            executable: "/bin/sleep", arguments: ["5"]))) { error in
+            executable: "/bin/sh",
+            arguments: ["-c", "trap '' TERM; exec /bin/sleep 5"]))) { error in
             XCTAssertEqual(
                 error as? PowerHelperPlatformError,
-                .commandTimedOut(executable: "/bin/sleep"))
+                .commandTimedOut(executable: "/bin/sh"))
         }
     }
 

--- a/docs/exec-plan-template.md
+++ b/docs/exec-plan-template.md
@@ -14,6 +14,13 @@ that it works.
 Name the behavior and components in scope. State important boundaries that must
 remain unchanged.
 
+## Contract delta
+
+For each affected `README.md` contract or durable spec, state the current and
+target behavior. Classify each requirement as ADDED, MODIFIED, or REMOVED. Name
+its user journey, scenarios, and acceptance evidence. If behavior and
+invariants do not change, write `No contract change` and give the evidence.
+
 ## Requirements and acceptance evidence
 
 For every requirement, name the authoritative evidence that will prove it:
@@ -25,6 +32,15 @@ missing or indirect evidence as incomplete.
 Name exact source files, durable specs, interfaces, and terms needed by someone
 with only this working tree and this plan. Summarize necessary external research
 and link its primary source.
+
+## Pre-implementation review
+
+Before primary implementation, review the contract delta, scope, non-goals,
+and acceptance evidence. Record the reviewer, approval source, and `Ready` or
+`Blocked` with a reason. The request is approval only when it fixes the same
+target behavior and boundaries. Ask the owner to resolve each material product,
+security, or release choice that it does not fix. Revise this checkpoint when a
+discovery changes the contract delta.
 
 ## Plan and progress
 
@@ -49,5 +65,6 @@ expected observable results, not only command names.
 ## Outcomes and retrospective
 
 At completion, compare the result with every requirement, name remaining gaps,
-and summarize evidence. Promote stable invariants to `docs/specs/`; do not
-turn temporary history into permanent agent context.
+and summarize evidence. Promote stable invariants to `docs/specs/`. Put a safe
+summary of the contract delta, durable decisions, and evidence in the pull
+request. Do not copy private ExecPlan content or temporary history.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,8 +12,8 @@ entry point.
   invariants.
 - Source code implements the contract.
 - Tests and `scripts/quality-gate` provide executable evidence.
-- An ignored ExecPlan under `docs/work/` records one task's temporary
-  intent, decisions, and progress.
+- An ignored ExecPlan under `docs/work/` records one task's reviewed contract
+  delta, temporary intent, decisions, and progress.
 
 When these disagree, do not silently choose one. Establish intended behavior,
 then update every affected durable artifact in the same change.

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -23,7 +23,8 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   claim verified STE compliance unless a reviewer checks it against the
   official standard.
 - Durable specs describe current contracts. Ignored `docs/work/` contains
-  temporary executable plans. Imports are not used for detailed specs because
+  temporary executable plans. A required plan states and reviews the contract
+  delta before primary implementation. Detailed specs are not imported because
   Claude expands imports eagerly.
 - Ignored `presentations/` contains internal presentation sources. Git and the
   quality gate do not treat these files as repository inputs.
@@ -42,22 +43,19 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - Resume evidence retains stage timing and digest-bound logs, binds its parent,
   requires the same authority, and cannot turn a prior time-budget regression
   into authoritative evidence.
-- Quality policy files contain only the current policy version and state. Git
-  is the policy history. Runtime tools do not keep migration decoders for old
-  policy schemas. The last green metrics artifact can use an earlier policy
-  number only when its evidence schema is current. This preserves metric
-  continuity and does not decode an old policy.
+- Quality policy files contain only current version and state; Git is history.
+  Runtime tools do not decode old policy schemas. A last-green metrics artifact
+  can use an earlier policy number only with the current evidence schema. This
+  preserves continuity without old-policy decoding.
 - The quality policy registers each tracked durable spec exactly once. It has
   no spec-history or lifecycle-status field. Each registered spec owns a route,
   a capability, and a requirement. Each requirement links to a user journey
   and at least one automated scenario. Generated JSON and Markdown views must
   match the policy.
-- Retained gate results contain execution history for timing and quality
-  trends. They are not policy history and cannot restore an old policy state.
-  A declared unsupported evidence schema is outside the current telemetry
+- Retained gates are timing and quality history, not policy history, and cannot
+  restore old policy. An unsupported evidence schema is outside the telemetry
   sample. Current-schema telemetry can span earlier policy identifiers without
-  requiring dashboard-only fields. Malformed telemetry evidence remains an
-  attention signal.
+  dashboard-only fields. Malformed evidence remains an attention signal.
 - `quality/evals.json` keeps current expected outcomes for historical changes,
   escaped defects, policy mutations, and scope violations. Its stable graders
   compare selected stages, specifications, capabilities, user journeys,
@@ -141,39 +139,41 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   at most the merge deadline. It disables auto-merge on timeout. The command
   rejects a changed head, an invalid ruleset, and a repair attempt above the
   policy maximum. It writes current-policy evidence under `app/build/`.
-- Dependabot checks pinned GitHub Actions and Swift packages each week. It
-  groups each ecosystem into at most one open update pull request so update
-  traffic cannot exhaust the feedback queue. A bounded CodeQL workflow scans
-  GitHub Actions source on Linux and explicitly built arm64 Swift source on
-  macOS. Before tracing, the Swift job restores the quality-gate dependency
-  graph and resolves only the tracked lock. It then removes cached products so
-  CodeQL observes fresh repository source without tracing dependency fetch or
-  version resolution. One supported `swift build` command builds the complete
-  package graph in the traced zone. It builds only arm64. It uses whole-module
-  optimization and three workers. It does not build one target at a time or
-  repeat package preparation in a matrix. The Swift job has a 30-minute
-  deadline. The workflow runs each week and on explicit request. It does not
-  run after each merge, add work to pull-request feedback, or enter a release
-  path. The workflow uploads its result before it enforces success. This keeps
-  failed analysis visible. The dashboard reads the workflow and the validated
-  result artifact. It shows the configured languages, cadence, job results,
-  analyzed commit, and exact run link. It fails if the configuration, result,
-  or result fingerprint does not match the security contract.
+- Weekly Dependabot checks pinned Actions and Swift packages. It groups each
+  ecosystem into at most one pull request to protect the feedback queue. The
+  bounded weekly/manual CodeQL workflow scans Actions on Linux and arm64 Swift
+  on macOS. Swift restores the gate dependency graph, resolves the tracked lock,
+  and removes cached products before tracing. One whole-module `swift build`
+  with three workers builds the complete arm64 graph without per-target builds
+  or repeated matrix preparation. The job has 30 minutes. It does not run after
+  merges, affect pull-request feedback, or enter release. It uploads results
+  before enforcement. The dashboard validates the configuration, result, and
+  fingerprint and shows languages, cadence, jobs, commit, and workflow link.
 - By default, put a ready task-scoped change on a topic branch. Review the
-  staged public diff, commit it, and push it. Open a pull request, then give its
-  number, exact head, and current repair attempt to `scripts/quality-merge`.
-  After its bounded PASS, verify that local `main` and upstream `main` are
-  equal. The owner can ask to keep the change local.
+  staged public diff, commit it, and push it. The pull request summarizes the
+  safe contract delta, durable decisions, and acceptance evidence; it never
+  copies private plan content. Give its number, exact head, and repair attempt
+  to `scripts/quality-merge`. After PASS, verify local and upstream `main` parity.
+  The owner can ask to keep the change local.
 - `tests/docs-contract.sh` enforces this structure and runs inside the
   static quality stage.
 
 ## Spec lifecycle
 
-Use a direct edit for a small, obvious task. Use the ExecPlan template when
-work crosses subsystems, contains material unknowns, changes security/release
-contracts, or needs a resumable multi-session handoff. Keep the plan
-self-contained and current while working. Promote only stable outcomes and
-invariants into the durable spec.
+Use a direct edit for a small, obvious task. Use the ExecPlan template when work
+crosses subsystems, has material unknowns, changes security or release contracts,
+or needs a resumable handoff. Before primary implementation, record and review
+the current-to-target contract delta for each affected `README.md` contract or
+durable spec. Classify requirements as ADDED, MODIFIED, or REMOVED, or record
+no contract change with evidence. Link changed requirements to journeys,
+scenarios, and evidence.
+
+Review scope, non-goals, and evidence in the same checkpoint. The request is
+approval only if it fixes the same target and boundaries. Otherwise ask the
+owner about material choices. Record the reviewer, approval source, and result.
+Revise the checkpoint when the delta changes. Promote only stable outcomes and
+invariants into durable specs. Keep the plan ignored and put only safe rationale
+in the pull request.
 
 When agent behavior repeatedly fails, prefer a deterministic check. If behavior
 cannot be enforced mechanically, update the narrow spec. Change `AGENTS.md`

--- a/tests/docs-contract.sh
+++ b/tests/docs-contract.sh
@@ -51,6 +51,7 @@ required=(
   docs/testing.md
   docs/quality-gates.md
   docs/exec-plan-template.md
+  .github/pull_request_template.md
 )
 for file in "${required[@]}"; do
   [ -f "$ROOT/$file" ] || fail "missing $file"
@@ -67,10 +68,40 @@ for spec in runtime power app release documentation; do
     fail "context map must reference $spec.md exactly once"
 done
 
-for heading in   '## Purpose and observable outcome'   '## Scope and non-goals'   '## Requirements and acceptance evidence'   '## Decisions'   '## Verification'   '## Outcomes and retrospective'; do
+for heading in   '## Purpose and observable outcome'   '## Scope and non-goals'   '## Contract delta'   '## Pre-implementation review'   '## Requirements and acceptance evidence'   '## Decisions'   '## Verification'   '## Outcomes and retrospective'; do
   grep -Fx "$heading" "$ROOT/docs/exec-plan-template.md" >/dev/null ||
     fail "ExecPlan template missing $heading"
 done
+
+grep -F 'Classify each requirement as ADDED, MODIFIED, or REMOVED.' \
+  "$ROOT/docs/exec-plan-template.md" >/dev/null ||
+  fail 'ExecPlan template must define the contract delta'
+grep -F 'and acceptance evidence. Record the reviewer, approval source, and `Ready` or' \
+  "$ROOT/docs/exec-plan-template.md" >/dev/null ||
+  fail 'ExecPlan template must require a pre-implementation review'
+grep -F 'The request is approval only when it fixes the same' \
+  "$ROOT/docs/exec-plan-template.md" >/dev/null ||
+  fail 'ExecPlan review must identify valid prior approval'
+grep -F 'Before implementation, write and review its current-to-target' \
+  "$ROOT/AGENTS.md" >/dev/null ||
+  fail 'agent instructions must require contract-delta review'
+grep -F 'contract delta, durable decisions, and evidence in the PR.' \
+  "$ROOT/AGENTS.md" >/dev/null ||
+  fail 'agent instructions must require a safe pull request summary'
+grep -F 'approval only if it fixes the same target and boundaries.' \
+  "$ROOT/docs/specs/documentation.md" >/dev/null ||
+  fail 'documentation spec must define the approval boundary'
+
+for heading in '## Contract delta' '## Durable decisions' '## Acceptance evidence'; do
+  grep -Fx "$heading" "$ROOT/.github/pull_request_template.md" >/dev/null ||
+    fail "pull request template missing $heading"
+done
+grep -F 'Do not copy private ExecPlan content' \
+  "$ROOT/.github/pull_request_template.md" >/dev/null ||
+  fail 'pull request template must protect private plan content'
+grep -F 'write "No contract change" and explain why.' \
+  "$ROOT/.github/pull_request_template.md" >/dev/null ||
+  fail 'pull request template must cover changes without a contract delta'
 
 git -C "$ROOT" check-ignore -q docs/work/example.md ||
   fail 'temporary ExecPlans must remain ignored'


### PR DESCRIPTION
## Contract delta

Current: complex ExecPlans record requirements, decisions, and evidence, but do
not require an explicit current-to-target contract delta or approval checkpoint.
Pull requests have no standard safe summary.

Target:

- MODIFIED: plan-required work records ADDED, MODIFIED, and REMOVED contract
  requirements, or proves that no behavior or invariant changes.
- MODIFIED: the pre-implementation checkpoint records its reviewer, approval
  source, and result. An existing request is approval only for the same target
  and boundaries; unresolved material choices return to the owner.
- ADDED: pull requests summarize the safe contract delta, durable decisions,
  and acceptance evidence without copying the private ExecPlan.
- No product contract change: the existing root-command timeout test now uses a
  child that ignores SIGTERM, so it always exercises the existing SIGKILL
  fallback without changing the test identity.

This changes the documentation workflow. It does not change product behavior or
the README user contract. The owning spec is docs/specs/documentation.md and the
journey is J-DOCS-CONSISTENCY.

## Durable decisions

- ExecPlans remain ignored and private.
- Git and the pull request keep the safe public rationale; there is no separate
  archived change-document layer.
- Hosted quality-gates remains the only ordinary merge-readiness authority.
- tests/docs-contract.sh enforces the new template and instruction boundaries.

## Acceptance evidence

- tests/docs-contract.sh: PASS.
- tests/test-suite-contract.sh: PASS.
- scripts/quality-gate: DIAGNOSTIC PASS, policy 41, static stage.
- scripts/quality-scenarios rerun SC-SESSION-DELETE-CODEX: diagnostic PASS
  outside the filesystem sandbox, 74 seconds.
- PowerHelperPlatformTests/testRootCommandRunnerTerminatesHungProcess: PASS.
- Coverage-enabled Swift suite: 768 tests PASS. The repaired local profile
  covers 516 of 608 PowerHelperPlatform.swift lines versus 515 in the baseline.
- scripts/quality-gate --base origin/main: DIAGNOSTIC PASS for static, swift,
  quality-contracts, and release-budget.
- git diff --cached --check: PASS before commit.
- Manual release gates: not applicable.

## Repair history

Attempt 0, run 31723512522, failed in two unchanged product areas:

- Coverage used the same 481 business tests and 7,213 executable lines as the
  last-green main artifact. Swift sources and tests are byte-identical between
  the baseline and this PR. The hosted run recorded 6,848 covered lines instead
  of 6,849; the one-line difference is in unchanged PowerHelperPlatform.swift.
- The unchanged Codex integration timed out after eight seconds while waiting
  for its one-second heartbeat to report an intentionally ambiguous thread
  switch. The exact owning diagnostic then passed locally in 74 seconds.

These were not caused by the documentation diff. Repair attempt 1 reran the
exact head. Codex passed, but coverage repeated the same 6,848-line result.
This proved that coverage was not a second transient.

The timeout test used ordinary /bin/sleep. It can exit after SIGTERM during the
grace interval, so the SIGKILL fallback line was timing-dependent. Commit
fe96726 makes the test child ignore SIGTERM. The local LLVM profile records one
execution of the fallback and raises the critical source above the baseline.
Repair attempt 2 tests this changed exact head. Both failed attempts remain in
the PR history and quality telemetry.
