### PR TITLE
Reuse exact packaged app in quality build shard

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -113,9 +113,11 @@ jobs:
       - name: Materialize exact Swift dependencies
         if: steps.swift-cache.outcome == 'success'
         run: scripts/quality-cache-warm --dependencies-only
-      - name: Verify exact packaged test app
+      - name: Verify and bind exact packaged test app
         if: matrix.needs_app && steps.app-cache.outputs.cache-hit == 'true'
-        run: app/scripts/verify-app.sh
+        run: |
+          app/scripts/verify-app.sh
+          printf 'DETACH_QUALITY_EXACT_APP=1\n' >>"$GITHUB_ENV"
       - name: Prepare packaged provider runtime
         if: matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true'
         env:

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -81,8 +81,8 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   more CPUs. Smaller hosts run them in order. UI waits for the app; metrics
   wait for Swift and UI. Later work uses two heavy lanes and one integration
   lane. Distribution waits for gate-contract.
-- Exact keys bind code, resources, scripts, version, and toolchain. Promoted
-  `main` warms Swift products and the test app. Warming is not evidence.
+- Exact keys bind code, resources, scripts, version, and toolchain. `main` warms
+  them. CI verifies the restored test app. Warming is not evidence.
 - CI uses the newest green `main` artifact with measured metrics. A later run
   without metrics does not replace it. Test identities, aggregate coverage,
   and critical-source coverage cannot decrease. Changed Swift lines need 90

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -659,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 47,
+  "policy": 48,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	47
+policy	48
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -46,7 +46,9 @@ grep -F 'key: detach-app-v1-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F "'app/scripts/verify-app.sh'" \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
-grep -F 'name: Verify exact packaged test app' \
+grep -F 'name: Verify and bind exact packaged test app' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'DETACH_QUALITY_EXACT_APP=1' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F "steps.app-cache.outputs.cache-hit != 'true'" \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -138,6 +138,36 @@ class QualityGateContract(unittest.TestCase):
             ROOT / "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp",
         )
 
+    def test_exact_hosted_app_is_verified_while_coverage_builds(self) -> None:
+        commands: list[list[str]] = []
+
+        class FakeProcess:
+            def __init__(self, command, *, cwd, env):
+                self.command = command
+
+            def wait(self):
+                return 0
+
+        def fake_child_run(command, *, cwd=ROOT, env=None):
+            commands.append(command)
+            return 0
+
+        environment = {
+            "DETACH_QUALITY_EXACT_APP": "1",
+            "DETACH_QUALITY_GATE_SELECTED_STAGES": "app,quality-contracts",
+            "DETACH_QUALITY_GATE_AUTHORITY": "ci-shard",
+            "GITHUB_ACTIONS": "true",
+        }
+        with patch.dict("os.environ", environment, clear=True), patch(
+            "quality_gate.subprocess.Popen", FakeProcess
+        ), patch("quality_gate.child_run", fake_child_run):
+            self.assertEqual(run_app_stage(ROOT), 0)
+        self.assertEqual(commands, [[str(ROOT / "app/scripts/verify-app.sh")]])
+
+        environment["DETACH_QUALITY_GATE_AUTHORITY"] = "local-diagnostic"
+        with patch.dict("os.environ", environment, clear=True):
+            self.assertEqual(run_app_stage(ROOT), 2)
+
 
 def main() -> int:
     suite = unittest.defaultTestLoader.loadTestsFromTestCase(QualityGateContract)

--- a/tests/quality_shard_contract.py
+++ b/tests/quality_shard_contract.py
@@ -73,6 +73,7 @@ class QualityShardContract(unittest.TestCase):
         self.assertEqual(len(flattened), len(stages))
         build = shard_for({"stages": stages}, "build-and-coverage")
         self.assertEqual(build["stages"], "swift,quality-contracts,app,ui-e2e")
+        self.assertTrue(build["needs_app"])
         self.assertTrue(build["needs_cache"])
         self.assertTrue(build["needs_metrics"])
         contracts = shard_for({"stages": stages}, "contracts-and-runtime")

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1137,6 +1137,7 @@ class QualityGate:
 
     def stage_environment(self, stage: str) -> dict[str, str]:
         environment = os.environ.copy()
+        exact_app = environment.pop("DETACH_QUALITY_EXACT_APP", "")
         for name in (
             "DETACH_RELEASE_TIMING_OVERRIDE",
             "DETACH_CONFIRM_RELEASE",
@@ -1177,6 +1178,8 @@ class QualityGate:
                 ),
             }
         )
+        if stage == "app" and exact_app:
+            environment["DETACH_QUALITY_EXACT_APP"] = exact_app
         if not self.test_direct:
             environment["DETACH_RELEASE_TESTS_DETACHED"] = "1"
         return environment
@@ -2150,9 +2153,25 @@ def split_quality_pipeline_jobs(
 
 def run_app_stage(root: Path) -> int:
     make_app = [str(root / "app/scripts/make-app.sh")]
+    exact_app = os.environ.get("DETACH_QUALITY_EXACT_APP", "")
+    if exact_app not in ("", "1"):
+        print("quality-gate: DETACH_QUALITY_EXACT_APP must be 1", file=sys.stderr)
+        return 2
+    if exact_app and (
+        os.environ.get("GITHUB_ACTIONS") != "true"
+        or os.environ.get("DETACH_QUALITY_GATE_AUTHORITY") != "ci-shard"
+    ):
+        print(
+            "quality-gate: exact app reuse requires hosted shard authority",
+            file=sys.stderr,
+        )
+        return 2
+    normal_command = (
+        [str(root / "app/scripts/verify-app.sh")] if exact_app else make_app
+    )
     selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
     if "quality-contracts" not in selected:
-        return child_run(make_app)
+        return child_run(normal_command)
 
     parallel_swift = "swift" in selected and (os.cpu_count() or 0) >= 3
     if parallel_swift:
@@ -2195,7 +2214,7 @@ def run_app_stage(root: Path) -> int:
         cwd=root / "app",
         env=coverage_environment,
     )
-    normal_status = child_run(make_app, env=normal_environment)
+    normal_status = child_run(normal_command, env=normal_environment)
     coverage_status = coverage_process.wait()
     return normal_status or coverage_status
 

--- a/tools/quality_shard.py
+++ b/tools/quality_shard.py
@@ -127,7 +127,7 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
             raise ShardError(f"planned stage has more than one shard: {sorted(overlap)[0]}")
         owned.update(stages)
         remaining.difference_update(stages)
-        needs_app = bool({"codex", "claude", "tmux-runtime"} & set(stages))
+        needs_app = bool({"app", "codex", "claude", "tmux-runtime"} & set(stages))
         needs_cache = bool({"swift", "app", "ui-e2e"} & set(stages))
         shards.append(
             {


### PR DESCRIPTION
## Contract delta
- Restore the exact packaged test app for the build-and-coverage shard.
- Verify the restored app before binding it to hosted shard execution.
- Reuse is accepted only by hosted ci-shard authority; local callers fail closed.
- Keep coverage-product construction concurrent with packaged-app verification.

## Evidence
- python3 tests/quality_gate_contract.py
- python3 tests/quality_shard_contract.py
- tests/quality-gate.sh
- scripts/quality-policy validate
- tests/docs-contract.sh
- git diff --check
- scripts/quality-gate --plan --explain

actionlint is not installed on the local machine. Hosted quality-gates remains readiness authority.