### PR TITLE
Speed up quality gate setup and Swift builds

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -26,6 +26,42 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - id: impact
+        name: Validate and plan exact pull-request impact
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DETACH_QUALITY_AUTHORITY: ci-merge
+        run: |
+          plan="$RUNNER_TEMP/quality-impact.json"
+          scripts/quality-gate --mode impact --base "$BASE_SHA" --plan \
+            --format json --without-release-budget >"$plan"
+          python3 - "$plan" "$GITHUB_OUTPUT" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          stages = value.get("stages")
+          if not isinstance(stages, list) or not all(isinstance(stage, str) for stage in stages):
+              raise SystemExit("quality impact plan has invalid stages")
+          selected = set(stages)
+          outputs = {
+              "needs_metrics": "quality-contracts" in selected,
+              "needs_swift_cache": bool({"swift", "app"} & selected),
+              "stages": ",".join(stages),
+          }
+          with Path(sys.argv[2]).open("a", encoding="utf-8") as output:
+              for name, value in outputs.items():
+                  output.write(f"{name}={str(value).lower()}\n")
+          PY
+      - name: Run fail-fast static contracts
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DETACH_QUALITY_GATE_RESULT_ROOT: ${{ runner.temp }}/quality-fail-fast
+          DETACH_QUALITY_AUTHORITY: ci-merge
+        run: scripts/quality-gate --mode impact --base "$BASE_SHA" --stage static --without-release-budget
       - id: promoted-main
         name: Promote exact pull-request evidence
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -42,7 +78,7 @@ jobs:
             printf 'promoted=false\n' >>"$GITHUB_OUTPUT"
           fi
       - name: Restore last green main quality metrics
-        if: steps.promoted-main.outputs.promoted != 'true'
+        if: steps.promoted-main.outputs.promoted != 'true' && (github.event_name != 'pull_request' || steps.impact.outputs.needs_metrics == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -50,15 +86,18 @@ jobs:
           printf 'DETACH_QUALITY_BASELINE_ROOT=%s\n' "$baseline_root" >>"$GITHUB_ENV"
       - name: Restore Swift and tmux caches
         id: swift-cache
-        if: steps.promoted-main.outputs.promoted != 'true'
+        if: steps.promoted-main.outputs.promoted == 'true' || github.event_name != 'pull_request' || steps.impact.outputs.needs_swift_cache == 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             app/.build
-          key: detach-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.resolved', 'scripts/build-tmux.sh') }}-${{ github.sha }}
+          key: detach-swift-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'app/scripts/make-app.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
           restore-keys: |
-            detach-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.resolved', 'scripts/build-tmux.sh') }}-
-            detach-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-
+            detach-swift-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-
+      - id: swift-warm
+        name: Warm exact promoted-main Swift cache
+        if: steps.promoted-main.outputs.promoted == 'true' && steps.swift-cache.outputs.cache-hit != 'true'
+        run: scripts/quality-cache-warm
       - name: Run authoritative pull-request gate
         if: github.event_name == 'pull_request'
         env:
@@ -71,12 +110,12 @@ jobs:
           DETACH_QUALITY_AUTHORITY: ci-main
         run: scripts/quality-gate --mode repository --keep-going --without-release-budget
       - name: Save Swift and tmux caches
-        if: always() && steps.promoted-main.outputs.promoted != 'true' && steps.swift-cache.outputs.cache-hit != 'true'
+        if: always() && steps.swift-cache.outcome == 'success' && steps.swift-cache.outputs.cache-hit != 'true' && (steps.promoted-main.outputs.promoted != 'true' || steps.swift-warm.outcome == 'success')
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             app/.build
-          key: detach-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.resolved', 'scripts/build-tmux.sh') }}-${{ github.sha }}
+          key: detach-swift-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'app/scripts/make-app.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Publish gate summary
         if: always()
         shell: bash

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -58,10 +58,8 @@ jobs:
       - name: Run fail-fast static contracts
         if: github.event_name == 'pull_request'
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DETACH_QUALITY_GATE_RESULT_ROOT: ${{ runner.temp }}/quality-fail-fast
-          DETACH_QUALITY_AUTHORITY: ci-merge
-        run: scripts/quality-gate --mode impact --base "$BASE_SHA" --stage static --without-release-budget
+        run: scripts/quality-gate --stage static
       - id: promoted-main
         name: Promote exact pull-request evidence
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -96,6 +96,10 @@ jobs:
         name: Warm exact promoted-main Swift cache
         if: steps.promoted-main.outputs.promoted == 'true' && steps.swift-cache.outputs.cache-hit != 'true'
         run: scripts/quality-cache-warm
+      - id: swift-dependencies
+        name: Materialize exact Swift dependencies
+        if: steps.swift-cache.outcome == 'success' && steps.promoted-main.outputs.promoted != 'true'
+        run: scripts/quality-cache-warm --dependencies-only
       - name: Run authoritative pull-request gate
         if: github.event_name == 'pull_request'
         env:
@@ -108,7 +112,7 @@ jobs:
           DETACH_QUALITY_AUTHORITY: ci-main
         run: scripts/quality-gate --mode repository --keep-going --without-release-budget
       - name: Save Swift and tmux caches
-        if: always() && steps.swift-cache.outcome == 'success' && steps.swift-cache.outputs.cache-hit != 'true' && (steps.promoted-main.outputs.promoted != 'true' || steps.swift-warm.outcome == 'success')
+        if: always() && steps.swift-cache.outcome == 'success' && steps.swift-cache.outputs.cache-hit != 'true' && ((steps.promoted-main.outputs.promoted == 'true' && steps.swift-warm.outcome == 'success') || (steps.promoted-main.outputs.promoted != 'true' && steps.swift-dependencies.outcome == 'success'))
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/app/scripts/make-app.sh
+++ b/app/scripts/make-app.sh
@@ -16,6 +16,7 @@ DOWNLOAD_URL="${DETACH_DOWNLOAD_URL:-}"
 SPARKLE_LICENSE_SOURCE="$APP_ROOT/Resources/ThirdParty/Sparkle/LICENSE.txt"
 SPARKLE_LICENSE_SHA256="389a4e4e9a32f059775b13a06e25a591445ba229d2838d26dd3e7c0c45127cfe"
 SWIFT_BUILD_JOBS="${DETACH_SWIFT_BUILD_JOBS:-}"
+QUALITY_APP_SCRATCH="${DETACH_QUALITY_APP_SCRATCH:-0}"
 APP="$APP_ROOT/build/Detach.app"
 PAYLOAD="$APP/Contents/Resources/DetachCLI"
 LAUNCH_AGENTS="$APP/Contents/Library/LaunchAgents"
@@ -72,6 +73,10 @@ if [ -n "$SWIFT_BUILD_JOBS" ] && ! [[ "$SWIFT_BUILD_JOBS" =~ ^[1-9][0-9]*$ ]]; t
   printf 'DETACH_SWIFT_BUILD_JOBS must be a positive integer\n' >&2
   exit 1
 fi
+[[ "$QUALITY_APP_SCRATCH" = 0 || "$QUALITY_APP_SCRATCH" = 1 ]] || {
+  printf 'DETACH_QUALITY_APP_SCRATCH must be 0 or 1\n' >&2
+  exit 1
+}
 if [ -n "$SPARKLE_FEED_URL" ] || [ -n "$SPARKLE_PUBLIC_ED_KEY" ]; then
   [[ "$SPARKLE_FEED_URL" =~ ^https://[^[:space:]]+$ ]] || {
     printf 'DETACH_SPARKLE_FEED_URL must be a valid HTTPS URL\n' >&2
@@ -216,6 +221,9 @@ build_arch() {
   # Sharing one scratch directory also shares the pinned Sparkle checkout and
   # binary artifact.
   local scratch="$APP_ROOT/.build"
+  if [ "$QUALITY_APP_SCRATCH" = 1 ]; then
+    scratch="$APP_ROOT/.build/quality-app-release"
+  fi
   local triple="$arch-apple-macosx26.0"
   local build_args=(
     --disable-sandbox
@@ -225,6 +233,9 @@ build_arch() {
     --triple "$triple"
     --scratch-path "$scratch"
   )
+  if [ "$QUALITY_APP_SCRATCH" = 1 ]; then
+    build_args+=(--cache-path "$APP_ROOT/.build")
+  fi
   if [ -n "$SWIFT_BUILD_JOBS" ]; then
     build_args+=(--jobs "$SWIFT_BUILD_JOBS")
   fi

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -140,8 +140,9 @@ it downloads optional metrics or Swift data. The authoritative gate recomputes
 both results. This fail-fast pass is diagnostic only.
 
 Swift tests, the normal app, and the instrumented app use isolated scratch and
-module-cache paths. A host with at least three CPUs splits workers and builds
-all three at the same time. Smaller hosts run Swift and app work in sequence.
+module-cache paths. CI materializes their shared dependency cache once before
+parallel builds. A host with at least three CPUs splits workers and builds all
+three at the same time. Smaller hosts run Swift and app work in sequence.
 The normal bundle is verified. Only the private UI copy gets the instrumented
 executable.
 The short packaged UI lane runs after the verified app and before the

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -135,12 +135,15 @@ Every executable stage has a policy-owned process deadline. The GitHub workflow
 has a ten-minute deadline and cancels superseded work. The pull request feedback
 SLO is less than ten minutes.
 
-Static validation runs before the parallel self-contract workers. This keeps
-its two-second local signal free of scheduler contention. Coverage compilation
-and the app build then get exclusive SwiftPM access. The app stage uses
-isolated build paths and splits the available workers to build the normal
-bundle and coverage-enabled release executable at the same time. It verifies
-the normal bundle. Only the private UI copy gets the instrumented executable.
+Pull-request CI validates its exact impact plan and runs static contracts before
+it downloads optional metrics or Swift data. The authoritative gate recomputes
+both results. This fail-fast pass is diagnostic only.
+
+Swift tests, the normal app, and the instrumented app use isolated scratch and
+module-cache paths. A host with at least three CPUs splits workers and builds
+all three at the same time. Smaller hosts run Swift and app work in sequence.
+The normal bundle is verified. Only the private UI copy gets the instrumented
+executable.
 The short packaged UI lane runs after the verified app and before the
 CPU-intensive provider, runtime, and gate-contract lanes. This prevents
 WindowServer event delivery from competing with those workers. After the UI and metric phases,
@@ -159,7 +162,10 @@ three process-heavy orchestrator shards on a host with at least eight logical
 CPUs, and two on a smaller host. This limit prevents process oversubscription
 without increasing the stage budget.
 
-Swift and Clang caches stay under `app/.build`. The packaged UI test uses a
+Swift and Clang caches stay under `app/.build`. Their hosted key covers the
+compiler, package, sources, tests, build scripts, and version metadata. A
+promoted `main` run can warm a missing key but emits no gate evidence. The
+packaged UI test uses a
 stripped process-private app, fake CLI, and private state. Provider tests use
 private state and socket roots plus the newly bundled `tmux` and
 `detach-state`. Tests do not use installed product state or ambient helpers.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -55,10 +55,9 @@ Journeys cover all main surfaces, Settings, onboarding, and focus. It
 disconnects Stop before it proves that the real control invokes the action.
 Only a visible control completes isolated onboarding.
 
-Coverage builds the normal bundle and instrumented release binary together in
-isolated paths with split workers. Only a signed private UI copy gets
-it. Neither it nor its profiles enter a verified bundle or public
-artifact.
+Coverage builds the normal bundle, instrumented binary, and Swift tests in
+isolated paths. UI waits for the bundle. Metrics wait for UI and Swift tests.
+Only the copy gets it. The binary and profiles stay out of public artifacts.
 If an overlay scroller ignores a page event, the driver reveals the measured
 semantic control, then posts the action to it.
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -67,30 +67,33 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - A local timing-budget failure creates performance work. Warm-cache or
   variance reruns cannot turn it into readiness; an unchanged rerun is allowed
   only for an evidenced unrelated external transient whose cause is recorded.
-- Pull-request CI runs each selected check once. Only the tested merge first
-  parent is a valid impact base. CI keeps timing ratchets but not reference-Mac
-  ceilings. Its overall deadline is ten minutes.
+- Pull-request CI runs each check once from the tested merge and first parent.
+  It validates the plan and static contracts before optional cache restore.
+  The gate recomputes both. CI keeps timing ratchets, a ten-minute deadline,
+  and no reference-Mac ceilings.
 - The gate-contract runner admits three process-heavy orchestrator shards on a
   host with at least eight logical CPUs, and two on a smaller host. Lightweight
   contracts stay concurrent. The runner does not increase a timing budget to
   hide process oversubscription.
-- After exclusive SwiftPM and UI phases, a priority queue starts ready work.
-  At most two top-level process-heavy lanes compete. One separate integration
-  and preflight lane can run with them. Short preflight and runtime checks can
-  use it during gate-contract. Distribution waits for gate-contract. A
-  completed stage opens its slot without a fixed wave barrier.
+- Swift tests and both release builds use separate caches. A host with three
+  CPUs splits them. Smaller hosts run Swift and app in order.
+  UI waits for the normal app; metrics wait for Swift tests and UI. Later work
+  uses two heavy lanes and one integration lane. Distribution waits for
+  gate-contract.
+- The Swift key covers the compiler, package, code, build scripts, and version
+  metadata. A promoted `main` run can warm the three
+  products. Warming emits no evidence and cannot replace a selected check.
 - CI uses the newest green `main` artifact with measured metrics. A later run
   without metrics does not replace it. Test identities, aggregate coverage,
   and critical-source coverage cannot decrease. Changed Swift lines need 90
   percent coverage. A person cannot raise floors. Policy-owned exclusions need
   scenario evidence and cannot cover critical sources. Named test-only regions
   stay in aggregate coverage but not changed-line metrics.
-- Authoritative UI coverage combines instrumented Swift tests with
-  packaged-app journeys. The app stage builds the normal bundle and an
-  instrumented release executable in isolated SwiftPM paths at the same time.
-  It splits the available workers between them and verifies the normal bundle.
-  Only the stripped private copy gets the instrumented executable. The metric
-  stage merges profiles after UI without another test run.
+- Authoritative coverage combines instrumented Swift tests and packaged-app
+  journeys. Their three builds have isolated paths and one content cache. The
+  gate splits workers and verifies the normal bundle. Only the stripped private
+  copy gets the instrumented executable. Metrics merge profiles without a
+  second test run.
 - `coverage-opportunities.json` is a separate digest-bound advisory artifact.
   It ranks uncovered UI sources from policy routes, release impact,
   requirements, and journeys. Its next milestone is the five-point boundary

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -89,8 +89,8 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   percent coverage. A person cannot raise floors. Policy-owned exclusions need
   scenario evidence and cannot cover critical sources. Named test-only regions
   stay in aggregate coverage but not changed-line metrics.
-- Authoritative coverage combines instrumented Swift tests and packaged-app
-  journeys. Their three builds have isolated paths and one content cache. The
+- Authoritative coverage combines Swift tests and packaged-app journeys. CI
+  resolves one shared cache, then three builds use isolated paths. The
   gate splits workers and verifies the normal bundle. Only the stripped private
   copy gets the instrumented executable. Metrics merge profiles without a
   second test run.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,12 @@
   its policy, exact source/base commits, input fingerprint, and stage coverage
   still match. `--keep-going` improves diagnosis but never turns a failed or
   blocked stage into readiness evidence.
+- Pull-request CI validates that machine plan and runs static contracts before
+  optional metrics and Swift cache downloads. The final gate recomputes both,
+  so the early pass is fail-fast diagnosis and not readiness evidence.
+- `scripts/quality-cache-warm` builds the three isolated Swift products for a
+  missing promoted-`main` cache key. It emits no gate evidence and never
+  replaces a selected stage.
 - `scripts/quality-scenarios rerun SC-ID` runs the owning diagnostic stage for
   an instrumented scenario, or its direct policy command otherwise. The stage
   process deadline bounds both forms. The helper has 30 seconds for evidence
@@ -93,8 +99,10 @@
   `DETACH_RELEASE_IGNORE_TIMING=1 scripts/release-version X.Y.Z`
   path may omit them for one intentionally busy-machine release, with the
   waiver recorded in private evidence. `--stage` is diagnostic only and is not
-  proof that a change is ready. The current policy keeps SwiftPM work
-  exclusive, then runs the isolated Codex and Claude suites concurrently
+  proof that a change is ready. On hosts with at least three CPUs, the current
+  policy splits workers across isolated Swift tests, normal app, and
+  instrumented app builds. Smaller hosts run Swift and app work in sequence.
+  It then runs the isolated Codex and Claude suites concurrently
   against the verified bundled tmux and state helper. It rejects reference-Mac
   wall or stage regressions and rejects attempts to lower quality floors or
   raise time budgets relative to their merge-base values. A quality-core or

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,8 @@
   so the early pass is fail-fast diagnosis and not readiness evidence.
 - `scripts/quality-cache-warm` builds the three isolated Swift products for a
   missing promoted-`main` cache key. It emits no gate evidence and never
-  replaces a selected stage.
+  replaces a selected stage. `--dependencies-only` materializes the shared
+  cache once before parallel builds.
 - `scripts/quality-scenarios rerun SC-ID` runs the owning diagnostic stage for
   an instrumented scenario, or its direct policy command otherwise. The stage
   process deadline bounds both forms. The helper has 30 seconds for evidence

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -659,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 44,
+  "policy": 45,
   "release_domains": [
     {
       "gates": "-",
@@ -877,6 +877,20 @@
     },
     {
       "pattern": "tools/quality_gate.py",
+      "priority": 1100,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "quality-core"
+    },
+    {
+      "pattern": "scripts/quality-cache-warm",
+      "priority": 1100,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "quality-core"
+    },
+    {
+      "pattern": "tools/quality_cache_warm.py",
       "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -2178,6 +2192,7 @@
         "quality/policy.tsv",
         "scripts/*",
         "scripts/quality-baseline",
+        "scripts/quality-cache-warm",
         "scripts/quality-care",
         "scripts/quality-dashboard",
         "scripts/quality-gate",
@@ -2200,6 +2215,7 @@
         "tests/shell-safety*",
         "tests/test-suite-contract.sh",
         "tools/quality_baseline.py",
+        "tools/quality_cache_warm.py",
         "tools/quality_care.py",
         "tools/quality_dashboard.py",
         "tools/quality_gate.py",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -33,6 +33,7 @@ It lists current specification ownership and verification links.
 - `quality/policy.tsv`
 - `scripts/*`
 - `scripts/quality-baseline`
+- `scripts/quality-cache-warm`
 - `scripts/quality-care`
 - `scripts/quality-dashboard`
 - `scripts/quality-gate`
@@ -55,6 +56,7 @@ It lists current specification ownership and verification links.
 - `tests/shell-safety*`
 - `tests/test-suite-contract.sh`
 - `tools/quality_baseline.py`
+- `tools/quality_cache_warm.py`
 - `tools/quality_care.py`
 - `tools/quality_dashboard.py`
 - `tools/quality_gate.py`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	44
+policy	45
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -81,6 +81,8 @@ route	1000	docs/quality-gates.md	policy	safe	docs/specs/documentation.md
 route	1000	docs/testing.md	policy	safe	docs/specs/documentation.md
 route	1100	scripts/quality-gate	quality-core	safe	docs/specs/documentation.md
 route	1100	tools/quality_gate.py	quality-core	safe	docs/specs/documentation.md
+route	1100	scripts/quality-cache-warm	quality-core	safe	docs/specs/documentation.md
+route	1100	tools/quality_cache_warm.py	quality-core	safe	docs/specs/documentation.md
 route	1000	scripts/quality-scenarios	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_scenarios.py	policy	safe	docs/specs/documentation.md
 route	1100	scripts/quality-policy	quality-core	safe	docs/specs/documentation.md

--- a/scripts/quality-cache-warm
+++ b/scripts/quality-cache-warm
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+exec python3 "$ROOT/tools/quality_cache_warm.py" "$@"

--- a/tests/quality-contracts.sh
+++ b/tests/quality-contracts.sh
@@ -11,7 +11,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
-build_path="$(cd -P "$APP_ROOT" && swift build --show-bin-path)"
+swift_scratch="${DETACH_SWIFT_TEST_SCRATCH:-}"
+build_path_args=(swift build --show-bin-path)
+test_list_args=(swift test list --skip-build --disable-sandbox)
+if [ -n "$swift_scratch" ]; then
+  [ "$swift_scratch" = "$APP_ROOT/.build/quality-swift-tests" ] || {
+    printf 'quality contracts: Swift scratch path is not the quality path\n' >&2
+    exit 2
+  }
+  build_path_args+=(--disable-automatic-resolution --cache-path "$APP_ROOT/.build" --scratch-path "$swift_scratch")
+  test_list_args+=(--disable-automatic-resolution --cache-path "$APP_ROOT/.build" --scratch-path "$swift_scratch")
+fi
+build_path="$(cd -P "$APP_ROOT" && "${build_path_args[@]}")"
 test_binary="$build_path/DetachAppPackageTests.xctest/Contents/MacOS/DetachAppPackageTests"
 profdata="$build_path/codecov/default.profdata"
 [ -f "$test_binary" ] && [ ! -L "$test_binary" ] && \
@@ -32,7 +43,7 @@ else
     cd -P "$APP_ROOT"
     mkdir -p .build/quality-codecov
     LLVM_PROFILE_FILE="$APP_ROOT/.build/quality-codecov/list-%p-%m.profraw" \
-      swift test list --skip-build --disable-sandbox
+      "${test_list_args[@]}"
   ) >"$tests"
 fi
 

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -29,10 +29,17 @@ grep -F 'scripts/quality-gate --mode impact --base "$BASE_SHA" --plan' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'name: Run fail-fast static contracts' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
-grep -F 'run: scripts/quality-gate --mode impact --base "$BASE_SHA" --stage static --without-release-budget' \
+grep -F 'run: scripts/quality-gate --stage static' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'DETACH_QUALITY_GATE_RESULT_ROOT: ${{ runner.temp }}/quality-fail-fast' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+fail_fast_step="$(sed -n \
+  '/name: Run fail-fast static contracts/,/run: scripts\/quality-gate --stage static/p' \
+  "$ROOT/.github/workflows/quality-gates.yml")"
+if printf '%s\n' "$fail_fast_step" | grep -F 'DETACH_QUALITY_AUTHORITY' >/dev/null; then
+  printf 'quality workflow gave merge authority to diagnostic fail-fast\n' >&2
+  exit 1
+fi
 grep -F "steps.impact.outputs.needs_metrics == 'true'" \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F "steps.impact.outputs.needs_swift_cache == 'true'" \

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -48,6 +48,12 @@ grep -F 'key: detach-swift-v2-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-cache-warm' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Materialize exact Swift dependencies' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'id: swift-dependencies' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'run: scripts/quality-cache-warm --dependencies-only' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 if grep -F 'jq ' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null; then
   printf 'quality workflow reintroduced ambient jq\n' >&2
   exit 1

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -23,6 +23,28 @@ grep -F 'run: scripts/quality-gate --mode impact --base "$BASE_SHA" --keep-going
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-gate --mode repository --keep-going --without-release-budget' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Validate and plan exact pull-request impact' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'scripts/quality-gate --mode impact --base "$BASE_SHA" --plan' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Run fail-fast static contracts' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'run: scripts/quality-gate --mode impact --base "$BASE_SHA" --stage static --without-release-budget' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'DETACH_QUALITY_GATE_RESULT_ROOT: ${{ runner.temp }}/quality-fail-fast' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "steps.impact.outputs.needs_metrics == 'true'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "steps.impact.outputs.needs_swift_cache == 'true'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'key: detach-swift-v2-' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'run: scripts/quality-cache-warm' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+if grep -F 'jq ' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null; then
+  printf 'quality workflow reintroduced ambient jq\n' >&2
+  exit 1
+fi
 grep -F 'name: Promote exact pull-request evidence' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F '  pull-requests: read' \
@@ -82,7 +104,7 @@ prepare_template() {
   printf '%s\n' baseline >"$TEMPLATE_REPO/README.md"
   printf '%s\n' actions.log results '*.out' /presentations/ >"$TEMPLATE_REPO/.gitignore"
   for stage in static gate-contract swift quality-contracts app ui-e2e codex claude distribution tmux-runtime release-preflight publish-preflight release-workflow; do
-    printf '#!/bin/bash\nset -eu\n[ -z "${DETACH_RELEASE_TIMING_OVERRIDE:-}" ] || { printf "release timing override leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_CONFIRM_RELEASE:-}" ] || { printf "release confirmation leaked into stage\\n" >&2; exit 1; }\n[ "${CLANG_MODULE_CACHE_PATH:-}" = "${GATE_EXPECTED_MODULE_CACHE:?}" ] || { printf "unexpected Clang module cache: %%s\\n" "${CLANG_MODULE_CACHE_PATH:-missing}" >&2; exit 1; }\n[ "${SWIFTPM_MODULECACHE_OVERRIDE:-}" = "$GATE_EXPECTED_MODULE_CACHE" ] || { printf "unexpected SwiftPM module cache: %%s\\n" "${SWIFTPM_MODULECACHE_OVERRIDE:-missing}" >&2; exit 1; }\nprintf "%%s\\n" "%s" >>"${GATE_ACTION_LOG:?}"\nsleep "${STAGE_SLEEP:-0}"\ncase " ${FAIL_STAGES:-} " in *" %s "*) exit 23 ;; esac\n' "$stage" "$stage" \
+    printf '#!/bin/bash\nset -eu\nexpected_cache="${GATE_EXPECTED_MODULE_CACHE:?}/%s"\n[ -z "${DETACH_RELEASE_TIMING_OVERRIDE:-}" ] || { printf "release timing override leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_CONFIRM_RELEASE:-}" ] || { printf "release confirmation leaked into stage\\n" >&2; exit 1; }\n[ "${CLANG_MODULE_CACHE_PATH:-}" = "$expected_cache" ] || { printf "unexpected Clang module cache: %%s\\n" "${CLANG_MODULE_CACHE_PATH:-missing}" >&2; exit 1; }\n[ "${SWIFTPM_MODULECACHE_OVERRIDE:-}" = "$expected_cache" ] || { printf "unexpected SwiftPM module cache: %%s\\n" "${SWIFTPM_MODULECACHE_OVERRIDE:-missing}" >&2; exit 1; }\nprintf "%%s\\n" "%s" >>"${GATE_ACTION_LOG:?}"\nsleep "${STAGE_SLEEP:-0}"\ncase " ${FAIL_STAGES:-} " in *" %s "*) exit 23 ;; esac\n' "$stage" "$stage" "$stage" \
       >"$TEMPLATE_REPO/tests/quality-gate-fixtures/$stage"
     chmod 0755 "$TEMPLATE_REPO/tests/quality-gate-fixtures/$stage"
   done
@@ -733,13 +755,27 @@ mkdir -p "$ORDER_ROOT"
 cat >"$REPO/tests/quality-gate-fixtures/swift" <<'SH'
 #!/bin/bash
 set -eu
+: >"${GATE_ORDER_ROOT:?}/swift-started"
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/app-started" ] && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/app-started" ]
 sleep 1
-: >"${GATE_ORDER_ROOT:?}/swift"
+: >"$GATE_ORDER_ROOT/swift"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/app" <<'SH'
 #!/bin/bash
 set -eu
-[ -f "${GATE_ORDER_ROOT:?}/swift" ]
+: >"${GATE_ORDER_ROOT:?}/app-started"
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/swift-started" ] && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/swift-started" ]
+[ ! -f "$GATE_ORDER_ROOT/swift" ]
 : >"$GATE_ORDER_ROOT/app"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/quality-contracts" <<'SH'

--- a/tests/quality_cache_warm_contract.py
+++ b/tests/quality_cache_warm_contract.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
@@ -12,7 +14,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "tools"))
 
-from quality_cache_warm import warm  # noqa: E402
+from quality_cache_warm import resolve_dependencies, warm  # noqa: E402
 
 
 class CacheWarmContract(unittest.TestCase):
@@ -29,22 +31,44 @@ class CacheWarmContract(unittest.TestCase):
             def terminate(self):
                 raise AssertionError("successful cache process was terminated")
 
-        with patch("quality_cache_warm.subprocess.Popen", FakeProcess):
-            self.assertEqual(warm(ROOT, 3), 0)
+        with TemporaryDirectory() as temporary:
+            test_root = Path(temporary)
+            app = test_root / "app"
+            (app / "scripts").mkdir(parents=True)
+            (app / "Package.swift").write_text("package\n", encoding="utf-8")
+            (app / "Package.resolved").write_text("resolved\n", encoding="utf-8")
+            with (
+                patch(
+                    "quality_cache_warm.subprocess.run",
+                    return_value=SimpleNamespace(returncode=0),
+                ) as resolve,
+                patch("quality_cache_warm.subprocess.Popen", FakeProcess),
+            ):
+                self.assertEqual(warm(test_root, 3), 0)
 
-        self.assertEqual(len(calls), 3)
-        test, normal, coverage = calls
-        self.assertIn("--build-tests", test[0])
-        self.assertIn(str(ROOT / "app/.build/quality-swift-tests"), test[0])
-        self.assertEqual(test[0][test[0].index("--jobs") + 1], "1")
-        self.assertEqual(normal[0], [str(ROOT / "app/scripts/make-app.sh")])
-        self.assertEqual(normal[2]["DETACH_QUALITY_APP_SCRATCH"], "1")
-        self.assertEqual(normal[2]["DETACH_SWIFT_BUILD_JOBS"], "1")
-        self.assertIn(str(ROOT / "app/.build/quality-ui-release"), coverage[0])
-        self.assertEqual(coverage[0][coverage[0].index("--jobs") + 1], "1")
-        module_caches = {call[2]["CLANG_MODULE_CACHE_PATH"] for call in calls}
-        self.assertEqual(len(module_caches), 3)
-        self.assertIn(str(ROOT / "app/.build/quality-ui-module-cache"), module_caches)
+            resolve_command = resolve.call_args.args[0]
+            self.assertEqual(resolve_command[:3], ["swift", "package", "resolve"])
+            self.assertIn(str(app / ".build"), resolve_command)
+            self.assertIn(
+                str(app / ".build/quality-dependency-resolve"), resolve_command
+            )
+            with patch("quality_cache_warm.subprocess.run") as cached_resolve:
+                self.assertEqual(resolve_dependencies(test_root), 0)
+                cached_resolve.assert_not_called()
+
+            self.assertEqual(len(calls), 3)
+            test, normal, coverage = calls
+            self.assertIn("--build-tests", test[0])
+            self.assertIn(str(app / ".build/quality-swift-tests"), test[0])
+            self.assertEqual(test[0][test[0].index("--jobs") + 1], "1")
+            self.assertEqual(normal[0], [str(app / "scripts/make-app.sh")])
+            self.assertEqual(normal[2]["DETACH_QUALITY_APP_SCRATCH"], "1")
+            self.assertEqual(normal[2]["DETACH_SWIFT_BUILD_JOBS"], "1")
+            self.assertIn(str(app / ".build/quality-ui-release"), coverage[0])
+            self.assertEqual(coverage[0][coverage[0].index("--jobs") + 1], "1")
+            module_caches = {call[2]["CLANG_MODULE_CACHE_PATH"] for call in calls}
+            self.assertEqual(len(module_caches), 3)
+            self.assertIn(str(app / ".build/quality-ui-module-cache"), module_caches)
 
 
 if __name__ == "__main__":

--- a/tests/quality_cache_warm_contract.py
+++ b/tests/quality_cache_warm_contract.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Contract tests for isolated Swift cache precomputation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+from quality_cache_warm import warm  # noqa: E402
+
+
+class CacheWarmContract(unittest.TestCase):
+    def test_three_build_graph_uses_isolated_paths_and_one_job_each(self) -> None:
+        calls: list[tuple[list[str], Path, dict[str, str]]] = []
+
+        class FakeProcess:
+            def __init__(self, command, *, cwd, env):
+                calls.append((command, cwd, env))
+
+            def wait(self):
+                return 0
+
+            def terminate(self):
+                raise AssertionError("successful cache process was terminated")
+
+        with patch("quality_cache_warm.subprocess.Popen", FakeProcess):
+            self.assertEqual(warm(ROOT, 3), 0)
+
+        self.assertEqual(len(calls), 3)
+        test, normal, coverage = calls
+        self.assertIn("--build-tests", test[0])
+        self.assertIn(str(ROOT / "app/.build/quality-swift-tests"), test[0])
+        self.assertEqual(test[0][test[0].index("--jobs") + 1], "1")
+        self.assertEqual(normal[0], [str(ROOT / "app/scripts/make-app.sh")])
+        self.assertEqual(normal[2]["DETACH_QUALITY_APP_SCRATCH"], "1")
+        self.assertEqual(normal[2]["DETACH_SWIFT_BUILD_JOBS"], "1")
+        self.assertIn(str(ROOT / "app/.build/quality-ui-release"), coverage[0])
+        self.assertEqual(coverage[0][coverage[0].index("--jobs") + 1], "1")
+        module_caches = {call[2]["CLANG_MODULE_CACHE_PATH"] for call in calls}
+        self.assertEqual(len(module_caches), 3)
+        self.assertIn(str(ROOT / "app/.build/quality-ui-module-cache"), module_caches)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False)
+    if result.result.wasSuccessful():
+        print("Quality cache warm contracts passed")
+    raise SystemExit(not result.result.wasSuccessful())

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -23,6 +23,7 @@ from quality_gate import (  # noqa: E402
     include_gate_orchestrators,
     parse_name_status,
     run_app_stage,
+    split_quality_pipeline_jobs,
     split_swift_build_jobs,
     ui_coverage_binary,
 )
@@ -112,6 +113,7 @@ class QualityGateContract(unittest.TestCase):
             self.assertEqual(events, ["coverage-started"])
             self.assertEqual(command, [str(ROOT / "app/scripts/make-app.sh")])
             self.assertEqual(env["DETACH_SWIFT_BUILD_JOBS"], "5")
+            self.assertEqual(env["DETACH_QUALITY_APP_SCRATCH"], "1")
             events.append("normal-finished")
             return 0
 
@@ -129,6 +131,8 @@ class QualityGateContract(unittest.TestCase):
             ["coverage-started", "normal-finished", "coverage-finished"],
         )
         self.assertEqual(split_swift_build_jobs(10), (5, 5))
+        self.assertEqual(split_quality_pipeline_jobs(3), (1, 1, 1))
+        self.assertEqual(split_quality_pipeline_jobs(10), (4, 3, 3))
         self.assertEqual(
             ui_coverage_binary(ROOT),
             ROOT / "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp",

--- a/tools/quality_cache_warm.py
+++ b/tools/quality_cache_warm.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 import subprocess
@@ -36,8 +37,51 @@ def module_environment(root: Path, name: str) -> dict[str, str]:
     return environment
 
 
+def dependency_fingerprint(app: Path) -> str:
+    digest = hashlib.sha256(b"detach-swift-dependencies-v1\0")
+    for name in ("Package.swift", "Package.resolved"):
+        path = app / name
+        if not path.is_file() or path.is_symlink():
+            raise CacheWarmError(f"missing or unsafe app/{name}")
+        digest.update(name.encode("utf-8") + b"\0" + path.read_bytes())
+    return digest.hexdigest()
+
+
+def resolve_dependencies(root: Path) -> int:
+    app = root / "app"
+    fingerprint = dependency_fingerprint(app)
+    sentinel = app / ".build/quality-dependencies-v1"
+    if sentinel.is_symlink():
+        raise CacheWarmError("dependency cache sentinel is a symlink")
+    if sentinel.is_file() and sentinel.read_text(encoding="utf-8").strip() == fingerprint:
+        print("quality-cache-warm: exact Swift dependencies are ready")
+        return 0
+    command = [
+        "swift", "package", "resolve", "--disable-sandbox",
+        "--cache-path", str(app / ".build"),
+        "--scratch-path", str(app / ".build/quality-dependency-resolve"),
+    ]
+    result = subprocess.run(
+        command,
+        cwd=app,
+        env=module_environment(root, "dependency-resolve"),
+        check=False,
+    )
+    if result.returncode == 0:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        temporary = sentinel.with_name(f".{sentinel.name}.{os.getpid()}")
+        temporary.write_text(f"{fingerprint}\n", encoding="utf-8")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, sentinel)
+        print("quality-cache-warm: exact Swift dependencies are ready")
+    return result.returncode
+
+
 def warm(root: Path, logical_cpus: int | None = None) -> int:
     app = root / "app"
+    dependency_status = resolve_dependencies(root)
+    if dependency_status:
+        return dependency_status
     swift_jobs, normal_jobs, coverage_jobs = split_quality_pipeline_jobs(logical_cpus)
     test_scratch = app / ".build" / SWIFT_TEST_SCRATCH
     coverage_scratch = app / ".build" / UI_COVERAGE_SCRATCH
@@ -94,8 +138,10 @@ def warm(root: Path, logical_cpus: int | None = None) -> int:
 
 
 def main(arguments: list[str]) -> int:
+    if arguments == ["--dependencies-only"]:
+        return resolve_dependencies(ROOT)
     if arguments:
-        raise CacheWarmError("this command takes no arguments")
+        raise CacheWarmError("usage: quality-cache-warm [--dependencies-only]")
     return warm(ROOT)
 
 

--- a/tools/quality_cache_warm.py
+++ b/tools/quality_cache_warm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Precompute exact SwiftPM build products outside merge-readiness evidence."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import NoReturn
+
+from quality_gate import SWIFT_TEST_SCRATCH, UI_COVERAGE_SCRATCH, split_quality_pipeline_jobs
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class CacheWarmError(Exception):
+    """The cache warmer cannot safely complete."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-cache-warm: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def module_environment(root: Path, name: str) -> dict[str, str]:
+    environment = os.environ.copy()
+    module_cache = root / "app/.build/module-cache" / name
+    environment.update(
+        {
+            "CLANG_MODULE_CACHE_PATH": str(module_cache),
+            "SWIFTPM_MODULECACHE_OVERRIDE": str(module_cache),
+        }
+    )
+    return environment
+
+
+def warm(root: Path, logical_cpus: int | None = None) -> int:
+    app = root / "app"
+    swift_jobs, normal_jobs, coverage_jobs = split_quality_pipeline_jobs(logical_cpus)
+    test_scratch = app / ".build" / SWIFT_TEST_SCRATCH
+    coverage_scratch = app / ".build" / UI_COVERAGE_SCRATCH
+
+    test_command = [
+        "swift", "build", "--build-tests", "--enable-code-coverage",
+        "--disable-sandbox", "--disable-automatic-resolution",
+        "--cache-path", str(app / ".build"),
+        "--scratch-path", str(test_scratch), "--jobs", str(swift_jobs),
+    ]
+    normal_environment = module_environment(root, "app")
+    normal_environment.update(
+        {
+            "DETACH_SWIFT_BUILD_JOBS": str(normal_jobs),
+            "DETACH_QUALITY_APP_SCRATCH": "1",
+        }
+    )
+    coverage_environment = os.environ.copy()
+    coverage_module_cache = app / ".build/quality-ui-module-cache"
+    coverage_environment.update(
+        {
+            "CLANG_MODULE_CACHE_PATH": str(coverage_module_cache),
+            "SWIFTPM_MODULECACHE_OVERRIDE": str(coverage_module_cache),
+        }
+    )
+    coverage_environment.pop("DETACH_APP_BUILD_MARKER_FILE", None)
+    coverage_command = [
+        "swift", "build", "--enable-code-coverage", "--disable-sandbox",
+        "--disable-automatic-resolution", "--cache-path", str(app / ".build"),
+        "-c", "release", "--triple", "arm64-apple-macosx26.0",
+        "--scratch-path", str(coverage_scratch), "--product", "DetachApp",
+        "--jobs", str(coverage_jobs),
+    ]
+    definitions = (
+        (test_command, app, module_environment(root, "swift")),
+        ([str(app / "scripts/make-app.sh")], root, normal_environment),
+        (coverage_command, app, coverage_environment),
+    )
+    processes: list[subprocess.Popen[bytes]] = []
+    try:
+        for command, cwd, environment in definitions:
+            processes.append(subprocess.Popen(command, cwd=cwd, env=environment))
+    except OSError as error:
+        for process in processes:
+            process.terminate()
+            process.wait()
+        raise CacheWarmError(f"cannot start cache build: {error}") from error
+    statuses = [process.wait() for process in processes]
+    for status in statuses:
+        if status:
+            return status
+    print("quality-cache-warm: exact Swift build cache is ready; no gate evidence emitted")
+    return 0
+
+
+def main(arguments: list[str]) -> int:
+    if arguments:
+        raise CacheWarmError("this command takes no arguments")
+    return warm(ROOT)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except CacheWarmError as error:
+        fail(str(error))

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -76,6 +76,7 @@ GATE_COMPATIBLE_INTEGRATION_STAGES = {
     "publish-preflight",
 }
 UI_COVERAGE_SCRATCH = "quality-ui-release"
+SWIFT_TEST_SCRATCH = "quality-swift-tests"
 
 
 class GateError(Exception):
@@ -1120,7 +1121,7 @@ class QualityGate:
             "DETACH_DOWNLOAD_URL",
         ):
             environment.pop(name, None)
-        module_cache = ROOT / "app/.build/module-cache"
+        module_cache = ROOT / "app/.build/module-cache" / stage
         module_cache.mkdir(parents=True, exist_ok=True)
         environment.update(
             {
@@ -1690,10 +1691,19 @@ class QualityGate:
         try:
             self.launch("static")
             self.wait_for(("static",))
+            parallel_swift_app = (
+                "swift" in self.selected
+                and "app" in self.selected
+                and (os.cpu_count() or 0) >= 3
+            )
             self.launch("swift")
-            self.wait_for(("swift",))
-            self.launch("app")
-            self.wait_for(("app",))
+            if parallel_swift_app:
+                self.launch("app")
+                self.wait_for(("swift", "app"))
+            else:
+                self.wait_for(("swift",))
+                self.launch("app")
+                self.wait_for(("app",))
             self.launch("ui-e2e")
             self.wait_for(("ui-e2e",))
             self.launch("quality-contracts")
@@ -1941,6 +1951,12 @@ def gate_contract_definitions(
             {},
             "Quality dashboard contracts passed",
         ),
+        (
+            "quality-cache-warm.log",
+            [sys.executable, str(root / "tests/quality_cache_warm_contract.py")],
+            {},
+            "Quality cache warm contracts passed",
+        ),
     ]
     if include_orchestrators:
         return contracts
@@ -2076,15 +2092,31 @@ def split_swift_build_jobs(logical_cpus: int | None = None) -> tuple[int, int]:
     return normal, total - normal
 
 
+def split_quality_pipeline_jobs(
+    logical_cpus: int | None = None,
+) -> tuple[int, int, int]:
+    available = logical_cpus if logical_cpus is not None else os.cpu_count()
+    total = max(3, available or 3)
+    swift = (total + 2) // 3
+    remaining = total - swift
+    normal = (remaining + 1) // 2
+    return swift, normal, remaining - normal
+
+
 def run_app_stage(root: Path) -> int:
     make_app = [str(root / "app/scripts/make-app.sh")]
     selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
     if "quality-contracts" not in selected:
         return child_run(make_app)
 
-    normal_jobs, coverage_jobs = split_swift_build_jobs()
+    parallel_swift = "swift" in selected and (os.cpu_count() or 0) >= 3
+    if parallel_swift:
+        _, normal_jobs, coverage_jobs = split_quality_pipeline_jobs()
+    else:
+        normal_jobs, coverage_jobs = split_swift_build_jobs()
     normal_environment = os.environ.copy()
     normal_environment["DETACH_SWIFT_BUILD_JOBS"] = str(normal_jobs)
+    normal_environment["DETACH_QUALITY_APP_SCRATCH"] = "1"
     coverage_environment = os.environ.copy()
     coverage_environment.pop("DETACH_APP_BUILD_MARKER_FILE", None)
     coverage_module_cache = root / "app/.build/quality-ui-module-cache"
@@ -2181,8 +2213,14 @@ def run_stage_worker(stage: str) -> int:
         )
     if stage == "swift":
         app = root / "app"
+        scratch = app / ".build" / SWIFT_TEST_SCRATCH
         (app / ".build/quality-codecov").mkdir(parents=True, exist_ok=True)
-        result = run(["swift", "build", "--show-bin-path"], cwd=app, text=True, check=False)
+        build_path_command = [
+            "swift", "build", "--show-bin-path", "--disable-automatic-resolution",
+            "--cache-path", str(app / ".build"),
+            "--scratch-path", str(scratch)
+        ]
+        result = run(build_path_command, cwd=app, text=True, check=False)
         assert isinstance(result.stdout, str)
         if result.returncode != 0:
             sys.stdout.write(result.stdout)
@@ -2194,12 +2232,22 @@ def run_stage_worker(stage: str) -> int:
         environment["LLVM_PROFILE_FILE"] = str(
             app / ".build/quality-codecov/%p-%m.profraw"
         )
+        command = [
+            "swift", "test", "--enable-code-coverage", "--disable-sandbox",
+            "--disable-automatic-resolution",
+            "--cache-path", str(app / ".build"), "--scratch-path", str(scratch),
+        ]
+        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+        if "app" in selected and (os.cpu_count() or 0) >= 3:
+            swift_jobs, _, _ = split_quality_pipeline_jobs()
+            command.extend(("--jobs", str(swift_jobs)))
         return child_run(
-            ["swift", "test", "--enable-code-coverage", "--disable-sandbox"],
+            command,
             cwd=app,
             env=environment,
         )
     if stage == "quality-contracts":
+        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
         environment = os.environ.copy()
         environment.update(
             {
@@ -2212,7 +2260,10 @@ def run_stage_worker(stage: str) -> int:
                 "DETACH_QUALITY_AUTHORITY": authority,
             }
         )
-        selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+        if "swift" in selected:
+            environment["DETACH_SWIFT_TEST_SCRATCH"] = str(
+                root / "app/.build" / SWIFT_TEST_SCRATCH
+            )
         if "ui-e2e" in selected:
             profile_directory = (
                 root / "app/build/quality-ui-coverage" / run_dir.name


### PR DESCRIPTION
## Contract delta

- Validate the exact pull-request plan and static contracts before optional downloads.
- Restore metrics and build data only when selected by impact.
- Run isolated Swift tests, normal app, and instrumented app builds concurrently.
- Use content-addressed build caches and warm missing promoted-main products without producing gate evidence.
- Keep the final gate authoritative by recomputing impact and static validation.

## Evidence

- Python gate and cache-warmer contracts pass.
- Full quality-gate orchestrator contracts pass.
- Documentation, policy generation, and 8/8 impact evals pass.
- Warm cache preparation: 8.86 seconds.
- Full local impact diagnostic: static 1s, Swift 10s, app 9s; restricted-workspace GUI and tmux socket stages were environment-limited.
- git diff --cached --check passed before commit.

## Next latency slice

Hosted timing from this pull request will set the measured baseline for exact distributed shards. Gate evidence remains the only readiness authority.