### PR TITLE
Add bulk cleanup for finished sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,13 @@ The dashboard gives every managed session:
 - ANSI-aware retained logs with color and common text attributes;
 - safe actions chosen from **Attach**, **Stop**, **Resume**, **Recover**, and
   **Delete** according to the proven state;
+- checkboxes in **Finished** for one-confirmation deletion of selected eligible
+  sessions; one failed deletion does not stop the remaining deletions;
 - optional notifications when a turn is ready for an answer, a session
   finishes or fails, or recovery becomes available;
 - a stable identity color shared by the sidebar and that session's tmux status
-  bar; saved sessions avoid reusing an occupied hue until the eight-color
-  palette is full.
+  bar. Current tasks avoid occupied hues across Codex and Claude. Finished
+  history does not keep a palette slot occupied.
 
 Sessions waiting for your reply move into **Answer ready**, ahead of agents
 that are still working. That signal comes from structured provider lifecycle
@@ -429,8 +431,10 @@ older one. Ordinary typed storage cleanup may also remove eligible histories.
 Every managed session receives a deterministic color based on provider and
 project. The app uses it in the sidebar; the tmux bar uses the same tint with
 provider, project, state, and power labels. Completed sessions fade and failed
-sessions turn red. All styling is session-local: Detach never edits the user's
-global tmux config.
+sessions turn red. A new or resumed task walks the shared palette when its
+preferred color is in use by another current task. Finished history keeps its
+displayed color but releases that palette slot. All styling is session-local:
+Detach never edits the user's global tmux config.
 
 Shells opened in user-created split panes close normally on `Ctrl-D` or exit.
 Only the managed Codex or Claude pane is retained after completion so Detach

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -24,6 +24,7 @@
 "Internal error: %@ must run in Terminal" = "Internal error: %@ must run in Terminal";
 "detach exited with status %d" = "detach exited with status %d";
 "Could not run detach: %@" = "Could not run detach: %@";
+"Session is not eligible for deletion from Finished." = "Session is not eligible for deletion from Finished.";
 "Unsupported detach doctor schema: %d" = "Unsupported detach doctor schema: %d";
 "CLI installation timed out" = "CLI installation timed out";
 "CLI installer exited with status %d" = "CLI installer exited with status %d";
@@ -95,12 +96,17 @@
 "Copy session UUID" = "Copy session UUID";
 "Could Not Complete Setup" = "Could Not Complete Setup";
 "Could not open Terminal" = "Could not open Terminal";
+"Could not delete some sessions" = "Could not delete some sessions";
 "Could not remove components: %@" = "Could not remove components: %@";
 "Could not request notification permission: %@" = "Could not request notification permission: %@";
 "Could not show notification: %@" = "Could not show notification: %@";
 "Created" = "Created";
 "Delete" = "Delete";
+"Delete %d" = "Delete %d";
+"Delete selected sessions (%d)?" = "Delete selected sessions (%d)?";
 "Delete session “%@”?" = "Delete session “%@”?";
+"Deselect %@ from deletion" = "Deselect %@ from deletion";
+"Done" = "Done";
 "Detach Background Service" = "Detach Background Service";
 "Detach background service" = "Detach background service";
 "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again." = "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again.";
@@ -173,6 +179,10 @@
 "Retry Setup" = "Retry Setup";
 "Running from a DMG or temporary copy is unreliable." = "Running from a DMG or temporary copy is unreliable.";
 "Select a session" = "Select a session";
+"Select" = "Select";
+"Select all" = "Select all";
+"Select %@ for deletion" = "Select %@ for deletion";
+"Clear selection" = "Clear selection";
 "Session can be recovered" = "Session can be recovered";
 "Session completed" = "Session completed";
 "Session failed" = "Session failed";
@@ -192,7 +202,8 @@
 "The background service is starting or needs attention" = "The background service is starting or needs attention";
 "The background service ran within the last three minutes" = "The background service ran within the last three minutes";
 "The bundled watchdog definition is missing or incomplete." = "The bundled watchdog definition is missing or incomplete.";
-"The harness state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude (~/.codex) will not be affected." = "The harness state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude (~/.codex) will not be affected.";
+"The Detach state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude or ~/.codex will not be affected." = "The Detach state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude or ~/.codex will not be affected.";
+"The selected Detach state directories and checkpoints will be permanently deleted. Provider transcripts in ~/.claude and ~/.codex will not be affected." = "The selected Detach state directories and checkpoints will be permanently deleted. Provider transcripts in ~/.claude and ~/.codex will not be affected.";
 "The installed CLI version will remain functional — retrying is safe." = "The installed CLI version will remain functional — retrying is safe.";
 "The manifest is missing, damaged, or contains a different version" = "The manifest is missing, damaged, or contains a different version";
 "The manifest matches the CLI" = "The manifest matches the CLI";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -24,6 +24,7 @@
 "Internal error: %@ must run in Terminal" = "Внутренняя ошибка: команда %@ должна выполняться в Terminal";
 "detach exited with status %d" = "detach завершился с кодом %d";
 "Could not run detach: %@" = "Не удалось запустить detach: %@";
+"Session is not eligible for deletion from Finished." = "Сессию нельзя удалить из раздела «Завершены».";
 "Unsupported detach doctor schema: %d" = "Неподдерживаемая схема detach doctor: %d";
 "CLI installation timed out" = "Истекло время ожидания установки CLI";
 "CLI installer exited with status %d" = "Установщик CLI завершился с кодом %d";
@@ -95,12 +96,17 @@
 "Copy session UUID" = "Скопировать UUID сессии";
 "Could Not Complete Setup" = "Не удалось завершить настройку";
 "Could not open Terminal" = "Не удалось открыть терминал";
+"Could not delete some sessions" = "Не удалось удалить некоторые сессии";
 "Could not remove components: %@" = "Не удалось удалить компоненты: %@";
 "Could not request notification permission: %@" = "Не удалось запросить разрешение на уведомления: %@";
 "Could not show notification: %@" = "Не удалось показать уведомление: %@";
 "Created" = "Создана";
 "Delete" = "Удалить";
+"Delete %d" = "Удалить: %d";
+"Delete selected sessions (%d)?" = "Удалить выбранные сессии (%d)?";
 "Delete session “%@”?" = "Удалить сессию «%@»?";
+"Deselect %@ from deletion" = "Убрать «%@» из выбранных для удаления";
+"Done" = "Готово";
 "Detach Background Service" = "Фоновая служба Detach";
 "Detach background service" = "Фоновая служба Detach";
 "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again." = "Detach не может обновиться из текущего расположения. Переместите Detach в /Applications. Активный CLI не изменился. Затем повторите попытку.";
@@ -173,6 +179,10 @@
 "Retry Setup" = "Повторить настройку";
 "Running from a DMG or temporary copy is unreliable." = "Запуск из DMG или временной копии ненадёжен.";
 "Select a session" = "Выберите сессию";
+"Select" = "Выбрать";
+"Select all" = "Выбрать все";
+"Select %@ for deletion" = "Выбрать «%@» для удаления";
+"Clear selection" = "Снять выделение";
 "Session can be recovered" = "Сессию можно восстановить";
 "Session completed" = "Сессия завершена";
 "Session failed" = "Сессия завершилась с ошибкой";
@@ -192,7 +202,8 @@
 "The background service is starting or needs attention" = "Фоновая служба запускается или требует внимания";
 "The background service ran within the last three minutes" = "Фоновая служба запускалась в последние три минуты";
 "The bundled watchdog definition is missing or incomplete." = "Встроенное определение фоновой службы отсутствует или неполно.";
-"The harness state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude (~/.codex) will not be affected." = "State-каталог и чекпойнты harness удаляются безвозвратно. Транскрипт провайдера в ~/.claude (~/.codex) не затрагивается.";
+"The Detach state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude or ~/.codex will not be affected." = "State-каталог и чекпойнты Detach будут удалены безвозвратно. Транскрипт провайдера в ~/.claude или ~/.codex не затрагивается.";
+"The selected Detach state directories and checkpoints will be permanently deleted. Provider transcripts in ~/.claude and ~/.codex will not be affected." = "Выбранные state-каталоги и чекпойнты Detach будут удалены безвозвратно. Транскрипты провайдеров в ~/.claude и ~/.codex не затрагиваются.";
 "The installed CLI version will remain functional — retrying is safe." = "Установленная версия CLI останется рабочей — повторная попытка безопасна.";
 "The manifest is missing, damaged, or contains a different version" = "Манифест отсутствует, повреждён или содержит другую версию";
 "The manifest matches the CLI" = "Манифест согласован с CLI";

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -60,7 +60,7 @@ struct SessionDetailView: View {
                             isPresented: $confirmDelete, titleVisibility: .visible) {
             Button(L10n.string("Delete"), role: .destructive) { run(.delete) }
         } message: {
-            Text(L10n.string("The harness state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude (~/.codex) will not be affected."))
+            Text(L10n.string("The Detach state directory and checkpoints will be permanently deleted. The provider transcript in ~/.claude or ~/.codex will not be affected."))
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("session-detail-\(session.id)")

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import DetachKit
 
+enum FinishedDeletionPresentation {
+    static func errorMessage(for failures: [SessionDeletionFailure]) -> String {
+        failures
+            .map { "\($0.displayTitle): \($0.message)" }
+            .joined(separator: "\n")
+    }
+}
+
 struct SidebarView: View {
     @Environment(\.appFontPointSize) private var fontPointSize
     let store: SessionStore
@@ -315,9 +323,8 @@ struct SidebarView: View {
             if failures.isEmpty {
                 isSelectingFinished = false
             } else {
-                finishedDeleteError = failures
-                    .map { "\($0.displayTitle): \($0.message)" }
-                    .joined(separator: "\n")
+                finishedDeleteError = FinishedDeletionPresentation.errorMessage(
+                    for: failures)
             }
         }
     }

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -8,9 +8,22 @@ struct SidebarView: View {
     @Binding var selectedID: String?
     @ObservedObject var navigation: MainNavigation
     @State private var showNewSession = false
+    @State private var isSelectingFinished = false
+    @State private var selectedFinishedIDs: Set<String> = []
+    @State private var confirmFinishedDelete = false
+    @State private var isDeletingFinished = false
+    @State private var finishedDeleteError: String?
 
     private func sessions(in section: SessionSection) -> [Session] {
         store.sessions.filter { $0.section == section }
+    }
+
+    private var deletableFinishedSessions: [Session] {
+        sessions(in: .finished).filter(\.canDeleteFromFinishedList)
+    }
+
+    private var selectedFinishedSessions: [Session] {
+        deletableFinishedSessions.filter { selectedFinishedIDs.contains($0.id) }
     }
 
     var body: some View {
@@ -23,9 +36,7 @@ struct SidebarView: View {
                             sessionRow(session)
                         }
                     } header: {
-                        Text(L10n.format("%@ · %d", section.displayName, items.count))
-                            .foregroundStyle(
-                                section == .answerReady ? Color.orange : Color.secondary)
+                        sectionHeader(section, count: items.count)
                     }
                 }
             }
@@ -44,7 +55,13 @@ struct SidebarView: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            StatusBar(store: store)
+            VStack(spacing: 0) {
+                if isSelectingFinished {
+                    finishedSelectionBar
+                    Divider()
+                }
+                StatusBar(store: store)
+            }
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -69,6 +86,30 @@ struct SidebarView: View {
         .sheet(isPresented: $showNewSession) {
             NewSessionSheet(detachPath: detachPath)
         }
+        .confirmationDialog(
+            L10n.format(
+                "Delete selected sessions (%d)?",
+                selectedFinishedSessions.count),
+            isPresented: $confirmFinishedDelete,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.string("Delete"), role: .destructive) {
+                deleteSelectedFinishedSessions()
+            }
+        } message: {
+            Text(L10n.string(
+                "The selected Detach state directories and checkpoints will be permanently deleted. Provider transcripts in ~/.claude and ~/.codex will not be affected."))
+        }
+        .alert(
+            L10n.string("Could not delete some sessions"),
+            isPresented: .init(
+                get: { finishedDeleteError != nil },
+                set: { if !$0 { finishedDeleteError = nil } })
+        ) {
+            Button(L10n.string("OK"), role: .cancel) {}
+        } message: {
+            Text(finishedDeleteError ?? "")
+        }
         // The menu can request a sheet before reopening the main window, so
         // consume an already-pending request on the sidebar's first render.
         .onChange(of: navigation.requestsNewSession, initial: true) { _, requested in
@@ -76,38 +117,208 @@ struct SidebarView: View {
             showNewSession = true
             navigation.requestsNewSession = false
         }
+        .onChange(of: deletableFinishedSessions.map(\.id)) { _, currentIDs in
+            selectedFinishedIDs.formIntersection(currentIDs)
+            if currentIDs.isEmpty && !isDeletingFinished {
+                isSelectingFinished = false
+            }
+        }
         .navigationSplitViewColumnWidth(
             min: max(230, fontPointSize * 18),
             ideal: max(260, fontPointSize * 20))
     }
 
     @ViewBuilder
+    private func sectionHeader(_ section: SessionSection, count: Int) -> some View {
+        HStack(spacing: 8) {
+            Text(L10n.format("%@ · %d", section.displayName, count))
+                .foregroundStyle(
+                    section == .answerReady ? Color.orange : Color.secondary)
+            Spacer(minLength: 0)
+            if section == .finished && !deletableFinishedSessions.isEmpty {
+                Button(L10n.string(isSelectingFinished ? "Done" : "Select")) {
+                    if isSelectingFinished {
+                        selectedFinishedIDs.removeAll()
+                    }
+                    isSelectingFinished.toggle()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Brand.indigo)
+                .disabled(isDeletingFinished)
+                .accessibilityIdentifier("finished-selection-mode-button")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                .background {
+                    if AppSettings.uiE2E != nil {
+                        UIE2EGeometryProbe(
+                            identifier: "finished-selection-mode-button",
+                            semanticLabel: isSelectingFinished ? "Done" : "Select",
+                            semanticRole: .button,
+                            semanticEnabled: !isDeletingFinished)
+                    }
+                }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+            }
+        }
+    }
+
+    @ViewBuilder
     private func sessionRow(_ session: Session) -> some View {
-        if session.isWaitingForUser {
+        let row = HStack(spacing: 8) {
+            if isSelectingFinished && session.canDeleteFromFinishedList {
+                Button {
+                    if selectedFinishedIDs.contains(session.id) {
+                        selectedFinishedIDs.remove(session.id)
+                    } else {
+                        selectedFinishedIDs.insert(session.id)
+                    }
+                } label: {
+                    Image(systemName: selectedFinishedIDs.contains(session.id)
+                          ? "checkmark.square.fill" : "square")
+                        .foregroundStyle(
+                            selectedFinishedIDs.contains(session.id)
+                                ? Brand.indigo : Color.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isDeletingFinished)
+                .accessibilityLabel(L10n.format(
+                    selectedFinishedIDs.contains(session.id)
+                        ? "Deselect %@ from deletion" : "Select %@ for deletion",
+                    session.displayTitle))
+                .accessibilityIdentifier("finished-selection-\(session.id)")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                .background {
+                    if AppSettings.uiE2E != nil {
+                        UIE2EGeometryProbe(
+                            identifier: "finished-selection-\(session.id)",
+                            semanticLabel: selectedFinishedIDs.contains(session.id)
+                                ? "Deselect \(session.displayTitle) from deletion"
+                                : "Select \(session.displayTitle) for deletion",
+                            semanticRole: .button,
+                            semanticEnabled: !isDeletingFinished)
+                    }
+                }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+            }
             SessionRow(session: session)
+        }
+
+        if session.isWaitingForUser {
+            row
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                 .background { uiE2EGeometryProbe(for: session) }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
                 .tag(session.id)
-                .accessibilityElement(children: .combine)
+                .accessibilityElement(children:
+                    isSelectingFinished && session.canDeleteFromFinishedList
+                        ? .contain : .combine)
                 .accessibilityLabel(session.displayTitle)
                 .accessibilityIdentifier("session-row-\(session.id)")
                 .accessibilityAction { selectedID = session.id }
                 .listRowBackground(Color.orange.opacity(0.10))
         } else {
-            SessionRow(session: session)
+            row
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                 .background { uiE2EGeometryProbe(for: session) }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
                 .tag(session.id)
-                .accessibilityElement(children: .combine)
+                .accessibilityElement(children:
+                    isSelectingFinished && session.canDeleteFromFinishedList
+                        ? .contain : .combine)
                 .accessibilityLabel(session.displayTitle)
                 .accessibilityIdentifier("session-row-\(session.id)")
                 .accessibilityAction { selectedID = session.id }
+        }
+    }
+
+    private var finishedSelectionBar: some View {
+        HStack(spacing: 8) {
+            Button(L10n.string(
+                selectedFinishedIDs.count == deletableFinishedSessions.count
+                    ? "Clear selection" : "Select all")) {
+                if selectedFinishedIDs.count == deletableFinishedSessions.count {
+                    selectedFinishedIDs.removeAll()
+                } else {
+                    selectedFinishedIDs = Set(deletableFinishedSessions.map(\.id))
+                }
+            }
+            .buttonStyle(.borderless)
+            .disabled(isDeletingFinished || deletableFinishedSessions.isEmpty)
+            .accessibilityIdentifier("finished-select-all-button")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+            .background {
+                if AppSettings.uiE2E != nil {
+                    UIE2EGeometryProbe(
+                        identifier: "finished-select-all-button",
+                        semanticLabel: selectedFinishedIDs.count
+                            == deletableFinishedSessions.count
+                            ? "Clear selection" : "Select all",
+                        semanticRole: .button,
+                        semanticEnabled: !isDeletingFinished
+                            && !deletableFinishedSessions.isEmpty)
+                }
+            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+
+            Spacer()
+
+            if isDeletingFinished {
+                ProgressView().controlSize(.small)
+            }
+            Button(role: .destructive) {
+                confirmFinishedDelete = true
+            } label: {
+                Label(
+                    L10n.format("Delete %d", selectedFinishedSessions.count),
+                    systemImage: "trash")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .disabled(isDeletingFinished || selectedFinishedSessions.isEmpty)
+            .accessibilityIdentifier("finished-delete-button")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+            .background {
+                if AppSettings.uiE2E != nil {
+                    UIE2EGeometryProbe(
+                        identifier: "finished-delete-button",
+                        semanticLabel: "Delete \(selectedFinishedSessions.count)",
+                        semanticRole: .button,
+                        semanticEnabled: !isDeletingFinished
+                            && !selectedFinishedSessions.isEmpty)
+                }
+            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func deleteSelectedFinishedSessions() {
+        let selected = selectedFinishedSessions
+        guard !selected.isEmpty else { return }
+        isDeletingFinished = true
+        Task { @MainActor in
+            let failures = await store.deleteFinished(selected)
+            selectedFinishedIDs = Set(failures.map(\.sessionName))
+            isDeletingFinished = false
+            if failures.isEmpty {
+                isSelectingFinished = false
+            } else {
+                finishedDeleteError = failures
+                    .map { "\($0.displayTitle): \($0.message)" }
+                    .joined(separator: "\n")
+            }
         }
     }
 

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -236,51 +236,6 @@ enum UIE2ETestDriver {
             checks.append("sidebar-selects-completed-session")
             trace("completed session selected")
 
-            let selectionMode = try await element(
-                identifier: "finished-selection-mode-button")
-            try requireSemanticControl(
-                selectionMode, name: "finished selection mode")
-            _ = try await clickUntilElement(
-                selectionMode,
-                name: "finished selection mode",
-                resultIdentifier: "finished-select-all-button")
-            let selectAll = try await element(identifier: "finished-select-all-button")
-            try requireSemanticControl(selectAll, name: "select all finished sessions")
-            try await click(selectAll, name: "select all finished sessions")
-            let bulkDeleteButton = try await element(identifier: "finished-delete-button")
-            try await waitUntil("enabled bulk delete button") {
-                find(identifier: "finished-delete-button")
-                    .map(isEnabled) == true
-            }
-            try requireSemanticControl(bulkDeleteButton, name: "bulk delete action")
-            let confirmDelete = try await clickUntilSheetButton(
-                bulkDeleteButton, name: "bulk delete action", label: "Delete")
-            try requireSemanticControl(confirmDelete, name: "delete confirmation")
-            try await clickUntil(
-                confirmDelete,
-                name: "delete confirmation",
-                outcome: "fake CLI records both delete actions") {
-                let actions = try? String(
-                    contentsOf: configuration.root
-                        .appendingPathComponent("fake/actions.log"),
-                    encoding: .utf8)
-                return actions?.contains(
-                    "claude delete --force \(completedID)") == true
-                    && actions?.contains(
-                        "codex delete --force detach-codex-ui-stopped") == true
-            }
-            checks.append("bulk-delete-reaches-fake-cli")
-            trace("bulk delete reached fake CLI")
-            let deleteObservedAt = Date()
-            try await waitUntil("post-delete session refresh") {
-                store.lastUpdated.map { $0 >= deleteObservedAt } == true
-            }
-            try await waitUntil("delete confirmation dismissal") {
-                NSApp.windows.allSatisfy(\.sheets.isEmpty)
-            }
-            try await activate(mainWindow)
-            try await Task.sleep(nanoseconds: 200_000_000)
-
             let runningID = "detach-codex-ui-running"
             let runningRow = try await element(
                 identifier: "session-row-\(runningID)")
@@ -337,6 +292,91 @@ enum UIE2ETestDriver {
             }
             checks.append("safe-action-reaches-fake-cli")
             trace("stop reached fake CLI")
+
+            let selectionMode = try await element(
+                identifier: "finished-selection-mode-button")
+            try requireSemanticControl(
+                selectionMode, name: "finished selection mode")
+            _ = try await clickUntilElement(
+                selectionMode,
+                name: "finished selection mode",
+                resultIdentifier: "finished-select-all-button")
+            let completedSelectionID = "finished-selection-\(completedID)"
+            var completedSelection = try await element(identifier: completedSelectionID)
+            try requireSemanticControl(
+                completedSelection, name: "completed session selection")
+            try await click(completedSelection, name: "select completed session")
+            try await waitUntil("selected completed session") {
+                find(identifier: completedSelectionID)
+                    .flatMap(label)?.hasPrefix("Deselect") == true
+            }
+            completedSelection = try await element(identifier: completedSelectionID)
+            try await click(completedSelection, name: "deselect completed session")
+            try await waitUntil("deselected completed session") {
+                find(identifier: completedSelectionID)
+                    .flatMap(label)?.hasPrefix("Select") == true
+            }
+
+            var selectAll = try await element(identifier: "finished-select-all-button")
+            try requireSemanticControl(selectAll, name: "select all finished sessions")
+            try await click(selectAll, name: "select all finished sessions")
+            try await waitUntil("all finished sessions selected") {
+                find(identifier: "finished-select-all-button")
+                    .flatMap(label) == "Clear selection"
+            }
+            selectAll = try await element(identifier: "finished-select-all-button")
+            try await click(selectAll, name: "clear finished selection")
+            try await waitUntil("finished selection cleared") {
+                find(identifier: "finished-select-all-button")
+                    .flatMap(label) == "Select all"
+            }
+
+            let done = try await element(identifier: "finished-selection-mode-button")
+            try await click(done, name: "leave finished selection mode")
+            try await waitUntil("finished selection mode closed") {
+                find(identifier: "finished-select-all-button") == nil
+            }
+            let selectAgain = try await element(
+                identifier: "finished-selection-mode-button")
+            _ = try await clickUntilElement(
+                selectAgain,
+                name: "reopen finished selection mode",
+                resultIdentifier: "finished-select-all-button")
+            selectAll = try await element(identifier: "finished-select-all-button")
+            try await click(selectAll, name: "select all finished sessions")
+            let bulkDeleteButton = try await element(identifier: "finished-delete-button")
+            try await waitUntil("enabled bulk delete button") {
+                find(identifier: "finished-delete-button")
+                    .map(isEnabled) == true
+            }
+            try requireSemanticControl(bulkDeleteButton, name: "bulk delete action")
+            let confirmDelete = try await clickUntilSheetButton(
+                bulkDeleteButton, name: "bulk delete action", label: "Delete")
+            try requireSemanticControl(confirmDelete, name: "delete confirmation")
+            try await clickUntil(
+                confirmDelete,
+                name: "delete confirmation",
+                outcome: "fake CLI records both delete actions") {
+                let actions = try? String(
+                    contentsOf: configuration.root
+                        .appendingPathComponent("fake/actions.log"),
+                    encoding: .utf8)
+                return actions?.contains(
+                    "claude delete --force \(completedID)") == true
+                    && actions?.contains(
+                        "codex delete --force detach-codex-ui-stopped") == true
+            }
+            checks.append("bulk-delete-reaches-fake-cli")
+            trace("bulk delete reached fake CLI")
+            let deleteObservedAt = Date()
+            try await waitUntil("post-delete session refresh") {
+                store.lastUpdated.map { $0 >= deleteObservedAt } == true
+            }
+            try await waitUntil("delete confirmation dismissal") {
+                NSApp.windows.allSatisfy(\.sheets.isEmpty)
+            }
+            try await activate(mainWindow)
+            try await Task.sleep(nanoseconds: 200_000_000)
 
             let newSession = try await element(identifier: "new-session-button")
             try requireSemanticControl(newSession, name: "new session action")

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -236,22 +236,41 @@ enum UIE2ETestDriver {
             checks.append("sidebar-selects-completed-session")
             trace("completed session selected")
 
+            let selectionMode = try await element(
+                identifier: "finished-selection-mode-button")
+            try requireSemanticControl(
+                selectionMode, name: "finished selection mode")
+            _ = try await clickUntilElement(
+                selectionMode,
+                name: "finished selection mode",
+                resultIdentifier: "finished-select-all-button")
+            let selectAll = try await element(identifier: "finished-select-all-button")
+            try requireSemanticControl(selectAll, name: "select all finished sessions")
+            try await click(selectAll, name: "select all finished sessions")
+            let bulkDeleteButton = try await element(identifier: "finished-delete-button")
+            try await waitUntil("enabled bulk delete button") {
+                find(identifier: "finished-delete-button")
+                    .map(isEnabled) == true
+            }
+            try requireSemanticControl(bulkDeleteButton, name: "bulk delete action")
             let confirmDelete = try await clickUntilSheetButton(
-                deleteButton, name: "delete action", label: "Delete")
+                bulkDeleteButton, name: "bulk delete action", label: "Delete")
             try requireSemanticControl(confirmDelete, name: "delete confirmation")
             try await clickUntil(
                 confirmDelete,
                 name: "delete confirmation",
-                outcome: "fake CLI records delete action") {
+                outcome: "fake CLI records both delete actions") {
                 let actions = try? String(
                     contentsOf: configuration.root
                         .appendingPathComponent("fake/actions.log"),
                     encoding: .utf8)
                 return actions?.contains(
                     "claude delete --force \(completedID)") == true
+                    && actions?.contains(
+                        "codex delete --force detach-codex-ui-stopped") == true
             }
-            checks.append("safe-delete-reaches-fake-cli")
-            trace("delete reached fake CLI")
+            checks.append("bulk-delete-reaches-fake-cli")
+            trace("bulk delete reached fake CLI")
             let deleteObservedAt = Date()
             try await waitUntil("post-delete session refresh") {
                 store.lastUpdated.map { $0 >= deleteObservedAt } == true

--- a/app/Sources/DetachKit/SessionPresentation.swift
+++ b/app/Sources/DetachKit/SessionPresentation.swift
@@ -21,6 +21,13 @@ public enum SessionAction: String, Codable, CaseIterable, Sendable {
 }
 
 public extension Session {
+    /// Finished-list bulk actions stay behind the same typed Delete permission
+    /// as the detail view. A terminal-looking row without that permission is
+    /// never selectable for removal.
+    var canDeleteFromFinishedList: Bool {
+        section == .finished && availableActions.contains(.delete)
+    }
+
     var isWaitingForUser: Bool {
         effectiveStatus == .running && agentTurnState == .waiting
     }

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -15,6 +15,11 @@ public struct SessionDeletionFailure: Equatable, Sendable {
 
 @Observable @MainActor
 public final class SessionStore {
+    private enum Mutation {
+        case stop
+        case delete
+    }
+
     public enum State: Equatable, Sendable {
         case ok
         case cliMissing
@@ -127,7 +132,8 @@ public final class SessionStore {
                 "Internal error: %@ must run in Terminal",
                 action.rawValue)
         }
-        let result = await run(action, on: session)
+        let mutation: Mutation = action == .stop ? .stop : .delete
+        let result = await run(mutation, on: session)
         if result.launched { await refresh() }
         return result.message
     }
@@ -162,19 +168,15 @@ public final class SessionStore {
     }
 
     private func run(
-        _ action: SessionAction,
+        _ mutation: Mutation,
         on session: Session
     ) async -> (message: String?, launched: Bool) {
         let arguments: [String]
-        switch action {
+        switch mutation {
         case .stop:
             arguments = [session.provider.rawValue, "stop", session.sessionName]
         case .delete:
             arguments = [session.provider.rawValue, "delete", "--force", session.sessionName]
-        case .attach, .resume, .recover:
-            return (L10n.format(
-                "Internal error: %@ must run in Terminal",
-                action.rawValue), false)
         }
         do {
             let result = try await cli.run(arguments: arguments, timeout: 30)

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -1,6 +1,18 @@
 import Foundation
 import Observation
 
+public struct SessionDeletionFailure: Equatable, Sendable {
+    public var sessionName: String
+    public var displayTitle: String
+    public var message: String
+
+    public init(sessionName: String, displayTitle: String, message: String) {
+        self.sessionName = sessionName
+        self.displayTitle = displayTitle
+        self.message = message
+    }
+}
+
 @Observable @MainActor
 public final class SessionStore {
     public enum State: Equatable, Sendable {
@@ -110,6 +122,49 @@ public final class SessionStore {
 
     /// Runs a non-interactive action (stop/delete). Returns an error message or nil.
     public func perform(_ action: SessionAction, on session: Session) async -> String? {
+        guard action == .stop || action == .delete else {
+            return L10n.format(
+                "Internal error: %@ must run in Terminal",
+                action.rawValue)
+        }
+        let result = await run(action, on: session)
+        if result.launched { await refresh() }
+        return result.message
+    }
+
+    /// Deletes every selected finished session and reports failures without
+    /// stopping the remaining operations. One final refresh publishes the
+    /// resulting list instead of polling between individual removals.
+    public func deleteFinished(
+        _ selectedSessions: [Session]
+    ) async -> [SessionDeletionFailure] {
+        var failures: [SessionDeletionFailure] = []
+        var seen: Set<String> = []
+        for session in selectedSessions where seen.insert(session.id).inserted {
+            guard let current = sessions.first(where: { $0.id == session.id }),
+                  current.canDeleteFromFinishedList else {
+                failures.append(SessionDeletionFailure(
+                    sessionName: session.sessionName,
+                    displayTitle: session.displayTitle,
+                    message: L10n.string(
+                        "Session is not eligible for deletion from Finished.")))
+                continue
+            }
+            if let message = await run(.delete, on: current).message {
+                failures.append(SessionDeletionFailure(
+                    sessionName: current.sessionName,
+                    displayTitle: current.displayTitle,
+                    message: message))
+            }
+        }
+        await refresh()
+        return failures
+    }
+
+    private func run(
+        _ action: SessionAction,
+        on session: Session
+    ) async -> (message: String?, launched: Bool) {
         let arguments: [String]
         switch action {
         case .stop:
@@ -117,20 +172,21 @@ public final class SessionStore {
         case .delete:
             arguments = [session.provider.rawValue, "delete", "--force", session.sessionName]
         case .attach, .resume, .recover:
-            return L10n.format(
+            return (L10n.format(
                 "Internal error: %@ must run in Terminal",
-                action.rawValue)
+                action.rawValue), false)
         }
         do {
             let result = try await cli.run(arguments: arguments, timeout: 30)
-            await refresh()
-            if result.exitCode == 0 { return nil }
+            if result.exitCode == 0 { return (nil, true) }
             let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            return stderr.isEmpty
+            return (stderr.isEmpty
                 ? L10n.format("detach exited with status %d", result.exitCode)
-                : stderr
+                : stderr, true)
         } catch {
-            return L10n.format("Could not run detach: %@", error.localizedDescription)
+            return (L10n.format(
+                "Could not run detach: %@",
+                error.localizedDescription), false)
         }
     }
 }

--- a/app/Tests/DetachAppTests/SidebarViewTests.swift
+++ b/app/Tests/DetachAppTests/SidebarViewTests.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import XCTest
+import DetachKit
+@testable import DetachApp
+
+private struct SidebarNoopCLI: DetachCLIRunning {
+    func run(
+        arguments: [String],
+        timeout: TimeInterval
+    ) async throws -> CLIResult {
+        CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
+    }
+}
+
+@MainActor
+final class SidebarViewTests: XCTestCase {
+    func testBuildsWithFreshFinishedSelectionState() {
+        let view = SidebarView(
+            store: SessionStore(cli: SidebarNoopCLI()),
+            detachPath: "/tmp/detach",
+            selectedID: .constant(nil),
+            navigation: MainNavigation())
+
+        _ = view.body
+    }
+
+    func testFormatsEveryFinishedDeletionFailure() {
+        let failures = [
+            SessionDeletionFailure(
+                sessionName: "first",
+                displayTitle: "First task",
+                message: "still busy"),
+            SessionDeletionFailure(
+                sessionName: "second",
+                displayTitle: "Second task",
+                message: "permission denied"),
+        ]
+
+        XCTAssertEqual(
+            FinishedDeletionPresentation.errorMessage(for: failures),
+            "First task: still busy\nSecond task: permission denied")
+    }
+}

--- a/app/Tests/DetachKitTests/SessionPresentationTests.swift
+++ b/app/Tests/DetachKitTests/SessionPresentationTests.swift
@@ -79,6 +79,19 @@ final class SessionPresentationTests: XCTestCase {
         XCTAssertEqual(make(.collision).availableActions, [])
     }
 
+    func testFinishedBulkDeleteUsesTypedDeletePermission() {
+        XCTAssertTrue(make(.completed).canDeleteFromFinishedList)
+        XCTAssertTrue(make(.failed).canDeleteFromFinishedList)
+        XCTAssertTrue(make(.interrupted).canDeleteFromFinishedList)
+        XCTAssertTrue(make(.stopped).canDeleteFromFinishedList)
+        XCTAssertFalse(make(.running).canDeleteFromFinishedList)
+        XCTAssertFalse(make(.recoverable).canDeleteFromFinishedList)
+
+        var blocked = make(.completed)
+        blocked.healthActions = []
+        XCTAssertFalse(blocked.canDeleteFromFinishedList)
+    }
+
     func testTypedHealthActionsOverrideLegacyStatusHeuristics() throws {
         let line = #"{"schema":1,"provider":"codex","session_name":"detach-codex-orphan","name":"orphan","effective_status":"hung","health_reason":"runtime_process_without_tmux","health_actions":[],"reconcile_action":"none","ownership_proven":false,"cleanup_eligible":false}"#
         let session = try XCTUnwrap(SessionListParser.parse(line).sessions.first)

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -201,6 +201,56 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertTrue(cli.calls.contains(["codex", "delete", "--force", "detach-codex-p-1"]))
     }
 
+    func testBulkFinishedDeleteContinuesAfterFailureAndRefreshesOnce() async throws {
+        let cli = FakeCLI()
+        let firstLine = line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"completed""#)
+        let secondLine = firstLine
+            .replacingOccurrences(of: "codex", with: "claude")
+            .replacingOccurrences(of: "detach-claude-p-1", with: "detach-claude-p-2")
+            .replacingOccurrences(of: #""name":"p-1""#, with: #""name":"p-2""#)
+        cli.responses["list --json"] = ok(firstLine + "\n" + secondLine)
+        cli.responses["claude delete --force detach-claude-p-2"] = .success(CLIResult(
+            exitCode: 17, stdout: "", stderr: "still busy", timedOut: false))
+        let store = SessionStore(cli: cli)
+        await store.refresh()
+
+        let failures = await store.deleteFinished(
+            store.sessions + [try XCTUnwrap(store.sessions.first)])
+
+        XCTAssertEqual(failures, [SessionDeletionFailure(
+            sessionName: "detach-claude-p-2",
+            displayTitle: "p",
+            message: "still busy")])
+        XCTAssertEqual(
+            cli.calls.filter { $0 == ["codex", "delete", "--force", "detach-codex-p-1"] }.count,
+            1)
+        XCTAssertEqual(
+            cli.calls.filter { $0 == ["claude", "delete", "--force", "detach-claude-p-2"] }.count,
+            1)
+        XCTAssertEqual(cli.calls.filter { $0 == ["list", "--json"] }.count, 2)
+    }
+
+    func testBulkFinishedDeleteRechecksCurrentTypedPermission() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line)
+        let store = SessionStore(cli: cli)
+        await store.refresh()
+        var staleFinishedSelection = store.sessions[0]
+        staleFinishedSelection.effectiveStatus = .completed
+
+        let failures = await store.deleteFinished([staleFinishedSelection])
+
+        XCTAssertEqual(failures.count, 1)
+        XCTAssertEqual(
+            failures.first?.message,
+            L10n.string("Session is not eligible for deletion from Finished."))
+        XCTAssertFalse(cli.calls.contains {
+            $0.contains("delete")
+        })
+    }
+
     func testFailedMutationReturnsStderr() async {
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line)

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -804,6 +804,24 @@ session_color_from_state_dir() {
   return 1
 }
 
+session_state_dir_reserves_color() {
+  local dir="$1"
+  local meta
+  local status
+
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+  for meta in "$dir/meta.json" "$dir/checkpoint/meta.json"; do
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    status="$("$STATE_BIN" meta get "$meta" status 2>/dev/null || true)"
+    case "$status" in
+      completed|failed|interrupted|stopped|start_failed) return 1 ;;
+      *) return 0 ;;
+    esac
+  done
+  # Unknown saved state remains conservative and keeps its hue occupied.
+  return 0
+}
+
 session_color_is_in_palette() {
   local wanted
   local color
@@ -828,6 +846,7 @@ session_color_used_by_other_session() {
     for dir in "$sessions_root"/*; do
       [ -d "$dir" ] && [ ! -L "$dir" ] || continue
       [ "$dir" = "$excluded_dir" ] && continue
+      session_state_dir_reserves_color "$dir" || continue
       color="$(session_color_from_state_dir "$dir" 2>/dev/null || true)"
       [ "$color" = "$wanted" ] && return 0
     done
@@ -882,8 +901,9 @@ allocate_session_color() {
   fi
 
   # Keep the path-derived hue as the first choice, then walk the palette in a
-  # stable order. The install lock serializes every Start/Resume/Recover, so a
-  # simultaneously starting session cannot claim the same free color.
+  # stable order. Finished history does not reserve a hue. The install lock
+  # serializes every Start/Resume/Recover, so current tasks cannot claim the
+  # same free color.
   for ((offset = 0; offset < ${#SESSION_COLOR_PALETTE[@]}; offset++)); do
     index=$(((preferred_index + offset) % ${#SESSION_COLOR_PALETTE[@]}))
     candidate="${SESSION_COLOR_PALETTE[$index]}"

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -87,10 +87,13 @@ Settings → General owns both menu bar toggles. Settings → System keeps the o
 Mac Power status and approval controls. Temperature safety has its own warning
 shape and the text **Mac can sleep: temperature**.
 
-The dashboard keeps identity, status, and Mac Power separate. A thin capsule
-carries identity; a filled circle carries status. The preview uses the tmux
-blend, not the raw hue. Power words use a neutral surface and semantic color.
-Sidebar and detail share one status-color function.
+The dashboard keeps identity, status, and Mac Power separate. Identity uses a
+thin capsule and the tmux blend. Status uses a filled circle through one shared
+sidebar/detail color function. Power words use a neutral surface and semantic
+color.
+
+**Finished** bulk Delete selects only rows with typed Delete, asks once,
+continues after failures, and does not remove provider transcripts.
 
 Every app CLI invocation runs in a fresh process group with concurrent bounded
 stdout/stderr draining. Its deadline sends TERM and then KILL to the complete

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -161,15 +161,14 @@ a dense blend of the session identity color behind light plain-text labels,
 plus a solid painted-space left edge (no font-dependent partial blocks), and
 puts the power label and clock in `status-right`. Finished sessions keep a
 faint tint of the same hue; failures tint the strip with the reserved red. The
-eight-hue identity palette deliberately omits pure red. Color allocation scans
-saved Codex and Claude sessions while Start/Resume/Recover holds the shared
-install lock: keep an existing unique session color, otherwise walk from the
-stable provider/project-derived preference to the first free hue, and permit a
-duplicate only when all eight hues are occupied. This preserves identity
-without avoidable collisions across providers. Every derived surface comes
-from the single `blend_session_color` formula rather than per-color pairs. The
-style snapshot saves and restores `status-right` and its
-length alongside the left side; a snapshot from an older Detach that never
+eight-hue identity palette omits pure red. Allocation scans both providers
+under the Start/Resume/Recover install lock. Known terminal history keeps its
+shown identity but does not reserve a hue; unknown state stays conservative.
+Keep an existing hue when unique among current state. Otherwise, walk from the
+stable provider/project preference to the first free hue, and duplicate only
+when all eight are occupied. The single `blend_session_color` formula makes
+every derived surface. The style snapshot saves and restores `status-right`
+and its length alongside the left side; a snapshot from an older Detach that never
 captured the right side must not clear the user's `status-right`. The text
 Plain text is the primary power signal: `MAC AWAKE`, `MAC CAN SLEEP`, `LOW
 BATTERY`, `MAC CAN SLEEP: TEMPERATURE`, `POWER UNAVAILABLE`, or a transition;

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -245,9 +245,10 @@
       "scenarios": [
         "SC-UI-DASHBOARD",
         "SC-UI-SESSION-DETAIL",
+        "SC-UI-SESSION-DELETE",
         "SC-UI-FAILURE"
       ],
-      "summary": "Packaged journeys cover sidebar control geometry and failure status."
+      "summary": "Packaged journeys cover sidebar control geometry, bulk Delete, and failure status."
     }
   ],
   "critical_sources": [
@@ -402,7 +403,7 @@
         "SC-SESSION-DELETE-CLAUDE",
         "SC-UI-SESSION-DELETE"
       ],
-      "summary": "A user deletes one completed session without affecting another session."
+      "summary": "A user deletes selected eligible sessions without affecting current work."
     },
     {
       "capability": "power-protection",
@@ -658,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 42,
+  "policy": 43,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	42
+policy	43
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -70,7 +70,7 @@ coverage-region	ui	app/Sources/DetachApp/OnboardingView.swift	ui-e2e-instrumenta
 coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged journeys cover the test-only semantic bridge and route.
 coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE	The packaged journey covers action geometry and its negative control.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	ui-e2e-instrumentation	SC-UI-SETTINGS	The packaged Settings journey covers its semantic control.
-coverage-region	ui	app/Sources/DetachApp/SidebarView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-FAILURE	Packaged journeys cover sidebar control geometry and failure status.
+coverage-region	ui	app/Sources/DetachApp/SidebarView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-FAILURE	Packaged journeys cover sidebar control geometry, bulk Delete, and failure status.
 route	1000	quality/*	policy	safe	docs/specs/documentation.md
 route	1000	.github/workflows/quality-gates.yml	policy	safe	docs/specs/documentation.md
 route	1000	.github/workflows/security.yml	policy	safe	docs/specs/documentation.md
@@ -238,7 +238,7 @@ journey	J-SESSION-CREATE	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP
 journey	J-SESSION-PERSIST	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-STORAGE	SC-SESSION-PERSIST-CODEX,SC-SESSION-PERSIST-CLAUDE	A live session remains available after the app exits.
 journey	J-SESSION-RECOVER	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	SC-SESSION-RECOVER-CODEX,SC-SESSION-RECOVER-CLAUDE	A user recovers the exact owned session after interruption.
 journey	J-SESSION-STOP	session-lifecycle	QC-RUNTIME-OWNERSHIP	SC-SESSION-STOP-CODEX,SC-SESSION-STOP-CLAUDE,SC-UI-SESSION-STOP	A user stops only the selected owned session.
-journey	J-SESSION-DELETE	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE,SC-UI-SESSION-DELETE	A user deletes one completed session without affecting another session.
+journey	J-SESSION-DELETE	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE,SC-UI-SESSION-DELETE	A user deletes selected eligible sessions without affecting current work.
 journey	J-POWER-ENABLE	power-protection	QC-POWER-ASSERTION,QC-POWER-LEASE,QC-POWER-CLI,QC-POWER-PLATFORM	SC-POWER-UNIT	A protected session acquires both required power protections.
 journey	J-POWER-LOW-BATTERY	power-protection	QC-POWER-PROTECTION	SC-POWER-LOW-BATTERY	Low battery removes unsafe protection and reports the reason.
 journey	J-POWER-HELPER-LEASE	power-protection	QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC	SC-POWER-HELPER	The helper accepts only an authorized bounded lease.

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -28,7 +28,8 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   fi
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["stop"]}' \
-    '{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"session_color":"#A855F7","power_protection_state":"allowed","health_actions":["delete"]}'
+    '{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"session_color":"#A855F7","power_protection_state":"allowed","health_actions":["delete"]}' \
+    '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-stopped","name":"UI Stopped","effective_status":"stopped","created_at":"2026-07-22T06:00:00Z","finished_at":"2026-07-22T06:30:00Z","exit_status":143,"session_color":"#1D4ED8","power_protection_state":"allowed","health_actions":["delete"]}'
   exit 0
 fi
 
@@ -62,6 +63,12 @@ fi
 
 if [ "$#" -eq 4 ] && [ "$1" = claude ] && [ "$2" = delete ] \
     && [ "$3" = --force ] && [ "$4" = detach-claude-ui-completed ]; then
+  printf '%s\n' "$*" >>"$ACTIONS"
+  exit 0
+fi
+
+if [ "$#" -eq 4 ] && [ "$1" = codex ] && [ "$2" = delete ] \
+    && [ "$3" = --force ] && [ "$4" = detach-codex-ui-stopped ]; then
   printf '%s\n' "$*" >>"$ACTIONS"
   exit 0
 fi

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -266,6 +266,27 @@ done
 [ "$("$SCRIPT" claude __allocate_session_color "$color_cwd")" = "$preferred_color" ]
 rm -rf "$codex_color_sessions" "$claude_color_sessions"
 
+# A full finished history must not exhaust colors for current tasks. Allocation
+# remains shared across providers, so simultaneous Codex and Claude tasks get
+# different hues even when all eight colors occur in retained history.
+color_index=0
+for color in "${palette[@]}"; do
+  color_dir="$codex_color_sessions/finished-$color_index"
+  mkdir -p "$color_dir"
+  "$STATE_HELPER" meta create "$color_dir/meta.json" \
+    --integer schema 1 --string session_name "finished-$color_index" \
+    --string status completed --string session_color "$color"
+  color_index=$((color_index + 1))
+done
+current_claude_color="$("$SCRIPT" claude __allocate_session_color "$color_cwd")"
+mkdir -p "$claude_color_sessions/current-claude"
+"$STATE_HELPER" meta create "$claude_color_sessions/current-claude/meta.json" \
+  --integer schema 1 --string session_name current-claude --string status running \
+  --string session_color "$current_claude_color"
+current_codex_color="$("$SCRIPT" codex __allocate_session_color "$color_cwd")"
+[ "$current_codex_color" != "$current_claude_color" ]
+rm -rf "$codex_color_sessions" "$claude_color_sessions"
+
 human_label='Rev (ai)'
 human_digest="$(printf '%s' "$human_label" | shasum -a 256 | \
   awk '{print substr($1, 1, 12)}')"

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -323,10 +323,10 @@ run_app_scenario main sessions 20 \
   background-app-starts-without-focus \
   dashboard-accessible \
   sidebar-selects-completed-session \
-  bulk-delete-reaches-fake-cli \
   session-signals-stay-distinct \
   disconnected-stop-blocks-action \
   safe-action-reaches-fake-cli \
+  bulk-delete-reaches-fake-cli \
   new-session-sheet-semantics \
   empty-dashboard-state \
   installed-app-focus-restored

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -18,6 +18,7 @@ approved_invocation() {
     'claude logs --ansi detach-claude-ui-completed'|\
     'codex stop detach-codex-ui-running'|\
     'claude delete --force detach-claude-ui-completed'|\
+    'codex delete --force detach-codex-ui-stopped'|\
     'storage --json'|\
     'config tmux-style'|\
     'config tmux-extended-keys') return 0 ;;
@@ -297,7 +298,7 @@ run_app_scenario() {
       background-app-starts-without-focus|disconnected-stop-blocks-action) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
-      safe-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
+      bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
       session-signals-stay-distinct) pass=SC-UI-SESSION-DETAIL ;;
       safe-action-reaches-fake-cli) pass=SC-UI-SESSION-STOP ;;
       new-session-sheet-semantics) pass=SC-UI-NEW-SESSION ;;
@@ -322,7 +323,7 @@ run_app_scenario main sessions 20 \
   background-app-starts-without-focus \
   dashboard-accessible \
   sidebar-selects-completed-session \
-  safe-delete-reaches-fake-cli \
+  bulk-delete-reaches-fake-cli \
   session-signals-stay-distinct \
   disconnected-stop-blocks-action \
   safe-action-reaches-fake-cli \


### PR DESCRIPTION
## Contract delta

- Add a Finished selection mode with per-row checkboxes, Select all, and one separate destructive Delete button.
- Recheck typed Delete eligibility before each operation, continue after individual failures, refresh once, and keep failed rows selected with their errors.
- Keep provider transcripts untouched and retain the existing per-session ownership/liveness checks.
- Stop completed/failed/interrupted/stopped history from reserving identity palette slots, so current Codex and Claude tasks avoid history-driven color collisions. Unknown state remains conservative.
- Synchronize English/Russian UI text, README, app/runtime specs, and the Delete journey policy.

## Evidence

- `swift test --filter 'Session(Store|Presentation)Tests'`: 33 passed.\n- Claude/runtime integration: passed, including a full finished palette plus distinct current Codex/Claude allocation.\n- Fresh packaged-app UI smoke: passed; it selected two Finished rows, confirmed once, and observed both exact provider Delete commands.\n- Documentation contract, policy generation check, shell syntax checks, final static diagnostic, and `git diff --check`: passed.\n- The full impact-selected local diagnostic passed every functional stage. Its aggregate reference-machine wall check was 212s versus 180s; all individual stages were within their budgets. Hosted pull-request CI is the readiness authority and does not enforce that local wall ceiling.\n\n## Safety\n\nBulk UI actions call the existing provider-specific forced Delete command. Runtime operation/checkpoint locks and final ownership/liveness checks remain authoritative. No provider transcript, credential, signing, power, release, or publication path changes.