### PR TITLE
App: require live helper readiness in Settings

### DIFF
--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -277,8 +277,8 @@
 "The bundled power helper definition is missing or incomplete." = "The bundled power helper definition is missing or incomplete.";
 "The current sleep state comes from the latest background power check." = "The current sleep state comes from the latest background power check.";
 "The helper is bundled with Detach; no third-party keep-awake app is needed." = "The helper is bundled with Detach; no third-party keep-awake app is needed.";
-"The native power helper is enabled." = "The native power helper is enabled.";
 "The native power helper is not registered yet." = "The native power helper is not registered yet.";
+"The native power helper is registered, but its live check failed." = "The native power helper is registered, but its live check failed.";
 "The native power helper is reachable" = "The native power helper is reachable";
 "The native power helper is unavailable." = "The native power helper is unavailable.";
 "The native power helper is unavailable or needs approval" = "The native power helper is unavailable or needs approval";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -277,8 +277,8 @@
 "The bundled power helper definition is missing or incomplete." = "Встроенная конфигурация системного помощника отсутствует или неполна.";
 "The current sleep state comes from the latest background power check." = "Текущий режим сна определяется по последней фоновой проверке питания.";
 "The helper is bundled with Detach; no third-party keep-awake app is needed." = "Помощник входит в Detach; стороннее приложение для блокировки сна не нужно.";
-"The native power helper is enabled." = "Встроенный системный помощник включён.";
 "The native power helper is not registered yet." = "Встроенный системный помощник ещё не зарегистрирован.";
+"The native power helper is registered, but its live check failed." = "Встроенный системный помощник зарегистрирован, но проверка связи с ним не пройдена.";
 "The native power helper is reachable" = "Встроенный системный помощник отвечает";
 "The native power helper is unavailable." = "Встроенный системный помощник недоступен.";
 "The native power helper is unavailable or needs approval" = "Встроенный системный помощник недоступен или ожидает разрешения";

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -100,6 +100,36 @@ struct MacPowerSettingsPresentation: Equatable {
     }
 }
 
+struct PowerHelperSettingsPresentation: Equatable {
+    let status: DiagnosticCheck.Status
+    let detailLocalizationKey: String?
+
+    init(
+        registrationStatus: PowerHelperRegistrationStatus,
+        readinessConfirmed: Bool
+    ) {
+        if registrationStatus == .enabled, readinessConfirmed {
+            status = .ok
+            detailLocalizationKey = nil
+            return
+        }
+
+        status = .error
+        switch registrationStatus {
+        case .enabled:
+            detailLocalizationKey =
+                "The native power helper is registered, but its live check failed."
+        case .requiresApproval:
+            detailLocalizationKey =
+                "One-time administrator approval is required for native sleep protection."
+        case .notRegistered:
+            detailLocalizationKey = "The native power helper is not registered yet."
+        case .unavailable:
+            detailLocalizationKey = "The native power helper is unavailable."
+        }
+    }
+}
+
 private extension SettingsDestination {
     /// Content height measured at the default text size; the window follows
     /// the selected tab like classic AppKit preference panes.
@@ -723,12 +753,13 @@ struct SettingsView: View {
                 macPowerHeroRow
                 requiredComponentStatus(
                     label: L10n.string("Sleep Protection Helper"),
-                    status: installation.powerHelperStatus == .enabled ? .ok : .error)
+                    status: powerHelperSettingsPresentation.status)
                 requiredComponentStatus(
                     label: L10n.string("Background Power Monitor"),
                     status: installation.watchdogStatus == .enabled ? .ok : .error)
-                if installation.powerHelperStatus != .enabled {
-                    Text(powerHelperStatusText)
+                if let detail = powerHelperSettingsPresentation
+                    .detailLocalizationKey {
+                    Text(L10n.string(detail))
                         .settingsMessage(color: .red)
                 }
                 macPowerAction
@@ -1061,18 +1092,12 @@ struct SettingsView: View {
         return requiredComponentStatus(label: label, status: status)
     }
 
-    private var powerHelperStatusText: String {
-        switch installation.powerHelperStatus {
-        case .enabled:
-            L10n.string("The native power helper is enabled.")
-        case .requiresApproval:
-            L10n.string(
-                "One-time administrator approval is required for native sleep protection.")
-        case .notRegistered:
-            L10n.string("The native power helper is not registered yet.")
-        case .unavailable:
-            L10n.string("The native power helper is unavailable.")
-        }
+    private var powerHelperSettingsPresentation:
+        PowerHelperSettingsPresentation
+    {
+        PowerHelperSettingsPresentation(
+            registrationStatus: installation.powerHelperStatus,
+            readinessConfirmed: installation.powerHelperReadinessConfirmed)
     }
 
     private func requiredComponentStatus(

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -3,6 +3,54 @@ import XCTest
 @testable import DetachApp
 
 final class MacPowerSettingsPresentationTests: XCTestCase {
+    func testPowerHelperHealthRequiresConfirmedLiveCheck() {
+        let unreachable = PowerHelperSettingsPresentation(
+            registrationStatus: .enabled,
+            readinessConfirmed: false)
+        XCTAssertEqual(unreachable.status, .error)
+        XCTAssertEqual(
+            unreachable.detailLocalizationKey,
+            "The native power helper is registered, but its live check failed.")
+
+        let reachable = PowerHelperSettingsPresentation(
+            registrationStatus: .enabled,
+            readinessConfirmed: true)
+        XCTAssertEqual(reachable.status, .ok)
+        XCTAssertNil(reachable.detailLocalizationKey)
+
+        let staleReadiness = PowerHelperSettingsPresentation(
+            registrationStatus: .notRegistered,
+            readinessConfirmed: true)
+        XCTAssertEqual(staleReadiness.status, .error)
+        XCTAssertEqual(
+            staleReadiness.detailLocalizationKey,
+            "The native power helper is not registered yet.")
+    }
+
+    func testPowerHelperHealthExplainsRegistrationFailures() {
+        let expected: [(PowerHelperRegistrationStatus, String)] = [
+            (
+                .requiresApproval,
+                "One-time administrator approval is required for native sleep protection."),
+            (
+                .notRegistered,
+                "The native power helper is not registered yet."),
+            (
+                .unavailable,
+                "The native power helper is unavailable."),
+        ]
+
+        for (registrationStatus, detailLocalizationKey) in expected {
+            let presentation = PowerHelperSettingsPresentation(
+                registrationStatus: registrationStatus,
+                readinessConfirmed: false)
+            XCTAssertEqual(presentation.status, .error)
+            XCTAssertEqual(
+                presentation.detailLocalizationKey,
+                detailLocalizationKey)
+        }
+    }
+
     func testStateLabelsDescribeSleepInWords() {
         let expected: [(PowerProtectionState, String)] = [
             (.protected, "Mac stays awake"),

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -134,16 +134,14 @@ recorded and the journal cleared. Approval and retry failures remain pending for
 the next launch. An ordinary helper SIGTERM/SIGINT uses only the process-local
 termination gate and must not create this persistent update state.
 
-Settings → System contains one **Mac Power** block; do not duplicate its status
-or approval controls elsewhere in that tab. It presents the sleep state in
-words, helper and background-monitor health, the 10% battery rule, and the
-appropriate approval, setup, repair, or refresh action. Its effective state is
-read from a healthy watchdog heartbeat newer than three minutes and is
-`unknown` when that snapshot is missing, stale, or malformed. Refresh the
-installation context when Settings appears or the app becomes active. While the
-System tab remains visible, publish a fresh heartbeat snapshot every ten seconds
-so the displayed state cannot remain stale merely because SwiftUI did not
-otherwise re-render.
+Settings → System owns one **Mac Power** block. It shows the sleep state,
+component health, the 10% battery rule, and the correct action. Helper Ready
+requires a doctor-confirmed live XPC connection. Registration alone is Needs
+attention. Power state comes from a healthy watchdog heartbeat no older than
+three minutes. A missing, stale, or malformed snapshot means `unknown`. Refresh
+the installation context when Settings appears or the app becomes active.
+While this tab is visible, publish a heartbeat snapshot every ten seconds so
+the state does not remain stale when SwiftUI does not re-render.
 
 The watchdog heartbeat carries both the effective power state and typed raw
 thermal state/latch. When notifications are enabled, the app emits one


### PR DESCRIPTION
## Summary

- Show `Sleep Protection Helper` as Ready only after the doctor check confirms
  live XPC reachability.
- Report a registered but unreachable helper as Needs attention with a direct
  explanation.
- Keep registration, live health, and the effective watchdog power state as
  separate signals.

## Contract delta

Current: Settings uses `SMAppService.status == .enabled` for the helper health
row. A registered helper can appear Ready while XPC is unreachable and provider
launch is blocked.

Target: Settings requires the existing doctor-backed readiness confirmation for
the Ready state. Registration without live reachability is visible as Needs
attention. Approval and registration failures keep their existing guidance.

## Durable decisions

- Do not weaken the root helper's Apple-anchored XPC requirement.
- Do not treat SMAppService registration as runtime health.
- Keep effective Mac Power state sourced from the fresh watchdog heartbeat.

## Evidence

- `swift test --filter MacPowerSettingsPresentationTests`: 9 tests passed.
- `tests/docs-contract.sh`: passed.
- Impact-aware `scripts/quality-gate`: diagnostic PASS, policy 42, fingerprint
  `9889186e27f0860fd3205889b35de57356683e445807361efadc1ec2bd351d92`.
- `git diff --check`: clean.

No real power, closed-lid, signing, notarization, tagging, upload, or
publication action was run.

Addresses the confirmed Settings inconsistency reported in #72. The issue stays
open while the environment-specific code-signing trust failure is investigated.
