### PR TITLE
Remove clean-account release matrix

### DIFF
--- a/app/Tests/DetachAppTests/SessionIdentityTests.swift
+++ b/app/Tests/DetachAppTests/SessionIdentityTests.swift
@@ -36,3 +36,26 @@ final class SessionActionPresentationTests: XCTestCase {
             "Recover in Ghostty")
     }
 }
+
+@MainActor
+final class ContextGaugeTests: XCTestCase {
+    func testBuildsEveryContextUsageBand() {
+        let sessions = [10, 80, 95].map(makeSession(contextUsedTokens:))
+
+        XCTAssertEqual(sessions.compactMap(\.contextFraction), [0.1, 0.8, 0.95])
+        for session in sessions {
+            _ = ContextGauge(session: session).body
+        }
+    }
+
+    private func makeSession(contextUsedTokens: Int) -> Session {
+        let json = """
+        {"schema":1,"provider":"codex","session_name":"work","name":"work",\
+        "effective_status":"running","context_used_tokens":\(contextUsedTokens),\
+        "context_window":100}
+        """
+        let parsed = SessionListParser.parse(json)
+        precondition(!parsed.sessions.isEmpty, "fixture must parse")
+        return parsed.sessions[0]
+    }
+}

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -33,25 +33,22 @@ change real power state, upload assets, or claim publication.
   DMG. The workflow never installs a mutable intermediate app build.
 - Developer ID signing, notarization, and the real signed power smoke are
   mandatory for every release. `scripts/release-impact` compares the last
-  published tag with the release source. It selects the clean-account/system UI
-  matrix only for install, onboarding, approval, update, entitlement, or
-  localization impact. It selects supervised closed-lid testing only for
-  power, helper, watchdog, lease, assertion, or lid-probe impact. An unknown
-  product path selects both manual gates. Test-only, documentation-only, and
-  known unrelated product paths do not select them.
+  published tag with the release source. It selects supervised closed-lid
+  testing only for power, helper, watchdog, lease, assertion, or lid-probe
+  impact. An unknown product path selects the closed-lid gate. Test-only,
+  documentation-only, and known unrelated product paths do not select it.
 - Notary credential preflight gives `notarytool` a private PTY and captures its
   output in private workflow evidence. This supports protected Keychain
   profiles without exposing submission history in the release log.
 - The path classifier is the fail-safe default. An explicit private semantic
   review can omit a false-positive manual gate only when it is permission-safe,
   ignored by Git, bound to the exact base and head commits, and gives a reason
-  for each decision. It cannot narrow unknown-path impact or omit automated
+  for the decision. It cannot narrow unknown-path impact or omit automated
   tests, signing, notarization, the signed power smoke, or artifact checks.
 - A selected closed-lid probe must emit its first liveness sample within a
   bounded ten-second launch window before owner confirmation is accepted.
-  Automated release tests cover failed install and update paths. A selected
-  clean-account/system UI matrix uses the short checklist in `docs/testing.md`
-  and does not repeat the signed power or lid gates.
+  Automated release tests cover install, repair, uninstall, update, CLI
+  synchronization, and helper replacement paths.
 - The release entry point supplies the low-level publication confirmation after
   all selected gates pass. After upload, every remote asset is downloaded and
   its digest is independently matched. Missing, extra, changed, or mismatched

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,17 +200,15 @@ matching temporary branch. It does not push release metadata directly to
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
 the signed candidate, runs the real power smoke, publishes, and independently
 downloads and hashes every remote asset. `scripts/release-impact` compares the
-last published tag with the release source. It selects the clean-account/system
-UI matrix only for install, onboarding, approval, update, entitlement, or
-localization impact. It selects the supervised closed-lid probe only for power,
-helper, watchdog, lease, assertion, or lid-probe impact. Unknown product paths
-select both manual gates. Its private resume state and impact evidence live
-under ignored `app/build/`.
+last published tag with the release source. It selects the supervised
+closed-lid probe only for power, helper, watchdog, lease, assertion, or
+lid-probe impact. Unknown product paths select the closed-lid gate. Its private
+resume state and impact evidence live under ignored `app/build/`.
 The path result is fail-safe. For a false positive, a release operator can
 supply `DETACH_RELEASE_IMPACT_REVIEW` with an absolute path directly under
 ignored `app/build/release-impact-reviews/`. The `0600` TSV file must bind the
-exact base and head commits, set both manual-gate decisions, and give a reason
-for each. It cannot narrow unknown-path impact or an automated release gate.
+exact base and head commits, set the manual-gate decision, and give a reason.
+It cannot narrow unknown-path impact or an automated release gate.
 Set `DETACH_RELEASE_IGNORE_TIMING=1` only when the owner explicitly accepts
 busy-machine timing for that single release; the script requires the same exact
 release-target confirmation before it omits reference-machine timing checks.
@@ -224,30 +222,3 @@ sidecar. `scripts/release-sbom` builds it from the pinned Swift and bundled tmux
 source metadata. The release manifest binds the SBOM digest to the exact tag
 and commit. Preflight and remote verification reject a missing, changed, or
 structurally invalid SBOM.
-
-## Clean installation and system UI release checklist
-
-Run this checklist only when `scripts/release-impact` selects the system UI
-matrix for the signed candidate. Automated tests cover Repair, keep/purge
-Uninstall, reinstall, failed updates, CLI synchronization, and helper
-replacement. This checklist covers only Finder and real macOS approval UI.
-
-1. Start a clean macOS 26 or later Apple Silicon account or VM in English.
-   Open the signed DMG. Confirm that Detach blocks setup from the DMG and tells
-   you to move the app. Use Finder to copy Detach to `/Applications`.
-2. Complete onboarding. Approve the background item and power helper. Allow
-   notifications. Confirm that Detach detects an authenticated provider. Start
-   the first managed session. Close the terminal and Detach, then reopen Detach
-   and confirm that the session is still live.
-3. In a second clean user account, select Russian. Deny notification access.
-   Confirm that the retry action opens System Settings. Confirm that the
-   background-item approval text and action are in Russian.
-4. Record the candidate tag and the result in private release notes. Do not run
-   the signed power smoke or closed-lid test as part of this checklist. Those
-   tests are separate release gates.
-
-After the checklist passes, resume the workflow with the exact release target:
-
-```bash
-DETACH_CONFIRM_INSTALL_MATRIX=owner/repository@vX.Y.Z scripts/release-version X.Y.Z
-```

--- a/quality/evals.json
+++ b/quality/evals.json
@@ -138,7 +138,6 @@
           "J-POWER-CLOSED-LID"
         ],
         "release_gates": [
-          "install",
           "lid"
         ],
         "unknown": false
@@ -180,7 +179,6 @@
           "J-POWER-CLOSED-LID"
         ],
         "release_gates": [
-          "install",
           "lid"
         ],
         "unknown": false
@@ -262,7 +260,6 @@
           "J-PUBLISH-ARTIFACTS"
         ],
         "release_gates": [
-          "install",
           "lid"
         ],
         "unknown": true

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -658,7 +658,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 41,
+  "policy": 42,
   "release_domains": [
     {
       "gates": "-",
@@ -666,7 +666,7 @@
       "unknown": false
     },
     {
-      "gates": "install",
+      "gates": "-",
       "id": "install",
       "unknown": false
     },
@@ -676,12 +676,12 @@
       "unknown": false
     },
     {
-      "gates": "install,lid",
+      "gates": "lid",
       "id": "both",
       "unknown": false
     },
     {
-      "gates": "install,lid",
+      "gates": "lid",
       "id": "unknown",
       "unknown": true
     }

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	41
+policy	42
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -57,10 +57,10 @@ test-domain	release-contract	static,gate-contract	update,publication
 test-domain	metadata	static	quality-system
 test-domain	unknown	*	*
 release-domain	safe	-	false
-release-domain	install	install	false
+release-domain	install	-	false
 release-domain	lid	lid	false
-release-domain	both	install,lid	false
-release-domain	unknown	install,lid	true
+release-domain	both	lid	false
+release-domain	unknown	lid	true
 coverage-exclusion	ui	app/Sources/DetachApp/UIE2E*.swift	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-SESSION-STOP,SC-UI-NEW-SESSION,SC-UI-EMPTY,SC-UI-FAILURE,SC-UI-FOCUS,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL,SC-UI-SETTINGS	The packaged real-control journeys own this test harness.
 coverage-exclusion	business	app/Sources/DetachKit/BoundedProcessRunner.swift	SC-POWER-UNIT	Process-group behavior uses bounded process integration evidence.
 coverage-exclusion	business	app/Sources/DetachKit/ClamshellLockRunner.swift	SC-POWER-UNIT	Platform lock behavior uses its dedicated process scenario.

--- a/scripts/release-impact
+++ b/scripts/release-impact
@@ -26,25 +26,16 @@ HEAD_COMMIT="$(git -C "$ROOT" rev-parse --verify "$HEAD^{commit}" 2>/dev/null)" 
 git -C "$ROOT" merge-base --is-ancestor "$BASE_COMMIT" "$HEAD_COMMIT" || \
   die 'base must be an ancestor of head'
 
-INSTALL_MATRIX_REQUIRED=false
 LID_TEST_REQUIRED=false
 UNKNOWN_IMPACT=false
-INSTALL_REASONS=()
 LID_REASONS=()
 UNKNOWN_REASONS=()
 SEMANTIC_REVIEW_APPLIED=false
-INSTALL_REVIEW_REASON=""
 LID_REVIEW_REASON=""
 
 add_unique() {
   local array_name="$1" value="$2" existing
   case "$array_name" in
-    INSTALL_REASONS)
-      for existing in "${INSTALL_REASONS[@]-}"; do
-        [ "$existing" != "$value" ] || return 0
-      done
-      INSTALL_REASONS+=( "$value" )
-      ;;
     LID_REASONS)
       for existing in "${LID_REASONS[@]-}"; do
         [ "$existing" != "$value" ] || return 0
@@ -61,21 +52,9 @@ add_unique() {
   esac
 }
 
-require_install_matrix() {
-  INSTALL_MATRIX_REQUIRED=true
-  add_unique INSTALL_REASONS "$1"
-}
-
 require_lid_test() {
   LID_TEST_REQUIRED=true
   add_unique LID_REASONS "$1"
-}
-
-require_both_unknown() {
-  UNKNOWN_IMPACT=true
-  add_unique UNKNOWN_REASONS "$1"
-  require_install_matrix "$1"
-  require_lid_test "$1"
 }
 
 review_value() {
@@ -89,7 +68,7 @@ review_value() {
 apply_semantic_review() {
   local review="${DETACH_RELEASE_IMPACT_REVIEW:-}" review_root review_parent
   local relative mode mode_value schema reviewed_base reviewed_head
-  local reviewed_install reviewed_lid key
+  local reviewed_lid key
 
   [ -n "$review" ] || return 0
   case "$review" in /*) ;; *) die 'impact review path must be absolute' ;; esac
@@ -115,33 +94,28 @@ apply_semantic_review() {
     die 'impact review must not be accessible by group/other'
   awk -F '\t' '
     NF != 2 {exit 1}
-    $1 !~ /^(schema|base_commit|head_commit|install_matrix_required|install_matrix_rationale|lid_test_required|lid_test_rationale)$/ {exit 1}
+    $1 !~ /^(schema|base_commit|head_commit|lid_test_required|lid_test_rationale)$/ {exit 1}
   ' "$review" || die 'impact review has malformed or unsupported fields'
-  for key in schema base_commit head_commit install_matrix_required \
-      install_matrix_rationale lid_test_required lid_test_rationale; do
+  for key in schema base_commit head_commit lid_test_required lid_test_rationale; do
     review_value "$review" "$key" >/dev/null
   done
   schema="$(review_value "$review" schema)"
   reviewed_base="$(review_value "$review" base_commit)"
   reviewed_head="$(review_value "$review" head_commit)"
-  reviewed_install="$(review_value "$review" install_matrix_required)"
-  INSTALL_REVIEW_REASON="$(review_value "$review" install_matrix_rationale)"
   reviewed_lid="$(review_value "$review" lid_test_required)"
   LID_REVIEW_REASON="$(review_value "$review" lid_test_rationale)"
-  [ "$schema" = 1 ] || die 'impact review schema is unsupported'
+  [ "$schema" = 2 ] || die 'impact review schema is unsupported'
   [ "$reviewed_base" = "$BASE_COMMIT" ] && [ "$reviewed_head" = "$HEAD_COMMIT" ] || \
     die 'impact review does not match the exact release source range'
-  case "$reviewed_install:$reviewed_lid" in
-    true:true|true:false|false:true|false:false) ;;
-    *) die 'impact review gate values must be true or false' ;;
+  case "$reviewed_lid" in
+    true|false) ;;
+    *) die 'impact review gate value must be true or false' ;;
   esac
-  [ "${#INSTALL_REVIEW_REASON}" -ge 20 ] && [ "${#LID_REVIEW_REASON}" -ge 20 ] || \
-    die 'impact review rationales must each contain at least 20 characters'
-  if [ "$UNKNOWN_IMPACT" = true ] && \
-     { [ "$reviewed_install" = false ] || [ "$reviewed_lid" = false ]; }; then
+  [ "${#LID_REVIEW_REASON}" -ge 20 ] || \
+    die 'impact review rationale must contain at least 20 characters'
+  if [ "$UNKNOWN_IMPACT" = true ] && [ "$reviewed_lid" = false ]; then
     die 'impact review cannot omit a gate selected by an unknown product path'
   fi
-  INSTALL_MATRIX_REQUIRED="$reviewed_install"
   LID_TEST_REQUIRED="$reviewed_lid"
   SEMANTIC_REVIEW_APPLIED=true
 }
@@ -160,7 +134,6 @@ classify_path() {
     IFS=, read -r -a selected_gates <<<"$gates"
     for gate in "${selected_gates[@]}"; do
       case "$gate" in
-        install) require_install_matrix "$path" ;;
         lid) require_lid_test "$path" ;;
         *) die "quality policy selected an unknown release gate: $gate" ;;
       esac
@@ -180,20 +153,15 @@ done < <(git -C "$ROOT" diff --name-status -z --find-renames "$BASE_COMMIT" "$HE
 
 apply_semantic_review
 
-printf 'schema\t1\n'
+printf 'schema\t2\n'
 printf 'base_commit\t%s\n' "$BASE_COMMIT"
 printf 'head_commit\t%s\n' "$HEAD_COMMIT"
-printf 'install_matrix_required\t%s\n' "$INSTALL_MATRIX_REQUIRED"
 printf 'lid_test_required\t%s\n' "$LID_TEST_REQUIRED"
 printf 'unknown_impact\t%s\n' "$UNKNOWN_IMPACT"
 printf 'semantic_review_applied\t%s\n' "$SEMANTIC_REVIEW_APPLIED"
 [ "$SEMANTIC_REVIEW_APPLIED" = false ] || {
-  printf 'install_matrix_review_reason\t%s\n' "$INSTALL_REVIEW_REASON"
   printf 'lid_test_review_reason\t%s\n' "$LID_REVIEW_REASON"
 }
-for path in "${INSTALL_REASONS[@]-}"; do
-  [ -z "$path" ] || printf 'install_matrix_reason\t%s\n' "$path"
-done
 for path in "${LID_REASONS[@]-}"; do
   [ -z "$path" ] || printf 'lid_test_reason\t%s\n' "$path"
 done

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -267,14 +267,13 @@ resolve_release_impact() {
   schema="$(impact_value "$temporary" schema)"
   base_commit="$(impact_value "$temporary" base_commit)"
   head_commit="$(impact_value "$temporary" head_commit)"
-  INSTALL_MATRIX_REQUIRED="$(impact_value "$temporary" install_matrix_required)"
   LID_TEST_REQUIRED="$(impact_value "$temporary" lid_test_required)"
   unknown="$(impact_value "$temporary" unknown_impact)"
-  [ "$schema" = 1 ] || die 'release impact schema is unsupported'
+  [ "$schema" = 2 ] || die 'release impact schema is unsupported'
   [[ "$base_commit" =~ ^[0-9a-f]{40}$ ]] || die 'release impact base commit is invalid'
   [ "$head_commit" = "$SOURCE_COMMIT" ] || die 'release impact head commit does not match source'
-  case "$INSTALL_MATRIX_REQUIRED:$LID_TEST_REQUIRED:$unknown" in
-    true:true:true|true:true:false|true:false:false|false:true:false|false:false:false) ;;
+  case "$LID_TEST_REQUIRED:$unknown" in
+    true:true|true:false|false:false) ;;
     *) die 'release impact booleans are invalid or fail-open' ;;
   esac
   if [ -f "$impact" ]; then
@@ -284,7 +283,7 @@ resolve_release_impact() {
   else
     mv -f "$temporary" "$impact"
   fi
-  note "manual release gates: install-matrix=$INSTALL_MATRIX_REQUIRED lid=$LID_TEST_REQUIRED"
+  note "manual release gate: lid=$LID_TEST_REQUIRED"
 }
 
 has_stage() {
@@ -343,8 +342,11 @@ release_tooling_path_allowed() {
     scripts/release-version|scripts/release-pr|scripts/release-sbom|\
     scripts/release-impact|scripts/quality-gate|scripts/quality-merge|\
     tools/release_pr.py|tools/release_sbom.py|tools/quality_merge.py|\
+    tools/quality_policy.py|tools/quality_care.py|\
     app/scripts/publish-release.sh|\
+    quality/policy.tsv|quality/evals.json|quality/generated/policy.json|\
     tests/quality-gate.sh|tests/release-impact.sh|tests/release-workflow.sh|\
+    tests/quality-policy.sh|\
     tests/publish-preflight.sh|tests/shell-safety.sh|tests/shell-safety-contract.sh|\
     docs/quality-gates.md|docs/specs/release.md|docs/testing.md)
       return 0
@@ -834,21 +836,6 @@ build_release_artifacts() {
   has_stage artifacts || record_stage artifacts
 }
 
-confirm_install_update_matrix() {
-  has_stage install-matrix && return
-  release_artifacts_valid || die 'release artifacts changed before install-matrix review'
-  if [ "$INSTALL_MATRIX_REQUIRED" = false ]; then
-    note 'skipping clean installation and system UI matrix: release impact does not select it'
-    record_stage install-matrix
-    return
-  fi
-  printf '%s\n' \
-    'Complete the clean installation and update checklist in docs/testing.md with the signed Detach.dmg. Use a clean macOS account or VM. Do not reuse the signed power or lid tests as evidence.'
-  exact_confirmation DETACH_CONFIRM_INSTALL_MATRIX \
-    'clean installation and update matrix'
-  record_stage install-matrix
-}
-
 installed_candidate_valid() {
   [ -d "$INSTALLED_APP" ] && [ ! -L "$INSTALLED_APP" ] || return 1
   [ "$(file_line "$INSTALLED_APP/Contents/Resources/DetachCLI/VERSION" 2>/dev/null || true)" = "$VERSION" ] || return 1
@@ -1135,7 +1122,6 @@ run_locked() {
   prepare_release_commit
   push_release_source
   build_release_artifacts
-  confirm_install_update_matrix
   install_release_candidate
   run_power_smoke
   run_lid_test

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -94,7 +94,17 @@ unknown="$("$ROOT/scripts/quality-policy" classify product/new-runtime)"
 [ "$(field "$unknown" 1)" = unknown ] || fail 'new product path must fail safe'
 [ "$(field "$unknown" 5)" = "$("$ROOT/scripts/quality-policy" stages all | paste -sd, -)" ] || \
   fail 'unknown product path must select every stage'
-[ "$(field "$unknown" 6)" = install,lid ] || fail 'unknown product path must select both release gates'
+[ "$(field "$unknown" 6)" = lid ] || fail 'unknown product path must select the closed-lid release gate'
+
+awk -F '\t' -v OFS='\t' \
+  '$1 == "release-domain" && $2 == "install" {$3="install"} {print}' \
+  "$ROOT/quality/policy.tsv" >"$TMP_ROOT/removed-install-gate.tsv"
+if DETACH_QUALITY_POLICY="$TMP_ROOT/removed-install-gate.tsv" \
+    "$ROOT/scripts/quality-policy" validate >"$TMP_ROOT/removed-install-gate.out" 2>&1; then
+  fail 'removed clean-account release gate was accepted'
+fi
+grep -F 'unknown release gate' "$TMP_ROOT/removed-install-gate.out" >/dev/null || \
+  fail 'removed clean-account gate failure is unclear'
 
 cp "$ROOT/quality/policy.tsv" "$TMP_ROOT/duplicate.tsv"
 printf '%s\n' $'route\t950\tREADME.md\tdocs\tsafe\tdocs/specs/documentation.md' \

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -51,34 +51,29 @@ assert_value() {
 BASE="$(git -C "$REPO" rev-parse HEAD)"
 SAFE_HEAD="$(commit_path app/Sources/DetachKit/TerminalLauncher.swift terminal)"
 "$REPO/scripts/release-impact" "$BASE" "$SAFE_HEAD" >"$TMP_ROOT/safe.tsv"
-assert_value "$TMP_ROOT/safe.tsv" install_matrix_required false
+assert_value "$TMP_ROOT/safe.tsv" schema 2
 assert_value "$TMP_ROOT/safe.tsv" lid_test_required false
 assert_value "$TMP_ROOT/safe.tsv" unknown_impact false
+! grep -F 'install_matrix' "$TMP_ROOT/safe.tsv" >/dev/null
 
 MATRIX_HEAD="$(commit_path app/Sources/DetachApp/OnboardingView.swift onboarding)"
 "$REPO/scripts/release-impact" "$SAFE_HEAD" "$MATRIX_HEAD" >"$TMP_ROOT/matrix.tsv"
-assert_value "$TMP_ROOT/matrix.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/matrix.tsv" lid_test_required false
 assert_value "$TMP_ROOT/matrix.tsv" unknown_impact false
-grep -F $'install_matrix_reason\tapp/Sources/DetachApp/OnboardingView.swift' \
-  "$TMP_ROOT/matrix.tsv" >/dev/null
 
 DMG_HEAD="$(commit_path app/scripts/make-dmg.sh dmg)"
 "$REPO/scripts/release-impact" "$MATRIX_HEAD" "$DMG_HEAD" >"$TMP_ROOT/dmg.tsv"
-assert_value "$TMP_ROOT/dmg.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/dmg.tsv" lid_test_required false
 assert_value "$TMP_ROOT/dmg.tsv" unknown_impact false
 
 CORE_HEAD="$(commit_path bin/detach-core core)"
 "$REPO/scripts/release-impact" "$DMG_HEAD" "$CORE_HEAD" >"$TMP_ROOT/core.tsv"
-assert_value "$TMP_ROOT/core.tsv" install_matrix_required false
 assert_value "$TMP_ROOT/core.tsv" lid_test_required true
 assert_value "$TMP_ROOT/core.tsv" unknown_impact false
 
 SHARED_POWER_HEAD="$(commit_path app/Sources/DetachKit/BoundedProcessRunner.swift runner)"
 "$REPO/scripts/release-impact" "$CORE_HEAD" "$SHARED_POWER_HEAD" \
   >"$TMP_ROOT/shared-power.tsv"
-assert_value "$TMP_ROOT/shared-power.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/shared-power.tsv" lid_test_required true
 assert_value "$TMP_ROOT/shared-power.tsv" unknown_impact false
 
@@ -86,11 +81,9 @@ REVIEW_ROOT="$REPO/app/build/release-impact-reviews"
 REVIEW="$REVIEW_ROOT/current.tsv"
 mkdir -m 0700 -p "$REVIEW_ROOT"
 cat >"$REVIEW" <<EOF
-schema	1
+schema	2
 base_commit	$CORE_HEAD
 head_commit	$SHARED_POWER_HEAD
-install_matrix_required	false
-install_matrix_rationale	Automated coverage proves this change does not alter clean-account system UI.
 lid_test_required	false
 lid_test_rationale	No assertion, lease, helper daemon, or closed-lid runtime behavior changed.
 EOF
@@ -98,12 +91,9 @@ chmod 0600 "$REVIEW"
 DETACH_RELEASE_IMPACT_REVIEW="$REVIEW" \
   "$REPO/scripts/release-impact" "$CORE_HEAD" "$SHARED_POWER_HEAD" \
   >"$TMP_ROOT/reviewed.tsv"
-assert_value "$TMP_ROOT/reviewed.tsv" install_matrix_required false
 assert_value "$TMP_ROOT/reviewed.tsv" lid_test_required false
 assert_value "$TMP_ROOT/reviewed.tsv" unknown_impact false
 assert_value "$TMP_ROOT/reviewed.tsv" semantic_review_applied true
-grep -F $'install_matrix_review_reason\tAutomated coverage proves' \
-  "$TMP_ROOT/reviewed.tsv" >/dev/null
 grep -F $'lid_test_review_reason\tNo assertion, lease' \
   "$TMP_ROOT/reviewed.tsv" >/dev/null
 
@@ -130,23 +120,19 @@ grep -F 'does not match the exact release source range' \
 POWER_HEAD="$(commit_path app/Sources/DetachPower/main.swift power)"
 "$REPO/scripts/release-impact" "$SHARED_POWER_HEAD" "$POWER_HEAD" \
   >"$TMP_ROOT/power.tsv"
-assert_value "$TMP_ROOT/power.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/power.tsv" lid_test_required true
 assert_value "$TMP_ROOT/power.tsv" unknown_impact false
 
 UNKNOWN_HEAD="$(commit_path product/new-runtime future)"
 "$REPO/scripts/release-impact" "$POWER_HEAD" "$UNKNOWN_HEAD" >"$TMP_ROOT/unknown.tsv"
-assert_value "$TMP_ROOT/unknown.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/unknown.tsv" lid_test_required true
 assert_value "$TMP_ROOT/unknown.tsv" unknown_impact true
 grep -F $'unknown_reason\tproduct/new-runtime' "$TMP_ROOT/unknown.tsv" >/dev/null
 
 cat >"$REVIEW" <<EOF
-schema	1
+schema	2
 base_commit	$POWER_HEAD
 head_commit	$UNKNOWN_HEAD
-install_matrix_required	false
-install_matrix_rationale	A semantic review cannot narrow an unknown product path impact selection.
 lid_test_required	false
 lid_test_rationale	A semantic review cannot narrow an unknown product path impact selection.
 EOF
@@ -163,7 +149,6 @@ grep -F 'cannot omit a gate selected by an unknown product path' \
 NEW_APP_HEAD="$(commit_path app/Sources/DetachApp/FutureFlow.swift future-app)"
 "$REPO/scripts/release-impact" "$UNKNOWN_HEAD" "$NEW_APP_HEAD" \
   >"$TMP_ROOT/new-app.tsv"
-assert_value "$TMP_ROOT/new-app.tsv" install_matrix_required true
 assert_value "$TMP_ROOT/new-app.tsv" lid_test_required true
 assert_value "$TMP_ROOT/new-app.tsv" unknown_impact true
 grep -F $'unknown_reason\tapp/Sources/DetachApp/FutureFlow.swift' \

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -472,7 +472,6 @@ SH
 run_workflow() {
   local fail_after="${1:-}" lid_confirmation="${2:-example/detach@$TARGET_TAG}"
   local release_confirmation="${3:-}" ignore_timing="${4:-0}"
-  local install_confirmation="${5:-example/detach@$TARGET_TAG}"
   (
     cd -P "$REPO"
     PATH="$BIN:/usr/bin:/bin" \
@@ -492,7 +491,6 @@ run_workflow() {
       DETACH_RELEASE_IGNORE_TIMING="$ignore_timing" \
       DETACH_QUALITY_AUTHORITY= \
       DETACH_CONFIRM_RELEASE="$release_confirmation" \
-      DETACH_CONFIRM_INSTALL_MATRIX="$install_confirmation" \
       DETACH_CONFIRM_LID_TEST="$lid_confirmation" \
       "$REPO/scripts/release-version" "$TARGET_VERSION"
   )
@@ -560,7 +558,7 @@ run_resume_case() {
   git -C "$REPO" add docs/testing.md
   git -C "$REPO" commit -qm 'adjust release tooling guidance'
   git -C "$REPO" push -q origin main
-  for stage in install-matrix installed power-smoke lid published verified; do
+  for stage in installed power-smoke lid published verified; do
     expect_failure "resume-$stage" "injected safe failure after $stage" \
       run_workflow "$stage"
   done
@@ -576,7 +574,8 @@ run_resume_case() {
   [ "$(grep -c '^release-preflight.sh$' "$ACTION_LOG")" = 2 ]
   [ "$(grep -c '^publish-preflight.sh$' "$ACTION_LOG")" = 2 ]
   [ -z "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
-  grep -F $'install_matrix_required\tfalse' \
+  [ ! -e "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-install-matrix" ]
+  grep -F $'schema\t2' \
     "$REPO/app/build/release-workflow/$TARGET_VERSION/release-impact.tsv" >/dev/null
   grep -F $'lid_test_required\tfalse' \
     "$REPO/app/build/release-workflow/$TARGET_VERSION/release-impact.tsv" >/dev/null
@@ -655,15 +654,6 @@ run_hardware_rejection_case() {
   git -C "$REPO" add app/Sources/DetachPower/main.swift
   git -C "$REPO" commit -qm 'change power runtime'
   git -C "$REPO" push -q origin main
-  expect_failure install-matrix-gate \
-    "clean installation and update matrix confirmation must exactly equal example/detach@$TARGET_TAG" \
-    run_workflow '' "example/detach@$TARGET_TAG" \
-      "example/detach@$TARGET_TAG" 0 wrong-confirmation
-  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-artifacts" ]
-  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-install-matrix" ]
-  ! grep -q '^power-smoke$' "$ACTION_LOG"
-  ! grep -q '^publish$' "$ACTION_LOG"
-
   expect_failure hardware-gate \
     "closed-lid hardware test confirmation must exactly equal example/detach@$TARGET_TAG" \
     run_workflow '' wrong-confirmation

--- a/tools/quality_care.py
+++ b/tools/quality_care.py
@@ -169,7 +169,7 @@ def impact(policy: Policy, paths: list[str]) -> dict[str, Any]:
             "specs": list(policy.specs),
             "capabilities": list(policy.capabilities),
             "journeys": list(policy.journeys),
-            "release_gates": ["install", "lid"],
+            "release_gates": ["lid"],
             "unknown": True,
         }
     stages = {
@@ -207,7 +207,7 @@ def impact(policy: Policy, paths: list[str]) -> dict[str, Any]:
         "specs": [identifier for identifier, (path, _) in policy.specs.items() if path in spec_paths],
         "capabilities": in_policy_order(capabilities, list(policy.capabilities)),
         "journeys": in_policy_order(journeys, list(policy.journeys)),
-        "release_gates": in_policy_order(gates, ["install", "lid"]),
+        "release_gates": in_policy_order(gates, ["lid"]),
         "unknown": False,
     }
 

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -221,7 +221,7 @@ class Policy:
                 name, gates, raw_unknown = values
                 if not IDENTIFIER.fullmatch(name) or not self._csv(gates, allow_dash=True):
                     raise PolicyError(f"line {line_number}: invalid release domain")
-                if gates != "-" and any(gate not in ("install", "lid") for gate in gates.split(",")):
+                if gates != "-" and any(gate != "lid" for gate in gates.split(",")):
                     raise PolicyError(f"line {line_number}: unknown release gate")
                 self._unique(self.release_domains, name, "release domain", line_number)
                 self.release_domains[name] = (gates, self._boolean(raw_unknown, line_number))


### PR DESCRIPTION
Summary
- remove the clean-account and system UI matrix from release orchestration
- keep automated install and update coverage, signing, notarization, signed power smoke, closed-lid testing, and remote artifact verification
- reduce release-impact schema and quality policy to the closed-lid manual gate

Durable contract
- unknown product paths still fail safe by selecting the closed-lid gate
- semantic reviews cannot omit that gate for unknown product impact
- release-tooling-only descendants remain resumable after a release tag

Evidence
- tests/release-impact.sh
- tests/quality-policy.sh
- tests/quality-care.sh
- tests/docs-contract.sh
- tests/release-workflow.sh
- scripts/quality-gate: DIAGNOSTIC PASS, policy 42, fingerprint 51eba91a3a0c4ba578788fe4dfc0010f6ff79639b3591819c195201b4ba35560