### PR TITLE
Stabilize bulk delete UI check

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -355,11 +355,12 @@ enum UIE2ETestDriver {
                 resultIdentifier: "finished-select-all-button")
             selectAll = try await element(identifier: "finished-select-all-button")
             try await click(selectAll, name: "select all finished sessions")
-            let bulkDeleteButton = try await element(identifier: "finished-delete-button")
+            var bulkDeleteButton = try await element(identifier: "finished-delete-button")
             try await waitUntil("enabled bulk delete button") {
                 find(identifier: "finished-delete-button")
                     .map(isEnabled) == true
             }
+            bulkDeleteButton = try await element(identifier: "finished-delete-button")
             try requireSemanticControl(bulkDeleteButton, name: "bulk delete action")
             let confirmDelete = try await clickUntilSheetButton(
                 bulkDeleteButton, name: "bulk delete action", label: "Delete")


### PR DESCRIPTION
Contract delta: no user-visible behavior changes. The packaged-app UI driver reacquires the enabled bulk Delete accessibility control after SwiftUI updates the selection bar, so it does not click a stale element.

Evidence:
- swift test --filter UIE2EEventWindowResolverTests
- tests/ui-e2e.sh
- git diff --check

This fixes the local pre-release blocker for v0.2.21. Hosted quality-gates remains readiness authority.