### PR TITLE
Resume a Claude UUID that never wrote a transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ detach reconcile --dry-run --json
 | `detach <provider> [start]` | Start a fresh conversation for the current project. |
 | `detach <provider> attach [name]` | Attach to a live managed session. |
 | `detach list [--json]` | List Codex and Claude sessions together; JSON mode emits JSONL. |
-| `detach resume <uuid>` | Detect provider and project, then continue that conversation. |
+| `detach resume <uuid>` | Detect provider and project, then continue that conversation. If Claude has not written a transcript yet, Resume starts the same owned session again. |
 | `detach <provider> status [name]` | Show runtime, checkpoint, and power state. |
 | `detach <provider> logs [--ansi] [name]` | Read retained output without attaching. |
 | `detach <provider> stop [name]` | Stop a live session only when its managed runtime is proven. |

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ detach reconcile --dry-run --json
 | `detach <provider> [start]` | Start a fresh conversation for the current project. |
 | `detach <provider> attach [name]` | Attach to a live managed session. |
 | `detach list [--json]` | List Codex and Claude sessions together; JSON mode emits JSONL. |
-| `detach resume <uuid>` | Detect provider and project, then continue that conversation. If Claude has not written a transcript yet, Resume starts the same owned session again. |
+| `detach resume <uuid>` | Detect provider and project, then continue the conversation. An owned Claude session without a transcript restarts with the same UUID. |
 | `detach <provider> status [name]` | Show runtime, checkpoint, and power state. |
 | `detach <provider> logs [--ansi] [name]` | Read retained output without attaching. |
 | `detach <provider> stop [name]` | Stop a live session only when its managed runtime is proven. |

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1855,6 +1855,22 @@ valid_claude_checkpoint_archive() {
     valid_claude_transcript_stream "$expected_id"
 }
 
+claude_matching_checkpoint_exists() {
+  local session="$1"
+  local id="$2"
+  local checkpoint_dir
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  if [ -s "$checkpoint_dir/claude-session.tar" ] && \
+     valid_claude_checkpoint_archive "$checkpoint_dir/claude-session.tar" "$id"; then
+    return 0
+  fi
+  if [ -s "$checkpoint_dir/transcript.jsonl" ] && \
+     valid_claude_transcript "$checkpoint_dir/transcript.jsonl" "$id"; then
+    return 0
+  fi
+  return 1
+}
+
 codex_home() {
   printf '%s\n' "${CODEX_HOME:-$HOME/.codex}"
 }
@@ -3785,6 +3801,7 @@ resume_agent_session() {
   if [ "$PROVIDER" = "claude" ]; then
     local saved_id
     local resolved_status
+    local transcript_present=0
     saved_id="$(read_meta_field "$session" agent_session_id 2>/dev/null || true)"
     saved_id="$(printf '%s' "$saved_id" | tr '[:upper:]' '[:lower:]')"
     if [ "$saved_id" = "$id" ]; then
@@ -3803,13 +3820,39 @@ resume_agent_session() {
         rollout="$saved_rollout"
       fi
     fi
-    [ -n "$rollout" ] || die "Claude session '$id' was not found"
-    restore_matching_claude_checkpoint "$session" "$id" "$rollout" || \
-      die "could not restore the matching Claude checkpoint"
-    valid_claude_transcript "$rollout" "$id" || die "Claude transcript for '$id' is missing or invalid"
-    start_under_project_lock "$session" "$cwd" "$display_name" \
-      "$id" "$rollout" 0 resume "$id" "$@" || \
-      die "could not start Claude resume session"
+    transcript_present=0
+    if [ -n "$rollout" ] && { [ -e "$rollout" ] || [ -L "$rollout" ]; }; then
+      transcript_present=1
+    fi
+    if [ "$transcript_present" -eq 1 ]; then
+      safe_claude_transcript_path "$rollout" "$id" || \
+        die "Claude transcript for '$id' is missing or invalid"
+      valid_claude_transcript "$rollout" "$id" || \
+        die "Claude transcript for '$id' is missing or invalid"
+      restore_matching_claude_checkpoint "$session" "$id" "$rollout" || \
+        die "could not restore the matching Claude checkpoint"
+      start_under_project_lock "$session" "$cwd" "$display_name" \
+        "$id" "$rollout" 0 resume "$id" "$@" || \
+        die "could not start Claude resume session"
+    elif claude_matching_checkpoint_exists "$session" "$id"; then
+      [ -n "$rollout" ] && safe_claude_transcript_path "$rollout" "$id" || \
+        die "Claude session '$id' was not found"
+      restore_matching_claude_checkpoint "$session" "$id" "$rollout" || \
+        die "could not restore the matching Claude checkpoint"
+      valid_claude_transcript "$rollout" "$id" || \
+        die "Claude transcript for '$id' is missing or invalid"
+      start_under_project_lock "$session" "$cwd" "$display_name" \
+        "$id" "$rollout" 0 resume "$id" "$@" || \
+        die "could not start Claude resume session"
+    elif [ "$saved_id" = "$id" ]; then
+      # Detach owns this UUID. Claude never wrote a transcript, and no
+      # matching checkpoint can recreate one, so --resume would fail.
+      start_under_project_lock "$session" "$cwd" "$display_name" \
+        "$id" "" 0 "$@" || \
+        die "could not start Claude resume session"
+    else
+      die "Claude session '$id' was not found"
+    fi
     [ "$detach" -eq 1 ] || attach_session "$session"
     return
   fi

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -194,25 +194,25 @@ in two helpers.
 
 ### Provider identity and checkpoints
 
-Claude gets a wrapper-owned UUID via `--session-id`. Resume uses `--resume`
-for a valid transcript or matching checkpoint, `--session-id` only when that
-owned UUID has neither, and fails closed on a present invalid transcript.
-Codex identity is resolved after launch by matching the run-token originator
-in rollout files and Codex's SQLite threads, refusing an ambiguous first
-binding. When the provider later switches to another run-owned user thread
-(for example `/clear`), discovery rebinds identity, transcript, and checkpoints
-to the newest originator-matched thread within one heartbeat or checkpoint
-tick, records superseded thread ids, and keeps a creation-time tie. Subagent threads never rebind a session. Wrapper-owned
-provider flags are rejected; policy defaults apply only when the user did not
-supply an allowed override.
+Claude gets a wrapper-owned UUID via `--session-id`. Resume uses `--resume` with
+a valid transcript or matching checkpoint. It uses `--session-id` only if both
+are absent. A present invalid transcript fails closed. Codex binds identity
+after launch by matching the run-token originator in rollout files and SQLite;
+an ambiguous first binding fails. If the provider switches to another run-owned
+user thread (for example `/clear`), discovery rebinds identity, transcript, and
+checkpoints to the newest originator-matched thread within one heartbeat or
+checkpoint tick. It records superseded thread IDs so the next switch stays
+unambiguous, and it keeps the current binding on a creation-time tie. Subagent
+threads never rebind a session. Wrapper-owned provider flags are rejected;
+policy defaults apply only without an allowed override.
 
-A per-session lock protects checkpoint creation every 300 seconds.
+Every 300 seconds by default, a per-session lock protects checkpoint creation.
 A checkpoint contains metadata, validated provider JSONL, pane capture, and a
 repository root from a real `.git` ancestor. Codex adds an integrity-checked
 SQLite backup. Claude archives its matching project session and companions.
-Staging copies provider hard links as regular files.
+Provider-created hard links become independent regular files in staging.
 Archives and restore destinations still reject hard links and non-plain
-entries.
+entries. A provider test override can disable the final `/bin/sync`.
 
 Only allowlisted provider flags are serialized to `resume-args.bin`. A provider
 flag that should survive Resume or Recover must be added deliberately.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -194,24 +194,25 @@ in two helpers.
 
 ### Provider identity and checkpoints
 
-Claude gets a wrapper-owned UUID via `--session-id`. Codex identity is resolved
-after launch by matching the run-token originator in rollout files and Codex's
-SQLite threads, refusing an ambiguous first binding. When the provider later
-switches to another run-owned user thread mid-run (for example `/clear`),
-discovery rebinds identity, transcript, and checkpoints to the newest
-originator-matched thread within one heartbeat or checkpoint tick, records the
-superseded thread ids so the next switch is again unambiguous, and keeps the
-current binding on a creation-time tie. Subagent threads never rebind a
-session. Wrapper-owned provider flags are rejected; policy defaults apply only
-when the user did not supply an allowed override.
+Claude gets a wrapper-owned UUID via `--session-id`. Resume uses `--resume`
+for a valid transcript or matching checkpoint, `--session-id` only when that
+owned UUID has neither, and fails closed on a present invalid transcript.
+Codex identity is resolved after launch by matching the run-token originator
+in rollout files and Codex's SQLite threads, refusing an ambiguous first
+binding. When the provider later switches to another run-owned user thread
+(for example `/clear`), discovery rebinds identity, transcript, and checkpoints
+to the newest originator-matched thread within one heartbeat or checkpoint
+tick, records superseded thread ids, and keeps a creation-time tie. Subagent threads never rebind a session. Wrapper-owned
+provider flags are rejected; policy defaults apply only when the user did not
+supply an allowed override.
 
-Every 300 seconds by default, a per-session lock protects checkpoint creation.
+A per-session lock protects checkpoint creation every 300 seconds.
 A checkpoint contains metadata, validated provider JSONL, pane capture, and a
 repository root from a real `.git` ancestor. Codex adds an integrity-checked
 SQLite backup. Claude archives its matching project session and companions.
-Provider-created hard links become independent regular files in staging.
+Staging copies provider hard links as regular files.
 Archives and restore destinations still reject hard links and non-plain
-entries. A provider test override can disable the final `/bin/sync`.
+entries.
 
 Only allowlisted provider flags are serialized to `resume-args.bin`. A provider
 flag that should survive Resume or Recover must be added deliberately.

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -814,6 +814,56 @@ if [ "$CLAUDE_TEST_PART" = history ]; then
   "$SCRIPT" claude delete --force "$human_label"
 fi
 
+# A wrapper-owned Claude UUID with no transcript (welcome screen, then stop)
+# must resume with --session-id instead of failing as "not found".
+empty_label='Empty resume'
+export FAKE_CLAUDE_SLEEP=20
+export FAKE_CLAUDE_EXIT=0
+export FAKE_CLAUDE_EXPECT_RESTORED=0
+reset_fake_claude_ready
+empty_output="$("$SCRIPT" claude --name "$empty_label" --detach -- 'empty resume')"
+wait_for_fake_claude_ready
+empty_session="$(printf '%s\n' "$empty_output" | awk '/^Started / { print $2; exit }')"
+empty_meta="$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/meta.json"
+empty_id="$("$STATE_HELPER" meta get "$empty_meta" agent_session_id)"
+[[ "$empty_id" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]]
+"$SCRIPT" claude stop "$empty_label"
+! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
+rm -rf \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl" \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id"
+rm -f \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session.tar" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
+"$STATE_HELPER" meta patch "$empty_meta" --null transcript_path --null last_checkpoint_at
+reset_fake_claude_ready
+"$SCRIPT" resume --detach "$empty_id"
+wait_for_fake_claude_ready
+grep -Fx -- '--session-id' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+! grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$empty_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+"$STATE_HELPER" meta matches "$empty_meta" claude "$empty_id"
+"$SCRIPT" claude stop "$empty_label"
+
+# A present invalid transcript must fail closed and must not start Claude.
+printf '{truncated claude transcript\n' \
+  >"$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl"
+"$STATE_HELPER" meta patch "$empty_meta" \
+  --string transcript_path "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl"
+rm -f \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session.tar" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
+reset_fake_claude_ready
+: >"$FAKE_CLAUDE_ARGS_FILE"
+if "$SCRIPT" resume --detach "$empty_id"; then
+  printf 'Resume started Claude from a present invalid transcript\n' >&2
+  exit 1
+fi
+[ ! -s "$FAKE_CLAUDE_ARGS_FILE" ]
+! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
+"$SCRIPT" claude delete --force "$empty_label"
+[ ! -d "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session" ]
+
 # Claude uses the same default history-series contract as Codex: a completed
 # run remains intact while the next fresh conversation receives a new slot.
 default_slug="$(basename "$ROOT" | LC_ALL=C tr -cs 'A-Za-z0-9_-' '-' | \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -612,7 +612,6 @@ bootstrap_codex_checkpoint() {
   meta="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/meta.json"
   checkpoint="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint"
   session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_color)"
-  expected_id="$("$STATE_HELPER" meta get "$meta" codex_session_id)"
   attempts=0
   while { [ ! -s "$checkpoint/rollout.jsonl" ] || \
           [ ! -s "$checkpoint/codex-state.sqlite" ]; } && \
@@ -622,6 +621,8 @@ bootstrap_codex_checkpoint() {
   done
   [ -s "$checkpoint/rollout.jsonl" ]
   [ -s "$checkpoint/codex-state.sqlite" ]
+  expected_id="$("$STATE_HELPER" meta get "$meta" codex_session_id)"
+  [ -n "$expected_id" ]
   run_codex stop integration
   upgraded_version="0.2.0"
   upgraded_payload="$install_root/libexec/detach/versions/$upgraded_version-test"


### PR DESCRIPTION
## Summary
- Resume a wrapper-owned Claude UUID when Claude never wrote a transcript
- use `--session-id` only when Detach owns the UUID and no transcript and no matching checkpoint exists
- keep a present invalid, mismatched, unsafe, or ambiguous transcript fail closed

Fixes #64

## Contract delta

`detach resume <uuid>` still detects provider and project, then continues that conversation. If Claude has not written a transcript yet, Resume starts the same owned session again. A present invalid transcript does not start the provider.

## Durable decisions

- Detach assigns the Claude UUID at start via `--session-id`, before any jsonl exists.
- `--resume` is only valid after a transcript or a checkpoint that can recreate one.
- Absence is not corruption. A present invalid transcript fails closed.

## Acceptance evidence

| Requirement | Check | Result |
| --- | --- | --- |
| Owned UUID, no transcript, no matching checkpoint uses `--session-id` | `tests/run-claude.sh` | pass (local `--stage claude`) |
| Present invalid transcript is rejected without starting the provider | `tests/run-claude.sh` invalid-transcript case | pass (local `--stage claude`) |
| Hosted repository gate | `quality-gates` on `macos-26` | pending |

## Test plan
- [x] `scripts/quality-gate --stage claude`
- [ ] hosted `quality-gates` on `macos-26`