### PR TITLE
Make power-state coverage deterministic

### DIFF
--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -400,27 +400,7 @@ final class InstallationStore {
     }
 
     private static var defaultPowerStateRoot: URL {
-        let environment = ProcessInfo.processInfo.environment
-        func path(_ key: String) -> String? {
-            guard let value = environment[key], !value.isEmpty else { return nil }
-            return value
-        }
-        if let explicit = path("DETACH_POWER_STATE_ROOT") {
-            return URL(fileURLWithPath: explicit, isDirectory: true)
-        }
-        let base: URL
-        if let explicit = path("DETACH_STATE_ROOT") {
-            base = URL(fileURLWithPath: explicit, isDirectory: true)
-        } else if let xdgStateHome = path("XDG_STATE_HOME") {
-            base = URL(fileURLWithPath: xdgStateHome, isDirectory: true)
-                .appendingPathComponent("detach", isDirectory: true)
-        } else {
-            let home = path("HOME").map {
-                URL(fileURLWithPath: $0, isDirectory: true)
-            } ?? FileManager.default.homeDirectoryForCurrentUser
-            base = home.appendingPathComponent(".local/state/detach", isDirectory: true)
-        }
-        return base.appendingPathComponent("power", isDirectory: true)
+        PowerHeartbeatReader.defaultStatusURL().deletingLastPathComponent()
     }
 
     @discardableResult

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -6,6 +6,14 @@ import XCTest
 
 @MainActor
 final class InstallationStorePowerStateTests: XCTestCase {
+    func testDefaultPowerStateRootUsesTheSharedHeartbeatResolver() {
+        let store = InstallationStore(detachPath: "/tmp/detach-test")
+
+        XCTAssertEqual(
+            store.watchdogHeartbeat.statusURL.standardizedFileURL,
+            PowerHeartbeatReader.defaultStatusURL().standardizedFileURL)
+    }
+
     func testInitialAppContextChecksTruthfullyDescribeUnconfiguredServices() throws {
         let root = try makeStateRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -203,6 +211,24 @@ final class InstallationStorePowerStateTests: XCTestCase {
                     providerInstalled: true,
                     onboardingEverCompleted: true)),
             .mainApp)
+    }
+
+    func testCompletedOnboardingShowsActionableLocationGuidance() {
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .actionRequired,
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: false,
+                    isBusy: false,
+                    failureMessage: nil,
+                    distributionMatchesBundle: true,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: true,
+                    providerInstalled: true,
+                    onboardingEverCompleted: true)),
+            .moveToApplications)
     }
 
     func testHealthyReadinessInputsStillProduceReadyPhase() {
@@ -697,6 +723,33 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertFalse(fixture.store.powerHelperReadinessConfirmed)
     }
 
+    func testRefreshRejectsAnApplicationLocationThatBecameUnstable()
+        async throws
+    {
+        var stableLocation = true
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("installed")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let fixture = try makePackagedInstallationFixture(
+            distribution: distribution,
+            watchdog: InstallationWatchdogProbe(status: .enabled),
+            powerHelper: InstallationPowerHelperProbe(status: .enabled),
+            applicationLocationValidator: { _ in stableLocation })
+        defer { fixture.cleanup() }
+        await fixture.store.bootstrap()
+        XCTAssertEqual(fixture.store.phase, .ready)
+
+        stableLocation = false
+        let refreshed = await fixture.store.refreshContext()
+
+        XCTAssertTrue(refreshed)
+        XCTAssertEqual(fixture.store.phase, .actionRequired)
+        XCTAssertEqual(distribution.doctorCallCount, 2)
+    }
+
     func testPostRegistrationDoctorFailureCannotPublishStaleReadiness()
         async throws
     {
@@ -1002,6 +1055,7 @@ final class InstallationStorePowerStateTests: XCTestCase {
         distribution: InstallationDistributionProbe,
         watchdog: InstallationWatchdogProbe,
         powerHelper: InstallationPowerHelperProbe,
+        applicationLocationValidator: @escaping @MainActor (URL) -> Bool = { _ in true },
         cli: InstallationCLIProbe = InstallationCLIProbe(result: .success(
             CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)))
     ) throws -> PackagedInstallationFixture {
@@ -1018,7 +1072,7 @@ final class InstallationStorePowerStateTests: XCTestCase {
             defaults: defaults,
             watchdog: watchdog,
             powerHelper: powerHelper,
-            applicationLocationValidator: { _ in true },
+            applicationLocationValidator: applicationLocationValidator,
             distributionClientFactory: { _, _, _, _ in distribution },
             cliFactory: { _ in cli })
         return PackagedInstallationFixture(


### PR DESCRIPTION
## Summary

- use `PowerHeartbeatReader.defaultStatusURL` as the single power-state path resolver in the app
- remove the duplicate environment resolver whose covered branch depended on the developer shell
- cover actionable onboarding and a packaged app location that becomes unstable during refresh

## Contract delta

There is no user-visible path-precedence change. The app now delegates to the existing typed resolver, which preserves `DETACH_POWER_STATE_ROOT`, `DETACH_STATE_ROOT`, `XDG_STATE_HOME`, and `HOME` precedence.

## Evidence

- `swift test --filter InstallationStorePowerStateTests`: 41 tests passed
- impact-aware local diagnostic passed after the resolver change
- the final baseline-bound diagnostic passed Swift, app build, tmux runtime, and distribution, then the local WindowServer did not activate the isolated test app before its bounded deadline; hosted `quality-gates` remains readiness authority
- `git diff --check` passed

This follow-up removes the environment-dependent coverage blocker found by the 0.2.19 release preflight.