### PR TITLE
Cache the exact packaged quality app

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: app/build/Detach.app
-          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
+          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Restore exact Swift and tmux inputs
         id: swift-cache
         if: matrix.needs_cache || (matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true')
@@ -206,7 +206,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: app/build/Detach.app
-          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
+          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Restore Swift and tmux caches
         id: swift-cache
         if: github.event_name != 'pull_request'
@@ -256,7 +256,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: app/build/Detach.app
-          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
+          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Publish gate summary
         if: always()
         shell: bash

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -90,9 +90,16 @@ jobs:
         run: |
           baseline_root="$(scripts/quality-baseline)"
           printf 'DETACH_QUALITY_BASELINE_ROOT=%s\n' "$baseline_root" >>"$GITHUB_ENV"
+      - name: Restore exact packaged test app
+        id: app-cache
+        if: matrix.needs_app
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: app/build/Detach.app
+          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Restore exact Swift and tmux inputs
         id: swift-cache
-        if: matrix.needs_cache
+        if: matrix.needs_cache || (matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true')
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -101,13 +108,16 @@ jobs:
           restore-keys: |
             detach-swift-v3-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-
       - name: Reuse exact cached Swift products
-        if: matrix.needs_cache && steps.swift-cache.outputs.cache-hit == 'true'
+        if: steps.swift-cache.outputs.cache-hit == 'true'
         run: scripts/quality-cache-warm --reuse-exact-products
       - name: Materialize exact Swift dependencies
-        if: matrix.needs_cache && steps.swift-cache.outcome == 'success'
+        if: steps.swift-cache.outcome == 'success'
         run: scripts/quality-cache-warm --dependencies-only
+      - name: Verify exact packaged test app
+        if: matrix.needs_app && steps.app-cache.outputs.cache-hit == 'true'
+        run: app/scripts/verify-app.sh
       - name: Prepare packaged provider runtime
-        if: matrix.needs_app
+        if: matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true'
         env:
           DETACH_QUALITY_APP_SCRATCH: 1
         run: app/scripts/make-app.sh
@@ -190,6 +200,13 @@ jobs:
         run: |
           baseline_root="$(scripts/quality-baseline)"
           printf 'DETACH_QUALITY_BASELINE_ROOT=%s\n' "$baseline_root" >>"$GITHUB_ENV"
+      - name: Restore exact packaged test app
+        id: app-cache
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: app/build/Detach.app
+          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Restore Swift and tmux caches
         id: swift-cache
         if: github.event_name != 'pull_request'
@@ -207,6 +224,12 @@ jobs:
         name: Warm exact promoted-main Swift cache
         if: steps.promoted-main.outputs.promoted == 'true' && steps.swift-cache.outputs.cache-hit != 'true'
         run: scripts/quality-cache-warm
+      - id: app-warm
+        name: Prepare exact promoted-main test app
+        if: steps.promoted-main.outputs.promoted == 'true' && steps.swift-cache.outputs.cache-hit == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        env:
+          DETACH_QUALITY_APP_SCRATCH: 1
+        run: app/scripts/make-app.sh
       - id: swift-dependencies
         name: Materialize exact Swift dependencies
         if: github.event_name != 'pull_request' && steps.swift-cache.outcome == 'success' && steps.promoted-main.outputs.promoted != 'true'
@@ -228,6 +251,12 @@ jobs:
           path: |
             app/.build
           key: detach-swift-v3-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'app/scripts/make-app.sh', 'scripts/build-tmux.sh', 'tools/quality_cache_warm.py', 'VERSION', 'BUILD') }}
+      - name: Save exact packaged test app
+        if: always() && github.event_name != 'pull_request' && steps.app-cache.outcome == 'success' && steps.app-cache.outputs.cache-hit != 'true' && ((steps.promoted-main.outputs.promoted == 'true' && (steps.swift-warm.outcome == 'success' || steps.app-warm.outcome == 'success')) || (steps.promoted-main.outputs.promoted != 'true' && steps.main-products.outcome == 'success'))
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: app/build/Detach.app
+          key: detach-app-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Publish gate summary
         if: always()
         shell: bash

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -81,8 +81,8 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   more CPUs. Smaller hosts run them in order. UI waits for the app; metrics
   wait for Swift and UI. Later work uses two heavy lanes and one integration
   lane. Distribution waits for gate-contract.
-- The Swift key covers the compiler, package, code, build scripts, and version.
-  A promoted `main` run can warm all products. Warming is not evidence.
+- Exact keys bind code, resources, scripts, version, and toolchain. Promoted
+  `main` warms Swift products and the test app. Warming is not evidence.
 - CI uses the newest green `main` artifact with measured metrics. A later run
   without metrics does not replace it. Test identities, aggregate coverage,
   and critical-source coverage cannot decrease. Changed Swift lines need 90

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -659,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 46,
+  "policy": 47,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	46
+policy	47
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -42,6 +42,12 @@ grep -F 'if: matrix.needs_metrics' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'if: matrix.needs_cache' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'key: detach-app-v1-' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Verify exact packaged test app' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "steps.app-cache.outputs.cache-hit != 'true'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'key: detach-swift-v3-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-cache-warm --reuse-exact-products' \

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -44,6 +44,8 @@ grep -F 'if: matrix.needs_cache' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'key: detach-app-v1-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "'app/scripts/verify-app.sh'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'name: Verify exact packaged test app' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F "steps.app-cache.outputs.cache-hit != 'true'" \

--- a/tests/quality_shard_contract.py
+++ b/tests/quality_shard_contract.py
@@ -80,6 +80,10 @@ class QualityShardContract(unittest.TestCase):
             contracts["stages"], "gate-contract,tmux-runtime,release-preflight"
         )
         self.assertTrue(contracts["needs_app"])
+        self.assertFalse(contracts["needs_cache"])
+        codex = shard_for({"stages": stages}, "codex")
+        self.assertTrue(codex["needs_app"])
+        self.assertFalse(codex["needs_cache"])
 
     def test_unowned_or_malformed_plan_fails_closed(self) -> None:
         with self.assertRaisesRegex(ShardError, "no shard owns"):

--- a/tools/quality_shard.py
+++ b/tools/quality_shard.py
@@ -128,9 +128,7 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
         owned.update(stages)
         remaining.difference_update(stages)
         needs_app = bool({"codex", "claude", "tmux-runtime"} & set(stages))
-        needs_cache = needs_app or bool(
-            {"swift", "app", "ui-e2e", "tmux-runtime"} & set(stages)
-        )
+        needs_cache = bool({"swift", "app", "ui-e2e"} & set(stages))
         shards.append(
             {
                 "id": identifier,


### PR DESCRIPTION
## Contract delta

- Add a separate exact cache for the packaged test app.
- Bind the app cache to source, resources, verification, payload scripts, version, runner architecture, and Xcode.
- Restore the full Swift graph only for build coverage or an app-cache miss.
- Keep cache warming outside merge evidence. An app-cache miss still builds and verifies the app.

## Durable decisions

- Provider and runtime shards consume the 21 MB app bundle instead of the 614 MB build graph when exact inputs match.
- The packaged app has no prefix restore path.
- Main creates the app cache only from a successful promoted warm or full gate.

## Evidence

- Branch diagnostic run 33020255529 passed the full repository gate.
- Exact cached Swift planning and build took 1.55 seconds; 787 tests took 8.09 seconds.
- `actionlint .github/workflows/quality-gates.yml`
- `python3 tests/quality_shard_contract.py`
- `DETACH_QUALITY_GATE_CONTRACT_SHARD=selection tests/quality-gate.sh`
- `DETACH_QUALITY_GATE_CONTRACT_SHARD=distributed tests/quality-gate.sh`
- `tests/docs-contract.sh`
- `tests/test-suite-contract.sh`
- `scripts/quality-policy validate`
- `scripts/quality-policy generate --check`
- `git diff --check`

Hosted pull-request `quality-gates` remains the readiness authority.