### PR TITLE
Stabilize packaged UI event delivery

### DIFF
--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -106,7 +106,11 @@ struct RootView: View {
             await notifications.configure(enabled: notificationsEnabled)
         }
 // quality-coverage:begin ui-e2e-instrumentation
-        .task { await UIE2ETestDriver.runIfRequested(installation: installation) }
+        .task {
+            await UIE2ETestDriver.runIfRequested(
+                installation: installation,
+                store: store)
+        }
 // quality-coverage:end ui-e2e-instrumentation
         .onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -106,11 +106,7 @@ struct RootView: View {
             await notifications.configure(enabled: notificationsEnabled)
         }
 // quality-coverage:begin ui-e2e-instrumentation
-        .task {
-            await UIE2ETestDriver.runIfRequested(
-                installation: installation,
-                store: store)
-        }
+        .task { await UIE2ETestDriver.runIfRequested(installation: installation, store: store) }
 // quality-coverage:end ui-e2e-instrumentation
         .onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Darwin
+import DetachKit
 import Foundation
 
 @MainActor
@@ -125,8 +126,13 @@ enum UIE2ETestDriver {
 
     private static var started = false
     private static var scenarioDeadline = TimeInterval.greatestFiniteMagnitude
+    private static var nextMouseEventNumber = Int(
+        ProcessInfo.processInfo.systemUptime * 1_000)
 
-    static func runIfRequested(installation: InstallationStore) async {
+    static func runIfRequested(
+        installation: InstallationStore,
+        store: SessionStore
+    ) async {
         guard let configuration = AppSettings.uiE2E, !started else { return }
         started = true
         Task { @MainActor in
@@ -137,7 +143,8 @@ enum UIE2ETestDriver {
                     + "(budget \(configuration.driverBudgetSeconds)s)")
             let report = await runScenario(
                 configuration: configuration,
-                installation: installation)
+                installation: installation,
+                store: store)
             trace("\(configuration.scenario) driver finished: \(report.passed)")
             try? write(report, to: configuration.result)
             NSApp.terminate(nil)
@@ -152,7 +159,8 @@ enum UIE2ETestDriver {
 
     private static func runScenario(
         configuration: UIE2EConfiguration,
-        installation: InstallationStore
+        installation: InstallationStore,
+        store: SessionStore
     ) async -> Report {
         switch configuration.scenario {
         case "failure":
@@ -174,12 +182,15 @@ enum UIE2ETestDriver {
                 evidenceIdentifier: "onboarding-open-system-settings",
                 check: "onboarding-explains-approval")
         default:
-            return await runMainScenario(configuration: configuration)
+            return await runMainScenario(
+                configuration: configuration,
+                store: store)
         }
     }
 
     private static func runMainScenario(
-        configuration: UIE2EConfiguration
+        configuration: UIE2EConfiguration,
+        store: SessionStore
     ) async -> Report {
         var checks: [String] = []
         let previousFrontmost = NSWorkspace.shared.frontmostApplication
@@ -241,9 +252,14 @@ enum UIE2ETestDriver {
             }
             checks.append("safe-delete-reaches-fake-cli")
             trace("delete reached fake CLI")
+            let deleteObservedAt = Date()
+            try await waitUntil("post-delete session refresh") {
+                store.lastUpdated.map { $0 >= deleteObservedAt } == true
+            }
             try await waitUntil("delete confirmation dismissal") {
                 NSApp.windows.allSatisfy(\.sheets.isEmpty)
             }
+            try await activate(mainWindow)
             try await Task.sleep(nanoseconds: 200_000_000)
 
             let runningID = "detach-codex-ui-running"
@@ -788,21 +804,31 @@ enum UIE2ETestDriver {
             }
             trace("hit chain for \(name): \(names.joined(separator: " > "))")
         }
+        var events: [NSEvent] = []
+        let timestamp = ProcessInfo.processInfo.systemUptime
         for type in [NSEvent.EventType.leftMouseDown, .leftMouseUp] {
+            let eventNumber = nextMouseEventNumber
+            nextMouseEventNumber += 1
             guard let event = NSEvent.mouseEvent(
                 with: type,
                 location: windowPoint,
                 modifierFlags: [],
-                timestamp: ProcessInfo.processInfo.systemUptime,
+                timestamp: timestamp + Double(events.count) / 1_000,
                 windowNumber: window.windowNumber,
                 context: nil,
-                eventNumber: 0,
+                eventNumber: eventNumber,
                 clickCount: 1,
                 pressure: type == .leftMouseDown ? 1 : 0)
             else { continue }
-            NSApp.postEvent(event, atStart: false)
-            try await Task.sleep(nanoseconds: 100_000_000)
+            events.append(event)
         }
+        // Queue the complete pair before yielding. Dispatching only mouseDown
+        // can enter AppKit's tracking loop before this main-actor task gets a
+        // chance to enqueue the matching mouseUp.
+        for event in events {
+            NSApp.postEvent(event, atStart: false)
+        }
+        try await Task.sleep(nanoseconds: 200_000_000)
     }
 
     private static func keyPress(

--- a/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
+++ b/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
@@ -5,6 +5,15 @@ import XCTest
 
 @MainActor
 final class OnboardingLivePollerTests: XCTestCase {
+    func testProductionWiringConstructsAnIdlePoller() {
+        let store = InstallationStore(detachPath: "/tmp/detach-test")
+        let poller = OnboardingLivePoller(store: store)
+
+        XCTAssertEqual(poller.providerAvailability, ProviderAvailability())
+        XCTAssertFalse(poller.heartbeatHealthy)
+        XCTAssertFalse(poller.installedCopyPresent)
+    }
+
     func testEnableTransitionTriggersExactlyOneReconcile() async {
         var enabled = false
         var confirmed = false

--- a/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
@@ -47,7 +47,7 @@ final class UIE2EEventWindowResolverTests: XCTestCase {
             candidate)
     }
 
-    func testAttachedSheetWinsOverItsAccessibilityOwner() {
+    func testAttachedSheetWinsOverItsAccessibilityOwner() throws {
         let owner = NSWindow(
             contentRect: NSRect(x: 100, y: 100, width: 400, height: 400),
             styleMask: .titled,
@@ -58,6 +58,8 @@ final class UIE2EEventWindowResolverTests: XCTestCase {
             styleMask: .titled,
             backing: .buffered,
             defer: false)
+        let view = NSView(frame: NSRect(x: 20, y: 30, width: 80, height: 40))
+        sheet.contentView?.addSubview(view)
         owner.beginSheet(sheet)
         defer { owner.endSheet(sheet) }
         let point = NSPoint(x: sheet.frame.midX, y: sheet.frame.midY)
@@ -70,6 +72,19 @@ final class UIE2EEventWindowResolverTests: XCTestCase {
                 at: point,
                 candidates: [sheet, owner]),
             sheet)
+
+        let localFrame = view.convert(view.bounds, to: nil)
+        let screenFrame = try XCTUnwrap(UIE2EEventWindowResolver.screenFrame(
+            view.bounds,
+            in: view))
+
+        XCTAssertEqual(
+            screenFrame,
+            CGRect(
+                x: sheet.frame.minX + localFrame.minX,
+                y: sheet.frame.minY + localFrame.minY,
+                width: localFrame.width,
+                height: localFrame.height))
     }
 
     func testClippedControlUsesTheRealScrollerTrackTowardIt() throws {

--- a/app/Tests/DetachAppTests/UIE2EGeometryProbeTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EGeometryProbeTests.swift
@@ -19,6 +19,10 @@ final class UIE2EGeometryProbeTests: XCTestCase {
     }
 
     func testSemanticProbeExposesNoActionOrHitTarget() {
+        let expectedFrame = CGRect(x: 40, y: 80, width: 120, height: 32)
+        UIE2EGeometryRegistry.set(
+            expectedFrame,
+            for: "settings-show-tips")
         let view = UIE2EGeometryView(
             identifier: "settings-show-tips",
             semanticLabel: "Show tips",
@@ -29,6 +33,7 @@ final class UIE2EGeometryProbeTests: XCTestCase {
         XCTAssertEqual(view.accessibilityIdentifier(), "settings-show-tips")
         XCTAssertEqual(view.accessibilityLabel(), "Show tips")
         XCTAssertEqual(view.accessibilityRole(), .checkBox)
+        XCTAssertEqual(view.accessibilityFrame(), expectedFrame)
         XCTAssertTrue(view.isAccessibilityEnabled())
         XCTAssertNil(view.hitTest(.zero))
         XCTAssertFalse(view.accessibilityPerformPress())

--- a/app/Tests/DetachAppTests/UIE2EGeometryProbeTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EGeometryProbeTests.swift
@@ -19,10 +19,6 @@ final class UIE2EGeometryProbeTests: XCTestCase {
     }
 
     func testSemanticProbeExposesNoActionOrHitTarget() {
-        let expectedFrame = CGRect(x: 40, y: 80, width: 120, height: 32)
-        UIE2EGeometryRegistry.set(
-            expectedFrame,
-            for: "settings-show-tips")
         let view = UIE2EGeometryView(
             identifier: "settings-show-tips",
             semanticLabel: "Show tips",
@@ -33,7 +29,6 @@ final class UIE2EGeometryProbeTests: XCTestCase {
         XCTAssertEqual(view.accessibilityIdentifier(), "settings-show-tips")
         XCTAssertEqual(view.accessibilityLabel(), "Show tips")
         XCTAssertEqual(view.accessibilityRole(), .checkBox)
-        XCTAssertEqual(view.accessibilityFrame(), expectedFrame)
         XCTAssertTrue(view.isAccessibilityEnabled())
         XCTAssertNil(view.hitTest(.zero))
         XCTAssertFalse(view.accessibilityPerformPress())

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -47,8 +47,9 @@ signed marker. UI smoke uses a stripped private copy at
 power, state, and tmux payloads. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
-The smoke keeps the prior app focused. It posts AppKit events to measured
-SwiftUI controls, then restores that app. Its semantic locator has no actions.
+The smoke preserves prior focus. It queues AppKit down/up pairs for
+measured SwiftUI controls, then restores focus. Its semantic locator has no
+actions.
 Each launch ends before its process deadline; the stage deadline is 40 seconds.
 Journeys cover all main surfaces, Settings, onboarding, and focus. It
 disconnects Stop before it proves that the real control invokes the action.


### PR DESCRIPTION
## Contract delta

- Queue each AppKit mouse-down/mouse-up pair before yielding to the tracking loop.
- Give synthetic mouse events monotonic event numbers and timestamps.
- Wait for the typed post-delete session snapshot and restore the key window after dialog dismissal.
- Keep the semantic locator action-free and preserve prior application focus.

## Evidence

- `swift test --filter UIE2EEventWindowResolverTests`: 4 passed.
- Direct packaged `tests/ui-e2e.sh`: PASS.
- Impact-selected `scripts/quality-gate`: DIAGNOSTIC PASS (`app/build/quality-gates/20260821T101340Z-74500/`).
- `git diff --check`: PASS.

Hosted pull-request `quality-gates` remains readiness authority.