### PR TITLE
Speed exact quality product reuse

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -99,9 +99,21 @@ jobs:
             app/build/Detach.app
             app/.build/tmux-runtime/arm64/product
           key: detach-app-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
+      - name: Restore exact executable quality products
+        id: product-cache
+        if: matrix.needs_cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            app/.build/quality-products-v1.json
+            app/.build/quality-swift-tests/arm64-apple-macosx/debug/DetachAppPackageTests.xctest
+            app/.build/quality-swift-tests/arm64-apple-macosx/debug/Sparkle.framework
+            app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp
+            app/.build/quality-ui-release/arm64-apple-macosx/release/Sparkle.framework
+          key: detach-quality-products-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
       - name: Restore exact Swift and tmux inputs
         id: swift-cache
-        if: matrix.needs_cache || (matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true')
+        if: (matrix.needs_cache && steps.product-cache.outputs.cache-hit != 'true') || (matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true')
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -115,6 +127,11 @@ jobs:
       - name: Materialize exact Swift dependencies
         if: steps.swift-cache.outcome == 'success'
         run: scripts/quality-cache-warm --dependencies-only
+      - name: Verify and bind exact executable quality products
+        if: matrix.needs_cache && steps.product-cache.outputs.cache-hit == 'true'
+        run: |
+          python3 tools/quality_products.py verify
+          printf 'DETACH_QUALITY_EXACT_PRODUCTS=1\n' >>"$GITHUB_ENV"
       - name: Verify and bind exact packaged test app
         if: matrix.needs_app && steps.app-cache.outputs.cache-hit == 'true'
         run: |
@@ -213,9 +230,21 @@ jobs:
             app/build/Detach.app
             app/.build/tmux-runtime/arm64/product
           key: detach-app-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
+      - name: Restore exact executable quality products
+        id: product-cache
+        if: github.event_name != 'pull_request'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            app/.build/quality-products-v1.json
+            app/.build/quality-swift-tests/arm64-apple-macosx/debug/DetachAppPackageTests.xctest
+            app/.build/quality-swift-tests/arm64-apple-macosx/debug/Sparkle.framework
+            app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp
+            app/.build/quality-ui-release/arm64-apple-macosx/release/Sparkle.framework
+          key: detach-quality-products-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
       - name: Restore Swift and tmux caches
         id: swift-cache
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && (steps.product-cache.outputs.cache-hit != 'true' || steps.app-cache.outputs.cache-hit != 'true')
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -226,6 +255,16 @@ jobs:
       - name: Reuse exact cached Swift products
         if: github.event_name != 'pull_request' && steps.swift-cache.outputs.cache-hit == 'true'
         run: scripts/quality-cache-warm --reuse-exact-products
+      - name: Verify and bind exact executable quality products
+        if: github.event_name != 'pull_request' && steps.product-cache.outputs.cache-hit == 'true'
+        run: |
+          python3 tools/quality_products.py verify
+          printf 'DETACH_QUALITY_EXACT_PRODUCTS=1\n' >>"$GITHUB_ENV"
+      - name: Verify and bind exact packaged test app
+        if: github.event_name != 'pull_request' && steps.app-cache.outputs.cache-hit == 'true'
+        run: |
+          app/scripts/verify-app.sh
+          printf 'DETACH_QUALITY_EXACT_APP=1\n' >>"$GITHUB_ENV"
       - id: swift-warm
         name: Warm exact promoted-main Swift cache
         if: steps.promoted-main.outputs.promoted == 'true' && steps.swift-cache.outputs.cache-hit != 'true'
@@ -250,6 +289,10 @@ jobs:
         name: Record completed main Swift products
         if: github.event_name != 'pull_request' && steps.swift-cache.outputs.cache-hit != 'true' && steps.promoted-main.outputs.promoted != 'true' && steps.main-gate.outcome == 'success'
         run: scripts/quality-cache-warm --record-product-inputs
+      - id: product-warm
+        name: Publish exact main executable products
+        if: github.event_name != 'pull_request' && steps.product-cache.outputs.cache-hit != 'true' && ((steps.promoted-main.outputs.promoted == 'true' && (steps.swift-cache.outputs.cache-hit == 'true' || steps.swift-warm.outcome == 'success')) || (steps.promoted-main.outputs.promoted != 'true' && steps.main-gate.outcome == 'success'))
+        run: python3 tools/quality_products.py publish
       - name: Save Swift and tmux caches
         if: always() && github.event_name != 'pull_request' && steps.swift-cache.outcome == 'success' && steps.swift-cache.outputs.cache-hit != 'true' && ((steps.promoted-main.outputs.promoted == 'true' && steps.swift-warm.outcome == 'success') || (steps.promoted-main.outputs.promoted != 'true' && steps.main-products.outcome == 'success'))
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -265,6 +308,17 @@ jobs:
             app/build/Detach.app
             app/.build/tmux-runtime/arm64/product
           key: detach-app-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
+      - name: Save exact executable quality products
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.product-cache.outcome == 'success' && steps.product-cache.outputs.cache-hit != 'true' && steps.product-warm.outcome == 'success'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            app/.build/quality-products-v1.json
+            app/.build/quality-swift-tests/arm64-apple-macosx/debug/DetachAppPackageTests.xctest
+            app/.build/quality-swift-tests/arm64-apple-macosx/debug/Sparkle.framework
+            app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp
+            app/.build/quality-ui-release/arm64-apple-macosx/release/Sparkle.framework
+          key: detach-quality-products-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
       - name: Publish gate summary
         if: always()
         shell: bash

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -74,15 +74,15 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   `quality-gates` job recomputes the plan and accepts only the shard set
   and valid digests. Ambiguity fails closed.
 - CI keeps a ten-minute timing ratchet with no reference-Mac limit.
-- The gate-contract runner admits three heavy shards on eight CPUs and two on
-  fewer CPUs. Light contracts stay concurrent. Time budgets do not hide
-  oversubscription.
+- Gate contracts admit three heavy shards on eight CPUs and two on
+  fewer CPUs. Light contracts stay concurrent. Budgets expose overload.
 - Swift tests and both release builds use separate caches and split three or
   more CPUs. Smaller hosts run them in order. UI waits for the app; metrics
   wait for Swift and UI. Later work uses two heavy lanes and one integration
   lane. Distribution waits for gate-contract.
 - Exact keys bind code, resources, scripts, version, and toolchain. `main` warms
-  them. CI verifies the restored test app. Warming is not evidence.
+  the app and executable products. CI verifies each hit; a miss
+  rebuilds. Warming is not evidence.
 - CI uses the newest green `main` artifact with measured metrics. A later run
   without metrics does not replace it. Test identities, aggregate coverage,
   and critical-source coverage cannot decrease. Changed Swift lines need 90

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -659,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 48,
+  "policy": 49,
   "release_domains": [
     {
       "gates": "-",
@@ -905,6 +905,13 @@
     },
     {
       "pattern": "tools/quality_cache_warm.py",
+      "priority": 1100,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "quality-core"
+    },
+    {
+      "pattern": "tools/quality_products.py",
       "priority": 1100,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -2239,6 +2246,7 @@
         "tools/quality_metrics.py",
         "tools/quality_mutation.py",
         "tools/quality_policy.py",
+        "tools/quality_products.py",
         "tools/quality_promote.py",
         "tools/quality_scenarios.py",
         "tools/quality_security.py",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -66,6 +66,7 @@ It lists current specification ownership and verification links.
 - `tools/quality_metrics.py`
 - `tools/quality_mutation.py`
 - `tools/quality_policy.py`
+- `tools/quality_products.py`
 - `tools/quality_promote.py`
 - `tools/quality_scenarios.py`
 - `tools/quality_security.py`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	48
+policy	49
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -85,6 +85,7 @@ route	1100	scripts/quality-shard	quality-core	safe	docs/specs/documentation.md
 route	1100	tools/quality_shard.py	quality-core	safe	docs/specs/documentation.md
 route	1100	scripts/quality-cache-warm	quality-core	safe	docs/specs/documentation.md
 route	1100	tools/quality_cache_warm.py	quality-core	safe	docs/specs/documentation.md
+route	1100	tools/quality_products.py	quality-core	safe	docs/specs/documentation.md
 route	1000	scripts/quality-scenarios	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_scenarios.py	policy	safe	docs/specs/documentation.md
 route	1100	scripts/quality-policy	quality-core	safe	docs/specs/documentation.md

--- a/tests/quality-contracts.sh
+++ b/tests/quality-contracts.sh
@@ -12,19 +12,40 @@ cleanup() {
 trap cleanup EXIT
 
 swift_scratch="${DETACH_SWIFT_TEST_SCRATCH:-}"
-build_path_args=(swift build --show-bin-path)
-test_list_args=(swift test list --skip-build --disable-sandbox)
-if [ -n "$swift_scratch" ]; then
-  [ "$swift_scratch" = "$APP_ROOT/.build/quality-swift-tests" ] || {
-    printf 'quality contracts: Swift scratch path is not the quality path\n' >&2
+exact_test_binary="${DETACH_SWIFT_TEST_BINARY:-}"
+exact_test_profile="${DETACH_SWIFT_TEST_PROFILE:-}"
+if { [ -n "$exact_test_binary" ] && [ -z "$exact_test_profile" ]; } || \
+   { [ -z "$exact_test_binary" ] && [ -n "$exact_test_profile" ]; }; then
+  printf 'quality contracts: exact Swift binary and profile must occur together\n' >&2
+  exit 2
+fi
+if [ -n "$exact_test_binary" ]; then
+  expected_binary="$APP_ROOT/.build/quality-swift-tests/arm64-apple-macosx/debug/DetachAppPackageTests.xctest/Contents/MacOS/DetachAppPackageTests"
+  case "$exact_test_profile" in "$ROOT"/app/build/quality-shards/*/*/exact-swift.profdata|"$ROOT"/app/build/quality-gates/*/exact-swift.profdata) ;; *)
+    printf 'quality contracts: exact Swift profile path is not a quality evidence path\n' >&2
+    exit 2
+  esac
+  [ "$exact_test_binary" = "$expected_binary" ] || {
+    printf 'quality contracts: exact Swift binary path is not the quality product\n' >&2
     exit 2
   }
-  build_path_args+=(--disable-automatic-resolution --cache-path "$APP_ROOT/.build" --scratch-path "$swift_scratch")
-  test_list_args+=(--disable-automatic-resolution --cache-path "$APP_ROOT/.build" --scratch-path "$swift_scratch")
+  test_binary="$exact_test_binary"
+  profdata="$exact_test_profile"
+else
+  build_path_args=(swift build --show-bin-path)
+  test_list_args=(swift test list --skip-build --disable-sandbox)
+  if [ -n "$swift_scratch" ]; then
+    [ "$swift_scratch" = "$APP_ROOT/.build/quality-swift-tests" ] || {
+      printf 'quality contracts: Swift scratch path is not the quality path\n' >&2
+      exit 2
+    }
+    build_path_args+=(--disable-automatic-resolution --cache-path "$APP_ROOT/.build" --scratch-path "$swift_scratch")
+    test_list_args+=(--disable-automatic-resolution --cache-path "$APP_ROOT/.build" --scratch-path "$swift_scratch")
+  fi
+  build_path="$(cd -P "$APP_ROOT" && "${build_path_args[@]}")"
+  test_binary="$build_path/DetachAppPackageTests.xctest/Contents/MacOS/DetachAppPackageTests"
+  profdata="$build_path/codecov/default.profdata"
 fi
-build_path="$(cd -P "$APP_ROOT" && "${build_path_args[@]}")"
-test_binary="$build_path/DetachAppPackageTests.xctest/Contents/MacOS/DetachAppPackageTests"
-profdata="$build_path/codecov/default.profdata"
 [ -f "$test_binary" ] && [ ! -L "$test_binary" ] && \
   [ -f "$profdata" ] && [ ! -L "$profdata" ] || {
   printf 'quality contracts: run the coverage-enabled Swift stage first\n' >&2
@@ -38,6 +59,10 @@ if [ -n "${DETACH_SWIFT_TEST_LOG:-}" ]; then
   }
   tests="$DETACH_SWIFT_TEST_LOG"
 else
+  [ -z "$exact_test_binary" ] || {
+    printf 'quality contracts: exact Swift evidence requires its test log\n' >&2
+    exit 2
+  }
   tests="$TMP_ROOT/tests.txt"
   (
     cd -P "$APP_ROOT"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -54,6 +54,22 @@ grep -F 'DETACH_QUALITY_EXACT_APP=1' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F "steps.app-cache.outputs.cache-hit != 'true'" \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'key: detach-quality-products-v1-' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'app/.build/quality-products-v1.json' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'python3 tools/quality_products.py verify' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'DETACH_QUALITY_EXACT_PRODUCTS=1' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F "steps.product-cache.outputs.cache-hit != 'true'" \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Publish exact main executable products' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'run: python3 tools/quality_products.py publish' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'name: Save exact executable quality products' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'key: detach-swift-v3-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'run: scripts/quality-cache-warm --reuse-exact-products' \

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -18,6 +18,7 @@ from quality_gate import (  # noqa: E402
     EXECUTION_PREREQUISITES,
     GateError,
     QualityGate,
+    exact_products_enabled,
     gate_contract_definitions,
     gate_orchestrator_limit,
     include_gate_orchestrators,
@@ -137,6 +138,10 @@ class QualityGateContract(unittest.TestCase):
             ui_coverage_binary(ROOT),
             ROOT / "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp",
         )
+        self.assertEqual(
+            ui_coverage_binary(ROOT, exact_products=True),
+            ROOT / "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp",
+        )
 
     def test_exact_hosted_app_is_verified_while_coverage_builds(self) -> None:
         commands: list[list[str]] = []
@@ -167,6 +172,33 @@ class QualityGateContract(unittest.TestCase):
         environment["DETACH_QUALITY_GATE_AUTHORITY"] = "local-diagnostic"
         with patch.dict("os.environ", environment, clear=True):
             self.assertEqual(run_app_stage(ROOT), 2)
+
+    def test_exact_products_are_hosted_only_and_skip_coverage_build(self) -> None:
+        commands: list[list[str]] = []
+
+        def fake_child_run(command, *, cwd=ROOT, env=None):
+            commands.append(command)
+            return 0
+
+        environment = {
+            "DETACH_QUALITY_EXACT_APP": "1",
+            "DETACH_QUALITY_EXACT_PRODUCTS": "1",
+            "DETACH_QUALITY_GATE_SELECTED_STAGES": "app,quality-contracts",
+            "DETACH_QUALITY_GATE_AUTHORITY": "ci-shard",
+            "GITHUB_ACTIONS": "true",
+        }
+        with patch.dict("os.environ", environment, clear=True), patch(
+            "quality_gate.subprocess.Popen"
+        ) as coverage, patch("quality_gate.child_run", fake_child_run):
+            self.assertTrue(exact_products_enabled())
+            self.assertEqual(run_app_stage(ROOT), 0)
+        coverage.assert_not_called()
+        self.assertEqual(commands, [[str(ROOT / "app/scripts/verify-app.sh")]])
+
+        environment["DETACH_QUALITY_GATE_AUTHORITY"] = "local-diagnostic"
+        with patch.dict("os.environ", environment, clear=True):
+            with self.assertRaisesRegex(GateError, "hosted CI authority"):
+                exact_products_enabled()
 
 
 def main() -> int:

--- a/tests/quality_products_contract.py
+++ b/tests/quality_products_contract.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Focused contracts for exact executable quality products."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(ROOT / "tools"))
+
+import quality_products  # noqa: E402
+
+
+class QualityProductsContract(unittest.TestCase):
+    def fixture(self, root: Path) -> None:
+        first = root / "products/tests"
+        second = root / "products/ui"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+        (first / "binary").write_text("tests\n", encoding="utf-8")
+        (first / "binary").chmod(0o755)
+        (first / "Current").symlink_to("binary")
+        (second / "binary").write_text("ui\n", encoding="utf-8")
+        (second / "binary").chmod(0o755)
+
+    def context(self):
+        return (
+            patch.object(
+                quality_products,
+                "PRODUCT_PATHS",
+                (("tests", Path("products/tests")), ("ui", Path("products/ui"))),
+            ),
+            patch.object(quality_products, "EXECUTABLE_PATHS", ()),
+            patch("quality_products.source_fingerprint", return_value="a" * 64),
+            patch(
+                "quality_products.toolchain_document",
+                return_value={"architecture": "arm64", "swift": "test", "xcode": "test"},
+            ),
+            patch.object(
+                quality_products,
+                "MANIFEST_RELATIVE",
+                Path("products/manifest.json"),
+            ),
+        )
+
+    def test_publish_verify_and_tamper_detection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.fixture(root)
+            patches = self.context()
+            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+                self.assertEqual(quality_products.publish(root), 0)
+                self.assertEqual(quality_products.verify(root), 0)
+                manifest = json.loads(
+                    (root / "products/manifest.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(manifest["schema"], 1)
+                self.assertEqual(set(manifest["products"]), {"tests", "ui"})
+                (root / "products/tests/binary").write_text("changed\n", encoding="utf-8")
+                with self.assertRaisesRegex(
+                    quality_products.ProductError, "inventory does not match"
+                ):
+                    quality_products.verify(root)
+
+    def test_escaping_symlink_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.fixture(root)
+            outside = root / "outside"
+            outside.write_text("outside\n", encoding="utf-8")
+            (root / "products/tests/escape").symlink_to("../../outside")
+            patches = self.context()
+            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+                with self.assertRaisesRegex(
+                    quality_products.ProductError, "symlink escapes"
+                ):
+                    quality_products.publish(root)
+
+    def test_manifest_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.fixture(root)
+            (root / "products/manifest-target").write_text("{}\n", encoding="utf-8")
+            (root / "products/manifest.json").symlink_to("manifest-target")
+            patches = self.context()
+            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+                with self.assertRaisesRegex(quality_products.ProductError, "symlink"):
+                    quality_products.publish(root)
+
+    def test_exact_coverage_inputs_fail_closed(self) -> None:
+        environment = os.environ.copy()
+        environment.pop("DETACH_SWIFT_TEST_BINARY", None)
+        environment.pop("DETACH_SWIFT_TEST_PROFILE", None)
+        environment["DETACH_SWIFT_TEST_BINARY"] = "/tmp/not-a-quality-product"
+        missing_pair = subprocess.run(
+            [str(ROOT / "tests/quality-contracts.sh")],
+            cwd=ROOT,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(missing_pair.returncode, 2)
+        self.assertIn("must occur together", missing_pair.stderr)
+
+        environment["DETACH_SWIFT_TEST_PROFILE"] = "/tmp/not-quality-evidence"
+        unsafe_profile = subprocess.run(
+            [str(ROOT / "tests/quality-contracts.sh")],
+            cwd=ROOT,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(unsafe_profile.returncode, 2)
+        self.assertIn("not a quality evidence path", unsafe_profile.stderr)
+
+
+def main() -> int:
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(QualityProductsContract)
+    result = unittest.TextTestRunner(verbosity=0).run(suite)
+    if not result.wasSuccessful():
+        return 1
+    print("Quality executable product contracts passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -77,6 +77,16 @@ GATE_COMPATIBLE_INTEGRATION_STAGES = {
 }
 UI_COVERAGE_SCRATCH = "quality-ui-release"
 SWIFT_TEST_SCRATCH = "quality-swift-tests"
+QUALITY_TEST_BUNDLE = Path(
+    "app/.build/quality-swift-tests/arm64-apple-macosx/debug/"
+    "DetachAppPackageTests.xctest"
+)
+QUALITY_TEST_BINARY = (
+    QUALITY_TEST_BUNDLE / "Contents/MacOS/DetachAppPackageTests"
+)
+QUALITY_UI_BINARY = Path(
+    "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp"
+)
 
 
 class GateError(Exception):
@@ -1138,6 +1148,7 @@ class QualityGate:
     def stage_environment(self, stage: str) -> dict[str, str]:
         environment = os.environ.copy()
         exact_app = environment.pop("DETACH_QUALITY_EXACT_APP", "")
+        exact_products = environment.pop("DETACH_QUALITY_EXACT_PRODUCTS", "")
         for name in (
             "DETACH_RELEASE_TIMING_OVERRIDE",
             "DETACH_CONFIRM_RELEASE",
@@ -1180,6 +1191,8 @@ class QualityGate:
         )
         if stage == "app" and exact_app:
             environment["DETACH_QUALITY_EXACT_APP"] = exact_app
+        if stage in ("swift", "app", "ui-e2e", "quality-contracts") and exact_products:
+            environment["DETACH_QUALITY_EXACT_PRODUCTS"] = exact_products
         if not self.test_direct:
             environment["DETACH_RELEASE_TESTS_DETACHED"] = "1"
         return environment
@@ -1793,6 +1806,70 @@ def child_run(arguments: list[str], *, cwd: Path = ROOT, env: dict[str, str] | N
     return process.returncode
 
 
+def exact_products_enabled() -> bool:
+    value = os.environ.get("DETACH_QUALITY_EXACT_PRODUCTS", "")
+    if value not in ("", "1"):
+        raise GateError("DETACH_QUALITY_EXACT_PRODUCTS must be 1")
+    if value and (
+        os.environ.get("GITHUB_ACTIONS") != "true"
+        or os.environ.get("DETACH_QUALITY_GATE_AUTHORITY")
+        not in ("ci-shard", "ci-main")
+    ):
+        raise GateError("exact product reuse requires hosted CI authority")
+    return value == "1"
+
+
+def exact_swift_profile(run_dir: Path) -> Path:
+    return run_dir / "exact-swift.profdata"
+
+
+def run_exact_swift_stage(root: Path, run_dir: Path) -> int:
+    bundle = root / QUALITY_TEST_BUNDLE
+    binary = root / QUALITY_TEST_BINARY
+    if (
+        not bundle.is_dir()
+        or bundle.is_symlink()
+        or not binary.is_file()
+        or binary.is_symlink()
+        or not os.access(binary, os.X_OK)
+    ):
+        print("quality-gate: exact Swift test product is missing or unsafe", file=sys.stderr)
+        return 2
+    raw_root = run_dir / "exact-swift-profiles"
+    if raw_root.exists():
+        if not raw_root.is_dir() or raw_root.is_symlink():
+            print("quality-gate: exact Swift profile root is unsafe", file=sys.stderr)
+            return 2
+        shutil.rmtree(raw_root)
+    raw_root.mkdir(mode=0o700)
+    environment = os.environ.copy()
+    environment["LLVM_PROFILE_FILE"] = str(raw_root / "%p-%m.profraw")
+    status = child_run(["xcrun", "xctest", str(bundle)], cwd=root, env=environment)
+    if status:
+        return status
+    profiles = sorted(
+        path for path in raw_root.glob("*.profraw")
+        if path.is_file() and not path.is_symlink()
+    )
+    if not profiles:
+        print("quality-gate: exact Swift tests emitted no coverage profile", file=sys.stderr)
+        return 2
+    profile = exact_swift_profile(run_dir)
+    profile.unlink(missing_ok=True)
+    return child_run(
+        [
+            "xcrun",
+            "llvm-profdata",
+            "merge",
+            "-sparse",
+            *[str(path) for path in profiles],
+            "-o",
+            str(profile),
+        ],
+        cwd=root,
+    )
+
+
 def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -> int:
     static_file = run_dir / "static-files.z"
     try:
@@ -2000,6 +2077,12 @@ def gate_contract_definitions(
             "Quality cache warm contracts passed",
         ),
         (
+            "quality-products.log",
+            [sys.executable, str(root / "tests/quality_products_contract.py")],
+            {},
+            "Quality executable product contracts passed",
+        ),
+        (
             "quality-shard.log",
             [sys.executable, str(root / "tests/quality_shard_contract.py")],
             {},
@@ -2126,7 +2209,9 @@ def tmux_preflight(tmux: Path) -> int:
         shutil.rmtree(preflight)
 
 
-def ui_coverage_binary(root: Path) -> Path:
+def ui_coverage_binary(root: Path, *, exact_products: bool = False) -> Path:
+    if exact_products:
+        return root / QUALITY_UI_BINARY
     return (
         root / "app/.build" / UI_COVERAGE_SCRATCH
         / "arm64-apple-macosx/release/DetachApp"
@@ -2159,10 +2244,11 @@ def run_app_stage(root: Path) -> int:
         return 2
     if exact_app and (
         os.environ.get("GITHUB_ACTIONS") != "true"
-        or os.environ.get("DETACH_QUALITY_GATE_AUTHORITY") != "ci-shard"
+        or os.environ.get("DETACH_QUALITY_GATE_AUTHORITY")
+        not in ("ci-shard", "ci-main")
     ):
         print(
-            "quality-gate: exact app reuse requires hosted shard authority",
+            "quality-gate: exact app reuse requires hosted CI authority",
             file=sys.stderr,
         )
         return 2
@@ -2171,6 +2257,13 @@ def run_app_stage(root: Path) -> int:
     )
     selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
     if "quality-contracts" not in selected:
+        return child_run(normal_command)
+    try:
+        exact_products = exact_products_enabled()
+    except GateError as error:
+        print(f"quality-gate: {error}", file=sys.stderr)
+        return 2
+    if exact_products:
         return child_run(normal_command)
 
     parallel_swift = "swift" in selected and (os.cpu_count() or 0) >= 3
@@ -2276,6 +2369,8 @@ def run_stage_worker(stage: str) -> int:
             root, include_orchestrators=include_orchestrators
         )
     if stage == "swift":
+        if exact_products_enabled():
+            return run_exact_swift_stage(root, run_dir)
         app = root / "app"
         scratch = app / ".build" / SWIFT_TEST_SCRATCH
         (app / ".build/quality-codecov").mkdir(parents=True, exist_ok=True)
@@ -2312,6 +2407,7 @@ def run_stage_worker(stage: str) -> int:
         )
     if stage == "quality-contracts":
         selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
+        exact_products = exact_products_enabled()
         environment = os.environ.copy()
         environment.update(
             {
@@ -2324,7 +2420,14 @@ def run_stage_worker(stage: str) -> int:
                 "DETACH_QUALITY_AUTHORITY": authority,
             }
         )
-        if "swift" in selected:
+        if exact_products:
+            environment.update(
+                {
+                    "DETACH_SWIFT_TEST_BINARY": str(root / QUALITY_TEST_BINARY),
+                    "DETACH_SWIFT_TEST_PROFILE": str(exact_swift_profile(run_dir)),
+                }
+            )
+        elif "swift" in selected:
             environment["DETACH_SWIFT_TEST_SCRATCH"] = str(
                 root / "app/.build" / SWIFT_TEST_SCRATCH
             )
@@ -2335,7 +2438,7 @@ def run_stage_worker(stage: str) -> int:
             environment.update(
                 {
                     "DETACH_UI_COVERAGE_BINARY": str(
-                        ui_coverage_binary(root)
+                        ui_coverage_binary(root, exact_products=exact_products)
                     ),
                     "DETACH_UI_COVERAGE_PROFILE_DIR": str(profile_directory),
                 }
@@ -2353,6 +2456,7 @@ def run_stage_worker(stage: str) -> int:
     if stage == "app":
         return run_app_stage(root)
     if stage == "ui-e2e":
+        exact_products = exact_products_enabled()
         status = child_run([str(root / "tests/ui-e2e-contract.sh")])
         if status:
             return status
@@ -2361,7 +2465,9 @@ def run_stage_worker(stage: str) -> int:
         selected = os.environ.get("DETACH_QUALITY_GATE_SELECTED_STAGES", "").split(",")
         coverage_dir = root / "app/build/quality-ui-coverage" / run_dir.name
         if "quality-contracts" in selected:
-            coverage_binary = ui_coverage_binary(root)
+            coverage_binary = ui_coverage_binary(
+                root, exact_products=exact_products
+            )
             if not coverage_binary.is_file() or coverage_binary.is_symlink():
                 print(
                     "quality-gate: app stage emitted no safe coverage executable",

--- a/tools/quality_products.py
+++ b/tools/quality_products.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Publish and verify the minimal exact executable quality products."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+from typing import NoReturn
+
+from quality_cache_warm import product_fingerprint, product_inputs
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_RELATIVE = Path("app/.build/quality-products-v1.json")
+PRODUCT_PATHS = (
+    (
+        "swift-tests",
+        Path(
+            "app/.build/quality-swift-tests/arm64-apple-macosx/debug/"
+            "DetachAppPackageTests.xctest"
+        ),
+    ),
+    (
+        "swift-sparkle",
+        Path(
+            "app/.build/quality-swift-tests/arm64-apple-macosx/debug/"
+            "Sparkle.framework"
+        ),
+    ),
+    (
+        "ui-app",
+        Path(
+            "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp"
+        ),
+    ),
+    (
+        "ui-sparkle",
+        Path(
+            "app/.build/quality-ui-release/arm64-apple-macosx/release/"
+            "Sparkle.framework"
+        ),
+    ),
+)
+EXECUTABLE_PATHS = (
+    Path(
+        "app/.build/quality-swift-tests/arm64-apple-macosx/debug/"
+        "DetachAppPackageTests.xctest/Contents/MacOS/DetachAppPackageTests"
+    ),
+    Path("app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp"),
+)
+
+
+class ProductError(Exception):
+    """Exact executable products are missing, stale, or unsafe."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-products: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def command_text(arguments: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            arguments,
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise ProductError(f"cannot start {arguments[0]}: {error}") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ProductError(f"command failed ({arguments[0]}): {detail}")
+    return result.stdout.strip()
+
+
+def toolchain_document() -> dict[str, str]:
+    return {
+        "architecture": command_text(["uname", "-m"]),
+        "swift": command_text(["swift", "--version"]).splitlines()[0],
+        "xcode": " ".join(command_text(["xcodebuild", "-version"]).splitlines()),
+    }
+
+
+def source_fingerprint(root: Path) -> str:
+    return product_fingerprint(product_inputs(root))
+
+
+def contained_symlink(path: Path, product_root: Path) -> str:
+    target = os.readlink(path)
+    if os.path.isabs(target):
+        raise ProductError(f"product has an absolute symlink: {path}")
+    try:
+        path.resolve(strict=True).relative_to(product_root.resolve(strict=True))
+    except (OSError, ValueError) as error:
+        raise ProductError(f"product symlink escapes its root: {path}") from error
+    return target
+
+
+def inventory(root: Path, relative: Path) -> list[dict[str, object]]:
+    root = root.resolve()
+    product = root / relative
+    if product.is_symlink() or not product.exists():
+        raise ProductError(f"missing or unsafe product: {relative.as_posix()}")
+    try:
+        product.resolve(strict=True).relative_to(root)
+    except (OSError, ValueError) as error:
+        raise ProductError(f"product escapes repository: {relative.as_posix()}") from error
+    candidates = [product]
+    if product.is_dir():
+        candidates.extend(sorted(product.rglob("*"), key=lambda path: path.as_posix()))
+    records: list[dict[str, object]] = []
+    for path in candidates:
+        details = path.lstat()
+        path_relative = path.relative_to(root).as_posix()
+        mode = stat.S_IMODE(details.st_mode)
+        if stat.S_ISLNK(details.st_mode):
+            records.append(
+                {
+                    "path": path_relative,
+                    "type": "symlink",
+                    "mode": mode,
+                    "target": contained_symlink(path, product),
+                }
+            )
+        elif stat.S_ISREG(details.st_mode):
+            records.append(
+                {
+                    "path": path_relative,
+                    "type": "file",
+                    "mode": mode,
+                    "sha256": sha256_file(path),
+                    "size": details.st_size,
+                }
+            )
+        elif not stat.S_ISDIR(details.st_mode):
+            raise ProductError(f"product has an unsupported entry: {path_relative}")
+    if not records:
+        raise ProductError(f"product has no files: {relative.as_posix()}")
+    return records
+
+
+def product_document(root: Path) -> dict[str, list[dict[str, object]]]:
+    return {
+        identifier: inventory(root, relative)
+        for identifier, relative in PRODUCT_PATHS
+    }
+
+
+def validate_executables(root: Path) -> None:
+    for relative in EXECUTABLE_PATHS:
+        binary = root / relative
+        if not binary.is_file() or binary.is_symlink() or not os.access(binary, os.X_OK):
+            raise ProductError(f"missing or unsafe executable product: {relative.as_posix()}")
+        if command_text(["lipo", "-archs", str(binary)]) != "arm64":
+            raise ProductError(f"executable product is not arm64-only: {relative.as_posix()}")
+
+
+def manifest_path(root: Path) -> Path:
+    return root / MANIFEST_RELATIVE
+
+
+def publish(root: Path) -> int:
+    root = root.resolve()
+    validate_executables(root)
+    document = {
+        "schema": 1,
+        "source_fingerprint": source_fingerprint(root),
+        "toolchain": toolchain_document(),
+        "products": product_document(root),
+    }
+    manifest = manifest_path(root)
+    if manifest.is_symlink():
+        raise ProductError("product manifest is a symlink")
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    temporary = manifest.with_name(f".{manifest.name}.{os.getpid()}")
+    temporary.write_text(
+        json.dumps(document, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n",
+        encoding="utf-8",
+    )
+    temporary.chmod(0o600)
+    os.replace(temporary, manifest)
+    print("quality-products: exact executable products published")
+    return 0
+
+
+def verify(root: Path) -> int:
+    root = root.resolve()
+    manifest = manifest_path(root)
+    if not manifest.is_file() or manifest.is_symlink():
+        raise ProductError("product manifest is missing or unsafe")
+    try:
+        document = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ProductError("product manifest is invalid") from error
+    if not isinstance(document, dict) or set(document) != {
+        "schema",
+        "source_fingerprint",
+        "toolchain",
+        "products",
+    }:
+        raise ProductError("product manifest has unknown or missing fields")
+    if document["schema"] != 1:
+        raise ProductError("product manifest schema is unsupported")
+    if document["source_fingerprint"] != source_fingerprint(root):
+        raise ProductError("product manifest does not match source content")
+    if document["toolchain"] != toolchain_document():
+        raise ProductError("product manifest does not match the toolchain")
+    if document["products"] != product_document(root):
+        raise ProductError("executable product inventory does not match its manifest")
+    validate_executables(root)
+    print("quality-products: exact executable products verified")
+    return 0
+
+
+def main(arguments: list[str]) -> int:
+    if arguments == ["publish"]:
+        return publish(ROOT)
+    if arguments == ["verify"]:
+        return verify(ROOT)
+    raise ProductError("usage: quality_products.py publish|verify")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main(sys.argv[1:]))
+    except ProductError as error:
+        fail(str(error))


### PR DESCRIPTION
## Contract delta

- Restore only the XCTest bundle, UI coverage executable, and their Sparkle frameworks on an exact hosted cache hit.
- Bind every restored entry to source content, toolchain, architecture, mode, size, and SHA-256 before reuse.
- Run all tests again and create fresh Swift and UI coverage evidence.
- Fall back to the existing complete Swift build on a cache miss. Local diagnostics cannot assert the shortcut.

## Durable decisions

- `main` is the only cache publisher. Warming is not readiness evidence.
- The minimal product key is separate from the packaged-app and SwiftPM graph keys.
- Policy 49 classifies the publisher as fail-closed quality-core work.

## Evidence

- Direct XCTest: 787 tests passed in 6.98 seconds.
- Existing `swift test`: the same 787 tests passed in 10.98 seconds.
- Both paths produced byte-identical quality metrics and coverage opportunities.
- `tests/quality-gate.sh`
- `python3 tests/quality_products_contract.py`
- `python3 tests/quality_gate_contract.py`
- `scripts/quality-policy validate`
- `tests/docs-contract.sh`
- `git diff --check`

Hosted `quality-gates` is the readiness authority. Signing, notarization, publication, and real power checks were not run.