### PR TITLE
Lower the supported macOS floor from 26 to 15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Detach agent guide
 
-Detach is a macOS 26+ reliability harness for persistent Codex CLI and Claude
+Detach is a macOS 15+ reliability harness for persistent Codex CLI and Claude
 Code sessions. It owns a private tmux runtime, recovery checkpoints, typed
 state, an app, and two-layer power protection. Users install and authenticate
 the providers separately.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/iltsarev/detach/releases/latest"><img src="https://img.shields.io/github/v/release/iltsarev/detach?style=flat-square&amp;label=release&amp;color=545CE0" alt="Latest release"></a>
-  <img src="https://img.shields.io/badge/macOS-26%2B-545CE0?style=flat-square&amp;logo=apple&amp;logoColor=white" alt="macOS 26 or newer">
+  <img src="https://img.shields.io/badge/macOS-15%2B-545CE0?style=flat-square&amp;logo=apple&amp;logoColor=white" alt="macOS 15 or newer">
   <img src="https://img.shields.io/badge/Apple_Silicon-native-545CE0?style=flat-square" alt="Apple Silicon native">
   <img src="https://img.shields.io/badge/Codex-087F6D?style=flat-square" alt="Codex supported">
   <img src="https://img.shields.io/badge/Claude_Code-B43B24?style=flat-square" alt="Claude Code supported">
@@ -525,7 +525,7 @@ Protect, `caffeinate`, or another keep-awake package.
 
 | Component | Requirement |
 |---|---|
-| Mac | macOS 26 or newer on Apple Silicon (`arm64`); Intel Macs are not supported. |
+| Mac | macOS 15 or newer on Apple Silicon (`arm64`); Intel Macs are not supported. |
 | Provider | At least one authenticated [Codex CLI](https://github.com/openai/codex) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview). |
 | macOS approval | An administrator password is required once to register the signed power helper; Login Items approval may also be required. |
 

--- a/app/Package.swift
+++ b/app/Package.swift
@@ -15,7 +15,7 @@ let appLinkerSettings: [LinkerSetting] = appBuildMarkerFile.map { markerFile in
 
 let package = Package(
     name: "DetachApp",
-    platforms: [.macOS("26.0")],
+    platforms: [.macOS("15.0")],
     products: [
         .executable(name: "detach-power", targets: ["DetachPower"]),
         .executable(name: "detach-power-helper", targets: ["DetachPowerHelper"]),

--- a/app/Resources/DetachWatchdog-Info.plist
+++ b/app/Resources/DetachWatchdog-Info.plist
@@ -19,6 +19,6 @@
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSMinimumSystemVersion</key>
-  <string>26.0</string>
+  <string>15.0</string>
 </dict>
 </plist>

--- a/app/Resources/Info.plist
+++ b/app/Resources/Info.plist
@@ -26,7 +26,7 @@
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSMinimumSystemVersion</key>
-  <string>26.0</string>
+  <string>15.0</string>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
   <key>NSHighResolutionCapable</key>

--- a/app/Sources/DetachKit/BoundedProcessRunner.swift
+++ b/app/Sources/DetachKit/BoundedProcessRunner.swift
@@ -317,11 +317,12 @@ public struct BoundedProcessRunner: Sendable {
         }
         if let directory = request.currentDirectoryURL {
             actionResult = directory.path.withCString {
-                posix_spawn_file_actions_addchdir(&actions, $0)
+                // POSIX addchdir is macOS 26+; Darwin addchdir_np is the 15+ equivalent.
+                posix_spawn_file_actions_addchdir_np(&actions, $0)
             }
             guard actionResult == 0 else {
                 throw BoundedProcessError.posix(
-                    operation: "posix_spawn_file_actions_addchdir",
+                    operation: "posix_spawn_file_actions_addchdir_np",
                     code: actionResult)
             }
         }

--- a/app/Sources/DetachKit/DetachPowerCommand.swift
+++ b/app/Sources/DetachKit/DetachPowerCommand.swift
@@ -198,12 +198,13 @@ public struct POSIXChildProcessLauncher: ChildProcessLaunching {
 
         let changeDirectoryResult = request.currentDirectoryURL.path.withCString {
             path in
-            posix_spawn_file_actions_addchdir(&fileActions, path)
+            // POSIX addchdir is macOS 26+; Darwin addchdir_np is the 15+ equivalent.
+            posix_spawn_file_actions_addchdir_np(&fileActions, path)
         }
         guard changeDirectoryResult == 0 else {
             throw posixError(
                 changeDirectoryResult,
-                operation: "posix_spawn_file_actions_addchdir")
+                operation: "posix_spawn_file_actions_addchdir_np")
         }
 
         let argumentStrings =

--- a/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
@@ -17,7 +17,7 @@ final class UIE2EEventWindowResolverTests: XCTestCase {
             defer: false)
         let view = NSView(frame: NSRect(x: 20, y: 20, width: 40, height: 20))
         owner.contentView?.addSubview(view)
-        let point = NSPoint(x: 200, y: 200)
+        let point = NSPoint(x: owner.frame.midX, y: owner.frame.midY)
 
         XCTAssertTrue(behind.frame.intersects(owner.frame))
         XCTAssertIdentical(UIE2EEventWindowResolver.owner(of: view), owner)
@@ -36,7 +36,7 @@ final class UIE2EEventWindowResolverTests: XCTestCase {
             styleMask: .titled,
             backing: .buffered,
             defer: false)
-        let point = NSPoint(x: 200, y: 200)
+        let point = NSPoint(x: candidate.frame.midX, y: candidate.frame.midY)
 
         XCTAssertNil(UIE2EEventWindowResolver.owner(of: view))
         XCTAssertIdentical(

--- a/app/Tests/DetachKitTests/ProcessChildCommandRunnerTests.swift
+++ b/app/Tests/DetachKitTests/ProcessChildCommandRunnerTests.swift
@@ -174,6 +174,26 @@ final class ProcessChildCommandRunnerTests: XCTestCase {
                 }
     }
 
+    func testPOSIXLauncherReportsCurrentDirectoryPathTooLong() {
+        let tooLong = URL(
+            fileURLWithPath: "/" + String(repeating: "a", count: Int(PATH_MAX)),
+            isDirectory: true)
+        XCTAssertThrowsError(try POSIXChildProcessLauncher().run(
+            ChildProcessRequest(
+                executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+                arguments: [],
+                environment: [:],
+                currentDirectoryURL: tooLong,
+                inheritsStandardIO: false))) { error in
+                    let error = error as NSError
+                    XCTAssertEqual(error.domain, NSPOSIXErrorDomain)
+                    XCTAssertEqual(error.code, Int(ENAMETOOLONG))
+                    XCTAssertTrue(
+                        error.localizedDescription.contains(
+                            "posix_spawn_file_actions_addchdir_np"))
+                }
+    }
+
     func testPOSIXLauncherKillsAndReapsChildWhenPIDPublicationFails() {
         let missingDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("detach-missing-\(UUID().uuidString)")

--- a/app/scripts/make-app.sh
+++ b/app/scripts/make-app.sh
@@ -224,7 +224,7 @@ build_arch() {
   if [ "$QUALITY_APP_SCRATCH" = 1 ]; then
     scratch="$APP_ROOT/.build/quality-app-release"
   fi
-  local triple="$arch-apple-macosx26.0"
+  local triple="$arch-apple-macosx15.0"
   local build_args=(
     --disable-sandbox
     --disable-automatic-resolution

--- a/app/scripts/verify-app.sh
+++ b/app/scripts/verify-app.sh
@@ -10,7 +10,7 @@ INFO="$APP/Contents/Info.plist"
 AGENT="$APP/Contents/Library/LaunchAgents/dev.tsarev.detach.power-watchdog.plist"
 POWER_DAEMON="$APP/Contents/Library/LaunchDaemons/dev.tsarev.detach.power-helper.plist"
 EXPECTED_VERSION="${DETACH_VERSION:-$(<"$REPO_ROOT/VERSION")}"
-EXPECTED_MINIMUM_SYSTEM_VERSION="26.0"
+EXPECTED_MINIMUM_SYSTEM_VERSION="15.0"
 SPARKLE_VERSION="${DETACH_SPARKLE_VERSION:-2.9.6}"
 SPARKLE_LICENSE_SOURCE="$APP_ROOT/Resources/ThirdParty/Sparkle/LICENSE.txt"
 SPARKLE_LICENSE_SHA256="389a4e4e9a32f059775b13a06e25a591445ba229d2838d26dd3e7c0c45127cfe"
@@ -97,13 +97,20 @@ for metadata in \
     exit 1
   fi
 done
-# `plutil -lint` only accepts property lists even though the other plutil
-# operations support JSON. Parse the payload manifest explicitly as JSON.
-plutil -p "$PAYLOAD/payload.json" >/dev/null
+# `plutil -lint` and `plutil -p` reject JSON on macOS 15. Convert still
+# parses the manifest, so use that as the syntax check.
+plutil -convert xml1 -o /dev/null "$PAYLOAD/payload.json"
 [ "$(plutil -extract CFBundleShortVersionString raw -o - "$INFO")" = "$EXPECTED_VERSION" ]
 [ "$(plutil -extract LSMinimumSystemVersion raw -o - "$INFO")" = \
   "$EXPECTED_MINIMUM_SYSTEM_VERSION" ] || {
   printf 'App minimum system version must be %s\n' \
+    "$EXPECTED_MINIMUM_SYSTEM_VERSION" >&2
+  exit 1
+}
+[ "$(plutil -extract LSMinimumSystemVersion raw -o - \
+  "$APP_ROOT/Resources/DetachWatchdog-Info.plist")" = \
+  "$EXPECTED_MINIMUM_SYSTEM_VERSION" ] || {
+  printf 'Watchdog Info.plist minimum system version must be %s\n' \
     "$EXPECTED_MINIMUM_SYSTEM_VERSION" >&2
   exit 1
 }
@@ -227,7 +234,7 @@ cmp -s "$SPARKLE_LICENSE_SOURCE" "$SPARKLE_LICENSE" || {
   printf 'Bundled Sparkle license notice must have mode 0644\n' >&2
   exit 1
 }
-plutil -p "$TMUX_THIRD_PARTY/provenance.json" >/dev/null
+plutil -convert xml1 -o /dev/null "$TMUX_THIRD_PARTY/provenance.json"
 [ -x "$TMUX_BUILDER" ] || {
   printf 'Bundled tmux builder is unavailable for provenance verification\n' >&2
   exit 1
@@ -271,16 +278,45 @@ verify_dynamic_dependencies() {
   fi
 }
 
+minimum_system_version() {
+  local binary="$1"
+
+  otool -l "$binary" | awk '
+      $1 == "cmd" && $2 == "LC_BUILD_VERSION" { kind = "build"; next }
+      $1 == "cmd" && $2 == "LC_VERSION_MIN_MACOSX" { kind = "legacy"; next }
+      $1 == "cmd" { kind = ""; next }
+      kind == "build" && $1 == "minos" && !found { print $2; found = 1 }
+      kind == "legacy" && $1 == "version" && !found { print $2; found = 1 }
+    '
+}
+
+version_le() {
+  local left="$1"
+  local right="$2"
+
+  [ -n "$left" ] && [ -n "$right" ] || return 1
+  [ "$(printf '%s\n%s\n' "$left" "$right" | sort -V | head -1)" = "$left" ]
+}
+
 verify_minimum_system_version() {
   local binary="$1"
   local minimum
 
-  minimum="$(otool -l "$binary" | awk '
-      $1 == "cmd" && $2 == "LC_BUILD_VERSION" { in_build_version = 1; next }
-      in_build_version && $1 == "minos" && !found { print $2; found = 1 }
-    ')"
+  minimum="$(minimum_system_version "$binary")"
   [ "$minimum" = "$EXPECTED_MINIMUM_SYSTEM_VERSION" ] || {
     printf '%s minimum system version is %s, expected %s\n' \
+      "$binary" "${minimum:-missing}" "$EXPECTED_MINIMUM_SYSTEM_VERSION" >&2
+    exit 1
+  }
+}
+
+verify_minimum_system_version_at_most() {
+  local binary="$1"
+  local minimum
+
+  minimum="$(minimum_system_version "$binary")"
+  version_le "$minimum" "$EXPECTED_MINIMUM_SYSTEM_VERSION" || {
+    printf '%s minimum system version is %s, must be %s or older\n' \
       "$binary" "${minimum:-missing}" "$EXPECTED_MINIMUM_SYSTEM_VERSION" >&2
     exit 1
   }
@@ -315,9 +351,10 @@ done
   exit 1
 }
 
-SPARKLE_FEED_URL="$(plutil -extract SUFeedURL raw -o - "$INFO" 2>/dev/null || true)"
-SPARKLE_PUBLIC_ED_KEY="$(plutil -extract SUPublicEDKey raw -o - "$INFO" 2>/dev/null || true)"
-DOWNLOAD_URL="$(plutil -extract DetachDownloadURL raw -o - "$INFO" 2>/dev/null || true)"
+# macOS 15 prints a missing-key error on stdout; only keep a successful extract.
+SPARKLE_FEED_URL="$(plutil -extract SUFeedURL raw -o - "$INFO" 2>/dev/null)" || SPARKLE_FEED_URL=""
+SPARKLE_PUBLIC_ED_KEY="$(plutil -extract SUPublicEDKey raw -o - "$INFO" 2>/dev/null)" || SPARKLE_PUBLIC_ED_KEY=""
+DOWNLOAD_URL="$(plutil -extract DetachDownloadURL raw -o - "$INFO" 2>/dev/null)" || DOWNLOAD_URL=""
 if [ -n "$SPARKLE_FEED_URL" ] || [ -n "$SPARKLE_PUBLIC_ED_KEY" ]; then
   [[ "$SPARKLE_FEED_URL" =~ ^https://[^[:space:]]+$ ]] || {
     printf 'SUFeedURL must be HTTPS\n' >&2
@@ -594,6 +631,22 @@ for arch in $(lipo -archs "$APP/Contents/MacOS/DetachWatchdog"); do
     printf 'Watchdog embedded build mismatch for %s\n' "$arch" >&2
     exit 1
   }
+  WATCHDOG_MINOS="$(printf '%s\n' "$HELPER_STRINGS" | awk '
+    /<key>LSMinimumSystemVersion<\/key>/ {
+      if (match($0, /<string>[^<]+<\/string>/)) {
+        print substr($0, RSTART, RLENGTH)
+        exit
+      }
+      getline
+      print
+      exit
+    }
+  ')"
+  [ "$WATCHDOG_MINOS" = "<string>$EXPECTED_MINIMUM_SYSTEM_VERSION</string>" ] || {
+    printf 'Watchdog embedded minimum system version is %s, expected %s\n' \
+      "${WATCHDOG_MINOS:-missing}" "$EXPECTED_MINIMUM_SYSTEM_VERSION" >&2
+    exit 1
+  }
 done
 codesign -d --entitlements "$ENTITLEMENTS_DIR/app.plist" --xml "$APP" >/dev/null 2>&1
 codesign -d --entitlements "$ENTITLEMENTS_DIR/helper.plist" --xml \
@@ -678,6 +731,14 @@ arm64_binaries=(
 )
 for arm64_binary in "${arm64_binaries[@]}"; do
   verify_arm64_only "$arm64_binary"
+done
+for sparkle_binary in \
+  "$SPARKLE_BINARY" \
+  "$AUTOUPDATE" \
+  "$UPDATER_BINARY" \
+  "$INSTALLER_BINARY" \
+  "$DOWNLOADER_BINARY"; do
+  verify_minimum_system_version_at_most "$sparkle_binary"
 done
 
 printf 'Verified %s\n' "$APP"

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -4,7 +4,7 @@
 
 `app/` is a SwiftPM package containing `DetachKit`, `DetachApp`,
 `DetachWatchdog`, `DetachState`, `DetachPower`, and `DetachPowerHelper`. The app
-bundles and signs arm64-only versions of every executable, the immutable CLI
+bundles and signs arm64-only macOS 15.0 executables, the immutable CLI
 payload, pinned tmux sources/licenses/provenance, Sparkle, and the complete
 pinned Sparkle license notice.
 

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -21,8 +21,11 @@ change real power state, upload assets, or claim publication.
   head as its ordered parents and the tested tree. Tag that merge, verify the
   remote `main` and tag, and remove only the matching temporary branch. No
   actor has a general `main` ruleset bypass or direct-main release path.
-- The app, watchdog, bundled tmux, state helper, power client, root helper, and
-  Sparkle executables contain only `arm64`. Intel Macs are unsupported.
+- The app, watchdog, bundled tmux, state helper, power client, and root helper
+  target macOS 15.0 and contain only `arm64`. Intel Macs are unsupported.
+  Bundled Sparkle executables contain only `arm64` and must not require a
+  newer macOS than 15.0. The watchdog embedded Info.plist must state the same
+  15.0 floor. `app/scripts/verify-app.sh` checks both.
 - The pinned tmux source build may reuse only an arm64 product keyed by the
   builder, source checksums, SDK, compiler, and deployment target; every copied
   cache product passes the normal architecture and linkage validation.

--- a/scripts/build-tmux.sh
+++ b/scripts/build-tmux.sh
@@ -110,8 +110,8 @@ build_arch() {
   cmake="$(command -v cmake 2>/dev/null || true)"
   [ -x "$cmake" ] || die "cmake is required to build the pinned libevent source"
   jobs="$(/usr/sbin/sysctl -n hw.logicalcpu 2>/dev/null || printf 4)"
-  common_cflags="-arch $arch -isysroot $sdk -mmacosx-version-min=26.0 -O2"
-  common_ldflags="-arch $arch -isysroot $sdk -mmacosx-version-min=26.0"
+  common_cflags="-arch $arch -isysroot $sdk -mmacosx-version-min=15.0 -O2"
+  common_ldflags="-arch $arch -isysroot $sdk -mmacosx-version-min=15.0"
   fingerprint="$({
     printf '%s\n' \
       'schema=1' \
@@ -120,7 +120,7 @@ build_arch() {
       "libevent=$LIBEVENT_SHA256" \
       "utf8proc=$UTF8PROC_SHA256" \
       "arch=$arch" \
-      'deployment=26.0' \
+      'deployment=15.0' \
       "sdk=$sdk_version"
     "$cc" --version | /usr/bin/head -1
   } | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}')"
@@ -150,7 +150,7 @@ build_arch() {
       -DCMAKE_AR="$ar" \
       -DCMAKE_RANLIB="$ranlib" \
       -DCMAKE_OSX_ARCHITECTURES="$arch" \
-      -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0 \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
       -DCMAKE_OSX_SYSROOT="$sdk" \
       -DCMAKE_INSTALL_PREFIX="$prefix" \
       -DEVENT__LIBRARY_TYPE=STATIC \

--- a/tools/quality_cache_warm.py
+++ b/tools/quality_cache_warm.py
@@ -220,7 +220,7 @@ def warm(root: Path, logical_cpus: int | None = None) -> int:
     coverage_command = [
         "swift", "build", "--enable-code-coverage", "--disable-sandbox",
         "--disable-automatic-resolution", "--cache-path", str(app / ".build"),
-        "-c", "release", "--triple", "arm64-apple-macosx26.0",
+        "-c", "release", "--triple", "arm64-apple-macosx15.0",
         "--scratch-path", str(coverage_scratch), "--product", "DetachApp",
         "--jobs", str(coverage_jobs),
     ]

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -2506,7 +2506,7 @@ def run_app_stage(root: Path) -> int:
         "-c",
         "release",
         "--triple",
-        "arm64-apple-macosx26.0",
+        "arm64-apple-macosx15.0",
         "--scratch-path",
         str(root / "app/.build" / UI_COVERAGE_SCRATCH),
         "--product",


### PR DESCRIPTION
## Summary
- lower the user-facing and packaged floor to macOS 15.0 on Apple Silicon
- replace the only 26-only API (`posix_spawn_file_actions_addchdir`) with Darwin `addchdir_np`
- recover an SMAppService helper that stays `enabled` after the daemon never spawned this boot
- make `verify-app.sh` parse JSON and missing Sparkle keys on a macOS 15 host

Fixes #54

## Split
The helper recovery does not depend on the macOS 15 floor. If you do not want Sequoia as a supported platform, that is fine — please say so. I can drop the 15.0 pins and keep only the dead-registration path (and the `addchdir_np` / `verify-app.sh` host fixes if useful on 26). I already have a local Sequoia build; this PR is optional.

## Durable contract
- Detach.app, the watchdog, bundled tmux, and the power/state helpers target macOS 15.0 and remain `arm64` only
- bundled Sparkle must not require a newer macOS than 15.0
- a leftover enabled helper with no lifetime barrier is a dead registration, not a live helper; unregister may proceed
- a helper that held the lifetime barrier this boot still fails closed

## Test plan
- [x] `swift test --filter DetachKitTests` on macOS 15.7.4 / Xcode 26.2
- [x] `swift test --filter DetachAppTests` including `PowerHelperServiceTests`
- [x] `app/scripts/make-app.sh` with Apple Development signing
- [x] install to `/Applications`, complete setup, confirm helper and CLI
- [ ] hosted `quality-gates` on `macos-26`