### PR TITLE
Power: refresh Developer ID trust before XPC listener

### DIFF
--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import Security
 
 // Swift imports Darwin's `struct flock` under the same name as flock(2), so
 // bind the process-scoped BSD syscall explicitly.
@@ -758,6 +759,12 @@ public final class SecureFilePowerHelperStateStore:
                 operation: "fsync directory", code: errno)
         }
     }
+}
+
+/// Security flags for root-helper startup validation.
+public enum PowerHelperCodeSigningValidationPolicy {
+    public static let helperSelfFlags = SecCSFlags(
+        rawValue: kSecCSStrictValidate | kSecCSAllowNetworkAccess)
 }
 
 /// Code requirement installed directly on the NSXPC listener. Foundation

--- a/app/Sources/DetachPowerHelper/main.swift
+++ b/app/Sources/DetachPowerHelper/main.swift
@@ -7,26 +7,57 @@ private func log(_ message: String) {
     FileHandle.standardError.write(Data("DetachPowerHelper: \(message)\n".utf8))
 }
 
-private final class CodeSigningIdentityResolver {
-    func ownTeamIdentifier() -> String? {
-        var code: SecCode?
-        guard SecCodeCopySelf([], &code) == errSecSuccess,
-              let code,
-              let info = signingInformation(for: code) else { return nil }
-        return info[kSecCodeInfoTeamIdentifier as String] as? String
-    }
+private enum CodeSigningIdentityError: Error, LocalizedError {
+    case security(operation: String, status: OSStatus)
+    case missingTeamIdentifier
 
-    private func signingInformation(for code: SecCode) -> [String: Any]? {
+    var errorDescription: String? {
+        switch self {
+        case let .security(operation, status):
+            return "code-signing \(operation) failed with Security status \(status)"
+        case .missingTeamIdentifier:
+            return "helper is missing a trusted Team ID signature"
+        }
+    }
+}
+
+private final class CodeSigningIdentityResolver {
+    func trustedOwnTeamIdentifier() throws -> String {
+        var code: SecCode?
+        let selfStatus = SecCodeCopySelf([], &code)
+        guard selfStatus == errSecSuccess, let code else {
+            throw CodeSigningIdentityError.security(
+                operation: "self lookup", status: selfStatus)
+        }
         var staticCode: SecStaticCode?
-        guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess,
-              let staticCode else { return nil }
+        let staticStatus = SecCodeCopyStaticCode(code, [], &staticCode)
+        guard staticStatus == errSecSuccess, let staticCode else {
+            throw CodeSigningIdentityError.security(
+                operation: "static-code lookup", status: staticStatus)
+        }
+        let validationStatus = SecStaticCodeCheckValidity(
+            staticCode,
+            PowerHelperCodeSigningValidationPolicy.helperSelfFlags,
+            nil)
+        guard validationStatus == errSecSuccess else {
+            throw CodeSigningIdentityError.security(
+                operation: "trust validation", status: validationStatus)
+        }
         var information: CFDictionary?
         let status = SecCodeCopySigningInformation(
             staticCode,
             SecCSFlags(rawValue: kSecCSSigningInformation),
             &information)
-        guard status == errSecSuccess else { return nil }
-        return information as? [String: Any]
+        guard status == errSecSuccess else {
+            throw CodeSigningIdentityError.security(
+                operation: "identity lookup", status: status)
+        }
+        guard let info = information as? [String: Any],
+              let teamIdentifier = info[
+                  kSecCodeInfoTeamIdentifier as String] as? String else {
+            throw CodeSigningIdentityError.missingTeamIdentifier
+        }
+        return teamIdentifier
     }
 }
 
@@ -93,9 +124,9 @@ do {
     // mutation. An ad-hoc or otherwise untrusted helper exits without touching
     // machine state.
     let resolver = CodeSigningIdentityResolver()
-    guard let teamIdentifier = resolver.ownTeamIdentifier(),
-          let clientRequirement = PowerHelperCodeSigningRequirement.client(
-              teamIdentifier: teamIdentifier) else {
+    let teamIdentifier = try resolver.trustedOwnTeamIdentifier()
+    guard let clientRequirement = PowerHelperCodeSigningRequirement.client(
+        teamIdentifier: teamIdentifier) else {
         log("helper is missing a trusted Team ID signature")
         exit(1)
     }

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -1,3 +1,4 @@
+import Security
 import XCTest
 @testable import DetachKit
 
@@ -463,6 +464,13 @@ final class PowerHelperPlatformTests: XCTestCase {
             teamIdentifier: "TOO-SHORT"))
         XCTAssertNil(PowerHelperCodeSigningRequirement.client(
             teamIdentifier: "AB12CD34E\""))
+    }
+
+    func testHelperSelfValidationAllowsNetworkAndRequiresStrictChecks() {
+        let flags = PowerHelperCodeSigningValidationPolicy.helperSelfFlags
+
+        XCTAssertNotEqual(flags.rawValue & kSecCSAllowNetworkAccess, 0)
+        XCTAssertNotEqual(flags.rawValue & kSecCSStrictValidate, 0)
     }
 
     func testPlatformErrorsHaveActionableStableDescriptions() {

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -38,6 +38,13 @@ surface is limited to status, acquire, renew, release, and the typed
 prepare/cancel unregistration lifecycle; it must never execute arbitrary paths,
 shell strings, or provider commands as root.
 
+Before it creates the listener or changes power state, the helper must pass a
+strict check of its own signature with Security network access enabled. This
+check lets macOS refresh the system trust result that the listener needs for
+the same Developer ID chain. If trust cannot be proved, the helper exits and
+launchd retries it. The listener requirement stays Apple-anchored and is not
+weakened for an unavailable trust service.
+
 The client opens a short-lived XPC connection for every request. After Fast
 User Switching, the previous background user's next heartbeat, status, or
 release request is rejected and an unrenewed lease expires through the normal


### PR DESCRIPTION
## Summary

- Strictly validate the root helper signature with Security network access before listener creation or power mutation.
- Keep the Apple anchor, Team ID, client identifier, and audit-token UID checks unchanged.
- Add a regression contract and update the durable power specification.

## Contract delta

Current: the helper reads its Team ID and starts an Apple-anchored listener without first refreshing the system trust result. A valid release client can be rejected when that result is absent or stale.

Target: the root helper first completes strict network-enabled validation of its own Developer ID signature. The same signing chain is then available to listener validation. Failure exits before mutation, and launchd retries the helper.

## Durable decisions

- Do not add a certificate-pin fallback or weaken the listener requirement.
- Run trust refresh in the root helper because listener validation uses the system trust domain.
- Keep failure fail-closed before reconciliation or any pmset operation.

## Evidence

- Published v0.2.18 ZIP and DMG digests match GitHub; Mach-O page hashes, CMS signatures, and the Developer ID certificate are intact.
- The mounted official DMG passes strict and deep codesign verification after network-enabled trust evaluation.
- swift test --filter Power: 316 tests passed.
- Impact-aware scripts/quality-gate: diagnostic PASS, policy 42, fingerprint 84631522c02f955c39644716d6503355fd0892cca20f9c644fafa828c7344e83.
- git diff --check: clean.

No real power, closed-lid, signing, notarization, tagging, upload, or publication action was run.

Fixes #72