### PR TITLE
Recover a dead SMAppService helper registration

### DIFF
--- a/app/Sources/DetachApp/PowerHelperService.swift
+++ b/app/Sources/DetachApp/PowerHelperService.swift
@@ -307,12 +307,13 @@ final class PowerHelperService {
         let systemHandoffLock = try systemHandoffLockProvider()
         if systemHandoffLock == nil {
             // Before the first helper launch no root-owned rendezvous inode
-            // exists yet. That pristine shape is safe only when no helper from
-            // this boot has ever held the lifetime barrier. Once either file
-            // exists, refusing the operation is safer than falling back to a
-            // per-user lock that cannot serialize Fast User Switching.
-            guard status != .enabled,
-                  try lifetimeBarrierStatus() == .missing else {
+            // exists yet. That shape is safe only when this boot never held
+            // the lifetime barrier. A leftover SMAppService "enabled" bit
+            // without that barrier is a dead registration, not a live helper.
+            // Once the lifetime file exists, refusing the operation is safer
+            // than falling back to a per-user lock that cannot serialize
+            // Fast User Switching.
+            guard try lifetimeBarrierStatus() == .missing else {
                 throw PowerHelperServiceError
                     .unregistrationBarrierDidNotComplete
             }
@@ -346,6 +347,16 @@ final class PowerHelperService {
             case .preparing:
                 switch status {
                 case .enabled:
+                    if try lifetimeBarrierStatus() == .missing {
+                        // launchd/BTM can keep an enabled job that never
+                        // spawned. There is no live helper to prepare.
+                        transaction.phase = .unregisterSubmitted
+                        transaction.bootSessionIdentifier =
+                            try currentBootSession()
+                        transaction.lifetimeBarrierExpected = false
+                        try handoffStore.save(transaction)
+                        continue
+                    }
                     let preparation = try await lifecycle
                         .prepareForUnregistration()
                     guard preparation == .prepared else {

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -1216,6 +1216,27 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
+    func testEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
+        let backend = FakePowerHelperBackend(
+            status: .enabled,
+            registrations: [.success(.enabled)])
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { .missing },
+            systemHandoffLockProvider: { nil })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-previous", forKey: "powerHelperDefinitionDigest")
+
+        _ = try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
+        XCTAssertEqual(backend.unregisterCalls, 1)
+        XCTAssertEqual(backend.registerCalls, 1)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 1)
+        XCTAssertNil(fixture.handoffStore.transaction)
+    }
+
     func testMissingSystemLockFailsClosedAfterAHelperHasRun() async {
         let backend = FakePowerHelperBackend(
             status: .enabled,

--- a/app/Tests/DetachKitTests/PowerHelperSystemHandoffLockTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperSystemHandoffLockTests.swift
@@ -42,6 +42,23 @@ final class PowerHelperSystemHandoffLockTests: XCTestCase {
             }
     }
 
+    func testAppProbeRejectsSymlinkSystemLock() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let target = fixture.root.appendingPathComponent("target")
+        try Data().write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.fileURL, withDestinationURL: target)
+
+        XCTAssertThrowsError(try PowerHelperSystemHandoffLock(
+            fileURL: fixture.fileURL,
+            expectedOwner: fixture.owner).acquire()) { error in
+                XCTAssertEqual(
+                    error as? PowerHelperPlatformError,
+                    .insecureSystemHandoffLock)
+            }
+    }
+
     private func makeFixture() throws -> (
         root: URL,
         fileURL: URL,

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -104,9 +104,9 @@ Node directories by semantic version.
 Helper replacement is a durable fail-closed transaction. One versioned JSON
 journal records `preparing`, `unregisterSubmitted`, `removed`, or `registering`,
 the install/remove goal, target digest, boot UUID, and lifetime-barrier contract.
-Every transition is written by atomic rename and fsynced with its directory
-before the corresponding side effect. A per-user `flock` protects that user's
-journal. In addition, the root helper creates a stable root-owned `0644` inode
+Each transition uses atomic rename and file/directory fsync before its side
+effect. A per-user `flock` protects the journal. In addition, the root helper
+creates a stable root-owned `0644` inode
 under `/var/run`; every app user opens it read-only and holds one exclusive
 kernel `flock` across the complete asynchronous SMAppService transaction. This
 is the machine-wide single-writer barrier across Fast User Switching, and the

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -117,7 +117,8 @@ acquire/renew without a wall-clock expiry, and restores and reads back only the
 setting Detach owns.
 
 The helper takes an exclusive, root-owned lifetime `flock` before its listener
-can answer prepare and holds it until process exit. The app writes
+can answer prepare and holds it until process exit. An enabled job with no
+lifetime barrier this boot is dead; unregister may proceed. The app writes
 `unregisterSubmitted` only after observing that lock. A fresh successful async
 SMAppService callback is the normal process-reaped barrier. If a crash loses the
 callback, exact `notRegistered` status plus acquisition of the released lifetime


### PR DESCRIPTION
## Summary

- treat an enabled SMAppService helper with no lifetime barrier this boot as a dead registration
- allow unregister without `prepareForUnregistration` only in that narrow state
- keep Fast User Switching fail-closed once the lifetime file exists

Fixes #80
Split from #54 / PR #55 as requested.

## Contract delta

`docs/specs/app.md`: an enabled job with no lifetime barrier this boot is dead; unregister may proceed.

## Durable decisions

- Missing system handoff lock plus `.enabled` is safe only while this boot never held the lifetime barrier.
- Once the lifetime file exists, refuse the missing-lock path. Do not fall back to a per-user lock.
- A zombie `.enabled` job does not call `prepareForUnregistration`; there is no live helper to prepare.

## Acceptance evidence

| Requirement | Check | Result |
| --- | --- | --- |
| Enabled + missing lifetime barrier reregisters | `swift test --filter PowerHelperServiceTests/testEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister` | pass |
| Missing system lock still fails closed after a helper has run | `swift test --filter PowerHelperServiceTests/testMissingSystemLockFailsClosedAfterAHelperHasRun` | pass |
| Focused power suite | `swift test --filter Power` | 323 tests pass |
| System-lock symlink rejection | `PowerHelperSystemHandoffLockTests.testAppProbeRejectsSymlinkSystemLock` | pass |
| Coverage-enabled Swift suite | `swift test --enable-code-coverage --disable-sandbox` | 796 tests pass; `PowerHelperPlatform.swift` 85.36% |
| Packaged app | `scripts/quality-gate --stage app` | pass |
| Documentation contract | `tests/docs-contract.sh` | pass |
| Packaged UI behavior | `tests/ui-e2e.sh` with macOS GUI access | pass |
| Hosted repository gate | `quality-gates` on `macos-26` | pass |

The local UI stage's functional smoke passed. Its aggregate diagnostic took 18 seconds against the local 15-second budget. The latest hosted main smoke also exceeds that local ceiling and passes because hosted shards run without release-budget enforcement; this PR does not change UI code.
