### PR TITLE
Inset finished selection control

### DIFF
--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -167,8 +167,18 @@ struct SidebarView: View {
                 }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
+                .padding(.trailing, 12)
             }
         }
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+        .background {
+            if AppSettings.uiE2E != nil && section == .finished {
+                UIE2EGeometryProbe(identifier: "finished-section-header")
+            }
+        }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
     }
 
     @ViewBuilder

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -297,6 +297,17 @@ enum UIE2ETestDriver {
                 identifier: "finished-selection-mode-button")
             try requireSemanticControl(
                 selectionMode, name: "finished selection mode")
+            let selectionModeFrame = try await measuredFrame(
+                identifier: "finished-selection-mode-button",
+                name: "finished selection mode")
+            let finishedHeaderFrame = try await measuredFrame(
+                identifier: "finished-section-header",
+                name: "finished section header")
+            guard finishedHeaderFrame.maxX - selectionModeFrame.maxX >= 10 else {
+                throw Failure(
+                    message: "finished selection mode has no trailing scroll clearance")
+            }
+            checks.append("finished-selection-clears-scrollbar")
             _ = try await clickUntilElement(
                 selectionMode,
                 name: "finished selection mode",

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -92,8 +92,8 @@ thin capsule and the tmux blend. Status uses a filled circle through one shared
 sidebar/detail color function. Power words use a neutral surface and semantic
 color.
 
-**Finished** bulk Delete selects only rows with typed Delete, asks once,
-continues after failures, and does not remove provider transcripts.
+**Finished** bulk Delete uses typed Delete, asks once, tolerates failures, and
+keeps provider transcripts. Select/Done has 12-point scroll clearance.
 
 Every app CLI invocation runs in a fresh process group with concurrent bounded
 stdout/stderr draining. Its deadline sends TERM and then KILL to the complete

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -295,7 +295,8 @@ run_app_scenario() {
       exit 1
     }
     case "$check" in
-      background-app-starts-without-focus|disconnected-stop-blocks-action) ;;
+      background-app-starts-without-focus|disconnected-stop-blocks-action|\
+      finished-selection-clears-scrollbar) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -326,6 +327,7 @@ run_app_scenario main sessions 20 \
   session-signals-stay-distinct \
   disconnected-stop-blocks-action \
   safe-action-reaches-fake-cli \
+  finished-selection-clears-scrollbar \
   bulk-delete-reaches-fake-cli \
   new-session-sheet-semantics \
   empty-dashboard-state \


### PR DESCRIPTION
## Contract delta

- Keep Select / Done 12 points from the trailing Finished header edge so the overlay scroll bar cannot cover it.
- Measure that clearance in the packaged-app UI smoke.
- Record the UI contract in docs/specs/app.md.

## Evidence

- swift test --filter SidebarViewTests: PASS (2 tests)
- tests/docs-contract.sh: PASS
- scripts/quality-gate --stage app: PASS
- Packaged UI smoke measured 12-point clearance and passed finished-selection-clears-scrollbar. The later existing bulk Delete confirmation interaction did not open in the local diagnostic, so local readiness is incomplete. Hosted quality-gates remains readiness authority.
- git diff --check: PASS