### PR TITLE
Fix Claude checkpoints for hard-linked artifacts

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1711,14 +1711,21 @@ canonical_claude_transcript_path() {
   printf '%s/%s\n' "$parent_real" "$(basename "$path")"
 }
 
-safe_plain_directory_tree() {
+safe_plain_source_tree() {
   local root="$1"
   local unsafe
 
   [ -d "$root" ] && [ ! -L "$root" ] || return 1
   unsafe="$(find "$root" -mindepth 1 ! -type d ! -type f -print -quit 2>/dev/null)" || \
     return 1
-  [ -z "$unsafe" ] || return 1
+  [ -z "$unsafe" ]
+}
+
+safe_plain_directory_tree() {
+  local root="$1"
+  local unsafe
+
+  safe_plain_source_tree "$root" || return 1
   unsafe="$(find "$root" -type f -links +1 -print -quit 2>/dev/null)" || return 1
   [ -z "$unsafe" ]
 }
@@ -2586,7 +2593,10 @@ copy_checkpoint_directory() {
   local destination="$2"
 
   [ -d "$source" ] || return 0
-  safe_plain_directory_tree "$source" || return 1
+  # Claude can hard-link tool results into a session companion directory.
+  # The private staging copy must contain independent regular files so the
+  # checkpoint archive and every later restore keep rejecting hard links.
+  safe_plain_source_tree "$source" || return 1
   mkdir -p "$(dirname "$destination")" || return 1
   cp -R "$source" "$destination" || return 1
   safe_plain_directory_tree "$destination"
@@ -2631,20 +2641,24 @@ checkpoint_claude_artifacts() {
   short_id="${id:0:8}"
   copy_checkpoint_directory "${transcript%.jsonl}" "$stage/project-session" || {
     rm -rf "$stage"
+    checkpoint_log "$session" "Claude checkpoint skipped because project companion artifacts could not be copied safely"
     return 1
   }
   copy_checkpoint_directory "$home/file-history/$id" "$stage/file-history" || {
     rm -rf "$stage"
+    checkpoint_log "$session" "Claude checkpoint skipped because file history artifacts could not be copied safely"
     return 1
   }
   copy_checkpoint_directory "$home/session-env/$id" "$stage/session-env" || {
     rm -rf "$stage"
+    checkpoint_log "$session" "Claude checkpoint skipped because session environment artifacts could not be copied safely"
     return 1
   }
   for task in "$home/tasks/$id" "$home/tasks/session-$short_id"; do
     [ -d "$task" ] || continue
     copy_checkpoint_directory "$task" "$stage/tasks/$(basename "$task")" || {
       rm -rf "$stage"
+      checkpoint_log "$session" "Claude checkpoint skipped because task artifacts could not be copied safely"
       return 1
     }
   done
@@ -2654,6 +2668,7 @@ checkpoint_claude_artifacts() {
     team="$(dirname "$config")"
     copy_checkpoint_directory "$team" "$stage/teams/$(basename "$team")" || {
       rm -rf "$stage"
+      checkpoint_log "$session" "Claude checkpoint skipped because team artifacts could not be copied safely"
       return 1
     }
   done

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -206,13 +206,13 @@ current binding on a creation-time tie. Subagent threads never rebind a
 session. Wrapper-owned provider flags are rejected; policy defaults apply only
 when the user did not supply an allowed override.
 
-Checkpoints run every `DETACH_<PROVIDER>_CHECKPOINT_INTERVAL` seconds (300 by
-default) under a per-session lock and include metadata, validated provider
-JSONL, tmux pane capture, and canonical repository-root context found from a
-real `.git` ancestor without invoking Git. Codex adds an integrity-checked
-SQLite backup. Claude atomically archives the matching project session, file
-history, session environment, tasks, and teams. `/bin/sync` follows unless the
-provider-specific `DETACH_*_SYNC=0` test override is set.
+Every 300 seconds by default, a per-session lock protects checkpoint creation.
+A checkpoint contains metadata, validated provider JSONL, pane capture, and a
+repository root from a real `.git` ancestor. Codex adds an integrity-checked
+SQLite backup. Claude archives its matching project session and companions.
+Provider-created hard links become independent regular files in staging.
+Archives and restore destinations still reject hard links and non-plain
+entries. A provider test override can disable the final `/bin/sync`.
 
 Only allowlisted provider flags are serialized to `resume-args.bin`. A provider
 flag that should survive Resume or Recover must be added deliberately.

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -480,9 +480,19 @@ json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
 [ -d "$CLAUDE_CONFIG_DIR/tasks/$session_id" ]
 [ -d "$CLAUDE_CONFIG_DIR/tasks/session-${session_id:0:8}" ]
 [ -d "$CLAUDE_CONFIG_DIR/teams/session-${session_id:0:8}" ]
+# Claude can hard-link a tool result from provider-managed scratch storage.
+# Checkpoint staging must turn it into an independent regular file while the
+# archive and restore paths keep their strict no-hard-link contract.
+hardlink_source="$TMP_ROOT/provider-tool-result"
+hardlink_result="$CLAUDE_CONFIG_DIR/projects/fake/$session_id/tool-results/hardlinked.txt"
+printf 'hard-linked tool result\n' >"$hardlink_source"
+ln "$hardlink_source" "$hardlink_result"
+[ "$(stat -f '%l' "$hardlink_result")" = 2 ]
 attempts=0
 while [ ! -s "$checkpoint/transcript.jsonl" ] || \
-    [ ! -s "$checkpoint/claude-session.tar" ]; do
+    [ ! -s "$checkpoint/claude-session.tar" ] || \
+    ! tar -tf "$checkpoint/claude-session.tar" 2>/dev/null | \
+      grep -F './project-session/tool-results/hardlinked.txt' >/dev/null; do
   attempts=$((attempts + 1))
   [ "$attempts" -lt 100 ] || {
     printf 'Claude checkpoint was not published within 10 seconds: %s\n' \
@@ -495,9 +505,16 @@ done
 "$STATE_HELPER" jsonl validate claude "$checkpoint/transcript.jsonl" "$session_id"
 [ -s "$checkpoint/claude-session.tar" ]
 tar -tf "$checkpoint/claude-session.tar" | grep -F './project-session/subagents/agent-fake.jsonl' >/dev/null
+tar -tf "$checkpoint/claude-session.tar" | grep -F './project-session/tool-results/hardlinked.txt' >/dev/null
 tar -tf "$checkpoint/claude-session.tar" | grep -F "./tasks/$session_id/task.json" >/dev/null
 tar -tf "$checkpoint/claude-session.tar" | grep -F "./tasks/session-${session_id:0:8}/task.json" >/dev/null
 tar -tf "$checkpoint/claude-session.tar" | grep -F "./teams/session-${session_id:0:8}/config.json" >/dev/null
+hardlink_extract="$TMP_ROOT/hardlink-checkpoint-extract"
+mkdir -p "$hardlink_extract"
+tar -xf "$checkpoint/claude-session.tar" -C "$hardlink_extract"
+grep -Fx 'hard-linked tool result' \
+  "$hardlink_extract/project-session/tool-results/hardlinked.txt" >/dev/null
+[ "$(stat -f '%l' "$hardlink_extract/project-session/tool-results/hardlinked.txt")" = 1 ]
 [ ! -e "$FAKE_GIT_MARKER" ]
 
 : >"$FAKE_CLAUDE_EXIT_GATE"


### PR DESCRIPTION
## Summary\n\n- accept provider-created hard links only in Claude checkpoint source trees\n- copy them into staging as independent regular files\n- keep checkpoint archives and restore destinations hard-link-free\n- log which Claude companion group prevented a safe checkpoint\n\n## Contract delta\n\nMODIFIED: Claude companion trees may contain provider-created hard links. Checkpoint staging normalizes them to independent regular files before archive validation. Restore safety remains unchanged.\n\n## Durable decisions\n\n- source compatibility and restore safety use separate validators\n- special files and symlinks remain rejected on input\n- staged files, archives, and restore destinations remain plain and hard-link-free\n\n## Evidence\n\n- tests/run-claude.sh: passed, including hard-link checkpoint and restore negative cases\n- tests/docs-contract.sh: passed\n- git diff --check: passed\n- impact diagnostic: static, app, Codex, Claude, distribution, and tmux-runtime passed\n- local UI E2E built the complete accessibility tree but macOS did not activate the test app while the installed Detach app was open; hosted quality-gates is pending