### PR TITLE
Make quality gates impact-aware and faster

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DETACH_QUALITY_AUTHORITY: ci-merge
-        run: scripts/quality-gate --mode repository --base "$BASE_SHA" --keep-going --without-release-budget
+        run: scripts/quality-gate --mode impact --base "$BASE_SHA" --keep-going --without-release-budget
       - name: Run main repository gate
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.promoted-main.outputs.promoted != 'true')
         env:
@@ -132,6 +132,13 @@ jobs:
         with:
           name: quality-gate-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: app/build/quality-gates
+      - id: metrics-baseline
+        name: Restore latest measured quality baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          root="$(scripts/quality-baseline)"
+          printf 'root=%s\n' "$root" >>"$GITHUB_OUTPUT"
       - id: mutation-evidence
         name: Restore latest mutation score when available
         env:
@@ -171,6 +178,7 @@ jobs:
             --result-root app/build/quality-gates \
             --output app/build/quality-dashboard \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --metrics-baseline "${{ steps.metrics-baseline.outputs.root }}" \
             "${mutation_args[@]}" \
             "${care_args[@]}" \
             "${security_args[@]}"

--- a/app/scripts/make-app.sh
+++ b/app/scripts/make-app.sh
@@ -15,6 +15,7 @@ SPARKLE_PUBLIC_ED_KEY="${DETACH_SPARKLE_PUBLIC_ED_KEY:-}"
 DOWNLOAD_URL="${DETACH_DOWNLOAD_URL:-}"
 SPARKLE_LICENSE_SOURCE="$APP_ROOT/Resources/ThirdParty/Sparkle/LICENSE.txt"
 SPARKLE_LICENSE_SHA256="389a4e4e9a32f059775b13a06e25a591445ba229d2838d26dd3e7c0c45127cfe"
+SWIFT_BUILD_JOBS="${DETACH_SWIFT_BUILD_JOBS:-}"
 APP="$APP_ROOT/build/Detach.app"
 PAYLOAD="$APP/Contents/Resources/DetachCLI"
 LAUNCH_AGENTS="$APP/Contents/Library/LaunchAgents"
@@ -67,6 +68,10 @@ trap cleanup EXIT
   printf 'DETACH_RELEASE_BUILD must be 0 or 1\n' >&2
   exit 1
 }
+if [ -n "$SWIFT_BUILD_JOBS" ] && ! [[ "$SWIFT_BUILD_JOBS" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'DETACH_SWIFT_BUILD_JOBS must be a positive integer\n' >&2
+  exit 1
+fi
 if [ -n "$SPARKLE_FEED_URL" ] || [ -n "$SPARKLE_PUBLIC_ED_KEY" ]; then
   [[ "$SPARKLE_FEED_URL" =~ ^https://[^[:space:]]+$ ]] || {
     printf 'DETACH_SPARKLE_FEED_URL must be a valid HTTPS URL\n' >&2
@@ -212,12 +217,19 @@ build_arch() {
   # binary artifact.
   local scratch="$APP_ROOT/.build"
   local triple="$arch-apple-macosx26.0"
-  swift build --disable-sandbox --disable-automatic-resolution \
-    --package-path "$APP_ROOT" -c release --triple "$triple" \
+  local build_args=(
+    --disable-sandbox
+    --disable-automatic-resolution
+    --package-path "$APP_ROOT"
+    -c release
+    --triple "$triple"
     --scratch-path "$scratch"
-  BUILT_BIN_PATH="$(swift build --disable-sandbox --disable-automatic-resolution \
-    --package-path "$APP_ROOT" -c release --triple "$triple" \
-    --scratch-path "$scratch" --show-bin-path)"
+  )
+  if [ -n "$SWIFT_BUILD_JOBS" ]; then
+    build_args+=(--jobs "$SWIFT_BUILD_JOBS")
+  fi
+  swift build "${build_args[@]}"
+  BUILT_BIN_PATH="$(swift build "${build_args[@]}" --show-bin-path)"
   BUILT_SPARKLE_FRAMEWORK="$(find_sparkle_framework "$scratch" "$BUILT_BIN_PATH")"
 }
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -8,8 +8,9 @@ generates `quality/generated/policy.json` and
 state. Git stores its history. Generated data must match the source.
 
 `scripts/quality-gate` applies the policy. Local runs are diagnostics. Hosted
-pull request CI runs every functional stage on the current merge commit and is
-the only ordinary merge authority. Unknown paths select the full plan.
+pull request CI runs the exact policy-selected impact plan on the current merge
+commit and is the only ordinary merge authority. Unknown paths and changes to
+the core planner, policy, or quality workflow select the full plan.
 For a normal local change, `gate-contract` runs direct self-contracts only.
 `--mode repository` runs the full orchestrator shards. An explicit local
 `--stage gate-contract` also runs all shards for diagnosis.
@@ -24,10 +25,17 @@ For a normal local change, `gate-contract` runs direct self-contracts only.
   resolved merge base.
 - `scripts/quality-gate --mode repository` runs every automated repository
   check. A local run remains diagnostic.
-- `scripts/quality-gate --mode release` runs the complete pre-release plan. It
-  omits only the recursive `scripts/release-version` test.
+- `scripts/quality-gate --mode impact --base <ref>` runs the committed
+  dependency-closed impact plan. Hosted merge authority requires this mode, a
+  clean checkout, and the tested merge first parent as `<ref>`.
+- `scripts/quality-gate --mode release --base <tag>` runs the release stages
+  selected by the accumulated diff from `<tag>`. It omits the recursive
+  `scripts/release-version` test. Release mode without a base fails safe to the
+  complete release plan.
 - `scripts/quality-gate --resume <run-dir>` reuses compatible passed stages.
   `--resume latest` selects the newest compatible local run.
+  `--resume auto` starts fresh when no compatible run exists. Releases use
+  this mode so an interrupted attempt does not repeat passed stages.
 - `scripts/quality-gate --stage <name>` reruns one diagnostic stage. It is not
   readiness evidence.
 - `scripts/quality-scenarios rerun SC-ID` runs the owning diagnostic stage for
@@ -129,23 +137,27 @@ SLO is less than ten minutes.
 
 Static validation runs before the parallel self-contract workers. This keeps
 its two-second local signal free of scheduler contention. Coverage compilation
-and the app build then get exclusive SwiftPM access. The app stage verifies the
-normal bundle before it builds a coverage-enabled release executable for the
-private UI copy. The short packaged UI lane runs after the verified app and
-before the CPU-intensive
-provider, runtime, and gate-contract lanes. This prevents WindowServer event
-delivery from competing with those workers. Provider lanes then run in
-parallel. After they drain, the runtime and gate-contract lanes run in
-parallel. This admits at most two process-heavy top-level lanes. Independent
-distribution and release lanes overlap after both groups drain.
+and the app build then get exclusive SwiftPM access. The app stage uses
+isolated build paths and splits the available workers to build the normal
+bundle and coverage-enabled release executable at the same time. It verifies
+the normal bundle. Only the private UI copy gets the instrumented executable.
+The short packaged UI lane runs after the verified app and before the
+CPU-intensive provider, runtime, and gate-contract lanes. This prevents
+WindowServer event delivery from competing with those workers. After the UI and metric phases,
+the scheduler starts ready process-heavy stages in descending policy timing
+order. It admits at most two process-heavy top-level lanes. One separate lane
+runs short runtime and release preflights during gate-contract. Distribution
+uses that lane only after gate-contract ends. A free slot starts the next ready
+stage without a fixed wave barrier.
 
 Quality analysis runs after the UI lane. It merges the completed Swift profile
 with all passed packaged-app profiles. It reads the existing Swift log and does
 not run a test twice.
 
-The gate-contract stage keeps lightweight contracts concurrent. It admits at
-most two process-heavy orchestrator shards at one time. This limit prevents
-process oversubscription without increasing the stage budget.
+The gate-contract stage keeps lightweight contracts concurrent. It admits
+three process-heavy orchestrator shards on a host with at least eight logical
+CPUs, and two on a smaller host. This limit prevents process oversubscription
+without increasing the stage budget.
 
 Swift and Clang caches stay under `app/.build`. The packaged UI test uses a
 stripped process-private app, fake CLI, and private state. Provider tests use
@@ -173,14 +185,18 @@ unknown path selects every functional stage and every release impact.
 | Release or publication | app, preflights, workflow contracts, and dependencies |
 | Unknown path | full repository plan |
 
-Hosted pull request CI does not trust the local selection as merge evidence. It
-runs the full functional plan exactly once on the merge commit.
+Hosted pull request CI does not trust a caller-supplied stage list. It requires
+the clean tested merge commit, classifies the exact base-to-merge diff, applies
+dependency closure, and records the result. Main promotion classifies the same
+diff again. Unknown paths and quality-core changes select the full plan.
 
 ## Automatic quality facts
 
-CI downloads the exact evidence from the last successful `main` run before it
-starts. An authoritative run accepts only a digest-bound
-`quality-metrics.json` from `ci-main`. It never reads a manual floor file.
+CI inspects recent successful `main` runs and downloads the newest exact
+evidence that contains quality metrics. A narrow run can omit metrics only when
+its impact does not select `quality-contracts`. An authoritative metric run
+accepts only a digest-bound `quality-metrics.json` from `ci-main`. It never
+reads a manual floor file.
 
 The metric artifact records exact UI and business test identities, aggregate
 line coverage, critical-source coverage, and changed executable Swift lines.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -55,9 +55,10 @@ Journeys cover all main surfaces, Settings, onboarding, and focus. It
 disconnects Stop before it proves that the real control invokes the action.
 Only a visible control completes isolated onboarding.
 
-Coverage validates the normal bundle, puts a coverage-enabled release
-executable only in the stripped copy, and signs it. The executable and profiles
-stay ignored or private and never enter a verified bundle or public artifact.
+Coverage builds the normal bundle and instrumented release binary together in
+isolated paths with split workers. Only a signed private UI copy gets
+it. Neither it nor its profiles enter a verified bundle or public
+artifact.
 If an overlay scroller ignores a page event, the driver reveals the measured
 semantic control, then posts the action to it.
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -32,9 +32,10 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   process behavior is the subject. Stdlib Python owns quality planning,
   scheduling, policy, evidence, comparison, mutation, and dashboard logic.
   Each Python tool has deterministic contract tests.
-- Fast local diagnostics close the edit loop. They never claim merge readiness.
-  Hosted pull-request CI runs the full repository gate on the exact change and
-  is the sole ordinary merge-readiness authority.
+- Local diagnostics close the edit loop. They never claim merge readiness.
+  Hosted pull-request CI is the
+  sole authority. It runs the tested merge's policy-selected impact plan.
+  Unknown and quality-core changes select the full plan.
 - `scripts/test critical`, `unit`, `coverage`, `smoke`, and `full` are the
   stable human entry points for the high-risk logic loop, complete Swift loop,
   measured coverage loop, freshly packaged product smoke, and exhaustive local
@@ -56,39 +57,40 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   restore old policy. An unsupported evidence schema is outside the telemetry
   sample. Current-schema telemetry can span earlier policy identifiers without
   dashboard-only fields. Malformed evidence remains an attention signal.
-- `quality/evals.json` keeps current expected outcomes for historical changes,
-  escaped defects, policy mutations, and scope violations. Its stable graders
-  compare selected stages, specifications, capabilities, user journeys,
-  release gates, and ignored private paths. A policy change must update an
-  expectation only when the intended observable outcome changes.
+- `quality/evals.json` keeps expected outcomes for historical changes, escaped
+  defects, policy mutations, and scope violations. Its graders compare stages,
+  specs, capabilities, journeys, release gates, and ignored paths. Change an
+  expectation only when the intended outcome changes.
 - Instrumented user scenarios emit addressable begin and pass events. Gate
   evidence records their requirement and journey links, duration, result, and
   bounded rerun command. A passed stage with missing scenario events fails.
 - A local timing-budget failure creates performance work. Warm-cache or
   variance reruns cannot turn it into readiness; an unchanged rerun is allowed
   only for an evidenced unrelated external transient whose cause is recorded.
-- Pull-request CI runs every functional check once and the timing-policy
-  ratchets. It does not enforce reference-machine wall or per-stage timing
-  ceilings. The workflow has a ten-minute overall deadline.
-- The gate-contract runner admits at most two process-heavy orchestrator shards
-  at one time. Lightweight contracts stay concurrent. The runner does not
-  increase a timing budget to hide process oversubscription.
-- The repository gate runs the Codex and Claude lanes together. It starts the
-  runtime and gate-contract lanes only after both provider lanes drain. Thus,
-  no more than two process-heavy top-level lanes compete on one macOS runner.
-- CI gets quality metrics from the last green `main` artifact. Test identities,
-  aggregate coverage, and critical-source coverage cannot decrease. Changed
-  executable Swift lines need at least 90 percent coverage. A person does not
-  edit or raise coverage floors. Coverage exclusions exist only in the quality
-  policy. Each exclusion links to automated scenario evidence and applies to
-  both aggregate and changed-line metrics. A critical source cannot be
-  excluded. A test-only region in a product source has a policy-owned name,
-  checked source markers, and automated scenario evidence. The region is
-  omitted only from changed-line metrics, not aggregate coverage.
+- Pull-request CI runs each selected check once. Only the tested merge first
+  parent is a valid impact base. CI keeps timing ratchets but not reference-Mac
+  ceilings. Its overall deadline is ten minutes.
+- The gate-contract runner admits three process-heavy orchestrator shards on a
+  host with at least eight logical CPUs, and two on a smaller host. Lightweight
+  contracts stay concurrent. The runner does not increase a timing budget to
+  hide process oversubscription.
+- After exclusive SwiftPM and UI phases, a priority queue starts ready work.
+  At most two top-level process-heavy lanes compete. One separate integration
+  and preflight lane can run with them. Short preflight and runtime checks can
+  use it during gate-contract. Distribution waits for gate-contract. A
+  completed stage opens its slot without a fixed wave barrier.
+- CI uses the newest green `main` artifact with measured metrics. A later run
+  without metrics does not replace it. Test identities, aggregate coverage,
+  and critical-source coverage cannot decrease. Changed Swift lines need 90
+  percent coverage. A person cannot raise floors. Policy-owned exclusions need
+  scenario evidence and cannot cover critical sources. Named test-only regions
+  stay in aggregate coverage but not changed-line metrics.
 - Authoritative UI coverage combines instrumented Swift tests with
-  packaged-app journeys. The app stage verifies the normal bundle, then builds
-  an instrumented release executable for the stripped private copy. The
-  metric stage merges profiles after UI without another test run.
+  packaged-app journeys. The app stage builds the normal bundle and an
+  instrumented release executable in isolated SwiftPM paths at the same time.
+  It splits the available workers between them and verifies the normal bundle.
+  Only the stripped private copy gets the instrumented executable. The metric
+  stage merges profiles after UI without another test run.
 - `coverage-opportunities.json` is a separate digest-bound advisory artifact.
   It ranks uncovered UI sources from policy routes, release impact,
   requirements, and journeys. Its next milestone is the five-point boundary
@@ -124,11 +126,9 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   main-branch Security run can deploy its passed or failed CodeQL result over
   the last green main evidence. A healthy care run closes the prior scoped
   attention issue.
-- An ordinary merged pull request does not repeat the full functional matrix
-  on `main`. The main workflow promotes the successful pull-request artifact
-  only when the tested merge and final merge have the same tree and ordered
-  parents. Promotion keeps both commit identities and every original digest.
-  Missing or ambiguous proof falls back to a full `ci-main` repository gate.
+- `main` promotes a successful pull-request artifact only when its stages equal
+  a fresh impact plan and both merges have the same tree and ordered parents.
+  Promotion keeps identities and digests. Ambiguity runs a full `ci-main` gate.
 - The active GitHub ruleset for `main` has no bypass actors. It requires a pull
   request, a current strict GitHub Actions `quality-gates` job, merge commits,
   and no approving review. It rejects deletion and non-fast-forward updates.

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -65,9 +65,18 @@ change real power state, upload assets, or claim publication.
   timing enforcement. Every functional, artifact, signing, power, lid, and
   publication gate remains mandatory, and the waiver is recorded in private
   gate and workflow evidence.
+- The pre-release quality gate classifies the complete diff from the last
+  published tag to synchronized `main`. It runs that dependency-closed plan on
+  the release Mac and applies the reference-machine budgets. An empty or
+  unknown diff selects the complete release plan. This selection does not omit
+  later signing, notarization, hardware, artifact, or publication gates.
+- A resumed release automatically reuses digest-bound passed stages from the
+  newest compatible local run. It starts fresh when no compatible run exists.
+  It inherits a failed wall budget, so a shorter retry cannot hide a regression.
 - Before the pre-release gate, the orchestrator downloads the evidence from the
-  last green `main` run. Test identities and measured coverage must not regress
-  from that artifact. Missing or invalid baseline evidence stops the release.
+  newest green `main` run that contains measured quality metrics. Test
+  identities and measured coverage must not regress from that artifact.
+  Missing or invalid baseline evidence stops the release.
 - Resume state is private under `app/build/`. Resume is allowed only when
   source, durable stage evidence, and existing asset digests still match.
 - A resume after the artifact stage requires only credentials for the remaining

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,8 +11,9 @@
   automatic test-identity, aggregate, critical-source, and changed-line
   metrics. This fast local diagnostic is unit-only. An authoritative gate adds
   the passed packaged-app profiles without another Swift test run. Hosted CI
-  compares the combined result with the last green `main` artifact. The local
-  command deletes only the active SwiftPM build path's prior profile, so stale
+  compares the combined result with the newest green `main` artifact that
+  contains measured metrics. The local command deletes only the active SwiftPM
+  build path's prior profile, so stale
   build evidence cannot satisfy the command.
 - `scripts/test smoke` — builds a fresh app, validates and runs the isolated
   packaged-app Accessibility flow, then verifies the bundled runtime. It needs
@@ -20,12 +21,15 @@
   app and tmux socket. Use `scripts/test --plan smoke` to inspect the steps.
 - `scripts/test full` — every automated repository check as a local diagnostic;
   it delegates exactly to `scripts/quality-gate --mode repository`. It does not
-  claim merge readiness. Pull-request CI runs the same functional matrix once
-  on the exact change and is merge authority.
+  claim merge readiness. Pull-request CI runs the exact impact-selected matrix
+  once on the tested merge commit and is merge authority.
 
 - `scripts/quality-gate` — the policy-versioned, impact-aware local diagnostic
   entry point. It selects checks from the diff and fails safe to the repository
   gate for unknown impact. See `docs/quality-gates.md`.
+- `scripts/quality-gate --mode impact --base <ref>` — the committed-diff mode
+  used by pull-request CI. Merge authority requires `<ref>` to be the tested
+  merge first parent and rejects a dirty checkout.
 - A normal change keeps `gate-contract` focused on direct self-contracts.
   `--mode repository` and an explicit `--stage gate-contract` run the full
   orchestrator contract set.
@@ -61,9 +65,10 @@
 - `scripts/quality-policy generate --check` checks both generated policy JSON
   and the readable current-spec traceability table.
 - `scripts/quality-promote` is the hosted post-merge path. It downloads the
-  exact successful pull-request artifact and proves tree and parent equality.
-  It does not run locally or change the tested evidence. A failed proof makes
-  the workflow run the full main repository gate.
+  exact successful pull-request artifact, classifies its impact again, and
+  proves tree and parent equality. It does not run locally or change the tested
+  evidence. A failed proof makes the workflow run the full main repository
+  gate.
 - `scripts/quality-dashboard generate` creates
   `app/build/quality-dashboard/{index.html,data.json}` from the newest schema-4
   evidence. `scripts/quality-dashboard serve --seconds 300` serves it only on
@@ -80,21 +85,24 @@
   deadline. This workflow does not run on pull requests. A successful run
   updates the GitHub Pages dashboard with its score.
 - `scripts/quality-gate --mode repository` — every automated repository check.
-  Local use is diagnostic. Pull-request CI uses the same entry point once with
+  Local use is diagnostic. Pull-request CI uses impact mode once with
   `ci-merge` authority and `--without-release-budget`, disabling local
   reference-machine wall and stage timing enforcement while retaining every
-  functional stage and the static timing-budget ratchet. A normal release enforces
-  the budgets; only the
-  owner-confirmed `DETACH_RELEASE_IGNORE_TIMING=1 scripts/release-version X.Y.Z`
+  selected functional stage and the static timing-budget ratchet. A normal
+  release enforces the budgets. Only the owner-confirmed
+  `DETACH_RELEASE_IGNORE_TIMING=1 scripts/release-version X.Y.Z`
   path may omit them for one intentionally busy-machine release, with the
   waiver recorded in private evidence. `--stage` is diagnostic only and is not
   proof that a change is ready. The current policy keeps SwiftPM work
   exclusive, then runs the isolated Codex and Claude suites concurrently
   against the verified bundled tmux and state helper. It rejects reference-Mac
   wall or stage regressions and rejects attempts to lower quality floors or
-  raise time budgets relative to their merge-base values. Resume inherits
-  timing and parent provenance. It preserves bounded failure diagnostics and
-  classifies known execution-environment denials without weakening FAIL.
+  raise time budgets relative to their merge-base values. A quality-core or
+  unknown change selects the full repository plan. `--resume auto` starts
+  fresh when no compatible run exists and is the release default. Resume
+  inherits timing and parent provenance. It preserves bounded failure
+  diagnostics and classifies known execution-environment denials without
+  weakening FAIL.
 
 - `DETACH_TEST_TMUX_BIN="$PWD/app/build/Detach.app/Contents/Resources/DetachCLI/tmux" tests/run.sh`
   — hermetic Codex integration with a fake provider, private tmux
@@ -186,7 +194,8 @@ specs, and the documentation workflow. It does not replace the selected gate.
 
 `scripts/release-version X.Y.Z` is the only normal release entry point. It
 requires a clean synchronized `main`, reads literal release settings from the
-ignored owner-only `.env.release`, runs the complete suite before changing Git,
+ignored owner-only `.env.release`, runs the impact-selected suite from the last
+published tag before changing Git,
 requires the tracked root `BUILD` to match the latest published manifest,
 increments it together with `VERSION` in one release commit, and creates one
 annotated tag. The invocation authorizes its automated commit, tag, and

--- a/quality/evals.json
+++ b/quality/evals.json
@@ -12,16 +12,65 @@
         "status": "known",
         "stages": [
           "static",
-          "gate-contract"
+          "gate-contract",
+          "swift",
+          "quality-contracts",
+          "app",
+          "ui-e2e",
+          "codex",
+          "claude",
+          "distribution",
+          "tmux-runtime",
+          "release-preflight",
+          "publish-preflight",
+          "release-workflow",
+          "release-budget"
         ],
         "specs": [
           "documentation"
         ],
         "capabilities": [
-          "quality-system"
+          "quality-system",
+          "documentation",
+          "session-lifecycle",
+          "power-protection",
+          "app-experience",
+          "onboarding",
+          "settings",
+          "update",
+          "diagnostics",
+          "installation",
+          "publication"
         ],
         "journeys": [
-          "J-QUALITY-CHANGE"
+          "J-QUALITY-CHANGE",
+          "J-DOCS-CONSISTENCY",
+          "J-SESSION-CREATE",
+          "J-SESSION-PERSIST",
+          "J-SESSION-RECOVER",
+          "J-SESSION-STOP",
+          "J-SESSION-DELETE",
+          "J-POWER-ENABLE",
+          "J-POWER-LOW-BATTERY",
+          "J-POWER-HELPER-LEASE",
+          "J-POWER-CLOSED-LID",
+          "J-APP-DASHBOARD",
+          "J-APP-DETAIL",
+          "J-APP-EMPTY",
+          "J-APP-FAILURE",
+          "J-APP-FOCUS",
+          "J-APP-NEW-SESSION",
+          "J-ONBOARD-FIRST-RUN",
+          "J-ONBOARD-PROVIDER",
+          "J-ONBOARD-APPROVAL",
+          "J-SETTINGS-CHANGE",
+          "J-UPDATE-CHECK",
+          "J-UPDATE-APPLY",
+          "J-DOCTOR-REPORT",
+          "J-INSTALL-CLEAN",
+          "J-INSTALL-REPAIR",
+          "J-INSTALL-UNINSTALL",
+          "J-PUBLISH-ARTIFACTS"
         ],
         "release_gates": [],
         "unknown": false

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -659,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 43,
+  "policy": 44,
   "release_domains": [
     {
       "gates": "-",
@@ -820,6 +820,13 @@
   ],
   "routes": [
     {
+      "pattern": "quality/policy.tsv",
+      "priority": 1100,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "quality-core"
+    },
+    {
       "pattern": "quality/*",
       "priority": 1000,
       "release_domain": "safe",
@@ -828,10 +835,10 @@
     },
     {
       "pattern": ".github/workflows/quality-gates.yml",
-      "priority": 1000,
+      "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
-      "test_domain": "policy"
+      "test_domain": "quality-core"
     },
     {
       "pattern": ".github/workflows/security.yml",
@@ -863,17 +870,17 @@
     },
     {
       "pattern": "scripts/quality-gate",
-      "priority": 1000,
+      "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
-      "test_domain": "policy"
+      "test_domain": "quality-core"
     },
     {
       "pattern": "tools/quality_gate.py",
-      "priority": 1000,
+      "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
-      "test_domain": "policy"
+      "test_domain": "quality-core"
     },
     {
       "pattern": "scripts/quality-scenarios",
@@ -891,17 +898,17 @@
     },
     {
       "pattern": "scripts/quality-policy",
-      "priority": 1000,
+      "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
-      "test_domain": "policy"
+      "test_domain": "quality-core"
     },
     {
       "pattern": "tools/quality_policy.py",
-      "priority": 1000,
+      "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
-      "test_domain": "policy"
+      "test_domain": "quality-core"
     },
     {
       "pattern": "scripts/quality-metrics",
@@ -2168,6 +2175,7 @@
         "docs/quality-gates.md",
         "docs/testing.md",
         "quality/*",
+        "quality/policy.tsv",
         "scripts/*",
         "scripts/quality-baseline",
         "scripts/quality-care",
@@ -3105,6 +3113,11 @@
       "capabilities": "quality-system",
       "id": "policy",
       "stages": "static,gate-contract"
+    },
+    {
+      "capabilities": "*",
+      "id": "quality-core",
+      "stages": "*"
     },
     {
       "capabilities": "documentation",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -30,6 +30,7 @@ It lists current specification ownership and verification links.
 - `docs/quality-gates.md`
 - `docs/testing.md`
 - `quality/*`
+- `quality/policy.tsv`
 - `scripts/*`
 - `scripts/quality-baseline`
 - `scripts/quality-care`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	43
+policy	44
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -28,6 +28,7 @@ stage	130	release-workflow	900	false
 stage	140	release-budget	1	true
 dependency	app	ui-e2e
 test-domain	policy	static,gate-contract	quality-system
+test-domain	quality-core	*	*
 test-domain	docs	static	documentation
 test-domain	state-runtime	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
 test-domain	power	static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget	power-protection
@@ -71,18 +72,19 @@ coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	S
 coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE	The packaged journey covers action geometry and its negative control.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	ui-e2e-instrumentation	SC-UI-SETTINGS	The packaged Settings journey covers its semantic control.
 coverage-region	ui	app/Sources/DetachApp/SidebarView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-FAILURE	Packaged journeys cover sidebar control geometry, bulk Delete, and failure status.
+route	1100	quality/policy.tsv	quality-core	safe	docs/specs/documentation.md
 route	1000	quality/*	policy	safe	docs/specs/documentation.md
-route	1000	.github/workflows/quality-gates.yml	policy	safe	docs/specs/documentation.md
+route	1100	.github/workflows/quality-gates.yml	quality-core	safe	docs/specs/documentation.md
 route	1000	.github/workflows/security.yml	policy	safe	docs/specs/documentation.md
 route	1000	.github/dependabot.yml	policy	safe	docs/specs/documentation.md
 route	1000	docs/quality-gates.md	policy	safe	docs/specs/documentation.md
 route	1000	docs/testing.md	policy	safe	docs/specs/documentation.md
-route	1000	scripts/quality-gate	policy	safe	docs/specs/documentation.md
-route	1000	tools/quality_gate.py	policy	safe	docs/specs/documentation.md
+route	1100	scripts/quality-gate	quality-core	safe	docs/specs/documentation.md
+route	1100	tools/quality_gate.py	quality-core	safe	docs/specs/documentation.md
 route	1000	scripts/quality-scenarios	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_scenarios.py	policy	safe	docs/specs/documentation.md
-route	1000	scripts/quality-policy	policy	safe	docs/specs/documentation.md
-route	1000	tools/quality_policy.py	policy	safe	docs/specs/documentation.md
+route	1100	scripts/quality-policy	quality-core	safe	docs/specs/documentation.md
+route	1100	tools/quality_policy.py	quality-core	safe	docs/specs/documentation.md
 route	1000	scripts/quality-metrics	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_metrics.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-baseline	policy	safe	docs/specs/documentation.md

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -505,8 +505,8 @@ file_line() {
 }
 
 run_full_tests() {
-  local baseline_root=""
-  note 'running the complete pre-release test suite before Git changes'
+  local impact_base="$1" baseline_root=""
+  note "running the impact-selected pre-release test suite from $impact_base"
   if [ "$TEST_MODE" != 1 ]; then
     baseline_root="$(DETACH_QUALITY_REPOSITORY="$REPOSITORY" \
       "$ROOT/scripts/quality-baseline")"
@@ -517,14 +517,17 @@ run_full_tests() {
       'Ignoring reference-machine timing budgets for this release'
     note 'owner waived reference-machine timing budgets for this release only'
     DETACH_RELEASE_TIMING_OVERRIDE="$REPOSITORY@$TAG" \
-      "$ROOT/scripts/quality-gate" --mode release --without-release-budget
+      "$ROOT/scripts/quality-gate" --mode release --base "$impact_base" \
+        --without-release-budget --resume auto
   else
-    "$ROOT/scripts/quality-gate" --mode release
+    "$ROOT/scripts/quality-gate" --mode release --base "$impact_base" \
+      --resume auto
   fi
 }
 
 initialize_workflow() {
   local current_version current_build published_manifest published_version published_build
+  local published_tag
   local target_release_status remote_main remote_tag configured_build
 
   verify_main_branch
@@ -557,8 +560,13 @@ initialize_workflow() {
   download_latest_manifest "$published_manifest"
   published_version="$(manifest_value "$published_manifest" version)"
   published_build="$(manifest_value "$published_manifest" build)"
+  published_tag="$(manifest_value "$published_manifest" tag)"
   valid_semver "$published_version" || die 'published release manifest has invalid SemVer'
   [[ "$published_build" =~ ^[1-9][0-9]*$ ]] || die 'published release manifest has invalid build'
+  [ "$published_tag" = "v$published_version" ] || \
+    die 'published release manifest tag does not match its version'
+  git -C "$ROOT" rev-parse --verify "$published_tag^{commit}" >/dev/null || \
+    die 'published release tag is missing locally'
   semver_greater_than "$VERSION" "$published_version" || \
     die "target version must be greater than published version ($published_version)"
   [ "$current_build" = "$published_build" ] || \
@@ -569,7 +577,7 @@ initialize_workflow() {
     die "release build must exceed published build $published_build"
   BUILD="$configured_build"
 
-  run_full_tests
+  run_full_tests "$published_tag"
   verify_clean_worktree
   fetch_origin
   remote_main="$(git -C "$ROOT" rev-parse --verify refs/remotes/origin/main)"

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -8,6 +8,7 @@ RESULT_ROOT="$TMP_ROOT/results"
 RUN_DIR="$RESULT_ROOT/20260811T100000Z-1"
 OUTPUT="$TMP_ROOT/dashboard"
 PROMOTED_OUTPUT="$TMP_ROOT/promoted-dashboard"
+FALLBACK_OUTPUT="$TMP_ROOT/fallback-dashboard"
 MUTATION_SUMMARY="$TMP_ROOT/mutation-summary.json"
 CARE_SUMMARY="$TMP_ROOT/care-summary.json"
 SECURITY_SUMMARY="$TMP_ROOT/security-summary.json"
@@ -266,7 +267,7 @@ import json
 import sys
 with open(sys.argv[1], encoding="utf-8") as source:
     data = json.load(source)
-assert data["schema"] == 3
+assert data["schema"] == 4
 assert data["run"]["authority"] == "ci-merge"
 assert data["run"]["result"] == "passed"
 assert [spec["id"] for spec in data["specifications"]] == ["app"]
@@ -317,6 +318,30 @@ except DashboardError:
     pass
 else:
     raise AssertionError("dashboard accepted incomplete merge evidence")
+PY
+
+METRICS_BASELINE="$TMP_ROOT/metrics-baseline"
+NO_METRICS_ROOT="$TMP_ROOT/no-metrics-results"
+mkdir -p "$METRICS_BASELINE" "$NO_METRICS_ROOT"
+cp -R "$RUN_DIR" "$METRICS_BASELINE/"
+awk -F '\t' -v OFS='\t' '$1 == "authority" {$2="ci-main"} {print}' \
+  "$METRICS_BASELINE/$(basename "$RUN_DIR")/manifest.tsv" \
+  >"$TMP_ROOT/baseline-manifest.tsv"
+mv "$TMP_ROOT/baseline-manifest.tsv" \
+  "$METRICS_BASELINE/$(basename "$RUN_DIR")/manifest.tsv"
+cp -R "$RUN_DIR" "$NO_METRICS_ROOT/"
+rm "$NO_METRICS_ROOT/$(basename "$RUN_DIR")/quality-metrics.json" \
+  "$NO_METRICS_ROOT/$(basename "$RUN_DIR")/coverage-opportunities.json"
+"$ROOT/scripts/quality-dashboard" generate --result-root "$NO_METRICS_ROOT" \
+  --output "$FALLBACK_OUTPUT" --metrics-baseline "$METRICS_BASELINE" >/dev/null
+python3 - "$FALLBACK_OUTPUT/data.json" <<'PY'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as source:
+    data = json.load(source)
+assert data["quality"]["coverage"]["suites"]["business"]["line_coverage"]["percent"] == 95.0
+assert data["quality"]["coverage_origin"] == "green-main-artifact"
+assert data["quality"]["coverage_opportunities"] == "not-yet-emitted"
 PY
 
 manifest_digest="$(shasum -a 256 "$RUN_DIR/manifest.tsv" | awk '{print $1}')"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -19,7 +19,7 @@ trap cleanup EXIT
 grep -F 'timeout-minutes: 10' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'DETACH_QUALITY_AUTHORITY: ci-merge' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
-grep -F 'run: scripts/quality-gate --mode repository --base "$BASE_SHA" --keep-going --without-release-budget' \
+grep -F 'run: scripts/quality-gate --mode impact --base "$BASE_SHA" --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-gate --mode repository --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
@@ -105,6 +105,19 @@ setup_fixture() {
   BASE="$(git -C "$REPO" rev-parse HEAD)"
   ACTION_LOG="$REPO/actions.log"
   RESULT_ROOT="$REPO/results"
+}
+
+commit_ci_merge() {
+  local path="$1" value="$2" feature
+  git -C "$REPO" checkout -qb impact-feature
+  mkdir -p "$(dirname "$REPO/$path")"
+  printf '%s\n' "$value" >"$REPO/$path"
+  git -C "$REPO" add "$path"
+  git -C "$REPO" commit -qm impact-feature
+  feature="$(git -C "$REPO" rev-parse HEAD)"
+  git -C "$REPO" checkout -qb tested-merge "$BASE"
+  git -C "$REPO" merge -q --no-ff --no-edit "$feature"
+  CI_MERGE="$(git -C "$REPO" rev-parse HEAD)"
 }
 
 gate() {
@@ -303,13 +316,41 @@ fi
 grep -F "quality-gate: PASS policy=$POLICY_VERSION authority=release" \
   "$REPO/release.out" >/dev/null
 
+setup_fixture impact-release
+mkdir -p "$REPO/app/Sources/DetachKit"
+printf '%s\n' 'struct ReleaseImpact {}' >"$REPO/app/Sources/DetachKit/ReleaseImpact.swift"
+git -C "$REPO" add .
+git -C "$REPO" commit -qm release-impact
+plan="$(gate --mode release --base "$BASE" --plan)"
+[[ "$plan" = *'stages=static,swift,quality-contracts,app,ui-e2e,release-budget'* ]]
+[[ "$plan" != *'codex'* ]]
+[[ "$plan" != *'release-workflow'* ]]
+
 setup_fixture github-budget
-plan="$(GITHUB_ACTIONS=true DETACH_QUALITY_AUTHORITY=ci-merge \
-  gate --mode repository --without-release-budget --plan)"
+commit_ci_merge .github/workflows/quality-gates.yml '# impact core'
+plan="$(GITHUB_ACTIONS=true GITHUB_SHA="$CI_MERGE" DETACH_QUALITY_AUTHORITY=ci-merge \
+  gate --mode impact --base "$BASE" --without-release-budget --plan)"
 [[ "$plan" = *'stages=static,gate-contract,swift,quality-contracts,app,ui-e2e,codex,claude,distribution,tmux-runtime,release-preflight,publish-preflight,release-workflow' ]]
 [[ "$plan" != *'release-budget'* ]]
 [[ "$plan" = *'authority=ci-merge'* ]]
-if DETACH_QUALITY_AUTHORITY=ci-merge gate --mode repository --plan \
+
+setup_fixture github-docs-impact
+commit_ci_merge README.md 'documentation impact'
+plan="$(GITHUB_ACTIONS=true GITHUB_SHA="$CI_MERGE" DETACH_QUALITY_AUTHORITY=ci-merge \
+  gate --mode impact --base "$BASE" --without-release-budget --plan)"
+[[ "$plan" = *'stages=static specs=documentation capabilities=documentation'* ]]
+[[ "$plan" != *'swift'* ]]
+if GITHUB_ACTIONS=true GITHUB_SHA="$CI_MERGE" DETACH_QUALITY_AUTHORITY=ci-merge \
+    gate --mode impact --base "$CI_MERGE^2" --without-release-budget --plan \
+    >"$REPO/wrong-impact-base.out" 2>&1; then
+  printf 'quality gate accepted a non-first-parent CI impact base\n' >&2
+  exit 1
+fi
+grep -F 'ci-merge base is not the tested merge first parent' \
+  "$REPO/wrong-impact-base.out" >/dev/null
+
+setup_fixture github-spoof
+if DETACH_QUALITY_AUTHORITY=ci-merge gate --mode impact --base "$BASE" --plan \
     >"$REPO/spoof-authority.out" 2>&1; then
   printf 'quality gate accepted spoofed CI merge authority\n' >&2
   exit 1
@@ -515,6 +556,14 @@ gate --mode repository --resume latest >"$REPO/latest-third.out"
 grep -F 'selected latest compatible evidence' "$REPO/latest-third.out" >/dev/null
 grep -F 'reusing gate-contract from matching evidence' "$REPO/latest-third.out" >/dev/null
 
+setup_fixture auto-resume
+printf '%s\n' docs >>"$REPO/README.md"
+gate --mode repository --resume auto >"$REPO/auto-first.out"
+grep -F 'starting a fresh compatible run' "$REPO/auto-first.out" >/dev/null
+gate --mode repository --resume auto >"$REPO/auto-second.out"
+grep -F 'selected latest compatible evidence' "$REPO/auto-second.out" >/dev/null
+grep -F 'reusing static from matching evidence' "$REPO/auto-second.out" >/dev/null
+
 setup_fixture source-commit
 if FAIL_STAGES=swift gate --mode repository >"$REPO/source-first.out" 2>&1; then
   exit 1
@@ -656,9 +705,9 @@ grep -F '<testsuite name="detach-quality-gate" tests="14" failures="1" skipped="
 setup_fixture parallel-lanes
 PARALLEL_ROOT="$REPO/parallel"
 mkdir -p "$PARALLEL_ROOT"
-for parallel_stage in distribution release-workflow; do
-  parallel_peer=distribution
-  [ "$parallel_stage" = distribution ] && parallel_peer=release-workflow
+for parallel_stage in codex claude; do
+  parallel_peer=codex
+  [ "$parallel_stage" = codex ] && parallel_peer=claude
   cat >"$REPO/tests/quality-gate-fixtures/$parallel_stage" <<SH
 #!/bin/bash
 set -eu
@@ -672,8 +721,8 @@ done
 SH
 done
 chmod 0755 \
-  "$REPO/tests/quality-gate-fixtures/distribution" \
-  "$REPO/tests/quality-gate-fixtures/release-workflow"
+  "$REPO/tests/quality-gate-fixtures/codex" \
+  "$REPO/tests/quality-gate-fixtures/claude"
 GATE_PARALLEL_ROOT="$PARALLEL_ROOT" gate --mode repository >"$REPO/parallel.out"
 [ "$(wc -l <"$ACTION_LOG" | tr -d ' ')" = 11 ]
 grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/parallel.out" >/dev/null
@@ -708,47 +757,67 @@ set -eu
 [ -f "${GATE_ORDER_ROOT:?}/app" ]
 : >"$GATE_ORDER_ROOT/ui-e2e"
 SH
-for provider_stage in codex claude; do
-  provider_peer=codex
-  [ "$provider_stage" = codex ] && provider_peer=claude
-  cat >"$REPO/tests/quality-gate-fixtures/$provider_stage" <<SH
+cat >"$REPO/tests/quality-gate-fixtures/codex" <<'SH'
 #!/bin/bash
 set -eu
-[ -f "\${GATE_ORDER_ROOT:?}/app" ]
-[ -f "\${GATE_ORDER_ROOT:?}/ui-e2e" ]
-[ -f "\${GATE_ORDER_ROOT:?}/quality-contracts" ]
+[ -f "${GATE_ORDER_ROOT:?}/app" ]
+[ -f "$GATE_ORDER_ROOT/ui-e2e" ]
+[ -f "$GATE_ORDER_ROOT/quality-contracts" ]
+: >"$GATE_ORDER_ROOT/codex-started"
+sleep 3
+: >"$GATE_ORDER_ROOT/codex"
+SH
+cat >"$REPO/tests/quality-gate-fixtures/gate-contract" <<'SH'
+#!/bin/bash
+set -eu
+[ -f "${GATE_ORDER_ROOT:?}/ui-e2e" ]
+[ -f "$GATE_ORDER_ROOT/quality-contracts" ]
+: >"$GATE_ORDER_ROOT/gate-contract-started"
 sleep 1
-: >"\$GATE_ORDER_ROOT/$provider_stage"
-attempt=0
-while [ ! -f "\$GATE_ORDER_ROOT/$provider_peer" ] && [ "\$attempt" -lt 50 ]; do
-  attempt=\$((attempt + 1))
-  sleep 0.1
-done
-[ -f "\$GATE_ORDER_ROOT/$provider_peer" ]
+: >"$GATE_ORDER_ROOT/gate-contract"
 SH
-done
-for contract_stage in tmux-runtime gate-contract; do
-  contract_peer=tmux-runtime
-  [ "$contract_stage" = tmux-runtime ] && contract_peer=gate-contract
-  cat >"$REPO/tests/quality-gate-fixtures/$contract_stage" <<SH
+cat >"$REPO/tests/quality-gate-fixtures/distribution" <<'SH'
 #!/bin/bash
 set -eu
-[ -f "\${GATE_ORDER_ROOT:?}/codex" ]
-[ -f "\${GATE_ORDER_ROOT:?}/claude" ]
-: >"\$GATE_ORDER_ROOT/$contract_stage"
+[ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
+[ -f "$GATE_ORDER_ROOT/codex-started" ]
+[ ! -f "$GATE_ORDER_ROOT/codex" ]
+: >"$GATE_ORDER_ROOT/integration-after-contract"
+SH
+cat >"$REPO/tests/quality-gate-fixtures/publish-preflight" <<'SH'
+#!/bin/bash
+set -eu
 attempt=0
-while [ ! -f "\$GATE_ORDER_ROOT/$contract_peer" ] && [ "\$attempt" -lt 50 ]; do
-  attempt=\$((attempt + 1))
+while { [ ! -f "${GATE_ORDER_ROOT:?}/gate-contract-started" ] || \
+        [ ! -f "$GATE_ORDER_ROOT/codex-started" ]; } && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
   sleep 0.1
 done
-[ -f "\$GATE_ORDER_ROOT/$contract_peer" ]
+[ -f "$GATE_ORDER_ROOT/gate-contract-started" ]
+[ -f "$GATE_ORDER_ROOT/codex-started" ]
+[ ! -f "$GATE_ORDER_ROOT/gate-contract" ]
+: >"$GATE_ORDER_ROOT/short-preflight-during-contract"
 SH
-done
-for ordered_stage in distribution release-preflight publish-preflight release-workflow; do
+cat >"$REPO/tests/quality-gate-fixtures/release-workflow" <<'SH'
+#!/bin/bash
+set -eu
+[ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
+: >"$GATE_ORDER_ROOT/release-workflow-started"
+sleep 1
+: >"$GATE_ORDER_ROOT/release-workflow"
+SH
+cat >"$REPO/tests/quality-gate-fixtures/claude" <<'SH'
+#!/bin/bash
+set -eu
+[ -f "${GATE_ORDER_ROOT:?}/release-workflow" ] || [ -f "$GATE_ORDER_ROOT/codex" ]
+: >"$GATE_ORDER_ROOT/third-heavy-waited"
+SH
+for ordered_stage in tmux-runtime release-preflight; do
   cat >"$REPO/tests/quality-gate-fixtures/$ordered_stage" <<'SH'
 #!/bin/bash
 set -eu
-for prerequisite_stage in ui-e2e codex claude tmux-runtime gate-contract; do
+[ -f "${GATE_ORDER_ROOT:?}/quality-contracts" ]
+for prerequisite_stage in ui-e2e; do
   [ -f "${GATE_ORDER_ROOT:?}/$prerequisite_stage" ]
 done
 SH
@@ -768,6 +837,18 @@ chmod 0755 \
   "$REPO/tests/quality-gate-fixtures/release-workflow"
 GATE_ORDER_ROOT="$ORDER_ROOT" gate --mode repository >"$REPO/resource-order.out"
 grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/resource-order.out" >/dev/null
+[ -f "$ORDER_ROOT/integration-after-contract" ] || {
+  printf 'bounded scheduler did not open integration after gate-contract\n' >&2
+  exit 1
+}
+[ -f "$ORDER_ROOT/short-preflight-during-contract" ] || {
+  printf 'bounded scheduler did not use the safe preflight lane\n' >&2
+  exit 1
+}
+[ -f "$ORDER_ROOT/third-heavy-waited" ] || {
+  printf 'bounded scheduler admitted a third process-heavy lane\n' >&2
+  exit 1
+}
 
 setup_fixture release-budget-wall
 set_manifest_value "$REPO/tests/release-budget.tsv" wall_seconds_max 1
@@ -812,12 +893,15 @@ grep -F 'stage budget: static regressed: 3s > 2s' "$RESULT_ROOT"/*/static.log >/
 grep -F $'static\tfailed\t3' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 
 setup_fixture github-no-timing-budgets
+commit_ci_merge .github/workflows/quality-gates.yml '# impact core'
 if ! GITHUB_ACTIONS=true DETACH_QUALITY_AUTHORITY=ci-merge \
+    GITHUB_SHA="$CI_MERGE" \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_STATIC=300 \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_SWIFT=300 \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_APP=300 \
     DETACH_QUALITY_GATE_TEST_STAGE_SECONDS_PUBLISH_PREFLIGHT=300 \
-    gate --mode repository --without-release-budget >"$REPO/github-no-budgets.out" 2>&1; then
+    gate --mode impact --base "$BASE" --without-release-budget \
+      >"$REPO/github-no-budgets.out" 2>&1; then
   cat "$REPO/github-no-budgets.out" >&2
   printf 'quality gate enforced reference-machine timing in GitHub Actions\n' >&2
   exit 1

--- a/tests/quality_baseline_contract.py
+++ b/tests/quality_baseline_contract.py
@@ -67,9 +67,11 @@ mode = os.environ.get("FAKE_GH_MODE", "success")
 if arguments[0] == "api" and "workflows/quality-gates.yml/runs" in arguments[1]:
     if mode == "malformed": print("{")
     elif mode == "no-runs": print(json.dumps({"workflow_runs": []}))
+    elif mode == "partial-latest": print(json.dumps({"workflow_runs": [{"id": 124}, {"id": 123}]}))
     else: print(json.dumps({"workflow_runs": [{"id": 123}]}))
 elif arguments[0] == "api" and "/artifacts" in arguments[1]:
-    values = [{"expired": False, "name": "quality-gate-evidence-123-1"}]
+    run_id = arguments[1].split("/actions/runs/")[1].split("/")[0]
+    values = [{"expired": False, "name": f"quality-gate-evidence-{run_id}-1"}]
     if mode == "duplicate":
         values.append({"expired": False, "name": "quality-gate-evidence-123-2"})
     print(json.dumps({"artifacts": values}))
@@ -78,6 +80,9 @@ elif arguments[:2] == ["run", "download"]:
         destination = Path(arguments[arguments.index("--dir") + 1]) / "run"
         destination.mkdir()
         (destination / "manifest.tsv").write_text("schema\\t4\\n")
+        run_id = arguments[2]
+        if mode != "no-metrics" and not (mode == "partial-latest" and run_id == "124"):
+            (destination / "quality-metrics.json").write_text("{}\\n")
 else:
     raise SystemExit(3)
 """,
@@ -90,8 +95,16 @@ else:
         restored = Path(success.stdout.strip())
         if restored != success_root / "123" or not (restored / "run/manifest.tsv").is_file():
             raise AssertionError("baseline artifact was not restored deterministically")
-        collision = invoke(fake_gh, success_root, expected=2)
-        require(collision, "destination already exists")
+        collision = invoke(fake_gh, success_root)
+        if Path(collision.stdout.strip()) != restored:
+            raise AssertionError("baseline cache reuse changed the selected evidence")
+
+        partial_root = root / "partial-latest"
+        partial = invoke(fake_gh, partial_root, mode="partial-latest")
+        if Path(partial.stdout.strip()) != partial_root / "123":
+            raise AssertionError("baseline did not skip a valid metrics-free main run")
+        if not (partial_root / "124/run/manifest.tsv").is_file():
+            raise AssertionError("partial main evidence was not inspected")
 
         malformed = invoke(fake_gh, root / "malformed", mode="malformed", expected=2)
         require(malformed, "response is malformed")
@@ -102,6 +115,9 @@ else:
         no_manifest = invoke(
             fake_gh, root / "missing-manifest", mode="missing-manifest", expected=2)
         require(no_manifest, "no unique quality manifest")
+        no_metrics = invoke(
+            fake_gh, root / "no-metrics", mode="no-metrics", expected=2)
+        require(no_metrics, "no successful main quality run has quality metrics")
         override = invoke(
             fake_gh, root / "production-override", expected=2, test_mode=False)
         require(override, "baseline output must use")

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -18,8 +19,12 @@ from quality_gate import (  # noqa: E402
     GateError,
     QualityGate,
     gate_contract_definitions,
+    gate_orchestrator_limit,
     include_gate_orchestrators,
     parse_name_status,
+    run_app_stage,
+    split_swift_build_jobs,
+    ui_coverage_binary,
 )
 from quality_policy import POLICY_FILE, Policy  # noqa: E402
 
@@ -77,12 +82,57 @@ class QualityGateContract(unittest.TestCase):
         self.assertTrue(include_gate_orchestrators("repository", ""))
         self.assertTrue(include_gate_orchestrators("change", "gate-contract"))
 
+    def test_gate_orchestrator_capacity_tracks_available_processors(self) -> None:
+        self.assertEqual(gate_orchestrator_limit(10), 3)
+        self.assertEqual(gate_orchestrator_limit(8), 3)
+        self.assertEqual(gate_orchestrator_limit(4), 2)
+
     def test_public_shell_entry_point_is_thin(self) -> None:
         wrapper = (ROOT / "scripts/quality-gate").read_text(encoding="utf-8")
         self.assertLessEqual(len(wrapper.splitlines()), 12)
         self.assertIn('exec python3 "$ROOT/tools/quality_gate.py" "$@"', wrapper)
         self.assertNotIn("jq ", wrapper)
         self.assertNotIn("awk ", wrapper)
+
+    def test_app_builds_normal_bundle_and_release_coverage_in_parallel(self) -> None:
+        events: list[str] = []
+
+        class FakeProcess:
+            def __init__(self, command, *, cwd, env):
+                self.command = command
+                self.cwd = cwd
+                self.env = env
+                events.append("coverage-started")
+
+            def wait(self):
+                events.append("coverage-finished")
+                return 0
+
+        def fake_child_run(command, *, cwd=ROOT, env=None):
+            self.assertEqual(events, ["coverage-started"])
+            self.assertEqual(command, [str(ROOT / "app/scripts/make-app.sh")])
+            self.assertEqual(env["DETACH_SWIFT_BUILD_JOBS"], "5")
+            events.append("normal-finished")
+            return 0
+
+        with patch.dict(
+            "os.environ",
+            {"DETACH_QUALITY_GATE_SELECTED_STAGES": "app,quality-contracts"},
+            clear=False,
+        ), patch("quality_gate.os.cpu_count", return_value=10), patch(
+            "quality_gate.subprocess.Popen", FakeProcess
+        ), patch("quality_gate.child_run", fake_child_run):
+            self.assertEqual(run_app_stage(ROOT), 0)
+
+        self.assertEqual(
+            events,
+            ["coverage-started", "normal-finished", "coverage-finished"],
+        )
+        self.assertEqual(split_swift_build_jobs(10), (5, 5))
+        self.assertEqual(
+            ui_coverage_binary(ROOT),
+            ROOT / "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp",
+        )
 
 
 def main() -> int:

--- a/tests/quality_promote_contract.py
+++ b/tests/quality_promote_contract.py
@@ -99,26 +99,31 @@ def opportunities_document() -> dict[str, object]:
     }
 
 
-def create_evidence(root: Path) -> Path:
+def create_evidence(root: Path, paths: list[str] | None = None) -> Path:
+    paths = paths or ["tools/quality_gate.py"]
+    impact = POLICY.impact(paths)
     run_dir = root / "20260812T120000Z-1"
     run_dir.mkdir(parents=True)
     summary_lines = [
         "policy\tmode\tstage\tstatus\tduration_seconds\tlog\tlog_sha256\torigin_run"
     ]
-    stages = [stage.name for stage in POLICY.stages if stage.name != "release-budget"]
+    stages = [stage for stage in impact.stages if stage != "release-budget"]
     for stage in stages:
         log = run_dir / f"{stage}.log"
         log.write_text(f"{stage} passed\n", encoding="utf-8")
         summary_lines.append(
-            f"{POLICY.version}\trepository\t{stage}\tpassed\t1\t{stage}.log\t"
+            f"{POLICY.version}\timpact\t{stage}\tpassed\t1\t{stage}.log\t"
             f"{digest(log)}\t-"
         )
     summary = run_dir / "summary.tsv"
     summary.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
     environment = run_dir / "environment.tsv"
     environment.write_text("schema\t1\narchitecture\ttest\n", encoding="utf-8")
-    write_json(run_dir / "quality-metrics.json", metrics_document())
-    write_json(run_dir / "coverage-opportunities.json", opportunities_document())
+    metric_names: tuple[str, ...] = ()
+    if "quality-contracts" in stages:
+        write_json(run_dir / "quality-metrics.json", metrics_document())
+        write_json(run_dir / "coverage-opportunities.json", opportunities_document())
+        metric_names = ("coverage-opportunities.json", "quality-metrics.json")
     (run_dir / "scenarios.jsonl").write_text("{}\n", encoding="utf-8")
     (run_dir / "scenarios.junit.xml").write_text(
         '<testsuite name="quality" tests="0"/>\n', encoding="utf-8"
@@ -128,12 +133,7 @@ def create_evidence(root: Path) -> Path:
         "schema\t1\n"
         + "".join(
             f"file\t{name}\t{digest(run_dir / name)}\n"
-            for name in (
-                "coverage-opportunities.json",
-                "quality-metrics.json",
-                "scenarios.jsonl",
-                "scenarios.junit.xml",
-            )
+            for name in (*metric_names, "scenarios.jsonl", "scenarios.junit.xml")
         ),
         encoding="utf-8",
     )
@@ -141,16 +141,16 @@ def create_evidence(root: Path) -> Path:
     manifest.write_text(
         "schema\t4\n"
         f"policy\t{POLICY.version}\n"
-        "mode\trepository\n"
+        "mode\timpact\n"
         "authority\tci-merge\n"
         f"source_commit\t{TESTED}\n"
         f"base_commit\t{BASE}\n"
         f"input_fingerprint\t{'1' * 64}\n"
         f"fingerprint\t{'2' * 64}\n"
         f"stages\t{','.join(stages)}\n"
-        f"specs\t{','.join(POLICY.specs)}\n"
-        f"capabilities\t{','.join(POLICY.capabilities)}\n"
-        f"journeys\t{','.join(POLICY.journeys)}\n"
+        f"specs\t{','.join(impact.specs)}\n"
+        f"capabilities\t{','.join(impact.capabilities)}\n"
+        f"journeys\t{','.join(impact.journeys)}\n"
         "started_at\t2026-08-12T12:00:00Z\n"
         "finished_at\t2026-08-12T12:03:00Z\n"
         "duration_seconds\t180\n"
@@ -171,7 +171,12 @@ def fake_tools(root: Path) -> tuple[Path, Path]:
     fake_git.write_text(
         f"""#!/usr/bin/env python3
 import os
+import sys
 mode = os.environ.get("FAKE_PROMOTE_MODE", "success")
+if len(sys.argv) > 1 and sys.argv[1] == "diff":
+    path = "README.md" if mode == "docs-impact" else "tools/quality_gate.py"
+    sys.stdout.write("M\\0" + path + "\\0")
+    raise SystemExit(0)
 parents = "{BASE} {HEAD}" if mode != "one-parent" else "{BASE}"
 print("{MAIN}")
 print("{TREE}")
@@ -329,6 +334,17 @@ def main() -> None:
             raise AssertionError("promotion evidence is not deterministic")
         if (run_dir / "promotion.md").read_bytes() != (second_run / "promotion.md").read_bytes():
             raise AssertionError("promotion summary is not deterministic")
+
+        docs_evidence = create_evidence(root / "docs-source", ["README.md"])
+        docs_output = root / "docs-impact"
+        invoke(fake_gh, fake_git, docs_evidence, docs_output, mode="docs-impact")
+        docs_run = next(path.parent for path in docs_output.glob("*/manifest.tsv"))
+        if (docs_run / "quality-metrics.json").exists():
+            raise AssertionError("documentation impact fabricated quality metrics")
+        if validate_promotion(
+            docs_run, read_tsv(docs_run / "manifest.tsv", "docs manifest")
+        ) is None:
+            raise AssertionError("documentation impact was not promoted")
 
         eventual = root / "eventual-pr"
         invoke(fake_gh, fake_git, evidence, eventual, mode="eventual-pr")

--- a/tools/quality_baseline.py
+++ b/tools/quality_baseline.py
@@ -8,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 from typing import Any, NoReturn
@@ -55,14 +56,16 @@ def document(raw: str, label: str) -> dict[str, Any]:
     return value
 
 
-def successful_run(value: dict[str, Any]) -> int:
+def successful_runs(value: dict[str, Any]) -> list[int]:
     runs = value.get("workflow_runs")
     if not isinstance(runs, list) or not runs:
         raise BaselineError("no successful main quality run is available")
-    first = runs[0]
-    if not isinstance(first, dict) or not isinstance(first.get("id"), int) or first["id"] <= 0:
-        raise BaselineError("successful main quality run id is invalid")
-    return first["id"]
+    identifiers: list[int] = []
+    for run in runs:
+        if not isinstance(run, dict) or not isinstance(run.get("id"), int) or run["id"] <= 0:
+            raise BaselineError("successful main quality run id is invalid")
+        identifiers.append(run["id"])
+    return identifiers
 
 
 def evidence_artifact(value: dict[str, Any], run_id: int) -> str:
@@ -94,40 +97,54 @@ def restore(
     if output_root.exists() and (not output_root.is_dir() or output_root.is_symlink()):
         raise BaselineError("baseline output is unsafe")
     output_root.mkdir(parents=True, exist_ok=True)
-    run_id = successful_run(document(
+    run_ids = successful_runs(document(
         gh(
             executable,
             [
                 "api",
                 f"repos/{repository}/actions/workflows/quality-gates.yml/runs"
-                "?branch=main&status=success&event=push&per_page=1",
+                "?branch=main&status=success&event=push&per_page=20",
             ],
         ),
         "workflow run",
     ))
-    artifact = evidence_artifact(document(
-        gh(executable, ["api", f"repos/{repository}/actions/runs/{run_id}/artifacts"]),
-        "artifact",
-    ), run_id)
-    destination = output_root / str(run_id)
-    if destination.exists():
-        raise BaselineError(f"baseline destination already exists: {destination}")
-    destination.mkdir()
-    gh(
-        executable,
-        [
-            "run", "download", str(run_id), "--repo", repository, "--name", artifact,
-            "--dir", str(destination),
-        ],
-    )
-    manifests = [
-        path for path in destination.glob("*/manifest.tsv")
-        if path.is_file() and not path.is_symlink()
-    ]
-    if len(manifests) != 1:
-        raise BaselineError("downloaded evidence has no unique quality manifest")
-    print(destination)
-    return destination
+    for run_id in run_ids:
+        destination = output_root / str(run_id)
+        if destination.exists():
+            if not destination.is_dir() or destination.is_symlink():
+                raise BaselineError(f"baseline destination is unsafe: {destination}")
+        else:
+            artifact = evidence_artifact(document(
+                gh(
+                    executable,
+                    ["api", f"repos/{repository}/actions/runs/{run_id}/artifacts"],
+                ),
+                "artifact",
+            ), run_id)
+            destination.mkdir()
+            try:
+                gh(
+                    executable,
+                    [
+                        "run", "download", str(run_id), "--repo", repository,
+                        "--name", artifact, "--dir", str(destination),
+                    ],
+                )
+            except Exception:
+                shutil.rmtree(destination, ignore_errors=True)
+                raise
+        manifests = [
+            path for path in destination.glob("*/manifest.tsv")
+            if path.is_file() and not path.is_symlink()
+        ]
+        if len(manifests) != 1:
+            raise BaselineError("downloaded evidence has no unique quality manifest")
+        run_dir = manifests[0].parent
+        metrics = run_dir / "quality-metrics.json"
+        if metrics.is_file() and not metrics.is_symlink():
+            print(destination)
+            return destination
+    raise BaselineError("no successful main quality run has quality metrics")
 
 
 def parser() -> argparse.ArgumentParser:

--- a/tools/quality_care.py
+++ b/tools/quality_care.py
@@ -155,61 +155,8 @@ def load_corpus(path: Path) -> list[dict[str, Any]]:
     return cases
 
 
-def in_policy_order(values: set[str], order: list[str]) -> list[str]:
-    return [value for value in order if value in values]
-
-
 def impact(policy: Policy, paths: list[str]) -> dict[str, Any]:
-    classifications = [policy.classify(path) for path in paths]
-    unknown = any(classification.status == "unknown" for classification in classifications)
-    if unknown:
-        return {
-            "status": "unknown",
-            "stages": [stage.name for stage in policy.stages],
-            "specs": list(policy.specs),
-            "capabilities": list(policy.capabilities),
-            "journeys": list(policy.journeys),
-            "release_gates": ["lid"],
-            "unknown": True,
-        }
-    stages = {
-        stage
-        for classification in classifications
-        for stage in classification.stages.split(",")
-    }
-    changed = True
-    while changed:
-        changed = False
-        for prerequisite, dependent in policy.dependencies:
-            if prerequisite in stages and dependent not in stages:
-                stages.add(dependent)
-                changed = True
-    spec_paths = {classification.spec for classification in classifications}
-    capabilities = {
-        capability
-        for classification in classifications
-        for capability in classification.capabilities.split(",")
-    }
-    journeys = {
-        journey
-        for classification in classifications
-        for journey in classification.journeys.split(",")
-    }
-    gates = {
-        gate
-        for classification in classifications
-        for gate in classification.release_gates.split(",")
-        if gate != "-"
-    }
-    return {
-        "status": "known",
-        "stages": [stage.name for stage in policy.stages if stage.name in stages],
-        "specs": [identifier for identifier, (path, _) in policy.specs.items() if path in spec_paths],
-        "capabilities": in_policy_order(capabilities, list(policy.capabilities)),
-        "journeys": in_policy_order(journeys, list(policy.journeys)),
-        "release_gates": in_policy_order(gates, ["lid"]),
-        "unknown": False,
-    }
+    return policy.impact(paths).document()
 
 
 def ignored(paths: list[str]) -> dict[str, bool]:

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -22,7 +22,12 @@ from quality_care import (
     validate_input_bindings as validate_care_inputs,
     validate_summary as validate_care_summary,
 )
-from quality_metrics import MetricsError, validate_metrics, validate_opportunities
+from quality_metrics import (
+    MetricsError,
+    load_baseline,
+    validate_metrics,
+    validate_opportunities,
+)
 from quality_mutation import MutationError, validate_summary
 from quality_promote import PromotionError, validate_promotion
 from quality_security import SecurityError, validate_summary as validate_security_summary
@@ -406,6 +411,7 @@ def build_data(
     mutation_summary: Optional[Path] = None,
     care_summary: Optional[Path] = None,
     security_summary: Optional[Path] = None,
+    metrics_baseline: Optional[Path] = None,
 ) -> dict[str, Any]:
     manifest = read_manifest(run_dir)
     effective_commit, effective_authority, promotion = effective_identity(
@@ -475,8 +481,16 @@ def build_data(
     trend_walls = [trend["wall_seconds"] for trend in trends]
     slowest = max(stages, key=lambda stage: stage["duration_seconds"], default=None)
     metrics = read_metrics(run_dir, manifest)
+    current_metrics = metrics
+    metrics_origin = "current-run"
+    if metrics is None and metrics_baseline is not None:
+        try:
+            metrics, _, _ = load_baseline(metrics_baseline)
+        except MetricsError as error:
+            raise DashboardError(f"quality metrics baseline is invalid: {error}") from error
+        metrics_origin = "green-main-artifact"
     coverage_opportunities = read_coverage_opportunities(
-        run_dir, manifest, metrics
+        run_dir, manifest, current_metrics
     )
     mutation = read_mutation_summary(mutation_summary, int(manifest["policy"]))
     care = read_care_summary(
@@ -488,7 +502,7 @@ def build_data(
         security_summary, int(manifest["policy"])
     )
     return {
-        "schema": 3,
+        "schema": 4,
         "run": {
             "id": run_dir.name,
             "commit": effective_commit,
@@ -522,6 +536,7 @@ def build_data(
             "run_wall_p50_seconds": percentile(trend_walls, 50),
             "run_wall_p95_seconds": percentile(trend_walls, 95),
             "coverage": metrics if metrics is not None else "not-yet-emitted",
+            "coverage_origin": metrics_origin if metrics is not None else "not-available",
             "coverage_opportunities": (
                 coverage_opportunities
                 if coverage_opportunities is not None
@@ -609,7 +624,8 @@ def render_html(data: dict[str, Any]) -> str:
         changed_coverage = coverage["changed_lines"]["line_coverage"]["percent"]
         coverage_text = (
             f"UI {ui_coverage:.2f}% · business {business_coverage:.2f}% · "
-            f"changed lines {changed_coverage:.2f}%"
+            f"changed lines {changed_coverage:.2f}% · "
+            f"{quality['coverage_origin']} source {coverage['source_commit'][:10]}"
         )
     else:
         coverage_text = str(coverage)
@@ -794,9 +810,10 @@ def generate(arguments: argparse.Namespace) -> int:
     mutation_summary = arguments.mutation_summary.resolve() if arguments.mutation_summary else None
     care_summary = arguments.care_summary.resolve() if arguments.care_summary else None
     security_summary = arguments.security_summary.resolve() if arguments.security_summary else None
+    metrics_baseline = arguments.metrics_baseline.resolve() if arguments.metrics_baseline else None
     data = build_data(
         run_dir, result_root, arguments.run_url, mutation_summary, care_summary,
-        security_summary
+        security_summary, metrics_baseline
     )
     output = arguments.output.resolve()
     if output == Path("/") or output == ROOT:
@@ -844,6 +861,7 @@ def parser() -> argparse.ArgumentParser:
     generate_parser.add_argument("--mutation-summary", type=Path)
     generate_parser.add_argument("--care-summary", type=Path)
     generate_parser.add_argument("--security-summary", type=Path)
+    generate_parser.add_argument("--metrics-baseline", type=Path)
     generate_parser.set_defaults(function=generate)
     serve_parser = commands.add_parser("serve", help="serve a generated dashboard for a bounded time")
     serve_parser.add_argument("--directory", type=Path, default=DEFAULT_OUTPUT)

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -57,20 +57,25 @@ EXECUTION_PREREQUISITES = {
     "claude": ("app",),
     "tmux-runtime": ("app",),
 }
-PROVIDER_WAVE = (
+POST_UI_STAGES = (
+    "gate-contract",
     "codex",
     "claude",
-)
-CONTRACT_WAVE = (
-    "tmux-runtime",
-    "gate-contract",
-)
-RELEASE_WAVE = (
     "distribution",
+    "tmux-runtime",
     "release-preflight",
     "publish-preflight",
     "release-workflow",
 )
+PROCESS_HEAVY_LIMIT = 2
+INTEGRATION_LANE_LIMIT = 1
+PROCESS_HEAVY_STAGES = {"gate-contract", "codex", "claude", "release-workflow"}
+GATE_COMPATIBLE_INTEGRATION_STAGES = {
+    "tmux-runtime",
+    "release-preflight",
+    "publish-preflight",
+}
+UI_COVERAGE_SCRATCH = "quality-ui-release"
 
 
 class GateError(Exception):
@@ -287,6 +292,7 @@ class QualityGate:
         self.effective_mode = ""
         self.resume_dir: Path | None = None
         self.resume_requested_latest = self.options.resume == "latest"
+        self.resume_requested_auto = self.options.resume == "auto"
         result_root = os.environ.get(
             "DETACH_QUALITY_GATE_RESULT_ROOT", str(ROOT / "app/build/quality-gates")
         )
@@ -317,7 +323,7 @@ class QualityGate:
             raise GateError("real static fixture mode is test-only")
         if self.test_direct and not self.test_mode:
             raise GateError("direct fixture mode is test-only")
-        if self.options.mode not in ("change", "repository", "release"):
+        if self.options.mode not in ("change", "impact", "repository", "release"):
             raise GateError(f"invalid mode: {self.options.mode}")
         requested = os.environ.get("DETACH_QUALITY_AUTHORITY", "")
         if not requested:
@@ -332,8 +338,9 @@ class QualityGate:
         elif self.authority in ("ci-merge", "ci-main"):
             if os.environ.get("GITHUB_ACTIONS") != "true":
                 raise GateError(f"{self.authority} authority is restricted to GitHub Actions")
-            if self.options.mode != "repository":
-                raise GateError(f"{self.authority} authority requires repository mode")
+            required_mode = "impact" if self.authority == "ci-merge" else "repository"
+            if self.options.mode != required_mode:
+                raise GateError(f"{self.authority} authority requires {required_mode} mode")
             if self.options.stage:
                 raise GateError(f"{self.authority} authority cannot run one diagnostic stage")
         elif self.authority == "release":
@@ -417,7 +424,9 @@ class QualityGate:
         ):
             raise GateError("--list-stages cannot be combined with another option")
 
-    def changed_entries(self) -> list[tuple[str, str, str | None]]:
+    def changed_entries(
+        self, *, include_worktree: bool = True
+    ) -> list[tuple[str, str, str | None]]:
         entries: list[tuple[str, str, str | None]] = []
         if self.resolved_base:
             entries.extend(
@@ -433,13 +442,26 @@ class QualityGate:
                     )
                 )
             )
-        entries.extend(
-            parse_name_status(
-                git_bytes(["diff", "--name-status", "-z", "--find-renames", "HEAD"])
+        if include_worktree:
+            entries.extend(
+                parse_name_status(
+                    git_bytes(["diff", "--name-status", "-z", "--find-renames", "HEAD"])
+                )
             )
-        )
-        entries.extend(("A", path, None) for path in untracked_paths())
+            entries.extend(("A", path, None) for path in untracked_paths())
         return entries
+
+    def validate_authoritative_impact(self) -> None:
+        if self.authority != "ci-merge":
+            return
+        github_sha = os.environ.get("GITHUB_SHA", "")
+        if github_sha != self.source_commit:
+            raise GateError("ci-merge source does not match GITHUB_SHA")
+        parents = git_text(["show", "-s", "--format=%P", "HEAD"]).split()
+        if len(parents) != 2 or parents[0] != self.resolved_base:
+            raise GateError("ci-merge base is not the tested merge first parent")
+        if git_bytes(["diff", "--binary", "HEAD"]) or untracked_paths():
+            raise GateError("ci-merge impact checkout must be clean")
 
     def select_all_impacts(self) -> None:
         self.specs = list(self.policy.specs)
@@ -488,17 +510,23 @@ class QualityGate:
             self.resolved_base = git_text(
                 ["rev-parse", "--verify", f"{self.options.base}^{{commit}}"]
             )
+        if self.options.mode == "impact" and not self.resolved_base:
+            raise GateError("impact mode requires --base")
+        self.validate_authoritative_impact()
         if self.options.stage:
             if self.options.stage not in self.all_stages:
                 raise GateError(f"unknown stage: {self.options.stage}")
             self.selected = [self.options.stage]
         elif self.options.mode == "repository":
             self.select_all()
-        elif self.options.mode == "release":
+        elif self.options.mode == "release" and not self.resolved_base:
             self.selected = list(self.release_stages)
             self.select_all_impacts()
         else:
-            for status, path, new_path in self.changed_entries():
+            include_worktree = self.options.mode == "change"
+            for status, path, new_path in self.changed_entries(
+                include_worktree=include_worktree
+            ):
                 if new_path is not None:
                     self.select_path(path, f"{status} old")
                     self.select_path(new_path, f"{status} new")
@@ -519,6 +547,9 @@ class QualityGate:
                     if prerequisite in self.selected and dependent not in self.selected:
                         self.add_stage(dependent, f"mandatory {prerequisite} prerequisite")
                         changed = True
+        if self.options.mode == "release":
+            self.selected = [stage for stage in self.selected if stage in self.release_stages]
+            self.add_stage("release-budget", "mandatory release timing postflight")
         self.selected = [stage for stage in self.all_stages if stage in self.selected]
         if self.options.without_release_budget:
             self.selected = [stage for stage in self.selected if stage != "release-budget"]
@@ -845,9 +876,18 @@ class QualityGate:
     def validate_resume(self) -> None:
         if not self.options.resume:
             return
-        self.resume_dir = (
-            self.latest_resume() if self.resume_requested_latest else Path(self.options.resume)
-        )
+        if self.resume_requested_auto:
+            try:
+                self.resume_dir = self.latest_resume()
+            except GateError as error:
+                print(f"quality-gate: {error}; starting a fresh compatible run")
+                return
+        else:
+            self.resume_dir = (
+                self.latest_resume()
+                if self.resume_requested_latest
+                else Path(self.options.resume)
+            )
         resume = self.resume_dir
         if not resume.is_dir() or resume.is_symlink():
             raise GateError("resume path must be a non-symlink run directory")
@@ -1240,6 +1280,58 @@ class QualityGate:
             if stage in self.results:
                 self.report(stage)
 
+    def run_post_ui_stages(self) -> None:
+        pending = [stage for stage in POST_UI_STAGES if stage in self.selected]
+        budgets = self.budget_values()
+
+        def expected_seconds(stage: str) -> int:
+            value = budgets.get(f"stage_{stage.replace('-', '_')}_seconds_max")
+            if value is None or not POSITIVE_INTEGER.fullmatch(value):
+                raise GateError(f"release stage budget must rank scheduled stage: {stage}")
+            return int(value)
+
+        pending.sort(key=lambda stage: (-expected_seconds(stage), self.all_stages.index(stage)))
+        while pending or any(stage in self.active for stage in POST_UI_STAGES):
+            while pending:
+                active_heavy = sum(
+                    stage in self.active for stage in PROCESS_HEAVY_STAGES
+                )
+                active_integration = sum(
+                    stage in self.active
+                    for stage in POST_UI_STAGES
+                    if stage not in PROCESS_HEAVY_STAGES
+                )
+                candidate = next(
+                    (
+                        stage for stage in pending
+                        if (
+                            active_heavy < PROCESS_HEAVY_LIMIT
+                            if stage in PROCESS_HEAVY_STAGES
+                            else (
+                                active_integration < INTEGRATION_LANE_LIMIT
+                                and (
+                                    "gate-contract" not in self.active
+                                    or stage in GATE_COMPATIBLE_INTEGRATION_STAGES
+                                )
+                            )
+                        )
+                    ),
+                    None,
+                )
+                if candidate is None:
+                    break
+                pending.remove(candidate)
+                stage = candidate
+                self.launch(stage)
+                if stage in self.results:
+                    self.report(stage)
+            self.poll_active()
+            for stage in POST_UI_STAGES:
+                if stage in self.results:
+                    self.report(stage)
+            if pending or any(stage in self.active for stage in POST_UI_STAGES):
+                time.sleep(0.05)
+
     def budget_values(self) -> dict[str, str | None]:
         if not self.release_budget.is_file() or self.release_budget.is_symlink():
             raise GateError("release budget is missing or unsafe")
@@ -1606,15 +1698,7 @@ class QualityGate:
             self.wait_for(("ui-e2e",))
             self.launch("quality-contracts")
             self.wait_for(("quality-contracts",))
-            for stage in PROVIDER_WAVE:
-                self.launch(stage)
-            self.wait_for(PROVIDER_WAVE)
-            for stage in CONTRACT_WAVE:
-                self.launch(stage)
-            self.wait_for(CONTRACT_WAVE)
-            for stage in RELEASE_WAVE:
-                self.launch(stage)
-            self.wait_for(RELEASE_WAVE)
+            self.run_post_ui_stages()
             for stage in self.selected:
                 if stage != "release-budget":
                     self.wait_for((stage,))
@@ -1867,12 +1951,17 @@ def gate_contract_definitions(
     ]
 
 
+def gate_orchestrator_limit(logical_cpus: int | None = None) -> int:
+    available = logical_cpus if logical_cpus is not None else os.cpu_count()
+    return 3 if (available or 0) >= 8 else 2
+
+
 def include_gate_orchestrators(mode: str, diagnostic_stage: str) -> bool:
     return mode != "change" or bool(diagnostic_stage)
 
 
 def run_gate_contract_stage(root: Path, *, include_orchestrators: bool) -> int:
-    orchestrator_limit = 2
+    orchestrator_limit = gate_orchestrator_limit()
     contracts = gate_contract_definitions(
         root, include_orchestrators=include_orchestrators
     )
@@ -1973,6 +2062,67 @@ def tmux_preflight(tmux: Path) -> int:
         shutil.rmtree(preflight)
 
 
+def ui_coverage_binary(root: Path) -> Path:
+    return (
+        root / "app/.build" / UI_COVERAGE_SCRATCH
+        / "arm64-apple-macosx/release/DetachApp"
+    )
+
+
+def split_swift_build_jobs(logical_cpus: int | None = None) -> tuple[int, int]:
+    available = logical_cpus if logical_cpus is not None else os.cpu_count()
+    total = max(2, available or 2)
+    normal = (total + 1) // 2
+    return normal, total - normal
+
+
+def run_app_stage(root: Path) -> int:
+    make_app = [str(root / "app/scripts/make-app.sh")]
+    selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+    if "quality-contracts" not in selected:
+        return child_run(make_app)
+
+    normal_jobs, coverage_jobs = split_swift_build_jobs()
+    normal_environment = os.environ.copy()
+    normal_environment["DETACH_SWIFT_BUILD_JOBS"] = str(normal_jobs)
+    coverage_environment = os.environ.copy()
+    coverage_environment.pop("DETACH_APP_BUILD_MARKER_FILE", None)
+    coverage_module_cache = root / "app/.build/quality-ui-module-cache"
+    coverage_environment.update(
+        {
+            "CLANG_MODULE_CACHE_PATH": str(coverage_module_cache),
+            "SWIFTPM_MODULECACHE_OVERRIDE": str(coverage_module_cache),
+        }
+    )
+    coverage_command = [
+        "swift",
+        "build",
+        "--enable-code-coverage",
+        "--disable-sandbox",
+        "--disable-automatic-resolution",
+        "--cache-path",
+        str(root / "app/.build"),
+        "-c",
+        "release",
+        "--triple",
+        "arm64-apple-macosx26.0",
+        "--scratch-path",
+        str(root / "app/.build" / UI_COVERAGE_SCRATCH),
+        "--product",
+        "DetachApp",
+        "--jobs",
+        str(coverage_jobs),
+    ]
+    coverage_process = subprocess.Popen(
+        coverage_command,
+        cwd=root / "app",
+        env=coverage_environment,
+    )
+    normal_status = child_run(make_app, env=normal_environment)
+    coverage_status = coverage_process.wait()
+    return normal_status or coverage_status
+
+
 def run_stage_worker(stage: str) -> int:
     root = Path(os.environ.get("DETACH_QUALITY_GATE_ROOT", ROOT))
     run_dir = Path(os.environ["DETACH_QUALITY_GATE_RUN_DIR"])
@@ -2070,7 +2220,7 @@ def run_stage_worker(stage: str) -> int:
             environment.update(
                 {
                     "DETACH_UI_COVERAGE_BINARY": str(
-                        root / "app/.build/arm64-apple-macosx/release/DetachApp"
+                        ui_coverage_binary(root)
                     ),
                     "DETACH_UI_COVERAGE_PROFILE_DIR": str(profile_directory),
                 }
@@ -2086,30 +2236,7 @@ def run_stage_worker(stage: str) -> int:
             shutil.rmtree(profile_directory, ignore_errors=True)
         return status
     if stage == "app":
-        status = child_run([str(root / "app/scripts/make-app.sh")])
-        if status:
-            return status
-        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
-        if "quality-contracts" not in selected:
-            return 0
-        return child_run(
-            [
-                "swift",
-                "build",
-                "--enable-code-coverage",
-                "--disable-sandbox",
-                "--disable-automatic-resolution",
-                "-c",
-                "release",
-                "--triple",
-                "arm64-apple-macosx26.0",
-                "--scratch-path",
-                ".build",
-                "--product",
-                "DetachApp",
-            ],
-            cwd=root / "app",
-        )
+        return run_app_stage(root)
     if stage == "ui-e2e":
         status = child_run([str(root / "tests/ui-e2e-contract.sh")])
         if status:
@@ -2119,9 +2246,7 @@ def run_stage_worker(stage: str) -> int:
         selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
         coverage_dir = root / "app/build/quality-ui-coverage" / run_dir.name
         if "quality-contracts" in selected:
-            coverage_binary = (
-                root / "app/.build/arm64-apple-macosx/release/DetachApp"
-            )
+            coverage_binary = ui_coverage_binary(root)
             if not coverage_binary.is_file() or coverage_binary.is_symlink():
                 print(
                     "quality-gate: app stage emitted no safe coverage executable",

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -81,6 +81,28 @@ class Classification:
         )
 
 
+@dataclass(frozen=True)
+class Impact:
+    status: str
+    stages: tuple[str, ...]
+    specs: tuple[str, ...]
+    capabilities: tuple[str, ...]
+    journeys: tuple[str, ...]
+    release_gates: tuple[str, ...]
+    unknown: bool
+
+    def document(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "stages": list(self.stages),
+            "specs": list(self.specs),
+            "capabilities": list(self.capabilities),
+            "journeys": list(self.journeys),
+            "release_gates": list(self.release_gates),
+            "unknown": self.unknown,
+        }
+
+
 class Policy:
     def __init__(self, path: Path) -> None:
         if not path.is_file() or path.is_symlink():
@@ -552,6 +574,63 @@ class Policy:
             "known", route.test_domain, route.release_domain, route.spec, stages,
             gates, unknown, route.pattern, route.priority, capabilities,
             ",".join(selected_journeys)
+        )
+
+    def impact(self, paths: Iterable[str]) -> Impact:
+        classifications = [self.classify(path) for path in paths]
+        if not classifications or any(
+            classification.status == "unknown" for classification in classifications
+        ):
+            return Impact(
+                "unknown",
+                tuple(stage.name for stage in self.stages),
+                tuple(self.specs),
+                tuple(self.capabilities),
+                tuple(self.journeys),
+                ("lid",),
+                True,
+            )
+        stages = {
+            stage
+            for classification in classifications
+            for stage in classification.stages.split(",")
+        }
+        changed = True
+        while changed:
+            changed = False
+            for prerequisite, dependent in self.dependencies:
+                if prerequisite in stages and dependent not in stages:
+                    stages.add(dependent)
+                    changed = True
+        spec_paths = {classification.spec for classification in classifications}
+        capabilities = {
+            capability
+            for classification in classifications
+            for capability in classification.capabilities.split(",")
+        }
+        journeys = {
+            journey
+            for classification in classifications
+            for journey in classification.journeys.split(",")
+        }
+        release_gates = {
+            gate
+            for classification in classifications
+            for gate in classification.release_gates.split(",")
+            if gate != "-"
+        }
+        return Impact(
+            "known",
+            tuple(stage.name for stage in self.stages if stage.name in stages),
+            tuple(
+                identifier
+                for identifier, (path, _) in self.specs.items()
+                if path in spec_paths
+            ),
+            tuple(value for value in self.capabilities if value in capabilities),
+            tuple(value for value in self.journeys if value in journeys),
+            tuple(value for value in ("lid",) if value in release_gates),
+            False,
         )
 
     def coverage_exclusion(self, path: str) -> str | None:

--- a/tools/quality_promote.py
+++ b/tools/quality_promote.py
@@ -230,7 +230,9 @@ def artifact_name(executable: str, repository: str, run_id: int, attempt: int) -
     return expected
 
 
-def artifact_inventory(run_dir: Path, manifest: dict[str, str]) -> dict[str, str]:
+def artifact_inventory(
+    run_dir: Path, manifest: dict[str, str], *, require_metrics: bool
+) -> dict[str, str]:
     inventory = safe_file(run_dir / "artifacts.tsv", "artifact inventory")
     if sha256(inventory) != manifest.get("artifacts_sha256"):
         raise PromotionError("artifact inventory digest does not match the manifest")
@@ -252,32 +254,41 @@ def artifact_inventory(run_dir: Path, manifest: dict[str, str]) -> dict[str, str
         if sha256(artifact) != fields[2]:
             raise PromotionError(f"evidence artifact digest does not match: {fields[1]}")
         values[fields[1]] = fields[2]
-    for required in (
-        "coverage-opportunities.json",
-        "quality-metrics.json",
-        "scenarios.jsonl",
-        "scenarios.junit.xml",
-    ):
+    required_artifacts = ["scenarios.jsonl", "scenarios.junit.xml"]
+    if require_metrics:
+        required_artifacts.extend(
+            ("coverage-opportunities.json", "quality-metrics.json")
+        )
+    for required in required_artifacts:
         if required not in values:
             raise PromotionError(f"required evidence artifact is missing: {required}")
+    if not require_metrics and any(
+        name in values
+        for name in ("coverage-opportunities.json", "quality-metrics.json")
+    ):
+        raise PromotionError("unselected quality metrics are present in impact evidence")
     return values
 
 
-def validate_summary(run_dir: Path, manifest: dict[str, str], policy: Policy) -> None:
+def validate_summary(
+    run_dir: Path,
+    manifest: dict[str, str],
+    policy: Policy,
+    expected_stages: list[str],
+) -> None:
     summary = safe_file(run_dir / "summary.tsv", "quality summary")
     if sha256(summary) != manifest.get("summary_sha256"):
         raise PromotionError("quality summary digest does not match the manifest")
     lines = summary.read_text(encoding="utf-8").splitlines()
     if not lines or lines[0] != SUMMARY_HEADER:
         raise PromotionError("quality summary schema is invalid")
-    expected_stages = [stage.name for stage in policy.stages if stage.name != "release-budget"]
     seen: list[str] = []
     for line in lines[1:]:
         fields = line.split("\t")
         if (
             len(fields) != 8
             or fields[0] != str(policy.version)
-            or fields[1] != "repository"
+            or fields[1] != "impact"
             or fields[3] != "passed"
             or not fields[4].isdigit()
             or not DIGEST.fullmatch(fields[6])
@@ -289,27 +300,65 @@ def validate_summary(run_dir: Path, manifest: dict[str, str], policy: Policy) ->
             raise PromotionError(f"stage log digest does not match: {fields[2]}")
         seen.append(fields[2])
     if seen != expected_stages:
-        raise PromotionError("quality summary is not the complete repository plan")
+        raise PromotionError("quality summary does not match the exact impact plan")
+
+
+def changed_paths(executable: str, base_commit: str, head_commit: str) -> list[str]:
+    raw = command(
+        executable,
+        [
+            "diff",
+            "--name-status",
+            "-z",
+            "--find-renames",
+            f"{base_commit}...{head_commit}",
+        ],
+    )
+    fields = raw.split("\0")
+    if fields and fields[-1] == "":
+        fields.pop()
+    paths: list[str] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        index += 1
+        if not status or index >= len(fields):
+            raise PromotionError("tested merge diff is malformed")
+        path = fields[index]
+        index += 1
+        if status[0] in ("R", "C"):
+            if index >= len(fields):
+                raise PromotionError("tested merge rename diff is malformed")
+            paths.extend((path, fields[index]))
+            index += 1
+        else:
+            paths.append(path)
+    return paths
 
 
 def validate_evidence(
-    run_dir: Path, policy: Policy, base_commit: str
+    run_dir: Path,
+    policy: Policy,
+    base_commit: str,
+    expected_impact: dict[str, object],
 ) -> tuple[dict[str, str], str]:
     manifest_path = safe_file(run_dir / "manifest.tsv", "quality manifest")
     manifest = read_tsv(manifest_path, "quality manifest")
     expected = {
         "schema": "4",
         "policy": str(policy.version),
-        "mode": "repository",
+        "mode": "impact",
         "authority": "ci-merge",
         "result": "passed",
         "base_commit": base_commit,
         "stages": ",".join(
-            stage.name for stage in policy.stages if stage.name != "release-budget"
+            stage
+            for stage in expected_impact["stages"]
+            if stage != "release-budget"
         ),
-        "specs": ",".join(policy.specs),
-        "capabilities": ",".join(policy.capabilities),
-        "journeys": ",".join(policy.journeys),
+        "specs": ",".join(expected_impact["specs"]),
+        "capabilities": ",".join(expected_impact["capabilities"]),
+        "journeys": ",".join(expected_impact["journeys"]),
     }
     for key, value in expected.items():
         if manifest.get(key) != value:
@@ -321,8 +370,14 @@ def validate_evidence(
         evidence = safe_file(run_dir / f"{name}.tsv", f"{name} evidence")
         if sha256(evidence) != manifest.get(f"{name}_sha256"):
             raise PromotionError(f"{name} evidence digest does not match the manifest")
-    validate_summary(run_dir, manifest, policy)
-    artifact_inventory(run_dir, manifest)
+    expected_stages = [
+        stage for stage in expected_impact["stages"] if stage != "release-budget"
+    ]
+    validate_summary(run_dir, manifest, policy, expected_stages)
+    require_metrics = "quality-contracts" in expected_stages
+    artifact_inventory(run_dir, manifest, require_metrics=require_metrics)
+    if not require_metrics:
+        return manifest, sha256(manifest_path)
     from quality_metrics import read_json, validate_metrics, validate_opportunities
 
     metrics = validate_metrics(
@@ -488,7 +543,11 @@ def promote(
         ):
             raise PromotionError("downloaded evidence run directory is unsafe")
         policy = Policy(POLICY_FILE)
-        manifest, manifest_digest = validate_evidence(run_dir, policy, parents[0])
+        paths = changed_paths(git_executable, parents[0], main_commit)
+        expected_impact = policy.impact(paths).document()
+        manifest, manifest_digest = validate_evidence(
+            run_dir, policy, parents[0], expected_impact
+        )
         tested_commit = manifest["source_commit"]
         tested_tree, tested_parents = github_commit(
             gh_executable, repository, tested_commit


### PR DESCRIPTION
## Summary

- Run pull-request CI on the exact dependency-closed impact of the tested merge. Unknown paths and changes to the quality planner, policy, or workflow still select the full repository graph.
- Recompute impact before main promotion. Keep narrow evidence valid without fabricating metrics, and retain the newest measured green-main baseline for dashboards and releases.
- Select release checks from the accumulated diff since the last published tag. Reuse only compatible digest-bound stage evidence on a resumed release.
- Replace fixed post-UI waves with a resource-bounded ready queue. Build the verified app and private coverage executable concurrently in isolated SwiftPM paths.

## Contract delta

- No functional gate, quality floor, timing budget, release gate, signing gate, or hardware gate is removed or raised.
- Pull-request authority requires a clean two-parent tested merge, `GITHUB_SHA` identity, and the exact first parent as the impact base.
- Empty or unknown impact fails safe to the complete applicable plan.
- `main` promotion validates the final merge diff and exact selected stages, capabilities, journeys, parents, tree, and artifact digests.

## Evidence

- Policy 44 care evaluation: 8/8 cases passed.
- Focused policy, baseline, promotion, dashboard, release-workflow, documentation, and scheduler contracts passed.
- All six repository gate-contract shards passed after the final scheduler change.
- Full change-mode diagnostic passed in 148 seconds. The previous release diagnostic took 309 seconds.
- Final repository scheduling diagnostic reached the last stage in 174 seconds. Its packaged UI driver hit a recorded local activation transient, so this timing is diagnostic only; hosted `quality-gates` remains readiness authority.
- `git diff --check` passed, and the staged public diff contains no local path or credential material.
