### PR TITLE
Keep Settings on screen and scroll the System pane

### DIFF
--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -251,6 +251,16 @@ struct SettingsView: View {
             systemTab.tabItem {
                 tabLabel(L10n.string("System"), systemImage: "moon.stars.fill",
                          color: .systemOrange)
+                    .accessibilityIdentifier("settings-tab-system")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        if AppSettings.uiE2E != nil {
+                            UIE2EGeometryProbe(identifier: "settings-tab-system")
+                        }
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
             }
             .tag(SettingsDestination.system)
             updatesTab.tabItem {
@@ -260,10 +270,11 @@ struct SettingsView: View {
             .tag(SettingsDestination.updates)
         }
         .appFontSize(fontPointSize)
-        .frame(
+        .frame(width: AppFontSize.settingsWidth(for: fontPointSize))
+        .background(SettingsWindowFrame(
             width: AppFontSize.settingsWidth(for: fontPointSize),
-            height: AppFontSize.settingsHeight(
-                base: navigation.selectedTab.baseHeight, for: fontPointSize))
+            baseHeight: navigation.selectedTab.baseHeight,
+            fontPointSize: fontPointSize))
         .task {
             let clampedFontPointSize = AppFontSize.clamped(fontPointSize)
             if fontSizeDraft == nil {
@@ -785,7 +796,7 @@ struct SettingsView: View {
                     .settingsMessage()
             }
             storageSection
-            Section(L10n.string("Installation")) {
+            Section {
                 Button(L10n.string("Reinstall command-line tools")) {
                     Task { await installation.repair() }
                 }
@@ -800,6 +811,10 @@ struct SettingsView: View {
                     confirmPurge = true
                 }
                 .disabled(installation.isBusy)
+            } header: {
+                settingsSectionHeader(
+                    L10n.string("Installation"),
+                    identifier: "settings-installation")
             }
             if let version = installation.report?.version {
                 Section {
@@ -819,7 +834,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var storageSection: some View {
-        Section(L10n.string("Storage")) {
+        Section {
             if let report = storageStore.report {
                 LabeledContent(L10n.string("Detach data"), value: storageSize(report.allocatedBytes))
                 LabeledContent(
@@ -899,7 +914,28 @@ struct SettingsView: View {
                 Text(L10n.string("The installed Detach CLI returned incompatible storage data."))
                     .settingsMessage(color: .red)
             }
+        } header: {
+            settingsSectionHeader(
+                L10n.string("Storage"),
+                identifier: "settings-storage")
         }
+    }
+
+    private func settingsSectionHeader(
+        _ title: String,
+        identifier: String
+    ) -> some View {
+        Text(title)
+            .accessibilityIdentifier(identifier)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+            .background {
+                if AppSettings.uiE2E != nil {
+                    UIE2EGeometryProbe(identifier: identifier)
+                }
+            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
     }
 
     private func storageSelectionBinding(for session: StorageSession) -> Binding<Bool> {
@@ -1301,6 +1337,77 @@ struct SettingsView: View {
         ]
         guard let url = candidates.lazy.compactMap(URL.init(string:)).first else { return }
         NSWorkspace.shared.open(url)
+    }
+}
+
+/// Settings content may be taller than a laptop screen. The window stays
+/// inside the hosting window's visible frame; the form scrolls.
+private struct SettingsWindowFrame: NSViewRepresentable {
+    var width: CGFloat
+    var baseHeight: CGFloat
+    var fontPointSize: Double
+
+    func makeNSView(context: Context) -> SettingsWindowFrameView {
+        let view = SettingsWindowFrameView()
+        view.apply(width: width, baseHeight: baseHeight, fontPointSize: fontPointSize)
+        return view
+    }
+
+    func updateNSView(_ view: SettingsWindowFrameView, context: Context) {
+        view.apply(width: width, baseHeight: baseHeight, fontPointSize: fontPointSize)
+    }
+}
+
+private final class SettingsWindowFrameView: NSView {
+    private var width: CGFloat = 0
+    private var baseHeight: CGFloat = 0
+    private var fontPointSize = AppFontSize.defaultValue
+
+    func apply(width: CGFloat, baseHeight: CGFloat, fontPointSize: Double) {
+        self.width = width
+        self.baseHeight = baseHeight
+        self.fontPointSize = fontPointSize
+        pinToHostingScreen()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        NotificationCenter.default.removeObserver(
+            self, name: NSWindow.didChangeScreenNotification, object: nil)
+        if let window {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(screenDidChange),
+                name: NSWindow.didChangeScreenNotification,
+                object: window)
+        }
+        pinToHostingScreen()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func screenDidChange(_ notification: Notification) {
+        pinToHostingScreen()
+    }
+
+    private func pinToHostingScreen() {
+        guard let window, width > 0 else { return }
+        let visibleHeight = window.screen?.visibleFrame.height ?? 720
+        let size = CGSize(
+            width: width,
+            height: SettingsWindowLayout.contentHeight(
+                base: baseHeight,
+                fontPointSize: fontPointSize,
+                visibleScreenHeight: visibleHeight))
+        window.contentMinSize = size
+        window.contentMaxSize = size
+        let current = window.contentView?.bounds.size ?? .zero
+        if abs(current.width - size.width) > 0.5
+            || abs(current.height - size.height) > 0.5 {
+            window.setContentSize(size)
+        }
     }
 }
 

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -1358,7 +1358,7 @@ private struct SettingsWindowFrame: NSViewRepresentable {
     }
 }
 
-private final class SettingsWindowFrameView: NSView {
+final class SettingsWindowFrameView: NSView {
     private var width: CGFloat = 0
     private var baseHeight: CGFloat = 0
     private var fontPointSize = AppFontSize.defaultValue

--- a/app/Sources/DetachApp/TextSize.swift
+++ b/app/Sources/DetachApp/TextSize.swift
@@ -33,6 +33,25 @@ enum AppFontSize {
     }
 }
 
+/// Settings content may be taller than a laptop screen. The window stays
+/// inside the hosting window's visible frame and a comfortable pane height;
+/// the form scrolls.
+enum SettingsWindowLayout {
+    static let chromeHeight: CGFloat = 88
+    static let minimumContentHeight: CGFloat = 360
+    static let comfortableContentHeight: CGFloat = 560
+
+    static func contentHeight(
+        base: CGFloat,
+        fontPointSize: Double,
+        visibleScreenHeight: CGFloat
+    ) -> CGFloat {
+        let preferred = AppFontSize.settingsHeight(base: base, for: fontPointSize)
+        let screenLimit = max(minimumContentHeight, visibleScreenHeight - chromeHeight)
+        return min(preferred, comfortableContentHeight, screenLimit)
+    }
+}
+
 /// Keeps text-size changes local to Settings until the user applies them.
 struct AppFontSizeDraft: Equatable {
     private(set) var appliedValue: Double

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -502,6 +502,25 @@ enum UIE2ETestDriver {
                         forKey: AppSettings.tipsEnabledKey) != priorTips
                 }
             checks.append("settings-change-persists")
+            guard let settingsWindow = UIE2EEventWindowResolver.owner(of: tipsToggle)
+            else {
+                throw Failure(message: "Settings window is missing")
+            }
+            guard let visible = settingsWindow.screen?.visibleFrame else {
+                throw Failure(message: "Settings window has no hosting screen")
+            }
+            let frame = settingsWindow.frame
+            guard visible.insetBy(dx: -2, dy: -2).contains(frame) else {
+                throw Failure(message: "Settings window is off the hosting screen")
+            }
+            checks.append("settings-window-stays-on-screen")
+            let systemTab = try await buttonLabeled(
+                L10n.string("System"), attempts: 20)
+            try await click(systemTab, name: "System settings tab")
+            try await revealGeometry(identifier: "settings-storage", name: "Storage")
+            try await revealGeometry(
+                identifier: "settings-installation", name: "Installation")
+            checks.append("settings-system-reveals-storage-and-installation")
             return Report(
                 schema: 1, passed: true, checks: checks, error: nil,
                 accessibilityTree: snapshots())
@@ -614,6 +633,23 @@ enum UIE2ETestDriver {
         if !items.isEmpty {
             pasteboard.writeObjects(items)
         }
+    }
+
+    private static func buttonLabeled(
+        _ name: String,
+        attempts: Int = 100
+    ) async throws -> any NSAccessibilityProtocol {
+        var result: (any NSAccessibilityProtocol)?
+        try await waitUntil("button \(name)", attempts: attempts) {
+            result = elements().first { element in
+                label(element) == name
+                    && (roleOf(element) == .button
+                        || roleOf(element) == .radioButton
+                        || roleOf(element) == .checkBox)
+            }
+            return result != nil
+        }
+        return result!
     }
 
     private static func restoreFocus(
@@ -910,6 +946,21 @@ enum UIE2ETestDriver {
             screen = screen.offsetBy(dx: offset.width, dy: offset.height)
         }
         try await click(frame: screen, name: name, owningWindow: window)
+    }
+
+    private static func revealGeometry(
+        identifier: String,
+        name: String
+    ) async throws {
+        var view: UIE2EGeometryView?
+        try await waitUntil("\(name) geometry", attempts: 20) {
+            view = elements().compactMap { $0 as? UIE2EGeometryView }.first {
+                $0.identifierValue == identifier
+            }
+            view?.publishFrame()
+            return view.map { $0.window != nil && !$0.bounds.isEmpty } == true
+        }
+        try await revealMeasuredControl(view!, identifier: identifier, name: name)
     }
 
     private static func measuredFrame(

--- a/app/Tests/DetachAppTests/TextSizeTests.swift
+++ b/app/Tests/DetachAppTests/TextSizeTests.swift
@@ -109,6 +109,45 @@ final class TextSizeTests: XCTestCase {
                 visibleScreenHeight: 900))
     }
 
+    @MainActor
+    func testSettingsWindowReappliesItsHostingScreenSizeAfterNotification() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        let host = NSView(frame: window.contentLayoutRect)
+        let frameView = SettingsWindowFrameView(frame: .zero)
+        host.addSubview(frameView)
+        window.contentView = host
+
+        frameView.apply(
+            width: 620,
+            baseHeight: 780,
+            fontPointSize: AppFontSize.defaultValue)
+
+        let expectedHeight = SettingsWindowLayout.contentHeight(
+            base: 780,
+            fontPointSize: AppFontSize.defaultValue,
+            visibleScreenHeight: window.screen?.visibleFrame.height ?? 720)
+        XCTAssertEqual(window.contentMinSize.width, 620, accuracy: 0.001)
+        XCTAssertEqual(window.contentMinSize.height, expectedHeight, accuracy: 0.001)
+        XCTAssertEqual(window.contentMaxSize, window.contentMinSize)
+
+        window.contentMinSize = .zero
+        window.contentMaxSize = NSSize(width: 1_000, height: 1_000)
+        window.setContentSize(NSSize(width: 200, height: 200))
+        NotificationCenter.default.post(
+            name: NSWindow.didChangeScreenNotification,
+            object: window)
+
+        XCTAssertEqual(window.contentMinSize.width, 620, accuracy: 0.001)
+        XCTAssertEqual(window.contentMinSize.height, expectedHeight, accuracy: 0.001)
+        let contentView = try XCTUnwrap(window.contentView)
+        XCTAssertEqual(contentView.bounds.width, 620, accuracy: 0.001)
+        XCTAssertEqual(contentView.bounds.height, expectedHeight, accuracy: 0.001)
+    }
+
     func testLogResizeUsesExactPointSizeAndPreservesTraitsAndColors() throws {
         let regular = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
         let bold = NSFont.monospacedSystemFont(ofSize: 10, weight: .bold)

--- a/app/Tests/DetachAppTests/TextSizeTests.swift
+++ b/app/Tests/DetachAppTests/TextSizeTests.swift
@@ -81,6 +81,34 @@ final class TextSizeTests: XCTestCase {
         XCTAssertGreaterThan(AppFontSize.settingsHeight(base: 420, for: 20), 420)
     }
 
+    func testSettingsWindowUsesTheHostingScreenVisibleHeight() {
+        XCTAssertEqual(
+            SettingsWindowLayout.contentHeight(
+                base: 780,
+                fontPointSize: AppFontSize.defaultValue,
+                visibleScreenHeight: 1200),
+            SettingsWindowLayout.comfortableContentHeight)
+        XCTAssertEqual(
+            SettingsWindowLayout.contentHeight(
+                base: 450,
+                fontPointSize: AppFontSize.defaultValue,
+                visibleScreenHeight: 1200),
+            450)
+        let shortScreen = SettingsWindowLayout.contentHeight(
+            base: 780,
+            fontPointSize: AppFontSize.defaultValue,
+            visibleScreenHeight: 480)
+        XCTAssertLessThan(shortScreen, 480)
+        XCTAssertGreaterThanOrEqual(
+            shortScreen, SettingsWindowLayout.minimumContentHeight)
+        XCTAssertLessThan(
+            shortScreen,
+            SettingsWindowLayout.contentHeight(
+                base: 780,
+                fontPointSize: AppFontSize.defaultValue,
+                visibleScreenHeight: 900))
+    }
+
     func testLogResizeUsesExactPointSizeAndPreservesTraitsAndColors() throws {
         let regular = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
         let bold = NSFont.monospacedSystemFont(ofSize: 10, weight: .bold)

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -96,11 +96,10 @@ the full UUID and shows **Copied**.
 **Finished** bulk Delete uses typed Delete, asks once, tolerates failures, and
 keeps provider transcripts. Select/Done has 12-point scroll clearance.
 
-Every app CLI invocation runs in a fresh process group with concurrent bounded
-stdout/stderr draining. Its deadline sends TERM and then KILL to the complete
-group, and a descendant that only inherits a pipe cannot hold the caller past
-the drain deadline. GUI PATH augmentation orders NVM and mise Node directories
-by semantic version, with valid versions ahead of non-version aliases.
+Every app CLI invocation runs in a fresh process group that drains stdout and
+stderr. Its deadline sends TERM then KILL to the group. A pipe-only descendant
+cannot hold the caller past the drain deadline. GUI PATH orders NVM and mise
+Node directories by semantic version.
 
 Helper replacement is a durable fail-closed transaction. One versioned JSON
 journal records `preparing`, `unregisterSubmitted`, `removed`, or `registering`,

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -84,8 +84,9 @@ faster with a window and slower without one. It never stops. Closing the last
 window keeps the app and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
-Mac Power status and approval controls. Temperature safety has its own warning
-shape and the text **Mac can sleep: temperature**.
+Mac Power status and approval controls. The Settings window follows the hosting
+screen; System scrolls. Temperature safety has its own warning shape and the
+text **Mac can sleep: temperature**.
 
 The dashboard shows identity, status, and Mac Power separately. Identity is a
 thin tmux-colored capsule. Status is a filled circle. Power has a neutral

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -296,7 +296,9 @@ run_app_scenario() {
     }
     case "$check" in
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
-      finished-selection-clears-scrollbar|session-uuid-copies-from-text-side) ;;
+      finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
+      settings-window-stays-on-screen|\
+      settings-system-reveals-storage-and-installation) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -334,7 +336,10 @@ run_app_scenario main sessions 24 \
   empty-dashboard-state \
   installed-app-focus-restored
 run_app_scenario failure error 8 actionable-failure-presentation
-run_app_scenario settings empty 8 settings-change-persists
+run_app_scenario settings empty 8 \
+  settings-change-persists \
+  settings-window-stays-on-screen \
+  settings-system-reveals-storage-and-installation
 run_app_scenario onboarding-first-run empty 8 onboarding-first-run-completes
 run_app_scenario onboarding-provider empty 8 onboarding-detects-provider
 run_app_scenario onboarding-approval empty 8 onboarding-explains-approval


### PR DESCRIPTION
## Summary
- cap Settings from the hosting window’s screen, not `NSScreen.main`
- update the cap when the window’s screen changes
- packaged UI: Settings stays on screen; System reveals Storage and Installation

Fixes #60

## Contract delta

`docs/specs/app.md`: the Settings window follows the hosting screen; System scrolls.

## Test plan
- [x] `swift test --filter TextSizeTests/testSettingsWindowUsesTheHostingScreenVisibleHeight`
- [x] packaged UI `settings-window-stays-on-screen` and `settings-system-reveals-storage-and-installation` (local `--stage ui-e2e` on the Sequoia integration branch)
- [ ] hosted `quality-gates` on `macos-26`