### PR TITLE
Stabilize packaged UI action evidence

### DIFF
--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -378,9 +378,11 @@ struct SessionDetailView: View {
     private func run(_ action: SessionAction) {
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
-        if action == .stop, AppSettings.uiE2E != nil,
-           UIE2EControlFault.stopActionDisconnected {
-            return
+        if action == .stop, AppSettings.uiE2E != nil {
+            UIE2EControlFault.stopActionAttempts += 1
+            if UIE2EControlFault.stopActionDisconnected {
+                return
+            }
         }
 #endif
 // quality-coverage:end ui-e2e-instrumentation

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -5,6 +5,7 @@ import Foundation
 @MainActor
 enum UIE2EControlFault {
     static var stopActionDisconnected = false
+    static var stopActionAttempts = 0
 }
 
 @MainActor
@@ -183,7 +184,10 @@ enum UIE2ETestDriver {
         var checks: [String] = []
         let previousFrontmost = NSWorkspace.shared.frontmostApplication
         let previousActivationPolicy = NSApp.activationPolicy()
-        defer { UIE2EControlFault.stopActionDisconnected = false }
+        defer {
+            UIE2EControlFault.stopActionDisconnected = false
+            UIE2EControlFault.stopActionAttempts = 0
+        }
         do {
             trace("driver started")
             guard !NSApp.isActive else {
@@ -221,9 +225,8 @@ enum UIE2ETestDriver {
             checks.append("sidebar-selects-completed-session")
             trace("completed session selected")
 
-            try await click(deleteButton, name: "delete action")
-            let confirmDelete = try await sheetButton(
-                label: "Delete")
+            let confirmDelete = try await clickUntilSheetButton(
+                deleteButton, name: "delete action", label: "Delete")
             try requireSemanticControl(confirmDelete, name: "delete confirmation")
             try await clickUntil(
                 confirmDelete,
@@ -253,9 +256,14 @@ enum UIE2ETestDriver {
                 resultIdentifier: "session-detail-\(runningID)")
             let stopButton = try await element(identifier: "session-action-stop")
             try requireSemanticControl(stopButton, name: "stop action")
+            UIE2EControlFault.stopActionAttempts = 0
             UIE2EControlFault.stopActionDisconnected = true
-            try await click(stopButton, name: "disconnected stop action")
-            try await Task.sleep(nanoseconds: 500_000_000)
+            try await clickUntil(
+                stopButton,
+                name: "disconnected stop action",
+                outcome: "disconnected stop action reaches fault boundary") {
+                UIE2EControlFault.stopActionAttempts > 0
+            }
             let disconnectedActions = try? String(
                 contentsOf: configuration.root
                     .appendingPathComponent("fake/actions.log"),
@@ -498,11 +506,14 @@ enum UIE2ETestDriver {
         return result!
     }
 
-    private static func sheetButton(label: String) async throws
+    private static func sheetButton(
+        label: String,
+        attempts: Int = 100
+    ) async throws
         -> any NSAccessibilityProtocol
     {
         var result: (any NSAccessibilityProtocol)?
-        try await waitUntil("sheet button \(label)") {
+        try await waitUntil("sheet button \(label)", attempts: attempts) {
             let sheetFrames = NSApp.windows.flatMap(\.sheets).map(\.frame)
             result = elements().first { element in
                 roleOf(element) == .button
@@ -513,6 +524,22 @@ enum UIE2ETestDriver {
             return result != nil
         }
         return result!
+    }
+
+    private static func clickUntilSheetButton(
+        _ control: any NSAccessibilityProtocol,
+        name: String,
+        label: String
+    ) async throws -> any NSAccessibilityProtocol {
+        for _ in 0..<3 {
+            try await click(control, name: name)
+            do {
+                return try await sheetButton(label: label, attempts: 10)
+            } catch {
+                continue
+            }
+        }
+        throw Failure(message: "\(name) did not present \(label) confirmation")
     }
 
     private static func waitUntil(

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1055,26 +1055,63 @@ switch_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 pre_switch_id="$("$STATE_HELPER" meta get "$meta" codex_session_id)"
 [ -n "$pre_switch_id" ]
 switch_base_ms="$(($(date '+%s') * 1000))"
-switch_thread() {
+write_switch_rollout() {
   local switch_id="$1"
-  local switch_ms="$2"
-  local switch_source="$3"
-  local switch_turn="$4"
+  local switch_source="$2"
+  local switch_turn="$3"
   local switch_rollout="$CODEX_HOME/sessions/2099/01/01/rollout-test-$switch_id.jsonl"
 
   printf '{"timestamp":"2099-01-01T00:20:00Z","type":"session_meta","payload":{"id":"%s","cwd":"%s","originator":"detach_%s"}}\n' \
     "$switch_id" "$switch_project_dir" "$switch_run_token" >"$switch_rollout"
   printf '{"timestamp":"2099-01-01T00:20:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"%s"}}\n' \
     "$switch_turn" >>"$switch_rollout"
+  printf '%s\n' "$switch_rollout"
+}
+
+switch_thread() {
+  local switch_id="$1"
+  local switch_ms="$2"
+  local switch_source="$3"
+  local switch_turn="$4"
+  local switch_rollout
+
+  switch_rollout="$(write_switch_rollout \
+    "$switch_id" "$switch_source" "$switch_turn")"
   test_sqlite "$CODEX_HOME/state_5.sqlite" \
     "INSERT OR REPLACE INTO threads (id, rollout_path, created_at_ms, updated_at_ms, source, thread_source, cwd) \
      VALUES ('$switch_id', '${switch_rollout//\'/\'\'}', $switch_ms, $switch_ms, 'cli', '$switch_source', '${switch_project_dir//\'/\'\'}');"
 }
+
+switch_thread_pair() {
+  local first_id="$1"
+  local first_ms="$2"
+  local first_source="$3"
+  local first_turn="$4"
+  local second_id="$5"
+  local second_ms="$6"
+  local second_source="$7"
+  local second_turn="$8"
+  local first_rollout
+  local second_rollout
+
+  first_rollout="$(write_switch_rollout \
+    "$first_id" "$first_source" "$first_turn")"
+  second_rollout="$(write_switch_rollout \
+    "$second_id" "$second_source" "$second_turn")"
+  test_sqlite "$CODEX_HOME/state_5.sqlite" \
+    "BEGIN IMMEDIATE; \
+     INSERT OR REPLACE INTO threads (id, rollout_path, created_at_ms, updated_at_ms, source, thread_source, cwd) \
+     VALUES ('$first_id', '${first_rollout//\'/\'\'}', $first_ms, $first_ms, 'cli', '$first_source', '${switch_project_dir//\'/\'\'}'); \
+     INSERT OR REPLACE INTO threads (id, rollout_path, created_at_ms, updated_at_ms, source, thread_source, cwd) \
+     VALUES ('$second_id', '${second_rollout//\'/\'\'}', $second_ms, $second_ms, 'cli', '$second_source', '${switch_project_dir//\'/\'\'}'); \
+     COMMIT;"
+}
 switch_a="22222222-2222-7222-8222-222222222222"
 switch_b="33333333-3333-7333-8333-333333333333"
 switch_subagent="44444444-4444-7444-8444-444444444444"
-switch_thread "$switch_a" "$((switch_base_ms + 1000))" user clear-turn-a
-switch_thread "$switch_b" "$((switch_base_ms + 1000))" user clear-turn-b
+switch_thread_pair \
+  "$switch_a" "$((switch_base_ms + 1000))" user clear-turn-a \
+  "$switch_b" "$((switch_base_ms + 1000))" user clear-turn-b
 switch_thread "$switch_subagent" "$((switch_base_ms + 5000))" subagent clear-turn-subagent
 wait_for_file_text "$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint.log" \
   'ambiguous Codex thread switch'
@@ -1113,8 +1150,9 @@ grep -F 'clear-turn-a' "$checkpoint/rollout.jsonl" >/dev/null
 # unambiguous.
 switch_c="55555555-5555-7555-8555-555555555555"
 switch_d="66666666-6666-7666-8666-666666666666"
-switch_thread "$switch_c" "$((switch_base_ms + 10000))" user clear-turn-c
-switch_thread "$switch_d" "$((switch_base_ms + 11000))" user clear-turn-d
+switch_thread_pair \
+  "$switch_c" "$((switch_base_ms + 10000))" user clear-turn-c \
+  "$switch_d" "$((switch_base_ms + 11000))" user clear-turn-d
 attempts=0
 while [ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" != "$switch_d" ] && \
       [ "$attempts" -lt 80 ]; do


### PR DESCRIPTION
## Summary

- retry the real Delete control until its confirmation sheet appears
- require the disconnected Stop control to reach its test-only fault boundary
- keep the semantic locator action-free and the production path unchanged

## Verification

- app diagnostic passed
- packaged UI smoke passed in 13s and 14s
- impact diagnostic passed every functional stage
- local Swift timing was 22s against the 20s reference budget; no warm-cache rerun was used

The hosted quality-gates job is the merge-readiness authority.