### PR TITLE
Copy the session UUID from the whole detail chip

### DIFF
--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 "Complete Setup" = "Complete Setup";
 "Connect Codex or Claude" = "Connect Codex or Claude";
 "Copy session UUID" = "Copy session UUID";
+"Copied" = "Copied";
 "Could Not Complete Setup" = "Could Not Complete Setup";
 "Could not open Terminal" = "Could not open Terminal";
 "Could not delete some sessions" = "Could not delete some sessions";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 "Complete Setup" = "Завершите настройку";
 "Connect Codex or Claude" = "Подключите Codex или Claude";
 "Copy session UUID" = "Скопировать UUID сессии";
+"Copied" = "Скопировано";
 "Could Not Complete Setup" = "Не удалось завершить настройку";
 "Could not open Terminal" = "Не удалось открыть терминал";
 "Could not delete some sessions" = "Не удалось удалить некоторые сессии";

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -135,7 +135,7 @@ struct SessionDetailView: View {
                              help: projectDir)
                 }
                 if let uuid = session.agentSessionId {
-                    uuidChip(uuid)
+                    SessionUUIDChip(uuid: uuid)
                 }
                 if let created = session.createdAt {
                     metaChip(L10n.format(
@@ -194,33 +194,6 @@ struct SessionDetailView: View {
         .background(Capsule().fill(.quaternary.opacity(0.6)))
         .help(help ?? text)
         .frame(maxWidth: 320, alignment: .leading)
-    }
-
-    private func uuidChip(_ uuid: String) -> some View {
-        HStack(spacing: 4) {
-            Text(shortUUID(uuid))
-                .appFont(.caption, design: .monospaced)
-                .lineLimit(1)
-            Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(uuid, forType: .string)
-            } label: {
-                Image(systemName: "doc.on.doc")
-                    .appFont(.caption2)
-            }
-            .buttonStyle(.borderless)
-            .accessibilityLabel(L10n.string("Copy session UUID"))
-        }
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 3)
-        .background(Capsule().fill(.quaternary.opacity(0.6)))
-        .help(uuid)
-    }
-
-    private func shortUUID(_ uuid: String) -> String {
-        guard uuid.count > 13 else { return uuid }
-        return "\(uuid.prefix(8))…\(uuid.suffix(4))"
     }
 
     private func abbreviatePath(_ path: String) -> String {
@@ -431,6 +404,91 @@ struct SessionDetailView: View {
                 actionError = message
             }
         }
+    }
+}
+
+enum SessionUUIDPresentation {
+    static func shortDisplay(_ uuid: String) -> String {
+        guard uuid.count > 13 else { return uuid }
+        return "\(uuid.prefix(8))…\(uuid.suffix(4))"
+    }
+
+    @discardableResult
+    static func copy(_ uuid: String, to pasteboard: NSPasteboard = .general) -> Bool {
+        pasteboard.clearContents()
+        return pasteboard.setString(uuid, forType: .string)
+    }
+}
+
+/// The whole chip is the control. A nested icon-only button inside
+/// `FlowLayout` often misses clicks on macOS.
+struct SessionUUIDChip: View {
+    let uuid: String
+    @State private var copied = false
+    @State private var resetTask: Task<Void, Never>?
+
+    var body: some View {
+        Button(action: copyUUID) {
+            HStack(spacing: 4) {
+                Text(SessionUUIDPresentation.shortDisplay(uuid))
+                    .appFont(.caption, design: .monospaced)
+                    .lineLimit(1)
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .appFont(.caption2)
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .foregroundStyle(copied ? Brand.teal : .secondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background {
+                Capsule().fill(
+                    copied
+                        ? AnyShapeStyle(Brand.teal.opacity(0.20))
+                        : AnyShapeStyle(.quaternary.opacity(0.6)))
+            }
+            .contentShape(Capsule())
+            .animation(.easeInOut(duration: 0.18), value: copied)
+        }
+        .buttonStyle(ChipPressStyle())
+        .help(copied ? L10n.string("Copied") : uuid)
+        .accessibilityLabel(L10n.string("Copy session UUID"))
+        .accessibilityValue(uuid)
+        .accessibilityIdentifier("session-uuid-chip")
+        .accessibilityAddTraits(.isButton)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+        .overlay(alignment: .leading) {
+            if AppSettings.uiE2E != nil {
+                UIE2EGeometryProbe(identifier: "session-uuid-chip")
+                    .frame(width: 2, height: 2)
+                    .padding(.leading, 10)
+            }
+        }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+        .onDisappear {
+            resetTask?.cancel()
+        }
+    }
+
+    private func copyUUID() {
+        guard SessionUUIDPresentation.copy(uuid) else { return }
+        copied = true
+        resetTask?.cancel()
+        resetTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            copied = false
+        }
+    }
+}
+
+private struct ChipPressStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.94 : 1)
+            .opacity(configuration.isPressed ? 0.72 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
     }
 }
 

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -451,17 +451,20 @@ struct SessionUUIDChip: View {
         }
         .buttonStyle(ChipPressStyle())
         .help(copied ? L10n.string("Copied") : uuid)
-        .accessibilityLabel(L10n.string("Copy session UUID"))
+        .accessibilityLabel(
+            copied ? L10n.string("Copied") : L10n.string("Copy session UUID"))
         .accessibilityValue(uuid)
         .accessibilityIdentifier("session-uuid-chip")
         .accessibilityAddTraits(.isButton)
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
-        .overlay(alignment: .leading) {
+        .overlay {
             if AppSettings.uiE2E != nil {
-                UIE2EGeometryProbe(identifier: "session-uuid-chip")
-                    .frame(width: 2, height: 2)
-                    .padding(.leading, 10)
+                UIE2EGeometryProbe(
+                    identifier: "session-uuid-chip",
+                    semanticLabel: copied
+                        ? L10n.string("Copied") : L10n.string("Copy session UUID"),
+                    semanticRole: .button)
             }
         }
 #endif

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -236,6 +236,20 @@ enum UIE2ETestDriver {
             checks.append("sidebar-selects-completed-session")
             trace("completed session selected")
 
+            let copiedUUID = "a9f58f1d-1234-5678-9abc-def012342ed9"
+            let pasteboardSnapshot = captureGeneralPasteboard()
+            defer { restoreGeneralPasteboard(pasteboardSnapshot) }
+            let pasteboardGeneration = NSPasteboard.general.changeCount
+            try await clickMeasuredControl(
+                identifier: "session-uuid-chip",
+                name: "session UUID chip text",
+                offset: CGSize(width: 24, height: 0),
+                size: CGSize(width: 36, height: 18))
+            try await waitUntil("copied full UUID and confirmation", attempts: 15) {
+                NSPasteboard.general.changeCount > pasteboardGeneration
+                    && NSPasteboard.general.string(forType: .string) == copiedUUID
+            }
+            checks.append("session-uuid-copies-from-text-side")
             let runningID = "detach-codex-ui-running"
             let runningRow = try await element(
                 identifier: "session-row-\(runningID)")
@@ -571,6 +585,28 @@ enum UIE2ETestDriver {
         FileHandle.standardError.write(Data("UI e2e: \(message)\n".utf8))
     }
 
+    private static func captureGeneralPasteboard() -> [[NSPasteboard.PasteboardType: Data]] {
+        (NSPasteboard.general.pasteboardItems ?? []).map { item in
+            Dictionary(uniqueKeysWithValues: item.types.compactMap { type in
+                item.data(forType: type).map { (type, $0) }
+            })
+        }
+    }
+
+    private static func restoreGeneralPasteboard(
+        _ snapshot: [[NSPasteboard.PasteboardType: Data]]
+    ) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        for payload in snapshot {
+            let item = NSPasteboardItem()
+            for (type, data) in payload {
+                item.setData(data, forType: type)
+            }
+            pasteboard.writeObjects([item])
+        }
+    }
+
     private static func restoreFocus(
         to application: NSRunningApplication?,
         policy: NSApplication.ActivationPolicy
@@ -834,6 +870,37 @@ enum UIE2ETestDriver {
             }
         }
         throw Failure(message: "\(name) did not produce \(outcome)")
+    }
+
+    private static func clickMeasuredControl(
+        identifier: String,
+        name: String,
+        offset: CGSize = .zero,
+        size: CGSize? = nil
+    ) async throws {
+        var target: UIE2EGeometryView?
+        try await waitUntil("measured control \(name)") {
+            target = elements().compactMap { $0 as? UIE2EGeometryView }.first {
+                $0.identifierValue == identifier
+            }
+            target?.publishFrame()
+            return target.map { $0.window != nil && !$0.bounds.isEmpty } == true
+        }
+        guard let view = target, let window = view.window else {
+            throw Failure(message: "\(name) has no measured control view")
+        }
+        let windowFrame = view.convert(view.bounds, to: nil)
+        var screen = window.convertToScreen(windowFrame)
+        if let size {
+            screen = CGRect(
+                x: screen.minX + offset.width,
+                y: screen.minY + offset.height - (size.height - screen.height) / 2,
+                width: size.width,
+                height: size.height)
+        } else if offset != .zero {
+            screen = screen.offsetBy(dx: offset.width, dy: offset.height)
+        }
+        try await click(frame: screen, name: name, owningWindow: window)
     }
 
     private static func measuredFrame(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1052,12 +1052,13 @@ enum UIE2ETestDriver {
             guard visited.insert(identifier).inserted else { continue }
             result.append(element)
             guard depth < 20 else { continue }
-            var children = (element.accessibilityWindows() ?? [])
-                + (element.accessibilityChildren() ?? [])
-                + (element.accessibilityVisibleChildren() ?? [])
-                + (element.accessibilityContents() ?? [])
-                + (element.accessibilityRows() ?? [])
-                + (element.accessibilityVisibleRows() ?? [])
+            var children: [Any] = []
+            children.append(contentsOf: element.accessibilityWindows() ?? [])
+            children.append(contentsOf: element.accessibilityChildren() ?? [])
+            children.append(contentsOf: element.accessibilityVisibleChildren() ?? [])
+            children.append(contentsOf: element.accessibilityContents() ?? [])
+            children.append(contentsOf: element.accessibilityRows() ?? [])
+            children.append(contentsOf: element.accessibilityVisibleRows() ?? [])
             if let view = element as? NSView {
                 children.append(contentsOf: view.subviews)
             }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -251,6 +251,10 @@ enum UIE2ETestDriver {
                     && NSPasteboard.general.changeCount > pasteboardGeneration
                     && NSPasteboard.general.string(forType: .string) == copiedUUID
             }
+            try await waitUntil("UUID copy confirmation reset", attempts: 25) {
+                find(identifier: "session-uuid-chip").flatMap(label)
+                    == L10n.string("Copy session UUID")
+            }
             checks.append("session-uuid-copies-from-text-side")
             let runningID = "detach-codex-ui-running"
             let runningRow = try await element(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -246,7 +246,9 @@ enum UIE2ETestDriver {
                 offset: CGSize(width: 24, height: 0),
                 size: CGSize(width: 36, height: 18))
             try await waitUntil("copied full UUID and confirmation", attempts: 15) {
-                NSPasteboard.general.changeCount > pasteboardGeneration
+                find(identifier: "session-uuid-chip").flatMap(label)
+                    == L10n.string("Copied")
+                    && NSPasteboard.general.changeCount > pasteboardGeneration
                     && NSPasteboard.general.string(forType: .string) == copiedUUID
             }
             checks.append("session-uuid-copies-from-text-side")
@@ -598,12 +600,15 @@ enum UIE2ETestDriver {
     ) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        for payload in snapshot {
+        let items = snapshot.map { payload in
             let item = NSPasteboardItem()
             for (type, data) in payload {
                 item.setData(data, forType: type)
             }
-            pasteboard.writeObjects([item])
+            return item
+        }
+        if !items.isEmpty {
+            pasteboard.writeObjects(items)
         }
     }
 

--- a/app/Tests/DetachAppTests/SessionIdentityTests.swift
+++ b/app/Tests/DetachAppTests/SessionIdentityTests.swift
@@ -108,6 +108,12 @@ final class SessionUUIDPresentationTests: XCTestCase {
             pasteboard.string(forType: .string),
             "a9f58f1d-1234-5678-9abc-def012342ed9")
     }
+
+    @MainActor
+    func testChipBuildsTheWholeCopyControl() {
+        _ = SessionUUIDChip(
+            uuid: "a9f58f1d-1234-5678-9abc-def012342ed9").body
+    }
 }
 
 final class SessionActionPresentationTests: XCTestCase {

--- a/app/Tests/DetachAppTests/SessionIdentityTests.swift
+++ b/app/Tests/DetachAppTests/SessionIdentityTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 import SwiftUI
 import DetachKit
@@ -85,6 +86,27 @@ final class SessionIdentityTests: XCTestCase {
                        accuracy: 0.001, file: file, line: line)
         XCTAssertEqual(actualRGB.alphaComponent, expectedRGB.alphaComponent,
                        accuracy: 0.001, file: file, line: line)
+    }
+}
+
+final class SessionUUIDPresentationTests: XCTestCase {
+    func testShortDisplayKeepsShortValuesAndTruncatesLongUUIDs() {
+        XCTAssertEqual(SessionUUIDPresentation.shortDisplay("abc"), "abc")
+        XCTAssertEqual(
+            SessionUUIDPresentation.shortDisplay("a9f58f1d-1234-5678-9abc-def012342ed9"),
+            "a9f58f1d…2ed9")
+    }
+
+    func testCopyWritesTheFullUUIDToThePasteboard() {
+        let pasteboard = NSPasteboard.withUniqueName()
+        defer { pasteboard.releaseGlobally() }
+        XCTAssertTrue(
+            SessionUUIDPresentation.copy(
+                "a9f58f1d-1234-5678-9abc-def012342ed9",
+                to: pasteboard))
+        XCTAssertEqual(
+            pasteboard.string(forType: .string),
+            "a9f58f1d-1234-5678-9abc-def012342ed9")
     }
 }
 

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -77,20 +77,20 @@ states use label or system colors resolved at composite time. VoiceOver names
 the session state. The first menu line is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. The shared `checked_at` heartbeat
-reader and app-level session poller supply the glyph and words. UI never calls
-`pmset` or root XPC. Freshness uses the document timestamp, not file mtime. One
-`detach list --json` poller serves the window, notifications, and menu. It polls
-faster with a visible window, slower after it closes, and never stops. Closing
-the last window keeps the app and icon alive.
+reader and session poller supply the glyph and words. UI never calls `pmset` or
+root XPC. Freshness uses the document timestamp, not file mtime. One
+`detach list --json` poller serves the window, notifications, and menu. It runs
+faster with a window and slower without one. It never stops. Closing the last
+window keeps the app and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
 Mac Power status and approval controls. Temperature safety has its own warning
 shape and the text **Mac can sleep: temperature**.
 
-The dashboard keeps identity, status, and Mac Power separate. Identity uses a
-thin capsule and the tmux blend. Status uses a filled circle through one shared
-sidebar/detail color function. Power words use a neutral surface and semantic
-color.
+The dashboard shows identity, status, and Mac Power separately. Identity is a
+thin tmux-colored capsule. Status is a filled circle. Power has a neutral
+surface and semantic color. The UUID chip is one copy control. Any click copies
+the full UUID and shows **Copied**.
 
 **Finished** bulk Delete uses typed Delete, asks once, tolerates failures, and
 keeps provider transcripts. Select/Done has 12-point scroll clearance.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -225,9 +225,10 @@
       "region": "ui-e2e-instrumentation",
       "scenarios": [
         "SC-UI-SESSION-STOP",
-        "SC-UI-SESSION-DELETE"
+        "SC-UI-SESSION-DELETE",
+        "SC-UI-SESSION-DETAIL"
       ],
-      "summary": "The packaged journey covers action geometry and its negative control."
+      "summary": "The packaged journey covers action geometry, UUID copy, and its negative control."
     },
     {
       "group": "ui",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -69,7 +69,7 @@ coverage-exclusion	business	app/Sources/DetachKit/DetachCLI.swift	SC-SESSION-CRE
 coverage-region	ui	app/Sources/DetachApp/NewSessionSheet.swift	ui-e2e-instrumentation	SC-UI-NEW-SESSION	The packaged journey covers test-only control geometry.
 coverage-region	ui	app/Sources/DetachApp/OnboardingView.swift	ui-e2e-instrumentation	SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged onboarding journeys own their semantic locators and safe poller.
 coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged journeys cover the test-only semantic bridge and route.
-coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE	The packaged journey covers action geometry and its negative control.
+coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE,SC-UI-SESSION-DETAIL	The packaged journey covers action geometry, UUID copy, and its negative control.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	ui-e2e-instrumentation	SC-UI-SETTINGS	The packaged Settings journey covers its semantic control.
 coverage-region	ui	app/Sources/DetachApp/SidebarView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-FAILURE	Packaged journeys cover sidebar control geometry, bulk Delete, and failure status.
 route	1100	quality/policy.tsv	quality-core	safe	docs/specs/documentation.md

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -28,7 +28,7 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   fi
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["stop"]}' \
-    '{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"session_color":"#A855F7","power_protection_state":"allowed","health_actions":["delete"]}' \
+    '{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"allowed","health_actions":["delete"]}' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-stopped","name":"UI Stopped","effective_status":"stopped","created_at":"2026-07-22T06:00:00Z","finished_at":"2026-07-22T06:30:00Z","exit_status":143,"session_color":"#1D4ED8","power_protection_state":"allowed","health_actions":["delete"]}'
   exit 0
 fi

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -320,7 +320,7 @@ run_app_scenario() {
   done
 }
 
-run_app_scenario main sessions 22 \
+run_app_scenario main sessions 24 \
   background-app-starts-without-focus \
   dashboard-accessible \
   sidebar-selects-completed-session \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -296,7 +296,7 @@ run_app_scenario() {
     }
     case "$check" in
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
-      finished-selection-clears-scrollbar) ;;
+      finished-selection-clears-scrollbar|session-uuid-copies-from-text-side) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -320,10 +320,11 @@ run_app_scenario() {
   done
 }
 
-run_app_scenario main sessions 20 \
+run_app_scenario main sessions 22 \
   background-app-starts-without-focus \
   dashboard-accessible \
   sidebar-selects-completed-session \
+  session-uuid-copies-from-text-side \
   session-signals-stay-distinct \
   disconnected-stop-blocks-action \
   safe-action-reaches-fake-cli \


### PR DESCRIPTION
## Summary
- make the whole session UUID chip the copy control, not only the tiny glyph
- write the full `agentSessionId` to the pasteboard
- add packaged UI that clicks the text side of `session-uuid-chip`, asserts the full UUID, and restores the general pasteboard

Fixes #62

## Durable decisions

- The whole chip is the control. Identifier: `session-uuid-chip`.
- Copy writes the full agent session UUID, not the truncated display form.
- The isolated UI fixture uses `a9f58f1d-1234-5678-9abc-def012342ed9`.
- Packaged UI preserves and restores the general pasteboard.

## Test plan
- [x] `swift test --filter SessionUUIDPresentationTests`
- [x] packaged UI `session-uuid-copies-from-text-side` (local `--stage ui-e2e` on the Sequoia integration branch)
- [ ] hosted `quality-gates` on `macos-26`