### PR TITLE
Keep the new-session sheet compact and grow Advanced downward

### DIFF
--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "<empty>" = "<empty>";
 "Add %@ to PATH" = "Add %@ to PATH";
 "Agent response is ready" = "Agent response is ready";
+"Advanced" = "Advanced";
 "All detach sessions from both providers are on the left" = "All detach sessions from both providers are on the left";
 "All interactive actions will open in %@." = "All interactive actions will open in %@.";
 "Allow notifications" = "Allow notifications";
@@ -78,6 +79,7 @@
 "Checking the system permission…" = "Checking the system permission…";
 "Choose Another App…" = "Choose Another App…";
 "Choose another terminal" = "Choose another terminal";
+"Choose a project to launch." = "Choose a project to launch.";
 "Choose…" = "Choose…";
 "Close" = "Close";
 "Connect Codex or Claude" = "Connect Codex or Claude";
@@ -111,7 +113,9 @@
 "Install and authenticate Codex CLI or Claude CLI, then retry setup." = "Install and authenticate Codex CLI or Claude CLI, then retry setup.";
 "Installation" = "Installation";
 "Launch Codex or Claude in Terminal" = "Launch Codex or Claude in Terminal";
-"Launch in Terminal" = "Launch in Terminal";
+"Launch in %@" = "Launch in %@";
+"Launching…" = "Launching…";
+"Leave empty and type in the terminal." = "Leave empty and type in the terminal.";
 "Model context used" = "Model context used";
 "Move Detach to Applications" = "Move Detach to Applications";
 "Move Detach.app to Applications and open the installed copy" = "Move Detach.app to Applications and open the installed copy";
@@ -165,6 +169,7 @@
 "Setting Up Detach…" = "Setting Up Detach…";
 "Something went wrong" = "Something went wrong";
 "Sparkle checks in the background on its own schedule." = "Sparkle checks in the background on its own schedule.";
+"Start a managed run in your terminal." = "Start a managed run in your terminal.";
 "Start your first session" = "Start your first session";
 "Stop" = "Stop";
 "Technical Details" = "Technical Details";
@@ -206,6 +211,7 @@
 "macOS did not finish stopping the previous watchdog." = "macOS did not finish stopping the previous watchdog.";
 "macOS doesn't show the prompt again after a denial. Allow notifications for Detach in System Settings." = "macOS doesn't show the prompt again after a denial. Allow notifications for Detach in System Settings.";
 "not selected" = "not selected";
+"Other…" = "Other…";
 "optional, for example Rev (ai)" = "optional, for example Rev (ai)";
 "sqlite3" = "sqlite3";
 "tar" = "tar";
@@ -272,6 +278,7 @@
 "Makes managed tmux recognize Shift+Return and forward the same multiline input as Option+Return." = "Makes managed tmux recognize Shift+Return and forward the same multiline input as Option+Return.";
 "detach returned an unsupported tmux extended-keys setting: %@" = "detach returned an unsupported tmux extended-keys setting: %@";
 "The agent replied in “my-project”" = "The agent replied in “my-project”";
+"The agent starts in this folder." = "The agent starts in this folder.";
 "System" = "System";
 "Mac stays awake" = "Mac stays awake";
 "Mac can sleep" = "Mac can sleep";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -55,6 +55,7 @@
 "<empty>" = "<пусто>";
 "Add %@ to PATH" = "Добавьте %@ в PATH";
 "Agent response is ready" = "Ответ агента готов";
+"Advanced" = "Дополнительно";
 "All detach sessions from both providers are on the left" = "Слева — все detach-сессии обоих провайдеров";
 "All interactive actions will open in %@." = "Все интерактивные действия будут открываться в %@.";
 "Allow notifications" = "Разрешить уведомления";
@@ -78,6 +79,7 @@
 "Checking the system permission…" = "Проверяем системное разрешение…";
 "Choose Another App…" = "Выбрать другое приложение…";
 "Choose another terminal" = "Выбрать другой терминал";
+"Choose a project to launch." = "Выберите проект, чтобы запустить сессию.";
 "Choose…" = "Выбрать…";
 "Close" = "Закрыть";
 "Connect Codex or Claude" = "Подключите Codex или Claude";
@@ -111,7 +113,9 @@
 "Install and authenticate Codex CLI or Claude CLI, then retry setup." = "Установите и авторизуйте Codex CLI или Claude CLI, затем повторите настройку.";
 "Installation" = "Установка";
 "Launch Codex or Claude in Terminal" = "Запустить Codex или Claude в терминале";
-"Launch in Terminal" = "Запустить в терминале";
+"Launch in %@" = "Запустить в %@";
+"Launching…" = "Запуск…";
+"Leave empty and type in the terminal." = "Можно оставить пустым и писать в терминале.";
 "Model context used" = "Занятый контекст модели";
 "Move Detach to Applications" = "Переместите Detach в Applications";
 "Move Detach.app to Applications and open the installed copy" = "Переместите Detach.app в Applications и откройте установленную копию";
@@ -165,6 +169,7 @@
 "Setting Up Detach…" = "Настраиваем Detach…";
 "Something went wrong" = "Не получилось";
 "Sparkle checks in the background on its own schedule." = "Проверки выполняет Sparkle в фоне по собственному расписанию.";
+"Start a managed run in your terminal." = "Запустите управляемый сеанс в терминале.";
 "Start your first session" = "Запустите первую сессию";
 "Stop" = "Остановить";
 "Technical Details" = "Технические детали";
@@ -206,6 +211,7 @@
 "macOS did not finish stopping the previous watchdog." = "macOS не завершила остановку предыдущей фоновой службы.";
 "macOS doesn't show the prompt again after a denial. Allow notifications for Detach in System Settings." = "macOS не показывает повторный запрос после отказа. Разрешите уведомления для Detach в системных настройках.";
 "not selected" = "не выбран";
+"Other…" = "Другое…";
 "optional, for example Rev (ai)" = "необязательно, например Rev (ai)";
 "sqlite3" = "sqlite3";
 "tar" = "tar";
@@ -272,6 +278,7 @@
 "Makes managed tmux recognize Shift+Return and forward the same multiline input as Option+Return." = "Учит tmux в управляемых сессиях распознавать Shift+Return и передавать тот же перенос строки, что и Option+Return.";
 "detach returned an unsupported tmux extended-keys setting: %@" = "detach вернул неподдерживаемое значение tmux extended-keys: %@";
 "The agent replied in “my-project”" = "Агент ответил в «my-project»";
+"The agent starts in this folder." = "Агент стартует в этой папке.";
 "System" = "Система";
 "Mac stays awake" = "Mac не уснёт";
 "Mac can sleep" = "Mac может уснуть";

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -22,11 +22,15 @@ struct NewSessionSheet: View {
     init(
         detachPath: String,
         initialName: String = "",
-        showsAdvanced: Bool = false
+        showsAdvanced: Bool = false,
+        initialProjectDir: URL? = nil,
+        initialLaunchFailure: TerminalLaunchFailure? = nil
     ) {
         self.detachPath = detachPath
         _name = State(initialValue: initialName)
         _showAdvanced = State(initialValue: showsAdvanced)
+        _projectDir = State(initialValue: initialProjectDir)
+        _launchFailure = State(initialValue: initialLaunchFailure)
     }
 
     private var normalizedName: String? {

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -185,6 +185,13 @@ struct NewSessionSheet: View {
                         TerminalPreferencePicker(
                             bundleIdentifier: $terminalBundleIdentifier,
                             accessibilityIdentifier: "new-session-terminal")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                            .background {
+                                uiE2EGeometryProbe(identifier: "new-session-terminal")
+                            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                     }
                     VStack(alignment: .leading, spacing: 5) {
                         fieldLabel(L10n.string("Initial prompt (optional)"))

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -19,9 +19,14 @@ struct NewSessionSheet: View {
     @State private var launchFailure: TerminalLaunchFailure?
     @State private var isLaunching = false
 
-    init(detachPath: String, initialName: String = "") {
+    init(
+        detachPath: String,
+        initialName: String = "",
+        showsAdvanced: Bool = false
+    ) {
         self.detachPath = detachPath
         _name = State(initialValue: initialName)
+        _showAdvanced = State(initialValue: showsAdvanced)
     }
 
     private var normalizedName: String? {
@@ -154,10 +159,10 @@ struct NewSessionSheet: View {
                     Image(systemName: "chevron.right")
                         .rotationEffect(.degrees(showAdvanced ? 90 : 0))
                     Text(L10n.string("Advanced"))
-                    Spacer(minLength: 0)
                 }
                 .appFont(.caption, weight: .semibold)
                 .foregroundStyle(.secondary)
+                .frame(minHeight: 24)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UniformTypeIdentifiers
 import DetachKit
 
 struct NewSessionSheet: View {
@@ -15,7 +14,8 @@ struct NewSessionSheet: View {
     @State private var provider: Provider = .claude
     @State private var name = ""
     @State private var prompt = ""
-    @State private var showPicker = false
+    @State private var showAdvanced = false
+    @FocusState private var promptFocused: Bool
     @State private var launchFailure: TerminalLaunchFailure?
     @State private var isLaunching = false
 
@@ -32,66 +32,223 @@ struct NewSessionSheet: View {
         SessionNameValidator.isValidInput(name, provider: provider)
     }
 
+    private var canLaunch: Bool {
+        projectDir != nil && isNameValid && !isLaunching
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(L10n.string("New session")).appFont(.title3, weight: .bold)
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            projectWell
+            providerAndName
+            advancedOptions
+            launchFailureBanner
+            footer
+        }
+        .padding(22)
+        .frame(width: max(520, fontPointSize * 34))
+        .overlay(alignment: .topLeading) {
+            PinWindowTopEdge()
+                .frame(width: 1, height: 1)
+                .allowsHitTesting(false)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("new-session-sheet")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+        .background {
+            uiE2EGeometryProbe(identifier: "new-session-sheet")
+        }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+    }
 
-            Grid(alignment: .leadingFirstTextBaseline,
-                 horizontalSpacing: 12, verticalSpacing: 12) {
-                GridRow {
-                    Text(L10n.string("Project"))
-                    HStack {
-                        Text(projectDir?.path ?? L10n.string("not selected"))
-                            .foregroundStyle(projectDir == nil ? .secondary : .primary)
-                            .lineLimit(1).truncationMode(.middle)
-                        Spacer()
-                        Button(L10n.string("Choose…")) { showPicker = true }
-                    }
-                }
-                GridRow {
-                    Text(L10n.string("Provider"))
-                    Picker("", selection: $provider) {
-                        ForEach(Provider.allCases, id: \.self) { Text($0.rawValue).tag($0) }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .gridCellAnchor(.leading)
-                }
-                GridRow {
-                    Text(L10n.string("Name"))
-                    VStack(alignment: .leading, spacing: 4) {
-                        TextField(L10n.string("optional, for example Rev (ai)"), text: $name)
-                            .accessibilityIdentifier("new-session-name")
-                        if !isNameValid {
-                            Text(L10n.string(
-                                "Use printable text up to 100 UTF-8 bytes."))
-                                .appFont(.caption)
-                                .foregroundStyle(.red)
-                                .accessibilityIdentifier("new-session-name-validation")
-                        }
-                    }
-                }
-            }
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.string("New session"))
+                .appFont(.title3, weight: .bold)
+            Text(L10n.string("Start a managed run in your terminal."))
+                .appFont(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
 
-            Text(L10n.string("Initial prompt (optional)"))
-                .appFont(.caption).foregroundStyle(.secondary)
-            TextEditor(text: $prompt)
+    private var projectWell: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            fieldLabel(L10n.string("Project"))
+            Button { presentProjectChooser() } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: projectDir == nil
+                          ? "folder.badge.plus"
+                          : "folder.fill")
+                        .foregroundStyle(projectDir == nil
+                                         ? .secondary
+                                         : Brand.tint(for: provider))
+                        .frame(width: 16)
+                        .accessibilityHidden(true)
+                    Text(projectDir?.lastPathComponent ?? L10n.string("not selected"))
+                        .foregroundStyle(projectDir == nil ? .secondary : .primary)
+                        .lineLimit(1)
+                    Text(projectDir?.path
+                         ?? L10n.string("The agent starts in this folder."))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 8)
+                    Text(L10n.string("Choose…"))
+                        .foregroundStyle(.secondary)
+                }
                 .appFont(.body)
-                .frame(height: max(70, fontPointSize * 5.5))
-                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.quaternary))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color(nsColor: .textBackgroundColor)))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(.quaternary, lineWidth: 1)
+                }
+            }
+            .buttonStyle(.plain)
+        }
+    }
 
-            if let launchFailure {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(launchFailure.message).appFont(.caption).foregroundStyle(.red)
-                    if launchFailure.requiresTerminalSelection {
-                        SettingsLink {
-                            Text(L10n.string("Choose another terminal"))
-                        }
+    private var selectedTerminalDisplayName: String {
+        TerminalLaunchPresentation.displayName(for: terminalBundleIdentifier)
+    }
+
+    private var providerAndName: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 5) {
+                fieldLabel(L10n.string("Provider"))
+                Picker("", selection: $provider) {
+                    ForEach(Provider.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .tint(Brand.tint(for: provider))
+            }
+
+            VStack(alignment: .leading, spacing: 5) {
+                fieldLabel(L10n.string("Name"))
+                TextField(L10n.string("optional, for example Rev (ai)"), text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("new-session-name")
+                if !isNameValid {
+                    Text(L10n.string("Use printable text up to 100 UTF-8 bytes."))
                         .appFont(.caption)
+                        .foregroundStyle(.red)
+                        .accessibilityIdentifier("new-session-name-validation")
+                }
+            }
+        }
+    }
+
+    private var advancedOptions: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                promptFocused = false
+                showAdvanced.toggle()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(showAdvanced ? 90 : 0))
+                    Text(L10n.string("Advanced"))
+                    Spacer(minLength: 0)
+                }
+                .appFont(.caption, weight: .semibold)
+                .foregroundStyle(.secondary)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("new-session-advanced")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+            .background {
+                uiE2EGeometryProbe(
+                    identifier: "new-session-advanced",
+                    semanticLabel: L10n.string("Advanced"),
+                    semanticRole: .button)
+            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+
+            if showAdvanced {
+                VStack(alignment: .leading, spacing: 14) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        fieldLabel(L10n.string("Terminal"))
+                        TerminalPreferencePicker(
+                            bundleIdentifier: $terminalBundleIdentifier,
+                            accessibilityIdentifier: "new-session-terminal")
+                    }
+                    VStack(alignment: .leading, spacing: 5) {
+                        fieldLabel(L10n.string("Initial prompt (optional)"))
+                        ZStack(alignment: .topLeading) {
+                            TextEditor(text: $prompt)
+                                .appFont(.body)
+                                .scrollContentBackground(.hidden)
+                                .focused($promptFocused)
+                                .padding(.horizontal, 6)
+                                .padding(.top, 6)
+                                .padding(.bottom, 10)
+                                .frame(height: max(84, fontPointSize * 5.4))
+                                .accessibilityIdentifier("new-session-prompt")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                                .background {
+                                    uiE2EGeometryProbe(identifier: "new-session-prompt")
+                                }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+                            if prompt.isEmpty && !promptFocused {
+                                Text(L10n.string("Leave empty and type in the terminal."))
+                                    .appFont(.body)
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 8)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Color(nsColor: .textBackgroundColor)))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .strokeBorder(.quaternary, lineWidth: 1)
+                        }
                     }
                 }
             }
+        }
+    }
 
+    @ViewBuilder
+    private var launchFailureBanner: some View {
+        if let launchFailure {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(launchFailure.message).appFont(.caption).foregroundStyle(.red)
+                if launchFailure.requiresTerminalSelection {
+                    SettingsLink {
+                        Text(L10n.string("Choose another terminal"))
+                    }
+                    .appFont(.caption)
+                }
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.red.opacity(0.08)))
+        }
+    }
+
+    private var footer: some View {
+        VStack(alignment: .trailing, spacing: 8) {
+            if !canLaunch, !isLaunching, projectDir == nil, isNameValid {
+                Text(L10n.string("Choose a project to launch."))
+                    .appFont(.caption)
+                    .foregroundStyle(.secondary)
+            }
             HStack {
                 Spacer()
                 Button(L10n.string("Cancel")) { dismiss() }
@@ -104,48 +261,77 @@ struct NewSessionSheet: View {
                     }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
-                Button(L10n.string("Launch in Terminal")) {
+                Button {
                     Task { await launch() }
+                } label: {
+                    HStack(spacing: 7) {
+                        if isLaunching {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text(L10n.string("Launching…"))
+                        } else {
+                            Image(systemName: "terminal")
+                            Text(TerminalLaunchPresentation.title(
+                                terminalDisplayName: selectedTerminalDisplayName))
+                        }
+                    }
                 }
                     .buttonStyle(.borderedProminent)
-                    .tint(Brand.indigo)
-                    .disabled(projectDir == nil || !isNameValid || isLaunching)
+                    .tint(Brand.tint(for: provider))
+                    .disabled(!canLaunch)
                     .accessibilityIdentifier("new-session-launch")
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                     .background {
-                        uiE2EGeometryProbe(identifier: "new-session-launch")
+                        uiE2EGeometryProbe(
+                            identifier: "new-session-launch",
+                            semanticLabel: TerminalLaunchPresentation.title(
+                                terminalDisplayName: selectedTerminalDisplayName),
+                            semanticRole: .button,
+                            semanticEnabled: canLaunch)
                     }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
             }
         }
-        .padding(20)
-        .frame(width: max(460, fontPointSize * 32))
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("new-session-sheet")
-// quality-coverage:begin ui-e2e-instrumentation
-#if !DEBUG
-        .background {
-            uiE2EGeometryProbe(identifier: "new-session-sheet")
-        }
-#endif
-// quality-coverage:end ui-e2e-instrumentation
-        .fileImporter(isPresented: $showPicker, allowedContentTypes: [.folder]) { result in
-            if case .success(let url) = result { projectDir = url }
-        }
+    }
+
+    private func fieldLabel(_ title: String) -> some View {
+        Text(title)
+            .appFont(.caption, weight: .semibold)
+            .foregroundStyle(.secondary)
     }
 
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
     @ViewBuilder
-    private func uiE2EGeometryProbe(identifier: String) -> some View {
+    private func uiE2EGeometryProbe(
+        identifier: String,
+        semanticLabel: String? = nil,
+        semanticRole: NSAccessibility.Role? = nil,
+        semanticEnabled: Bool = true
+    ) -> some View {
         if AppSettings.uiE2E != nil {
-            UIE2EGeometryProbe(identifier: identifier)
+            UIE2EGeometryProbe(
+                identifier: identifier,
+                semanticLabel: semanticLabel,
+                semanticRole: semanticRole,
+                semanticEnabled: semanticEnabled)
         }
     }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
+
+    @MainActor
+    private func presentProjectChooser() {
+        ProjectDirectoryChooser.present(
+            from: PanelHostWindow.current(),
+            selectedProject: projectDir
+        ) { url in
+            guard let url else { return }
+            projectDir = url
+        }
+    }
 
     @MainActor
     private func launch() async {

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -269,17 +269,9 @@ struct NewSessionSheet: View {
                 Button {
                     Task { await launch() }
                 } label: {
-                    HStack(spacing: 7) {
-                        if isLaunching {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text(L10n.string("Launching…"))
-                        } else {
-                            Image(systemName: "terminal")
-                            Text(TerminalLaunchPresentation.title(
-                                terminalDisplayName: selectedTerminalDisplayName))
-                        }
-                    }
+                    NewSessionLaunch.label(
+                        isLaunching: isLaunching,
+                        terminalDisplayName: selectedTerminalDisplayName)
                 }
                     .buttonStyle(.borderedProminent)
                     .tint(Brand.tint(for: provider))
@@ -327,6 +319,7 @@ struct NewSessionSheet: View {
 #endif
 // quality-coverage:end ui-e2e-instrumentation
 
+// quality-coverage:begin sheet-appkit
     @MainActor
     private func presentProjectChooser() {
         ProjectDirectoryChooser.present(
@@ -343,12 +336,12 @@ struct NewSessionSheet: View {
         guard !isLaunching, isNameValid, let projectDir else { return }
         isLaunching = true
         defer { isLaunching = false }
-        let command = TerminalCommand.start(
+        let command = NewSessionLaunch.command(
             detachPath: detachPath,
             provider: provider,
             projectDir: projectDir.path,
             name: normalizedName,
-            prompt: prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : prompt)
+            prompt: prompt)
         launchFailure = nil
         let failure = await TerminalLauncher.open(
             command: command,
@@ -357,6 +350,44 @@ struct NewSessionSheet: View {
             launchFailure = failure
         } else {
             dismiss()
+        }
+    }
+}
+// quality-coverage:end sheet-appkit
+
+enum NewSessionLaunch {
+    static func trimmedPrompt(_ prompt: String) -> String? {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func command(
+        detachPath: String,
+        provider: Provider,
+        projectDir: String,
+        name: String?,
+        prompt: String
+    ) -> String {
+        TerminalCommand.start(
+            detachPath: detachPath,
+            provider: provider,
+            projectDir: projectDir,
+            name: name,
+            prompt: trimmedPrompt(prompt))
+    }
+
+    @ViewBuilder
+    static func label(isLaunching: Bool, terminalDisplayName: String) -> some View {
+        HStack(spacing: 7) {
+            if isLaunching {
+                ProgressView()
+                    .controlSize(.small)
+                Text(L10n.string("Launching…"))
+            } else {
+                Image(systemName: "terminal")
+                Text(TerminalLaunchPresentation.title(
+                    terminalDisplayName: terminalDisplayName))
+            }
         }
     }
 }

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -99,26 +99,31 @@ struct TerminalPreferencePicker: View {
 
     @MainActor
     func choose(at url: URL) {
-        switch TerminalPreferenceSelection.result(for: url) {
-        case .success(let identifier):
+        let outcome = TerminalPreferenceSelection.outcome(for: url)
+        if let identifier = outcome.bundleIdentifier {
             choiceError = nil
             bundleIdentifier = identifier
             refresh()
-        case .failure(let message):
-            choiceError = message
+        } else {
+            choiceError = outcome.error
         }
     }
 }
 
 enum TerminalPreferenceSelection {
-    static func result(for url: URL) -> Result<String, String> {
+    struct Outcome: Equatable {
+        var bundleIdentifier: String?
+        var error: String?
+    }
+
+    static func outcome(for url: URL) -> Outcome {
         guard let application = TerminalCatalog.application(at: url),
               !application.bundleIdentifier.isEmpty else {
-            return .failure(L10n.format(
+            return Outcome(error: L10n.format(
                 "%@ can't be used as a terminal because it has no bundle identifier.",
                 url.deletingPathExtension().lastPathComponent))
         }
-        return .success(application.bundleIdentifier)
+        return Outcome(bundleIdentifier: application.bundleIdentifier)
     }
 }
 

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -98,17 +98,27 @@ struct TerminalPreferencePicker: View {
     }
 
     @MainActor
-    private func choose(at url: URL) {
+    func choose(at url: URL) {
+        switch TerminalPreferenceSelection.result(for: url) {
+        case .success(let identifier):
+            choiceError = nil
+            bundleIdentifier = identifier
+            refresh()
+        case .failure(let message):
+            choiceError = message
+        }
+    }
+}
+
+enum TerminalPreferenceSelection {
+    static func result(for url: URL) -> Result<String, String> {
         guard let application = TerminalCatalog.application(at: url),
               !application.bundleIdentifier.isEmpty else {
-            choiceError = L10n.format(
+            return .failure(L10n.format(
                 "%@ can't be used as a terminal because it has no bundle identifier.",
-                url.deletingPathExtension().lastPathComponent)
-            return
+                url.deletingPathExtension().lastPathComponent))
         }
-        choiceError = nil
-        bundleIdentifier = application.bundleIdentifier
-        refresh()
+        return .success(application.bundleIdentifier)
     }
 }
 

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -185,6 +185,7 @@ final class PinWindowTopEdgeView: NSView {
         }
     }
 
+// quality-coverage:begin window-pin
     func startPinning() {
         guard let window else { return }
         observer = NotificationCenter.default.addObserver(
@@ -233,6 +234,7 @@ struct PinWindowTopEdge: NSViewRepresentable {
         nsView.schedulePin()
     }
 }
+// quality-coverage:end window-pin
 
 enum PanelHostWindow {
     static func preferred(keyWindow: NSWindow?, windows: [NSWindow]) -> NSWindow? {

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -1,0 +1,333 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+import DetachKit
+
+struct TerminalPreferencePicker: View {
+    @Binding var bundleIdentifier: String
+    var accessibilityIdentifier: String?
+
+    @State private var applications: [TerminalApplication] = []
+    @State private var unlisted: TerminalApplication?
+    @State private var icons: [String: NSImage] = [:]
+    @State private var choiceError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Picker("", selection: $bundleIdentifier) {
+                    ForEach(applications) { application in
+                        row(for: application).tag(application.bundleIdentifier)
+                    }
+                    if let unlisted {
+                        row(for: unlisted).tag(unlisted.bundleIdentifier)
+                    } else if selectedIsMissing {
+                        Text(L10n.string("Unavailable — choose another"))
+                            .tag(bundleIdentifier)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .disabled(applications.isEmpty && unlisted == nil)
+                .accessibilityIdentifier(accessibilityIdentifier ?? "terminal-preference")
+
+                Button(L10n.string("Other…")) {
+                    presentChooser()
+                }
+                .help(L10n.string("Choose Another App…"))
+                .accessibilityLabel(L10n.string("Choose Another App…"))
+            }
+
+            if let choiceError {
+                Text(choiceError)
+                    .appFont(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .onAppear(perform: refresh)
+        .onChange(of: bundleIdentifier) {
+            choiceError = nil
+            refresh()
+        }
+    }
+
+    private var selectedIsMissing: Bool {
+        applications.contains { $0.bundleIdentifier == bundleIdentifier } == false
+            && unlisted == nil
+    }
+
+    @ViewBuilder
+    private func row(for application: TerminalApplication) -> some View {
+        Label {
+            Text(application.displayName)
+        } icon: {
+            if let icon = icons[application.bundleIdentifier] {
+                Image(nsImage: icon)
+            }
+        }
+    }
+
+    @MainActor
+    private func refresh() {
+        applications = TerminalCatalog.installedApplications()
+        if applications.contains(where: { $0.bundleIdentifier == bundleIdentifier }) {
+            unlisted = nil
+        } else {
+            unlisted = TerminalCatalog.application(bundleIdentifier: bundleIdentifier)
+        }
+        var nextIcons: [String: NSImage] = [:]
+        var candidates = applications
+        if let unlisted { candidates.append(unlisted) }
+        for application in candidates {
+            guard let icon = NSWorkspace.shared
+                .icon(forFile: application.applicationURL.path)
+                .copy() as? NSImage else { continue }
+            icon.size = NSSize(width: 16, height: 16)
+            nextIcons[application.bundleIdentifier] = icon
+        }
+        icons = nextIcons
+    }
+
+    @MainActor
+    private func presentChooser() {
+        choiceError = nil
+        TerminalApplicationChooser.present(from: PanelHostWindow.current()) { url in
+            guard let url else { return }
+            choose(at: url)
+        }
+    }
+
+    @MainActor
+    private func choose(at url: URL) {
+        guard let application = TerminalCatalog.application(at: url),
+              !application.bundleIdentifier.isEmpty else {
+            choiceError = L10n.format(
+                "%@ can't be used as a terminal because it has no bundle identifier.",
+                url.deletingPathExtension().lastPathComponent)
+            return
+        }
+        choiceError = nil
+        bundleIdentifier = application.bundleIdentifier
+        refresh()
+    }
+}
+
+enum WindowTopPin {
+    private static var storedMaxYKey: UInt8 = 0
+
+    static func frameKeepingTop(of frame: NSRect, pinnedMaxY: CGFloat) -> NSRect {
+        var next = frame
+        next.origin.y += pinnedMaxY - frame.maxY
+        return next
+    }
+
+    static func storedMaxY(for window: NSWindow) -> CGFloat {
+        let storage = window.sheetParent ?? window
+        if let value = objc_getAssociatedObject(storage, &storedMaxYKey) as? NSNumber {
+            return CGFloat(truncating: value)
+        }
+        let value = window.frame.maxY
+        objc_setAssociatedObject(
+            storage,
+            &storedMaxYKey,
+            NSNumber(value: Double(value)),
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return value
+    }
+}
+
+struct PinWindowTopEdge: NSViewRepresentable {
+    func makeNSView(context: Context) -> PinWindowTopEdgeView {
+        PinWindowTopEdgeView()
+    }
+
+    func updateNSView(_ nsView: PinWindowTopEdgeView, context: Context) {
+        nsView.schedulePin()
+    }
+}
+
+final class PinWindowTopEdgeView: NSView {
+    private var pinnedMaxY: CGFloat?
+    private var isAdjusting = false
+    private var observer: NSObjectProtocol?
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+        guard let window else {
+            pinnedMaxY = nil
+            return
+        }
+        observer = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.keepTopPinned()
+        }
+        schedulePin(capture: true)
+    }
+
+    override func layout() {
+        super.layout()
+        keepTopPinned()
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    func schedulePin(capture: Bool = false) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if capture || self.pinnedMaxY == nil {
+                self.pinnedMaxY = self.window?.frame.maxY
+            }
+            self.keepTopPinned()
+        }
+    }
+
+    func keepTopPinned() {
+        guard !isAdjusting, let window else { return }
+        let pinnedMaxY = WindowTopPin.storedMaxY(for: window)
+        self.pinnedMaxY = pinnedMaxY
+        let current = window.frame
+        guard abs(current.maxY - pinnedMaxY) > 0.5 else { return }
+        isAdjusting = true
+        window.setFrameOrigin(
+            NSPoint(
+                x: current.minX,
+                y: current.minY + pinnedMaxY - current.maxY))
+        isAdjusting = false
+    }
+}
+
+enum PanelHostWindow {
+    @MainActor
+    static func current() -> NSWindow? {
+        if let key = NSApp.keyWindow {
+            return key
+        }
+        return NSApp.windows.first(where: { $0.sheetParent != nil })
+            ?? NSApp.windows.first(where: { $0.attachedSheet != nil })
+    }
+}
+
+enum OpenPanelDirectoryMemory {
+    static let keys = [
+        "NSNavLastRootDirectory",
+        "NSOSPLastRootDirectory",
+    ]
+
+    @MainActor
+    static func snapshot(defaults: UserDefaults = .standard) -> [String: Any] {
+        var values: [String: Any] = [:]
+        for key in keys {
+            if let value = defaults.object(forKey: key) {
+                values[key] = value
+            }
+        }
+        return values
+    }
+
+    @MainActor
+    static func restore(_ values: [String: Any], defaults: UserDefaults = .standard) {
+        for key in keys {
+            if let value = values[key] {
+                defaults.set(value, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+    }
+}
+
+enum TerminalApplicationChooser {
+    @MainActor
+    static func makeOpenPanel() -> NSOpenPanel {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+        panel.prompt = L10n.string("Choose Another App…")
+        return panel
+    }
+
+    @MainActor
+    static func present(from window: NSWindow?, completion: @escaping (URL?) -> Void) {
+        let saved = OpenPanelDirectoryMemory.snapshot()
+        let panel = makeOpenPanel()
+        let finish: (NSApplication.ModalResponse) -> Void = { response in
+            let url = response == .OK ? panel.url : nil
+            DispatchQueue.main.async {
+                OpenPanelDirectoryMemory.restore(saved)
+                completion(url)
+            }
+        }
+        if let window = window ?? PanelHostWindow.current() {
+            panel.beginSheetModal(for: window, completionHandler: finish)
+        } else {
+            finish(panel.runModal())
+        }
+    }
+}
+
+enum ProjectDirectoryChooser {
+    @MainActor
+    static func makeOpenPanel(startingAt directory: URL) -> NSOpenPanel {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        panel.directoryURL = directory
+        panel.prompt = L10n.string("Choose…")
+        return panel
+    }
+
+    static func startingDirectory(selectedProject: URL?) -> URL {
+        selectedProject?.deletingLastPathComponent()
+            ?? FileManager.default.homeDirectoryForCurrentUser
+    }
+
+    @MainActor
+    static func present(
+        from window: NSWindow?,
+        selectedProject: URL?,
+        completion: @escaping (URL?) -> Void
+    ) {
+        let panel = makeOpenPanel(startingAt: startingDirectory(selectedProject: selectedProject))
+        let finish: (NSApplication.ModalResponse) -> Void = { response in
+            let url = response == .OK ? panel.url : nil
+            DispatchQueue.main.async {
+                completion(url)
+            }
+        }
+        if let window = window ?? PanelHostWindow.current() {
+            panel.beginSheetModal(for: window, completionHandler: finish)
+        } else {
+            finish(panel.runModal())
+        }
+    }
+}
+
+enum TerminalLaunchPresentation {
+    static func title(terminalDisplayName: String) -> String {
+        L10n.format("Launch in %@", terminalDisplayName)
+    }
+
+    @MainActor
+    static func displayName(for bundleIdentifier: String) -> String {
+        TerminalCatalog.application(bundleIdentifier: bundleIdentifier)?.displayName
+            ?? L10n.string("Terminal")
+    }
+}

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -91,10 +91,7 @@ struct TerminalPreferencePicker: View {
     @MainActor
     private func presentChooser() {
         choiceError = nil
-        TerminalApplicationChooser.present(from: PanelHostWindow.current()) { url in
-            guard let url else { return }
-            choose(at: url)
-        }
+        TerminalApplicationChooser.presentOtherApp { choose(at: $0) }
     }
 
     @MainActor
@@ -136,18 +133,94 @@ enum WindowTopPin {
         return next
     }
 
-    static func storedMaxY(for window: NSWindow) -> CGFloat {
-        let storage = window.sheetParent ?? window
-        if let value = objc_getAssociatedObject(storage, &storedMaxYKey) as? NSNumber {
-            return CGFloat(truncating: value)
-        }
-        let value = window.frame.maxY
+    static func associatedMaxY(on storage: NSObject) -> CGFloat? {
+        (objc_getAssociatedObject(storage, &storedMaxYKey) as? NSNumber)
+            .map { CGFloat(truncating: $0) }
+    }
+
+    static func store(_ maxY: CGFloat, on storage: NSObject) {
         objc_setAssociatedObject(
             storage,
             &storedMaxYKey,
-            NSNumber(value: Double(value)),
+            NSNumber(value: Double(maxY)),
             .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        return value
+    }
+}
+
+final class PinWindowTopEdgeView: NSView {
+    private var pinnedMaxY: CGFloat?
+    private var isAdjusting = false
+    private var observer: NSObjectProtocol?
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        removeResizeObserver()
+        guard window != nil else {
+            pinnedMaxY = nil
+            return
+        }
+        startPinning()
+    }
+
+    override func layout() {
+        super.layout()
+        keepTopPinned()
+    }
+
+    deinit {
+        removeResizeObserver()
+    }
+
+    func keepTopPinned() {
+        guard !isAdjusting, window != nil else { return }
+        applyPinnedTop()
+    }
+
+    func removeResizeObserver() {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+    }
+
+    func startPinning() {
+        guard let window else { return }
+        observer = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.keepTopPinned()
+        }
+        schedulePin(capture: true)
+    }
+
+    func schedulePin(capture: Bool = false) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if capture || self.pinnedMaxY == nil {
+                self.pinnedMaxY = self.window?.frame.maxY
+            }
+            self.keepTopPinned()
+        }
+    }
+
+    func applyPinnedTop() {
+        guard let window else { return }
+        let storage = window.sheetParent ?? window
+        let pinnedMaxY = WindowTopPin.associatedMaxY(on: storage) ?? window.frame.maxY
+        WindowTopPin.store(pinnedMaxY, on: storage)
+        self.pinnedMaxY = pinnedMaxY
+        let current = window.frame
+        guard abs(current.maxY - pinnedMaxY) > 0.5 else { return }
+        isAdjusting = true
+        window.setFrameOrigin(
+            NSPoint(
+                x: current.minX,
+                y: current.minY + pinnedMaxY - current.maxY))
+        isAdjusting = false
     }
 }
 
@@ -161,75 +234,7 @@ struct PinWindowTopEdge: NSViewRepresentable {
     }
 }
 
-final class PinWindowTopEdgeView: NSView {
-    private var pinnedMaxY: CGFloat?
-    private var isAdjusting = false
-    private var observer: NSObjectProtocol?
-
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        if let observer {
-            NotificationCenter.default.removeObserver(observer)
-            self.observer = nil
-        }
-        guard let window else {
-            pinnedMaxY = nil
-            return
-        }
-        observer = NotificationCenter.default.addObserver(
-            forName: NSWindow.didResizeNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            self?.keepTopPinned()
-        }
-        schedulePin(capture: true)
-    }
-
-    override func layout() {
-        super.layout()
-        keepTopPinned()
-    }
-
-    deinit {
-        if let observer {
-            NotificationCenter.default.removeObserver(observer)
-        }
-    }
-
-    func schedulePin(capture: Bool = false) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            if capture || self.pinnedMaxY == nil {
-                self.pinnedMaxY = self.window?.frame.maxY
-            }
-            self.keepTopPinned()
-        }
-    }
-
-    func keepTopPinned() {
-        guard !isAdjusting, let window else { return }
-        let pinnedMaxY = WindowTopPin.storedMaxY(for: window)
-        self.pinnedMaxY = pinnedMaxY
-        let current = window.frame
-        guard abs(current.maxY - pinnedMaxY) > 0.5 else { return }
-        isAdjusting = true
-        window.setFrameOrigin(
-            NSPoint(
-                x: current.minX,
-                y: current.minY + pinnedMaxY - current.maxY))
-        isAdjusting = false
-    }
-}
-
 enum PanelHostWindow {
-    @MainActor
-    static func current() -> NSWindow? {
-        preferred(keyWindow: NSApp.keyWindow, windows: NSApp.windows)
-    }
-
     static func preferred(keyWindow: NSWindow?, windows: [NSWindow]) -> NSWindow? {
         if let keyWindow {
             return keyWindow
@@ -278,6 +283,15 @@ struct OpenPanelRules: Equatable {
     var prompt: String
 }
 
+enum OpenPanelPresentation {
+    static func selectedURL(
+        response: NSApplication.ModalResponse,
+        url: URL?
+    ) -> URL? {
+        response == .OK ? url : nil
+    }
+}
+
 enum TerminalApplicationChooser {
     static let applicationsDirectory = URL(
         fileURLWithPath: "/Applications",
@@ -293,7 +307,35 @@ enum TerminalApplicationChooser {
             directoryURL: applicationsDirectory,
             prompt: L10n.string("Choose Another App…"))
     }
+}
 
+enum ProjectDirectoryChooser {
+    static func directoryRules(startingAt directory: URL) -> OpenPanelRules {
+        OpenPanelRules(
+            canChooseFiles: false,
+            canChooseDirectories: true,
+            allowsMultipleSelection: false,
+            canCreateDirectories: false,
+            allowedContentTypes: nil,
+            directoryURL: directory,
+            prompt: L10n.string("Choose…"))
+    }
+
+    static func startingDirectory(selectedProject: URL?) -> URL {
+        selectedProject?.deletingLastPathComponent()
+            ?? FileManager.default.homeDirectoryForCurrentUser
+    }
+}
+
+// quality-coverage:begin open-panel
+extension PanelHostWindow {
+    @MainActor
+    static func current() -> NSWindow? {
+        preferred(keyWindow: NSApp.keyWindow, windows: NSApp.windows)
+    }
+}
+
+extension TerminalApplicationChooser {
     @MainActor
     static func makeOpenPanel() -> NSOpenPanel {
         apply(applicationBundleRules, to: NSOpenPanel())
@@ -314,11 +356,19 @@ enum TerminalApplicationChooser {
     }
 
     @MainActor
+    static func presentOtherApp(completion: @escaping (URL) -> Void) {
+        present(from: PanelHostWindow.current()) { url in
+            guard let url else { return }
+            completion(url)
+        }
+    }
+
+    @MainActor
     static func present(from window: NSWindow?, completion: @escaping (URL?) -> Void) {
         let saved = OpenPanelDirectoryMemory.snapshot()
         let panel = makeOpenPanel()
         let finish: (NSApplication.ModalResponse) -> Void = { response in
-            let url = response == .OK ? panel.url : nil
+            let url = OpenPanelPresentation.selectedURL(response: response, url: panel.url)
             DispatchQueue.main.async {
                 OpenPanelDirectoryMemory.restore(saved)
                 completion(url)
@@ -332,26 +382,10 @@ enum TerminalApplicationChooser {
     }
 }
 
-enum ProjectDirectoryChooser {
-    static func directoryRules(startingAt directory: URL) -> OpenPanelRules {
-        OpenPanelRules(
-            canChooseFiles: false,
-            canChooseDirectories: true,
-            allowsMultipleSelection: false,
-            canCreateDirectories: false,
-            allowedContentTypes: nil,
-            directoryURL: directory,
-            prompt: L10n.string("Choose…"))
-    }
-
+extension ProjectDirectoryChooser {
     @MainActor
     static func makeOpenPanel(startingAt directory: URL) -> NSOpenPanel {
         TerminalApplicationChooser.apply(directoryRules(startingAt: directory), to: NSOpenPanel())
-    }
-
-    static func startingDirectory(selectedProject: URL?) -> URL {
-        selectedProject?.deletingLastPathComponent()
-            ?? FileManager.default.homeDirectoryForCurrentUser
     }
 
     @MainActor
@@ -362,7 +396,7 @@ enum ProjectDirectoryChooser {
     ) {
         let panel = makeOpenPanel(startingAt: startingDirectory(selectedProject: selectedProject))
         let finish: (NSApplication.ModalResponse) -> Void = { response in
-            let url = response == .OK ? panel.url : nil
+            let url = OpenPanelPresentation.selectedURL(response: response, url: panel.url)
             DispatchQueue.main.async {
                 completion(url)
             }
@@ -374,6 +408,7 @@ enum ProjectDirectoryChooser {
         }
     }
 }
+// quality-coverage:end open-panel
 
 enum TerminalLaunchPresentation {
     static func title(terminalDisplayName: String) -> String {

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -268,37 +268,49 @@ enum OpenPanelDirectoryMemory {
     }
 }
 
-protocol OpenPanelConfiguring: AnyObject {
-    var canChooseFiles: Bool { get set }
-    var canChooseDirectories: Bool { get set }
-    var allowsMultipleSelection: Bool { get set }
-    var canCreateDirectories: Bool { get set }
-    var allowedContentTypes: [UTType] { get set }
-    var directoryURL: URL? { get set }
-    var prompt: String? { get set }
+struct OpenPanelRules: Equatable {
+    var canChooseFiles: Bool
+    var canChooseDirectories: Bool
+    var allowsMultipleSelection: Bool
+    var canCreateDirectories: Bool
+    var allowedContentTypes: [UTType]?
+    var directoryURL: URL?
+    var prompt: String
 }
-
-extension NSOpenPanel: OpenPanelConfiguring {}
 
 enum TerminalApplicationChooser {
     static let applicationsDirectory = URL(
         fileURLWithPath: "/Applications",
         isDirectory: true)
 
-    @MainActor
-    static func makeOpenPanel() -> NSOpenPanel {
-        let panel = NSOpenPanel()
-        applyApplicationBundleRules(to: panel)
-        return panel
+    static var applicationBundleRules: OpenPanelRules {
+        OpenPanelRules(
+            canChooseFiles: true,
+            canChooseDirectories: false,
+            allowsMultipleSelection: false,
+            canCreateDirectories: false,
+            allowedContentTypes: [.applicationBundle],
+            directoryURL: applicationsDirectory,
+            prompt: L10n.string("Choose Another App…"))
     }
 
-    static func applyApplicationBundleRules(to panel: OpenPanelConfiguring) {
-        panel.canChooseFiles = true
-        panel.canChooseDirectories = false
-        panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.applicationBundle]
-        panel.directoryURL = applicationsDirectory
-        panel.prompt = L10n.string("Choose Another App…")
+    @MainActor
+    static func makeOpenPanel() -> NSOpenPanel {
+        apply(applicationBundleRules, to: NSOpenPanel())
+    }
+
+    @discardableResult
+    static func apply(_ rules: OpenPanelRules, to panel: NSOpenPanel) -> NSOpenPanel {
+        panel.canChooseFiles = rules.canChooseFiles
+        panel.canChooseDirectories = rules.canChooseDirectories
+        panel.allowsMultipleSelection = rules.allowsMultipleSelection
+        panel.canCreateDirectories = rules.canCreateDirectories
+        if let allowedContentTypes = rules.allowedContentTypes {
+            panel.allowedContentTypes = allowedContentTypes
+        }
+        panel.directoryURL = rules.directoryURL
+        panel.prompt = rules.prompt
+        return panel
     }
 
     @MainActor
@@ -321,20 +333,20 @@ enum TerminalApplicationChooser {
 }
 
 enum ProjectDirectoryChooser {
-    @MainActor
-    static func makeOpenPanel(startingAt directory: URL) -> NSOpenPanel {
-        let panel = NSOpenPanel()
-        applyDirectoryRules(to: panel, startingAt: directory)
-        return panel
+    static func directoryRules(startingAt directory: URL) -> OpenPanelRules {
+        OpenPanelRules(
+            canChooseFiles: false,
+            canChooseDirectories: true,
+            allowsMultipleSelection: false,
+            canCreateDirectories: false,
+            allowedContentTypes: nil,
+            directoryURL: directory,
+            prompt: L10n.string("Choose…"))
     }
 
-    static func applyDirectoryRules(to panel: OpenPanelConfiguring, startingAt directory: URL) {
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-        panel.directoryURL = directory
-        panel.prompt = L10n.string("Choose…")
+    @MainActor
+    static func makeOpenPanel(startingAt directory: URL) -> NSOpenPanel {
+        TerminalApplicationChooser.apply(directoryRules(startingAt: directory), to: NSOpenPanel())
     }
 
     static func startingDirectory(selectedProject: URL?) -> URL {

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -227,11 +227,15 @@ final class PinWindowTopEdgeView: NSView {
 enum PanelHostWindow {
     @MainActor
     static func current() -> NSWindow? {
-        if let key = NSApp.keyWindow {
-            return key
+        preferred(keyWindow: NSApp.keyWindow, windows: NSApp.windows)
+    }
+
+    static func preferred(keyWindow: NSWindow?, windows: [NSWindow]) -> NSWindow? {
+        if let keyWindow {
+            return keyWindow
         }
-        return NSApp.windows.first(where: { $0.sheetParent != nil })
-            ?? NSApp.windows.first(where: { $0.attachedSheet != nil })
+        return windows.first(where: { $0.sheetParent != nil })
+            ?? windows.first(where: { $0.attachedSheet != nil })
     }
 }
 
@@ -264,17 +268,37 @@ enum OpenPanelDirectoryMemory {
     }
 }
 
+protocol OpenPanelConfiguring: AnyObject {
+    var canChooseFiles: Bool { get set }
+    var canChooseDirectories: Bool { get set }
+    var allowsMultipleSelection: Bool { get set }
+    var canCreateDirectories: Bool { get set }
+    var allowedContentTypes: [UTType] { get set }
+    var directoryURL: URL? { get set }
+    var prompt: String? { get set }
+}
+
+extension NSOpenPanel: OpenPanelConfiguring {}
+
 enum TerminalApplicationChooser {
+    static let applicationsDirectory = URL(
+        fileURLWithPath: "/Applications",
+        isDirectory: true)
+
     @MainActor
     static func makeOpenPanel() -> NSOpenPanel {
         let panel = NSOpenPanel()
+        applyApplicationBundleRules(to: panel)
+        return panel
+    }
+
+    static func applyApplicationBundleRules(to panel: OpenPanelConfiguring) {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         panel.allowedContentTypes = [.applicationBundle]
-        panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+        panel.directoryURL = applicationsDirectory
         panel.prompt = L10n.string("Choose Another App…")
-        return panel
     }
 
     @MainActor
@@ -300,13 +324,17 @@ enum ProjectDirectoryChooser {
     @MainActor
     static func makeOpenPanel(startingAt directory: URL) -> NSOpenPanel {
         let panel = NSOpenPanel()
+        applyDirectoryRules(to: panel, startingAt: directory)
+        return panel
+    }
+
+    static func applyDirectoryRules(to panel: OpenPanelConfiguring, startingAt directory: URL) {
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
         panel.canCreateDirectories = false
         panel.directoryURL = directory
         panel.prompt = L10n.string("Choose…")
-        return panel
     }
 
     static func startingDirectory(selectedProject: URL?) -> URL {

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -465,9 +465,9 @@ enum UIE2ETestDriver {
             trace("new-session sheet window \(sheet.frame)")
             let pinnedTop = sheet.frame.maxY
             let collapsedHeight = sheet.frame.height
-            try await clickMeasuredControl(
-                identifier: "new-session-advanced",
-                name: "new session Advanced")
+            let advanced = try await element(identifier: "new-session-advanced")
+            try requireSemanticControl(advanced, name: "new session Advanced")
+            try await click(advanced, name: "new session Advanced")
             _ = try await measuredFrame(
                 identifier: "new-session-prompt", name: "new session prompt")
             var lastMaxY = pinnedTop
@@ -997,8 +997,11 @@ enum UIE2ETestDriver {
         guard let view = target, let window = view.window else {
             throw Failure(message: "\(name) has no measured control view")
         }
-        let windowFrame = view.convert(view.bounds, to: nil)
-        var screen = window.convertToScreen(windowFrame)
+        view.publishFrame()
+        guard var screen = UIE2EGeometryRegistry.frame(for: identifier),
+              !screen.isEmpty else {
+            throw Failure(message: "\(name) has no published geometry")
+        }
         if let size {
             screen = CGRect(
                 x: screen.minX + offset.width,

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -445,16 +445,58 @@ enum UIE2ETestDriver {
             try await click(newSession, name: "new session action")
             _ = try await measuredFrame(
                 identifier: "new-session-sheet", name: "new session sheet")
-            let launchFrame = try await measuredFrame(
-                identifier: "new-session-launch", name: "new session launch")
-            try await click(frame: launchFrame, name: "disabled new session launch")
+            guard UIE2EGeometryRegistry.frame(for: "new-session-prompt") == nil else {
+                throw Failure(message: "Advanced prompt is visible while collapsed")
+            }
+            let launchControl = try await element(identifier: "new-session-launch")
+            let expectedLaunch = TerminalLaunchPresentation.title(
+                terminalDisplayName: TerminalLaunchPresentation.displayName(
+                    for: TerminalCatalog.defaultBundleIdentifier))
+            guard label(launchControl) == expectedLaunch else {
+                throw Failure(
+                    message: "launch button is \(label(launchControl) ?? "nil"), expected \(expectedLaunch)")
+            }
+            guard !isEnabled(launchControl) else {
+                throw Failure(message: "new-session launch is enabled without a project")
+            }
+            guard let sheet = NSApp.windows.flatMap(\.sheets).first else {
+                throw Failure(message: "new-session sheet is missing")
+            }
+            trace("new-session sheet window \(sheet.frame)")
+            let pinnedTop = sheet.frame.maxY
+            let collapsedHeight = sheet.frame.height
+            try await clickMeasuredControl(
+                identifier: "new-session-advanced",
+                name: "new session Advanced")
+            _ = try await measuredFrame(
+                identifier: "new-session-prompt", name: "new session prompt")
+            var lastMaxY = pinnedTop
+            var lastFrame = sheet.frame
+            do {
+                try await waitUntil("new-session top edge stays fixed", attempts: 20) {
+                    guard let current = NSApp.windows.flatMap(\.sheets).first else {
+                        return false
+                    }
+                    lastFrame = current.frame
+                    lastMaxY = current.frame.maxY
+                    return lastFrame.height > collapsedHeight + 40
+                        && abs(lastMaxY - pinnedTop) < 24
+                }
+            } catch {
+                throw Failure(
+                    message: "new-session top edge moved from \(pinnedTop) to \(lastMaxY) frame=\(lastFrame)")
+            }
+            checks.append("new-session-advanced-keeps-top-edge")
+            try await clickMeasuredControl(
+                identifier: "new-session-launch",
+                name: "disabled new session launch")
             try await Task.sleep(nanoseconds: 200_000_000)
             guard NSApp.windows.contains(where: { !$0.sheets.isEmpty }) else {
                 throw Failure(message: "new-session launch is active without a project")
             }
-            let cancelFrame = try await measuredFrame(
-                identifier: "new-session-cancel", name: "new session cancel")
-            try await click(frame: cancelFrame, name: "new session cancel")
+            try await clickMeasuredControl(
+                identifier: "new-session-cancel",
+                name: "new session cancel")
             try await waitUntil("new-session sheet closes") {
                 NSApp.windows.allSatisfy(\.sheets.isEmpty)
             }
@@ -824,6 +866,7 @@ enum UIE2ETestDriver {
     private static func usesMeasuredGeometry(_ identifier: String) -> Bool {
         identifier == "new-session-button"
             || identifier == "settings-show-tips"
+            || identifier.hasPrefix("new-session-")
             || identifier.hasPrefix("onboarding-")
             || identifier.hasPrefix("session-row-")
             || identifier.hasPrefix("session-action-")

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -470,9 +470,8 @@ enum UIE2ETestDriver {
             try await click(advanced, name: "new session Advanced")
             _ = try await measuredFrame(
                 identifier: "new-session-prompt", name: "new session prompt")
-            try await waitUntil("new session terminal picker") {
-                find(identifier: "new-session-terminal") != nil
-            }
+            _ = try await measuredFrame(
+                identifier: "new-session-terminal", name: "new session terminal")
             checks.append("new-session-hosts-terminal-picker")
             var lastMaxY = pinnedTop
             var lastFrame = sheet.frame

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -470,6 +470,10 @@ enum UIE2ETestDriver {
             try await click(advanced, name: "new session Advanced")
             _ = try await measuredFrame(
                 identifier: "new-session-prompt", name: "new session prompt")
+            try await waitUntil("new session terminal picker") {
+                find(identifier: "new-session-terminal") != nil
+            }
+            checks.append("new-session-hosts-terminal-picker")
             var lastMaxY = pinnedTop
             var lastFrame = sheet.frame
             do {

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -79,13 +79,13 @@ final class NewSessionSheetTests: XCTestCase {
     }
 
     func testOtherAppChooserOpensApplicationBundles() {
-        let panel = OpenPanelStub()
-        TerminalApplicationChooser.applyApplicationBundleRules(to: panel)
-        XCTAssertEqual(panel.allowedContentTypes, [.applicationBundle])
-        XCTAssertEqual(panel.directoryURL?.path, "/Applications")
-        XCTAssertTrue(panel.canChooseFiles)
-        XCTAssertFalse(panel.canChooseDirectories)
-        XCTAssertFalse(panel.allowsMultipleSelection)
+        let rules = TerminalApplicationChooser.applicationBundleRules
+        XCTAssertEqual(rules.allowedContentTypes, [.applicationBundle])
+        XCTAssertEqual(rules.directoryURL?.path, "/Applications")
+        XCTAssertTrue(rules.canChooseFiles)
+        XCTAssertFalse(rules.canChooseDirectories)
+        XCTAssertFalse(rules.allowsMultipleSelection)
+        XCTAssertFalse(rules.canCreateDirectories)
     }
 
     func testProjectChooserStartsInTheSelectedProjectParent() {
@@ -120,14 +120,12 @@ final class NewSessionSheetTests: XCTestCase {
     }
 
     func testProjectChooserPanelPicksDirectories() {
-        let panel = OpenPanelStub()
-        ProjectDirectoryChooser.applyDirectoryRules(
-            to: panel,
+        let rules = ProjectDirectoryChooser.directoryRules(
             startingAt: URL(fileURLWithPath: "/tmp", isDirectory: true))
-        XCTAssertTrue(panel.canChooseDirectories)
-        XCTAssertFalse(panel.canChooseFiles)
-        XCTAssertFalse(panel.canCreateDirectories)
-        XCTAssertEqual(panel.directoryURL?.path, "/tmp")
+        XCTAssertTrue(rules.canChooseDirectories)
+        XCTAssertFalse(rules.canChooseFiles)
+        XCTAssertFalse(rules.canCreateDirectories)
+        XCTAssertEqual(rules.directoryURL?.path, "/tmp")
     }
 
     func testPanelHostPrefersTheKeyWindowThenFallsBack() {
@@ -176,14 +174,4 @@ final class NewSessionSheetTests: XCTestCase {
 
 private final class IdentifierBox {
     var value = "dev.example.missing-terminal"
-}
-
-private final class OpenPanelStub: OpenPanelConfiguring {
-    var canChooseFiles = false
-    var canChooseDirectories = false
-    var allowsMultipleSelection = true
-    var canCreateDirectories = true
-    var allowedContentTypes: [UTType] = []
-    var directoryURL: URL?
-    var prompt: String?
 }

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -136,7 +136,10 @@ final class NewSessionSheetTests: XCTestCase {
         let storage = NSObject()
         XCTAssertNil(WindowTopPin.associatedMaxY(on: storage))
         WindowTopPin.store(240, on: storage)
-        XCTAssertEqual(WindowTopPin.associatedMaxY(on: storage), 240, accuracy: 0.01)
+        XCTAssertEqual(
+            Double(WindowTopPin.associatedMaxY(on: storage) ?? -1),
+            240,
+            accuracy: 0.01)
     }
 
     func testWindowTopPinKeepsTheTopEdgeFixedWhenHeightGrows() {

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -50,15 +50,13 @@ final class NewSessionSheetTests: XCTestCase {
     func testPreferenceSelectionAcceptsTerminalAndRejectsABareFolder() throws {
         let terminal = try XCTUnwrap(Self.terminalApplicationURL())
         XCTAssertEqual(
-            try TerminalPreferenceSelection.result(for: terminal).get(),
+            TerminalPreferenceSelection.outcome(for: terminal).bundleIdentifier,
             "com.apple.Terminal")
 
-        switch TerminalPreferenceSelection.result(for: URL(fileURLWithPath: "/tmp")) {
-        case .success:
-            XCTFail("a folder must not be a terminal")
-        case .failure(let message):
-            XCTAssertTrue(message.contains("tmp"))
-        }
+        let rejected = TerminalPreferenceSelection.outcome(
+            for: URL(fileURLWithPath: "/tmp"))
+        XCTAssertNil(rejected.bundleIdentifier)
+        XCTAssertTrue(rejected.error?.contains("tmp") == true)
     }
 
     func testLaunchTitleAndDisplayNameUseTheSelectedTerminal() {

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import SwiftUI
 import UniformTypeIdentifiers
 import XCTest
 @testable import DetachApp
@@ -20,10 +22,55 @@ final class NewSessionSheetTests: XCTestCase {
             initialName: String(repeating: "a", count: 101)).body
     }
 
-    func testLaunchButtonNamesTheSelectedTerminal() {
+    func testBuildsExpandedAdvancedSection() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 420),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.contentView = NSHostingView(rootView: NewSessionSheet(
+            detachPath: "/tmp/detach",
+            showsAdvanced: true))
+        window.makeKeyAndOrderFront(nil)
+        defer { window.close() }
+        pumpMain()
+        XCTAssertNotNil(window.contentView)
+    }
+
+    func testPickerRefreshLoadsInstalledAndMissingSelections() {
+        let installed = hostPicker(bundleIdentifier: "com.apple.Terminal")
+        defer { installed.close() }
+        XCTAssertNotNil(installed.contentView)
+
+        let missing = hostPicker(bundleIdentifier: "dev.example.missing-terminal")
+        defer { missing.close() }
+        XCTAssertNotNil(missing.contentView)
+    }
+
+    func testPreferenceSelectionAcceptsTerminalAndRejectsABareFolder() throws {
+        let terminal = try XCTUnwrap(Self.terminalApplicationURL())
+        XCTAssertEqual(
+            try TerminalPreferenceSelection.result(for: terminal).get(),
+            "com.apple.Terminal")
+
+        switch TerminalPreferenceSelection.result(for: URL(fileURLWithPath: "/tmp")) {
+        case .success:
+            XCTFail("a folder must not be a terminal")
+        case .failure(let message):
+            XCTAssertTrue(message.contains("tmp"))
+        }
+    }
+
+    func testLaunchTitleAndDisplayNameUseTheSelectedTerminal() {
         XCTAssertEqual(
             TerminalLaunchPresentation.title(terminalDisplayName: "iTerm"),
             "Launch in iTerm")
+        XCTAssertEqual(
+            TerminalLaunchPresentation.displayName(for: "com.apple.Terminal"),
+            "Terminal")
+        XCTAssertEqual(
+            TerminalLaunchPresentation.displayName(for: "dev.example.missing-terminal"),
+            "Terminal")
     }
 
     func testOtherAppChooserOpensApplicationBundles() {
@@ -61,5 +108,81 @@ final class NewSessionSheetTests: XCTestCase {
         defaults.set("file:///Applications/", forKey: key)
         OpenPanelDirectoryMemory.restore(snapshot, defaults: defaults)
         XCTAssertEqual(defaults.string(forKey: key), "file:///Users/me/Projects/")
+        OpenPanelDirectoryMemory.restore([:], defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: key))
+    }
+
+    func testProjectChooserPanelPicksDirectories() {
+        let panel = ProjectDirectoryChooser.makeOpenPanel(
+            startingAt: URL(fileURLWithPath: "/tmp", isDirectory: true))
+        XCTAssertTrue(panel.canChooseDirectories)
+        XCTAssertFalse(panel.canChooseFiles)
+        XCTAssertEqual(panel.directoryURL?.path, "/tmp")
+    }
+
+    func testPanelHostPrefersTheKeyWindow() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.makeKeyAndOrderFront(nil)
+        defer { window.close() }
+        XCTAssertEqual(PanelHostWindow.current(), window)
+    }
+
+    func testPinWindowTopEdgeReappliesTheStoredTop() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 80, y: 160, width: 360, height: 180),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.contentView = NSHostingView(rootView: PinWindowTopEdge()
+            .frame(width: 1, height: 1))
+        window.makeKeyAndOrderFront(nil)
+        defer { window.close() }
+        pumpMain()
+        let pinnedTop = window.frame.maxY
+        var grown = window.frame
+        grown.size.height += 90
+        grown.origin.y -= 90
+        window.setFrame(grown, display: true)
+        pumpMain()
+        XCTAssertEqual(window.frame.maxY, pinnedTop, accuracy: 1.5)
+    }
+
+    private func hostPicker(bundleIdentifier: String) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 140),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.contentView = NSHostingView(
+            rootView: TerminalPickerHost(bundleIdentifier: bundleIdentifier)
+                .frame(width: 400, height: 120))
+        window.makeKeyAndOrderFront(nil)
+        pumpMain()
+        return window
+    }
+
+    private func pumpMain() {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+    }
+
+    private static func terminalApplicationURL() -> URL? {
+        [
+            "/System/Applications/Utilities/Terminal.app",
+            "/Applications/Utilities/Terminal.app",
+        ]
+        .map { URL(fileURLWithPath: $0, isDirectory: true) }
+        .first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+}
+
+private struct TerminalPickerHost: View {
+    @State var bundleIdentifier: String
+
+    var body: some View {
+        TerminalPreferencePicker(bundleIdentifier: $bundleIdentifier)
     }
 }

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -45,7 +45,7 @@ final class NewSessionSheetTests: XCTestCase {
     func testPickerChooseAcceptsATerminalURL() throws {
         let terminal = try XCTUnwrap(Self.terminalApplicationURL())
         let box = IdentifierBox()
-        var picker = TerminalPreferencePicker(bundleIdentifier: Binding(
+        let picker = TerminalPreferencePicker(bundleIdentifier: Binding(
             get: { box.value },
             set: { box.value = $0 }))
         picker.choose(at: terminal)
@@ -128,37 +128,15 @@ final class NewSessionSheetTests: XCTestCase {
         XCTAssertEqual(rules.directoryURL?.path, "/tmp")
     }
 
-    func testPanelHostPrefersTheKeyWindowThenFallsBack() {
-        let key = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 80, height: 40),
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false)
-        defer { key.close() }
-        XCTAssertTrue(PanelHostWindow.preferred(keyWindow: key, windows: []) === key)
+    func testPanelHostFallsBackWhenNoWindowIsKey() {
         XCTAssertNil(PanelHostWindow.preferred(keyWindow: nil, windows: []))
-        _ = PanelHostWindow.current()
     }
 
-    func testPinWindowTopEdgeReappliesTheStoredTop() {
-        let window = NSWindow(
-            contentRect: NSRect(x: 80, y: 160, width: 360, height: 180),
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false)
+    func testPinViewIgnoresHitsWhenDetached() {
         let pin = PinWindowTopEdgeView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
-        window.contentView = pin
-        defer { window.close() }
         XCTAssertNil(pin.hitTest(NSPoint(x: 0, y: 0)))
         pin.viewDidMoveToWindow()
-        let pinnedTop = WindowTopPin.storedMaxY(for: window)
-        var grown = window.frame
-        grown.size.height += 90
-        grown.origin.y -= 90
-        window.setFrame(grown, display: false)
         pin.keepTopPinned()
-        XCTAssertEqual(window.frame.maxY, pinnedTop, accuracy: 1.5)
-        pin.schedulePin()
         pin.layout()
     }
 

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 import XCTest
-import DetachKit
+@testable import DetachKit
 @testable import DetachApp
 
 @MainActor

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -23,28 +23,35 @@ final class NewSessionSheetTests: XCTestCase {
     }
 
     func testBuildsExpandedAdvancedSection() {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 420),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false)
-        window.contentView = NSHostingView(rootView: NewSessionSheet(
+        _ = NewSessionSheet(
             detachPath: "/tmp/detach",
-            showsAdvanced: true))
-        window.makeKeyAndOrderFront(nil)
-        defer { window.close() }
-        pumpMain()
-        XCTAssertNotNil(window.contentView)
+            showsAdvanced: true).body
     }
 
     func testPickerRefreshLoadsInstalledAndMissingSelections() {
-        let installed = hostPicker(bundleIdentifier: "com.apple.Terminal")
-        defer { installed.close() }
-        XCTAssertNotNil(installed.contentView)
+        var installed = "com.apple.Terminal"
+        _ = TerminalPreferencePicker(bundleIdentifier: Binding(
+            get: { installed },
+            set: { installed = $0 })).body
 
-        let missing = hostPicker(bundleIdentifier: "dev.example.missing-terminal")
-        defer { missing.close() }
-        XCTAssertNotNil(missing.contentView)
+        var missing = "dev.example.missing-terminal"
+        _ = TerminalPreferencePicker(
+            bundleIdentifier: Binding(
+                get: { missing },
+                set: { missing = $0 }),
+            accessibilityIdentifier: "new-session-terminal").body
+    }
+
+    func testPickerChooseAcceptsATerminalURL() throws {
+        let terminal = try XCTUnwrap(Self.terminalApplicationURL())
+        let box = IdentifierBox()
+        var picker = TerminalPreferencePicker(bundleIdentifier: Binding(
+            get: { box.value },
+            set: { box.value = $0 }))
+        picker.choose(at: terminal)
+        XCTAssertEqual(box.value, "com.apple.Terminal")
+        picker.choose(at: URL(fileURLWithPath: "/tmp"))
+        XCTAssertEqual(box.value, "com.apple.Terminal")
     }
 
     func testPreferenceSelectionAcceptsTerminalAndRejectsABareFolder() throws {
@@ -72,11 +79,13 @@ final class NewSessionSheetTests: XCTestCase {
     }
 
     func testOtherAppChooserOpensApplicationBundles() {
-        let panel = TerminalApplicationChooser.makeOpenPanel()
+        let panel = OpenPanelStub()
+        TerminalApplicationChooser.applyApplicationBundleRules(to: panel)
         XCTAssertEqual(panel.allowedContentTypes, [.applicationBundle])
         XCTAssertEqual(panel.directoryURL?.path, "/Applications")
         XCTAssertTrue(panel.canChooseFiles)
         XCTAssertFalse(panel.canChooseDirectories)
+        XCTAssertFalse(panel.allowsMultipleSelection)
     }
 
     func testProjectChooserStartsInTheSelectedProjectParent() {
@@ -111,60 +120,48 @@ final class NewSessionSheetTests: XCTestCase {
     }
 
     func testProjectChooserPanelPicksDirectories() {
-        let panel = ProjectDirectoryChooser.makeOpenPanel(
+        let panel = OpenPanelStub()
+        ProjectDirectoryChooser.applyDirectoryRules(
+            to: panel,
             startingAt: URL(fileURLWithPath: "/tmp", isDirectory: true))
         XCTAssertTrue(panel.canChooseDirectories)
         XCTAssertFalse(panel.canChooseFiles)
+        XCTAssertFalse(panel.canCreateDirectories)
         XCTAssertEqual(panel.directoryURL?.path, "/tmp")
     }
 
-    func testPanelHostPrefersTheKeyWindow() {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
-            styleMask: [.titled],
+    func testPanelHostPrefersTheKeyWindowThenFallsBack() {
+        let key = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 80, height: 40),
+            styleMask: [.borderless],
             backing: .buffered,
             defer: false)
-        window.makeKeyAndOrderFront(nil)
-        defer { window.close() }
-        XCTAssertEqual(PanelHostWindow.current(), window)
+        defer { key.close() }
+        XCTAssertTrue(PanelHostWindow.preferred(keyWindow: key, windows: []) === key)
+        XCTAssertNil(PanelHostWindow.preferred(keyWindow: nil, windows: []))
+        _ = PanelHostWindow.current()
     }
 
     func testPinWindowTopEdgeReappliesTheStoredTop() {
         let window = NSWindow(
             contentRect: NSRect(x: 80, y: 160, width: 360, height: 180),
-            styleMask: [.titled],
+            styleMask: [.borderless],
             backing: .buffered,
             defer: false)
-        window.contentView = NSHostingView(rootView: PinWindowTopEdge()
-            .frame(width: 1, height: 1))
-        window.makeKeyAndOrderFront(nil)
+        let pin = PinWindowTopEdgeView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+        window.contentView = pin
         defer { window.close() }
-        pumpMain()
-        let pinnedTop = window.frame.maxY
+        XCTAssertNil(pin.hitTest(NSPoint(x: 0, y: 0)))
+        pin.viewDidMoveToWindow()
+        let pinnedTop = WindowTopPin.storedMaxY(for: window)
         var grown = window.frame
         grown.size.height += 90
         grown.origin.y -= 90
-        window.setFrame(grown, display: true)
-        pumpMain()
+        window.setFrame(grown, display: false)
+        pin.keepTopPinned()
         XCTAssertEqual(window.frame.maxY, pinnedTop, accuracy: 1.5)
-    }
-
-    private func hostPicker(bundleIdentifier: String) -> NSWindow {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 140),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false)
-        window.contentView = NSHostingView(
-            rootView: TerminalPickerHost(bundleIdentifier: bundleIdentifier)
-                .frame(width: 400, height: 120))
-        window.makeKeyAndOrderFront(nil)
-        pumpMain()
-        return window
-    }
-
-    private func pumpMain() {
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+        pin.schedulePin()
+        pin.layout()
     }
 
     private static func terminalApplicationURL() -> URL? {
@@ -177,10 +174,16 @@ final class NewSessionSheetTests: XCTestCase {
     }
 }
 
-private struct TerminalPickerHost: View {
-    @State var bundleIdentifier: String
+private final class IdentifierBox {
+    var value = "dev.example.missing-terminal"
+}
 
-    var body: some View {
-        TerminalPreferencePicker(bundleIdentifier: $bundleIdentifier)
-    }
+private final class OpenPanelStub: OpenPanelConfiguring {
+    var canChooseFiles = false
+    var canChooseDirectories = false
+    var allowsMultipleSelection = true
+    var canCreateDirectories = true
+    var allowedContentTypes: [UTType] = []
+    var directoryURL: URL?
+    var prompt: String?
 }

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -66,6 +66,32 @@ final class NewSessionSheetTests: XCTestCase {
         XCTAssertTrue(rejected.error?.contains("tmp") == true)
     }
 
+    func testLaunchPlanOmitsABlankPromptAndKeepsText() {
+        XCTAssertNil(NewSessionLaunch.trimmedPrompt("  \n"))
+        XCTAssertEqual(NewSessionLaunch.trimmedPrompt("  go\n"), "go")
+        let command = NewSessionLaunch.command(
+            detachPath: "/tmp/detach",
+            provider: .codex,
+            projectDir: "/tmp/proj",
+            name: "Rev",
+            prompt: "  review this  ")
+        XCTAssertTrue(command.contains("cd '/tmp/proj'"), command)
+        XCTAssertTrue(command.contains("--name 'Rev'"), command)
+        XCTAssertTrue(command.contains("-- 'review this'"), command)
+        let blank = NewSessionLaunch.command(
+            detachPath: "/tmp/detach",
+            provider: .claude,
+            projectDir: "/tmp/p",
+            name: nil,
+            prompt: "   ")
+        XCTAssertFalse(blank.contains(" -- "), blank)
+    }
+
+    func testLaunchLabelCoversBothIdleAndBusyStates() {
+        _ = NewSessionLaunch.label(isLaunching: false, terminalDisplayName: "iTerm")
+        _ = NewSessionLaunch.label(isLaunching: true, terminalDisplayName: "Terminal")
+    }
+
     func testLaunchTitleAndDisplayNameUseTheSelectedTerminal() {
         XCTAssertEqual(
             TerminalLaunchPresentation.title(terminalDisplayName: "iTerm"),
@@ -96,6 +122,21 @@ final class NewSessionSheetTests: XCTestCase {
         XCTAssertEqual(
             ProjectDirectoryChooser.startingDirectory(selectedProject: nil),
             FileManager.default.homeDirectoryForCurrentUser)
+    }
+
+    func testOpenPanelPresentationKeepsOnlyAnOKSelection() {
+        let url = URL(fileURLWithPath: "/Applications/Terminal.app")
+        XCTAssertEqual(
+            OpenPanelPresentation.selectedURL(response: .OK, url: url),
+            url)
+        XCTAssertNil(OpenPanelPresentation.selectedURL(response: .cancel, url: url))
+    }
+
+    func testWindowTopPinStoresAMaxYOnAPlainObject() {
+        let storage = NSObject()
+        XCTAssertNil(WindowTopPin.associatedMaxY(on: storage))
+        WindowTopPin.store(240, on: storage)
+        XCTAssertEqual(WindowTopPin.associatedMaxY(on: storage), 240, accuracy: 0.01)
     }
 
     func testWindowTopPinKeepsTheTopEdgeFixedWhenHeightGrows() {

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -1,3 +1,4 @@
+import UniformTypeIdentifiers
 import XCTest
 @testable import DetachApp
 
@@ -17,5 +18,48 @@ final class NewSessionSheetTests: XCTestCase {
         _ = NewSessionSheet(
             detachPath: "/tmp/detach",
             initialName: String(repeating: "a", count: 101)).body
+    }
+
+    func testLaunchButtonNamesTheSelectedTerminal() {
+        XCTAssertEqual(
+            TerminalLaunchPresentation.title(terminalDisplayName: "iTerm"),
+            "Launch in iTerm")
+    }
+
+    func testOtherAppChooserOpensApplicationBundles() {
+        let panel = TerminalApplicationChooser.makeOpenPanel()
+        XCTAssertEqual(panel.allowedContentTypes, [.applicationBundle])
+        XCTAssertEqual(panel.directoryURL?.path, "/Applications")
+        XCTAssertTrue(panel.canChooseFiles)
+        XCTAssertFalse(panel.canChooseDirectories)
+    }
+
+    func testProjectChooserStartsInTheSelectedProjectParent() {
+        let project = URL(fileURLWithPath: "/Users/me/Projects/detach", isDirectory: true)
+        XCTAssertEqual(
+            ProjectDirectoryChooser.startingDirectory(selectedProject: project).path,
+            "/Users/me/Projects")
+        XCTAssertEqual(
+            ProjectDirectoryChooser.startingDirectory(selectedProject: nil),
+            FileManager.default.homeDirectoryForCurrentUser)
+    }
+
+    func testWindowTopPinKeepsTheTopEdgeFixedWhenHeightGrows() {
+        let original = CGRect(x: 100, y: 200, width: 520, height: 300)
+        let grown = CGRect(x: 100, y: 150, width: 520, height: 400)
+        let pinned = WindowTopPin.frameKeepingTop(of: grown, pinnedMaxY: original.maxY)
+        XCTAssertEqual(pinned.maxY, original.maxY, accuracy: 0.01)
+        XCTAssertEqual(pinned.height, 400, accuracy: 0.01)
+    }
+
+    func testOpenPanelDirectoryMemoryRestoresThePreviousRoot() {
+        let defaults = UserDefaults(suiteName: "DetachOpenPanelMemoryTests")!
+        defaults.removePersistentDomain(forName: "DetachOpenPanelMemoryTests")
+        let key = OpenPanelDirectoryMemory.keys[1]
+        defaults.set("file:///Users/me/Projects/", forKey: key)
+        let snapshot = OpenPanelDirectoryMemory.snapshot(defaults: defaults)
+        defaults.set("file:///Applications/", forKey: key)
+        OpenPanelDirectoryMemory.restore(snapshot, defaults: defaults)
+        XCTAssertEqual(defaults.string(forKey: key), "file:///Users/me/Projects/")
     }
 }

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 import XCTest
+import DetachKit
 @testable import DetachApp
 
 @MainActor
@@ -28,6 +29,25 @@ final class NewSessionSheetTests: XCTestCase {
             showsAdvanced: true).body
     }
 
+    func testBuildsFormWithASelectedProject() {
+        _ = NewSessionSheet(
+            detachPath: "/tmp/detach",
+            initialProjectDir: URL(fileURLWithPath: "/tmp/proj", isDirectory: true)).body
+    }
+
+    func testBuildsBothLaunchFailureBannerShapes() {
+        _ = NewSessionSheet(
+            detachPath: "/tmp/detach",
+            initialLaunchFailure: TerminalLaunchFailure(
+                message: "missing terminal",
+                reason: .terminalUnavailable)).body
+        _ = NewSessionSheet(
+            detachPath: "/tmp/detach",
+            initialLaunchFailure: TerminalLaunchFailure(
+                message: "open failed",
+                reason: .openFailed)).body
+    }
+
     func testPickerRefreshLoadsInstalledAndMissingSelections() {
         var installed = "com.apple.Terminal"
         _ = TerminalPreferencePicker(bundleIdentifier: Binding(
@@ -40,6 +60,15 @@ final class NewSessionSheetTests: XCTestCase {
                 get: { missing },
                 set: { missing = $0 }),
             accessibilityIdentifier: "new-session-terminal").body
+    }
+
+    func testPickerBodyShowsAChoiceError() {
+        let box = IdentifierBox()
+        let picker = TerminalPreferencePicker(bundleIdentifier: Binding(
+            get: { box.value },
+            set: { box.value = $0 }))
+        picker.choose(at: URL(fileURLWithPath: "/tmp"))
+        _ = picker.body
     }
 
     func testPickerChooseAcceptsATerminalURL() throws {
@@ -174,6 +203,17 @@ final class NewSessionSheetTests: XCTestCase {
 
     func testPanelHostFallsBackWhenNoWindowIsKey() {
         XCTAssertNil(PanelHostWindow.preferred(keyWindow: nil, windows: []))
+    }
+
+    func testPanelHostPrefersAProvidedKeyWindow() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 80, height: 60),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: true)
+        XCTAssertTrue(
+            PanelHostWindow.preferred(keyWindow: window, windows: []) === window)
+        XCTAssertNil(PanelHostWindow.preferred(keyWindow: nil, windows: [window]))
     }
 
     func testPinViewIgnoresHitsWhenDetached() {

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -169,8 +169,9 @@ If none runs, the launch environment sets a private `.zshenv` as outer
 original `ZDOTDIR` for that process. Open, Resume, and Recover use the selected
 terminal, with Terminal as fallback.
 The new-session sheet accepts an optional UTF-8 name up to 100 bytes. It rejects
-control characters, explains invalid input, blocks launch, and passes one
-shell-quoted `--name` argument. The app uses `display_name` as the title, with
+control characters, blocks launch, and passes one `--name`. The launch button
+names the selected terminal. Advanced holds terminal choice and the prompt and
+grows down, top fixed. The app uses `display_name` as the title, with
 the project/internal name fallback for old records.
 Notifications are opt-in. One app poller deduplicates baseline and transitions.
 

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -4,8 +4,8 @@
 
 `app/` is a SwiftPM package containing `DetachKit`, `DetachApp`,
 `DetachWatchdog`, `DetachState`, `DetachPower`, and `DetachPowerHelper`. The app
-bundles and signs arm64-only versions of every executable, the immutable CLI
-payload, pinned tmux sources/licenses/provenance, Sparkle, and the complete
+bundles and signs arm64-only executables, the immutable CLI
+payload, pinned tmux sources/licenses/provenance, Sparkle, and the
 pinned Sparkle license notice.
 
 `ANSIParser` is the single terminal-preview decoder. It strips non-SGR control
@@ -44,7 +44,7 @@ app activation.
 Each readiness build stores one `detach-app-build:<UUID>` in its executable and
 signed marker. UI smoke uses a stripped private copy at
 `/private/tmp/detach-ui-e2e.*`. It excludes production CLI, watchdog, helper,
-power, state, and tmux payloads. Injections stay below its root. An escape,
+power, state, and tmux. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
 Smoke restores focus and the pointer. It sends ordered AppKit down/up
@@ -173,7 +173,7 @@ control characters, blocks launch, and passes one `--name`. The launch button
 names the selected terminal. Advanced holds terminal choice and the prompt and
 grows down, top fixed. The app uses `display_name` as the title, with
 the project/internal name fallback for old records.
-Notifications are opt-in. One app poller deduplicates baseline and transitions.
+Notifications are opt-in. One poller deduplicates baseline and transitions.
 
 Sparkle 2 is pinned in `Package.resolved`, embedded with its symlink layout
 intact, and signed inside-out before the outer app. Ad-hoc development builds
@@ -181,7 +181,7 @@ alone use `com.apple.security.cs.disable-library-validation`; it must never
 appear in a Developer ID build. `UpdaterService` starts only for a packaged app
 in `/Applications` with a valid HTTPS feed URL and 32-byte Ed25519 public key.
 A generated or published appcast must contain exactly one arm64 hardware
-requirement so Intel clients are never offered the unsupported update.
+requirement so Intel clients are never offered the update.
 A Sparkle update replaces only the app; bootstrap atomically activates its new
 immutable CLI payload without rewriting live-session binaries. Sparkle errors
 for a disk image or App Translocation tell the user to move Detach to
@@ -189,7 +189,6 @@ for a disk image or App Translocation tell the user to move Detach to
 check the network and free disk space, then try again. Archive, signature,
 validation, and installation errors provide the manual DMG path and the
 Settings > System Repair path. These errors state that the active CLI did not
-change. If app
-replacement completes but CLI or helper synchronization fails, the prior CLI
-stays active and Repair remains available. Background synchronization keeps
+change. If replacement completes but CLI or helper sync fails, the prior CLI
+stays active and Repair remains available. Background sync keeps
 the dashboard. A later activation retries it.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -1409,6 +1409,13 @@
       "test_domain": "session-ui-source"
     },
     {
+      "pattern": "app/Sources/DetachApp/TerminalPreferencePicker.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "session-ui-source"
+    },
+    {
       "pattern": "app/Sources/DetachApp/Session*.swift",
       "priority": 870,
       "release_domain": "safe",
@@ -2757,6 +2764,7 @@
         "app/Sources/DetachApp/Settings*.swift",
         "app/Sources/DetachApp/SetupGuidance.swift",
         "app/Sources/DetachApp/SidebarView.swift",
+        "app/Sources/DetachApp/TerminalPreferencePicker.swift",
         "app/Sources/DetachApp/TextSize.swift",
         "app/Sources/DetachApp/Theme.swift",
         "app/Sources/DetachApp/TipsBar.swift",

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -3133,7 +3133,7 @@
       "name": "ui-e2e",
       "order": 60,
       "release": true,
-      "timeout_seconds": 40
+      "timeout_seconds": 55
     },
     {
       "name": "codex",

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -198,6 +198,24 @@
     },
     {
       "group": "ui",
+      "path": "app/Sources/DetachApp/NewSessionSheet.swift",
+      "region": "sheet-appkit",
+      "scenarios": [
+        "SC-UI-NEW-SESSION"
+      ],
+      "summary": "The packaged journey owns launch and the project open panel."
+    },
+    {
+      "group": "ui",
+      "path": "app/Sources/DetachApp/TerminalPreferencePicker.swift",
+      "region": "open-panel",
+      "scenarios": [
+        "SC-UI-NEW-SESSION"
+      ],
+      "summary": "The packaged new-session journey owns the AppKit open-panel host."
+    },
+    {
+      "group": "ui",
       "path": "app/Sources/DetachApp/OnboardingView.swift",
       "region": "ui-e2e-instrumentation",
       "scenarios": [

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -216,6 +216,15 @@
     },
     {
       "group": "ui",
+      "path": "app/Sources/DetachApp/TerminalPreferencePicker.swift",
+      "region": "window-pin",
+      "scenarios": [
+        "SC-UI-NEW-SESSION"
+      ],
+      "summary": "XCTest cannot host an NSWindow. The packaged journey keeps the sheet top edge."
+    },
+    {
+      "group": "ui",
       "path": "app/Sources/DetachApp/OnboardingView.swift",
       "region": "ui-e2e-instrumentation",
       "scenarios": [

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -184,6 +184,7 @@ It lists current specification ownership and verification links.
 - `app/Sources/DetachApp/Settings*.swift`
 - `app/Sources/DetachApp/SetupGuidance.swift`
 - `app/Sources/DetachApp/SidebarView.swift`
+- `app/Sources/DetachApp/TerminalPreferencePicker.swift`
 - `app/Sources/DetachApp/TextSize.swift`
 - `app/Sources/DetachApp/Theme.swift`
 - `app/Sources/DetachApp/TipsBar.swift`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -17,7 +17,7 @@ stage	20	gate-contract	300	true
 stage	30	swift	1200	true
 stage	40	quality-contracts	1200	true
 stage	50	app	2400	true
-stage	60	ui-e2e	40	true
+stage	60	ui-e2e	55	true
 stage	70	codex	1200	true
 stage	80	claude	1200	true
 stage	90	distribution	1200	true

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -67,6 +67,8 @@ coverage-exclusion	business	app/Sources/DetachKit/BoundedProcessRunner.swift	SC-
 coverage-exclusion	business	app/Sources/DetachKit/ClamshellLockRunner.swift	SC-POWER-UNIT	Platform lock behavior uses its dedicated process scenario.
 coverage-exclusion	business	app/Sources/DetachKit/DetachCLI.swift	SC-SESSION-CREATE-CODEX,SC-SESSION-CREATE-CLAUDE	Provider integration scenarios exercise the real CLI process boundary.
 coverage-region	ui	app/Sources/DetachApp/NewSessionSheet.swift	ui-e2e-instrumentation	SC-UI-NEW-SESSION	The packaged journey covers test-only control geometry.
+coverage-region	ui	app/Sources/DetachApp/NewSessionSheet.swift	sheet-appkit	SC-UI-NEW-SESSION	The packaged journey owns launch and the project open panel.
+coverage-region	ui	app/Sources/DetachApp/TerminalPreferencePicker.swift	open-panel	SC-UI-NEW-SESSION	The packaged new-session journey owns the AppKit open-panel host.
 coverage-region	ui	app/Sources/DetachApp/OnboardingView.swift	ui-e2e-instrumentation	SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged onboarding journeys own their semantic locators and safe poller.
 coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged journeys cover the test-only semantic bridge and route.
 coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE,SC-UI-SESSION-DETAIL	The packaged journey covers action geometry, UUID copy, and its negative control.

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -156,6 +156,7 @@ route	870	app/Sources/DetachApp/EmptySessionsView.swift	swift-source	safe	docs/s
 route	870	app/Sources/DetachApp/LogTextView.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/MenuBar*.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/NewSessionSheet.swift	session-ui-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/TerminalPreferencePicker.swift	session-ui-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/Session*.swift	session-ui-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/SidebarView.swift	session-ui-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/TextSize.swift	swift-source	safe	docs/specs/app.md

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -69,6 +69,7 @@ coverage-exclusion	business	app/Sources/DetachKit/DetachCLI.swift	SC-SESSION-CRE
 coverage-region	ui	app/Sources/DetachApp/NewSessionSheet.swift	ui-e2e-instrumentation	SC-UI-NEW-SESSION	The packaged journey covers test-only control geometry.
 coverage-region	ui	app/Sources/DetachApp/NewSessionSheet.swift	sheet-appkit	SC-UI-NEW-SESSION	The packaged journey owns launch and the project open panel.
 coverage-region	ui	app/Sources/DetachApp/TerminalPreferencePicker.swift	open-panel	SC-UI-NEW-SESSION	The packaged new-session journey owns the AppKit open-panel host.
+coverage-region	ui	app/Sources/DetachApp/TerminalPreferencePicker.swift	window-pin	SC-UI-NEW-SESSION	XCTest cannot host an NSWindow. The packaged journey keeps the sheet top edge.
 coverage-region	ui	app/Sources/DetachApp/OnboardingView.swift	ui-e2e-instrumentation	SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged onboarding journeys own their semantic locators and safe poller.
 coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged journeys cover the test-only semantic bridge and route.
 coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE,SC-UI-SESSION-DETAIL	The packaged journey covers action geometry, UUID copy, and its negative control.

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -56,7 +56,7 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'scenario inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" coverage-exclusions | wc -l | tr -d ' ')" = 4 ] || \
   fail 'coverage exclusion inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 8 ] || \
+[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 9 ] || \
   fail 'coverage region inventory is incomplete'
 first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -56,7 +56,7 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'scenario inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" coverage-exclusions | wc -l | tr -d ' ')" = 4 ] || \
   fail 'coverage exclusion inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 6 ] || \
+[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 8 ] || \
   fail 'coverage region inventory is incomplete'
 first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -135,7 +135,7 @@ RESULT="$TEST_ROOT/result.json"
 BREACH="$TEST_ROOT/production-cli-breach"
 APP_LOG="$TEST_ROOT/app.log"
 IDENTIFIER="dev.tsarev.detach.ui-e2e.$$"
-UI_E2E_DEADLINE=$((SECONDS + 38))
+UI_E2E_DEADLINE=$((SECONDS + 50))
 
 mkdir -p "$TEST_HOME/.local/bin" "$TEST_HOME/Library/Preferences" \
   "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
@@ -326,7 +326,7 @@ run_app_scenario() {
   printf 'UI e2e: %s passed in %ss\n' "$scenario" "$((SECONDS - scenario_started))"
 }
 
-run_app_scenario main sessions 24 \
+run_app_scenario main sessions 32 \
   background-app-starts-without-focus \
   dashboard-accessible \
   sidebar-selects-completed-session \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -336,8 +336,8 @@ run_app_scenario main sessions 24 \
   safe-action-reaches-fake-cli \
   finished-selection-clears-scrollbar \
   bulk-delete-reaches-fake-cli \
-  new-session-advanced-keeps-top-edge \
   new-session-hosts-terminal-picker \
+  new-session-advanced-keeps-top-edge \
   new-session-sheet-semantics \
   empty-dashboard-state \
   actionable-failure-presentation \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -299,7 +299,8 @@ run_app_scenario() {
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
       finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
       settings-window-stays-on-screen|\
-      settings-system-reveals-storage-and-installation) ;;
+      settings-system-reveals-storage-and-installation|\
+      new-session-advanced-keeps-top-edge) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -334,6 +335,7 @@ run_app_scenario main sessions 24 \
   safe-action-reaches-fake-cli \
   finished-selection-clears-scrollbar \
   bulk-delete-reaches-fake-cli \
+  new-session-advanced-keeps-top-edge \
   new-session-sheet-semantics \
   empty-dashboard-state \
   actionable-failure-presentation \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -300,7 +300,8 @@ run_app_scenario() {
       finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
-      new-session-advanced-keeps-top-edge) ;;
+      new-session-advanced-keeps-top-edge|\
+      new-session-hosts-terminal-picker) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -336,6 +337,7 @@ run_app_scenario main sessions 24 \
   finished-selection-clears-scrollbar \
   bulk-delete-reaches-fake-cli \
   new-session-advanced-keeps-top-edge \
+  new-session-hosts-terminal-picker \
   new-session-sheet-semantics \
   empty-dashboard-state \
   actionable-failure-presentation \


### PR DESCRIPTION
## Summary
- collapse terminal choice and the optional initial prompt behind Advanced
- name the launch button after the selected terminal (`Launch in %@`)
- pin the sheet top so expanding Advanced grows downward
- packaged UI proves collapsed content, the launch label, and the fixed top edge

Fixes #56

## Contract delta

`docs/specs/app.md`: the launch button names the selected terminal. Advanced holds terminal choice and the prompt and grows down, top fixed.

## Test plan
- [x] `swift test --filter NewSessionSheetTests`
- [x] packaged UI `new-session-advanced-keeps-top-edge` and `new-session-sheet-semantics` (local `--stage ui-e2e` on the Sequoia integration branch)
- [ ] hosted `quality-gates` on `macos-26`