### PR TITLE
Separate dashboard identity, status, and power signals

### DIFF
--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -83,12 +83,22 @@ struct SessionDetailView: View {
     private var headerCard: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
-                Circle()
+                Capsule(style: .continuous)
                     .fill(identityColor)
-                    .frame(width: 11, height: 11)
+                    .frame(
+                        width: SessionDetailSignalPresentation.identityMarkerWidth,
+                        height: SessionDetailSignalPresentation.identityMarkerHeight)
                     .help(session.sessionColor.map {
                         L10n.format("Session base color: %@", $0.hex)
                     } ?? "")
+                    .accessibilityHidden(true)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        uiE2EGeometryProbe(identifier: "session-detail-identity-marker")
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                 Text(session.displayTitle)
                     .appFont(.title2, weight: .bold)
                     .lineLimit(1)
@@ -250,27 +260,57 @@ struct SessionDetailView: View {
     @ViewBuilder
     private var sessionColorStrip: some View {
         if let sessionColor = session.sessionColor {
-            let emphasis = SessionIdentity.emphasis(for: session.effectiveStatus)
+            let tint = sessionColor.tmuxStatusTint(percent:
+                SessionDetailSignalPresentation.identityTintPercent(
+                    for: session.effectiveStatus))
             HStack(spacing: 0) {
-                Text(verbatim: "● \(session.displayTitle)")
-                    .font(.system(size: 10, design: .monospaced))
-                    .lineLimit(1)
-                Spacer(minLength: 0)
+                HStack(spacing: 0) {
+                    Text(session.displayTitle)
+                        .font(.system(size: 10, design: .monospaced))
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 8)
+                .frame(maxWidth: .infinity, minHeight: 18)
+                .background(SessionIdentity.color(tint))
+                .foregroundStyle(Color.white.opacity(0.92))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(L10n.string("Session identity color"))
+                .accessibilityValue(sessionColor.hex)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                .background {
+                    uiE2EGeometryProbe(identifier: "session-preview-identity")
+                }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+
+                Rectangle()
+                    .fill(Color.white.opacity(0.12))
+                    .frame(width: 1)
+                    .accessibilityHidden(true)
+
                 Label(
                     session.powerProtectionLabel,
                     systemImage: session.powerProtectionSystemImage)
                     .font(.system(size: 10, weight: .medium))
                     .lineLimit(1)
+                    .padding(.horizontal, 8)
+                    .frame(minHeight: 18)
+                    .background(Color(nsColor: ANSIParser.terminalBackground))
+                    .foregroundStyle(SessionDetailSignalPresentation.powerColor(
+                        for: session.powerProtectionState))
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(Text(session.powerProtectionLabel))
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        uiE2EGeometryProbe(identifier: "session-preview-power")
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
             }
-            .padding(.horizontal, 8)
-            .frame(height: 16)
-            .background(SessionIdentity.color(sessionColor).opacity(emphasis))
-            // The identity palette is dark and saturated; only a light
-            // foreground stays readable on every one of its colors.
-            .foregroundStyle(Color.white.opacity(0.92))
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(L10n.string("Session identity color"))
-            .accessibilityValue(sessionColor.hex)
+            .frame(height: 18)
         }
     }
 

--- a/app/Sources/DetachApp/Theme.swift
+++ b/app/Sources/DetachApp/Theme.swift
@@ -52,6 +52,36 @@ enum SessionIdentity {
     }
 }
 
+enum SessionDetailSignalPresentation {
+    static let identityMarkerWidth: CGFloat = 4
+    static let identityMarkerHeight: CGFloat = 24
+
+    /// These strengths match the dense, muted-edge, and faint tmux blends.
+    static func identityTintPercent(for status: EffectiveStatus) -> UInt8 {
+        switch status {
+        case .completed, .stopped, .interrupted:
+            25
+        case .recoverable, .orphaned, .corrupt, .collision, .unknown:
+            45
+        case .starting, .running, .recovering, .hung, .failed:
+            55
+        }
+    }
+
+    static func powerColor(for state: PowerProtectionState?) -> Color {
+        switch state ?? .unknown {
+        case .protected:
+            Brand.teal
+        case .transitioning, .lowBattery, .temperature:
+            .orange
+        case .unavailable:
+            .red
+        case .allowed, .unknown:
+            Color.white.opacity(0.70)
+        }
+    }
+}
+
 /// Small circle carrying the three brand colors; used as a discreet signature.
 struct TriColorDot: View {
     var size: CGFloat = 8

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -270,6 +270,23 @@ enum UIE2ETestDriver {
                 runningRow,
                 name: "running session row",
                 resultIdentifier: "session-detail-\(runningID)")
+            let identityMarker = try await measuredFrame(
+                identifier: "session-detail-identity-marker",
+                name: "session identity marker")
+            guard identityMarker.height >= identityMarker.width * 3 else {
+                throw Failure(message: "session identity marker reads as a status dot")
+            }
+            let previewIdentity = try await measuredFrame(
+                identifier: "session-preview-identity",
+                name: "session preview identity")
+            let previewPower = try await measuredFrame(
+                identifier: "session-preview-power",
+                name: "session preview power")
+            guard previewIdentity.intersection(previewPower).width <= 1,
+                  previewIdentity.maxX <= previewPower.minX + 1 else {
+                throw Failure(message: "session identity and power share one surface")
+            }
+            checks.append("session-signals-stay-distinct")
             let stopButton = try await element(identifier: "session-action-stop")
             try requireSemanticControl(stopButton, name: "stop action")
             UIE2EControlFault.stopActionAttempts = 0

--- a/app/Sources/DetachKit/Session.swift
+++ b/app/Sources/DetachKit/Session.swift
@@ -57,6 +57,25 @@ public struct SessionColor: Equatable, Hashable, Sendable, Codable {
         self.hex = String(format: "#%02X%02X%02X", red, green, blue)
     }
 
+    private init(red: UInt8, green: UInt8, blue: UInt8) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        hex = String(format: "#%02X%02X%02X", red, green, blue)
+    }
+
+    /// Applies the same dark-anchor blend as the private tmux status line.
+    /// Callers use fixed presentation strengths from 0 through 100.
+    public func tmuxStatusTint(percent: UInt8) -> SessionColor {
+        precondition(percent <= 100, "tmux status tint percent must be at most 100")
+        let foreground = Int(percent)
+        let background = 100 - foreground
+        return SessionColor(
+            red: UInt8((Int(red) * foreground + 32 * background) / 100),
+            green: UInt8((Int(green) * foreground + 32 * background) / 100),
+            blue: UInt8((Int(blue) * foreground + 43 * background) / 100))
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)

--- a/app/Tests/DetachAppTests/SessionIdentityTests.swift
+++ b/app/Tests/DetachAppTests/SessionIdentityTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftUI
 import DetachKit
 @testable import DetachApp
 
@@ -14,6 +15,76 @@ final class SessionIdentityTests: XCTestCase {
         XCTAssertLessThan(SessionIdentity.emphasis(for: .completed), 1)
         XCTAssertLessThan(SessionIdentity.emphasis(for: .stopped), 1)
         XCTAssertLessThan(SessionIdentity.emphasis(for: .interrupted), 1)
+    }
+
+    func testDetailIdentityMarkerCannotReadAsAStatusDot() {
+        XCTAssertLessThan(
+            SessionDetailSignalPresentation.identityMarkerWidth,
+            SessionDetailSignalPresentation.identityMarkerHeight)
+        XCTAssertGreaterThanOrEqual(
+            SessionDetailSignalPresentation.identityMarkerHeight,
+            SessionDetailSignalPresentation.identityMarkerWidth * 3)
+    }
+
+    func testPreviewUsesTheRuntimeTintStrengths() {
+        XCTAssertEqual(
+            SessionDetailSignalPresentation.identityTintPercent(for: .running),
+            55)
+        XCTAssertEqual(
+            SessionDetailSignalPresentation.identityTintPercent(for: .completed),
+            25)
+        XCTAssertEqual(
+            SessionDetailSignalPresentation.identityTintPercent(for: .recoverable),
+            45)
+    }
+
+    func testEveryTypedPowerStateHasItsOwnExpectedSignalColor() throws {
+        try assertColorsEqual(
+            SessionDetailSignalPresentation.powerColor(for: .protected),
+            Brand.teal)
+        for state in [
+            PowerProtectionState.transitioning,
+            .lowBattery,
+            .temperature,
+        ] {
+            try assertColorsEqual(
+                SessionDetailSignalPresentation.powerColor(for: state),
+                .orange)
+        }
+        try assertColorsEqual(
+            SessionDetailSignalPresentation.powerColor(for: .unavailable),
+            .red)
+        for state in [
+            PowerProtectionState.allowed,
+            .unknown,
+            nil,
+        ] {
+            try assertColorsEqual(
+                SessionDetailSignalPresentation.powerColor(for: state),
+                Color.white.opacity(0.70))
+        }
+    }
+
+    private func assertColorsEqual(
+        _ actual: Color,
+        _ expected: Color,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let actualRGB = try XCTUnwrap(
+            NSColor(actual).usingColorSpace(.deviceRGB),
+            file: file, line: line)
+        let expectedRGB = try XCTUnwrap(
+            NSColor(expected).usingColorSpace(.deviceRGB),
+            file: file, line: line)
+        XCTAssertEqual(actualRGB.redComponent, expectedRGB.redComponent,
+                       accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualRGB.greenComponent, expectedRGB.greenComponent,
+                       accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualRGB.blueComponent, expectedRGB.blueComponent,
+                       accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(actualRGB.alphaComponent, expectedRGB.alphaComponent,
+                       accuracy: 0.001, file: file, line: line)
     }
 }
 

--- a/app/Tests/DetachKitTests/SessionColorTests.swift
+++ b/app/Tests/DetachKitTests/SessionColorTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import DetachKit
+
+final class SessionColorTests: XCTestCase {
+    func testTmuxStatusTintUsesTheRuntimeBlendFormula() throws {
+        let color = try XCTUnwrap(SessionColor(hex: "#C2410C"))
+
+        XCTAssertEqual(color.tmuxStatusTint(percent: 55).hex, "#793219")
+        XCTAssertEqual(color.tmuxStatusTint(percent: 45).hex, "#682E1D")
+        XCTAssertEqual(color.tmuxStatusTint(percent: 25).hex, "#482823")
+    }
+
+    func testTmuxStatusTintPreservesFormulaEndpoints() throws {
+        let color = try XCTUnwrap(SessionColor(hex: "#36C5F0"))
+
+        XCTAssertEqual(color.tmuxStatusTint(percent: 0).hex, "#20202B")
+        XCTAssertEqual(color.tmuxStatusTint(percent: 100), color)
+    }
+
+    func testCodableRoundTripUsesTheCanonicalHexValue() throws {
+        let color = try XCTUnwrap(SessionColor(hex: "#c2410c"))
+
+        let encoded = try JSONEncoder().encode(color)
+
+        XCTAssertEqual(String(decoding: encoded, as: UTF8.self), "\"#C2410C\"")
+        XCTAssertEqual(try JSONDecoder().decode(SessionColor.self, from: encoded), color)
+    }
+}

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -68,28 +68,29 @@ without a fresh heartbeat must be replaced through the same durable
 unregister/barrier/register transaction. Ordinary activation refreshes must not
 force replacement merely because a heartbeat is temporarily stale.
 
-The menu bar item is display-only. Its image is the Detach prompt mark:
-a filled dot means protected, the dimmed mark means sleep is allowed, an
-exclamation badge means attention, and an outline means unknown. Active
-sessions additionally tint the glyph's dot — green while working, orange when
-a session waits for a reply (answer-ready outranks working; the badge states
-suppress the tint so a power warning stays visible). The image stays template
-while monochrome; only the tinted states draw with real color, using
-label/system colors resolved at composite time, and VoiceOver names the
-session state in words. The first menu line is `state · reason · freshness`.
-Protected state counts working sessions. Allowed state names all-waiting or an
-unprotected working session and never claims no sessions. The glyph and words
-derive from the shared `checked_at`-based heartbeat reader and the
-app-level shared session poller — never `pmset` or root XPC from UI, and
-freshness comes from the document timestamp, not file mtime. One
-`detach list --json` poller serves the window, notifications, and the menu
-(foreground cadence with the window visible, slower idle cadence after it
-closes — polling never stops while the app runs). Closing the last window keeps
-the app and icon alive; ⌘Q and Quit genuinely terminate the app while sessions,
-checkpoints, and protection continue. Settings → General owns the two menu bar
-toggles; the Mac Power block in Settings → System remains the single place for
-power status and approval controls. Temperature safety uses its own warning
+The menu bar item is display-only. Its Detach prompt mark uses a filled dot for
+protected, a dim mark for sleep allowed, an exclamation badge for attention,
+and an outline for unknown. With active sessions, green means working and
+orange means waiting. Waiting outranks working. A badge suppresses both tints
+so a power warning stays visible. Monochrome states remain template. Tinted
+states use label or system colors resolved at composite time. VoiceOver names
+the session state. The first menu line is `state · reason · freshness`.
+Protected counts working sessions. Allowed names all-waiting or an unprotected
+working session and never claims no sessions. The shared `checked_at` heartbeat
+reader and app-level session poller supply the glyph and words. UI never calls
+`pmset` or root XPC. Freshness uses the document timestamp, not file mtime. One
+`detach list --json` poller serves the window, notifications, and menu. It polls
+faster with a visible window, slower after it closes, and never stops. Closing
+the last window keeps the app and icon alive.
+⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
+Settings → General owns both menu bar toggles. Settings → System keeps the only
+Mac Power status and approval controls. Temperature safety has its own warning
 shape and the text **Mac can sleep: temperature**.
+
+The dashboard keeps identity, status, and Mac Power separate. A thin capsule
+carries identity; a filled circle carries status. The preview uses the tmux
+blend, not the raw hue. Power words use a neutral surface and semantic color.
+Sidebar and detail share one status-color function.
 
 Every app CLI invocation runs in a fresh process group with concurrent bounded
 stdout/stderr draining. Its deadline sends TERM and then KILL to the complete

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -296,8 +296,9 @@ run_app_scenario() {
     case "$check" in
       background-app-starts-without-focus|disconnected-stop-blocks-action) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
-      sidebar-selects-completed-session) pass=SC-UI-SESSION-DETAIL ;;
+      sidebar-selects-completed-session) ;;
       safe-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
+      session-signals-stay-distinct) pass=SC-UI-SESSION-DETAIL ;;
       safe-action-reaches-fake-cli) pass=SC-UI-SESSION-STOP ;;
       new-session-sheet-semantics) pass=SC-UI-NEW-SESSION ;;
       empty-dashboard-state) pass=SC-UI-EMPTY ;;
@@ -322,6 +323,7 @@ run_app_scenario main sessions 20 \
   dashboard-accessible \
   sidebar-selects-completed-session \
   safe-delete-reaches-fake-cli \
+  session-signals-stay-distinct \
   disconnected-stop-blocks-action \
   safe-action-reaches-fake-cli \
   new-session-sheet-semantics \


### PR DESCRIPTION
## Contract

- Replace the detail identity dot with a thin capsule.
- Tint the preview identity segment with the existing tmux blend formula.
- Put typed power words on a separate neutral surface with power-specific color.
- Keep sidebar and detail status colors on the shared status function.

## Regression evidence

- Pin the Swift tint output to the runtime formula at 25%, 45%, and 55%.
- Pin the detail identity marker aspect ratio.
- Extend packaged UI smoke to measure a 4 by 24 point marker and non-overlapping identity and power segments.
- Update the durable app contract.

## Diagnostics

- Focused unit tests: PASS (8 tests).
- Full local diagnostic: static, Swift, app, Codex, Claude, distribution, and tmux-runtime PASS.
- Local UI e2e did not finish because its existing synthetic click path failed after the new geometry check. The integrated baseline without this change failed in the same path. The new packaged geometry check passed before that unrelated failure.
- Hosted quality-gates remains the readiness authority.

Closes #66