### PR TITLE
release: allow resume after app test changes

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -75,11 +75,12 @@ change real power state, upload assets, or claim publication.
   requires the Developer ID, notarization, and Sparkle credentials again.
 - After the atomic main/tag push, a paused release can resume from a newer
   synchronized `main` only when the release commit remains an ancestor and all
-  later paths are release tooling, release tests, or release documentation.
-  The annotated tag and artifact manifest stay bound to the release commit.
+  later paths are release tooling, release documentation, or test-only source
+  under `app/Tests/`. Product sources and build inputs remain rejected. The
+  annotated tag and artifact manifest stay bound to the release commit.
 - The release orchestrator gives the lower-level publisher the exact manifest
   commit. The publisher requires the tag to match it and the current `HEAD` to
-  contain it. The orchestrator separately rejects non-tooling descendants.
+  contain it. The orchestrator separately rejects all other descendants.
 - Sparkle remains pinned and signed inside-out. Production builds never carry
   the development library-validation exception. Appcasts contain exactly one
   arm64 hardware requirement.

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -337,12 +337,13 @@ remote_ref_commit() {
   printf '%s\n' "$commit"
 }
 
-release_tooling_path_allowed() {
+release_resume_path_allowed() {
   case "$1" in
     scripts/release-version|scripts/release-pr|scripts/release-sbom|\
     scripts/release-impact|scripts/quality-gate|scripts/quality-merge|\
     tools/release_pr.py|tools/release_sbom.py|tools/quality_merge.py|\
     tools/quality_policy.py|tools/quality_care.py|\
+    app/Tests/*|\
     app/scripts/publish-release.sh|\
     quality/policy.tsv|quality/evals.json|quality/generated/policy.json|\
     tests/quality-gate.sh|tests/release-impact.sh|tests/release-workflow.sh|\
@@ -357,11 +358,11 @@ release_tooling_path_allowed() {
   esac
 }
 
-release_tooling_descendant_valid() {
+release_resume_descendant_valid() {
   local descendant="$1" path
   git -C "$ROOT" merge-base --is-ancestor "$RELEASE_COMMIT" "$descendant" || return 1
   while IFS= read -r -d '' path; do
-    release_tooling_path_allowed "$path" || return 1
+    release_resume_path_allowed "$path" || return 1
   done < <(git -C "$ROOT" diff --name-only -z "$RELEASE_COMMIT" "$descendant")
 }
 
@@ -372,8 +373,8 @@ verify_release_remote_refs() {
   [ "$remote_tag" = "$RELEASE_COMMIT" ] || \
     die 'remote release tag does not match the release commit'
   if [ "$remote_main" != "$RELEASE_COMMIT" ]; then
-    release_tooling_descendant_valid "$remote_main" || \
-      die 'remote main advanced after the release with non-tooling changes'
+    release_resume_descendant_valid "$remote_main" || \
+      die 'remote main advanced after the release with disallowed changes'
   fi
 }
 
@@ -393,8 +394,8 @@ verify_resumable_release_head() {
   remote_main="$(git -C "$ROOT" rev-parse --verify refs/remotes/origin/main)"
   [ "$head" = "$remote_main" ] || \
     die 'resumed release tooling must use synchronized main'
-  release_tooling_descendant_valid "$head" || \
-    die 'main advanced after the release with non-tooling changes'
+  release_resume_descendant_valid "$head" || \
+    die 'main advanced after the release with disallowed changes'
 }
 
 release_api_status() {

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -553,10 +553,12 @@ run_resume_case() {
   printf '%s\n' development \
     >"$REPO/app/build/Detach.app/Contents/Resources/DetachCLI/VERSION"
   export FAKE_NOTARY_UNAVAILABLE=1
-  mkdir -p "$REPO/docs"
+  mkdir -p "$REPO/docs" "$REPO/app/Tests/DetachAppTests"
   printf '%s\n' 'release tooling follow-up' >"$REPO/docs/testing.md"
-  git -C "$REPO" add docs/testing.md
-  git -C "$REPO" commit -qm 'adjust release tooling guidance'
+  printf '%s\n' 'test-only Swift source' \
+    >"$REPO/app/Tests/DetachAppTests/ResumeTests.swift"
+  git -C "$REPO" add docs/testing.md app/Tests/DetachAppTests/ResumeTests.swift
+  git -C "$REPO" commit -qm 'adjust release tooling and app tests'
   git -C "$REPO" push -q origin main
   for stage in installed power-smoke lid published verified; do
     expect_failure "resume-$stage" "injected safe failure after $stage" \
@@ -680,7 +682,7 @@ run_post_push_main_rejection_case() {
   git -C "$REPO" commit -qm 'advance product source after tag'
   git -C "$REPO" push -q origin main
   expect_failure post-push-main \
-    'main advanced after the release with non-tooling changes' run_workflow
+    'main advanced after the release with disallowed changes' run_workflow
   [ ! -f "$RELEASE_EXISTS" ]
 }
 


### PR DESCRIPTION
## Contract delta

- Allow a paused release to resume when newer main changes are confined to app/Tests.
- Continue to reject app sources, package metadata, and other product or build inputs.
- Keep the release tag, manifest, and signed artifacts bound to the original release commit.

## Why

The signed and notarized 0.2.18 workflow is paused after artifact creation. A later CI-stabilization change added only a Swift test, but the resume allowlist classifies it as disallowed.

## Evidence

- tests/release-workflow.sh
- tests/docs-contract.sh
- impact-aware local diagnostic PASS, policy 42, fingerprint 12e430e601dca13f24787cb4c03586838c685b2c383ce712f6bb715e12553ba0
- preserved negative coverage for product-source descendants