### PR TITLE
Parallelize provider quality gates

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -19,13 +19,11 @@ concurrency:
 jobs:
   quality-plan:
     if: github.event_name == 'pull_request'
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.impact.outputs.matrix }}
       has_shards: ${{ steps.impact.outputs.has_shards }}
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -75,7 +73,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 10
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{ fromJSON(needs.quality-plan.outputs.matrix) }}
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
@@ -160,7 +158,7 @@ jobs:
     needs:
       - quality-plan
       - quality-shards
-    runs-on: macos-26
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-26' }}
     timeout-minutes: 10
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -135,9 +135,13 @@ Every executable stage has a policy-owned process deadline. The GitHub workflow
 has a ten-minute deadline and cancels superseded work. The pull request feedback
 SLO is less than ten minutes.
 
-Pull-request CI validates its exact impact plan and runs static contracts before
-it downloads optional metrics or Swift data. The authoritative gate recomputes
-both results. This fail-fast pass is diagnostic only.
+Pull-request CI validates its exact impact plan and runs static contracts on a
+Linux control runner before it downloads optional metrics or Swift data. The
+macOS shards run every selected product check. The final Linux control runner
+recomputes the plan and validates the exact digest-bound shard set. These
+control runners do not execute or replace macOS product evidence. The early
+fail-fast pass is diagnostic only. A failed matrix shard cancels its peers; the
+final aggregate still fails when evidence is missing.
 
 Swift tests, the normal app, and the instrumented app use isolated scratch and
 module-cache paths. CI materializes their shared dependency cache once before
@@ -169,7 +173,10 @@ promoted `main` run can warm a missing key but emits no gate evidence. The
 packaged UI test uses a
 stripped process-private app, fake CLI, and private state. Provider tests use
 private state and socket roots plus the newly bundled `tmux` and
-`detach-state`. Tests do not use installed product state or ambient helpers.
+`detach-state`. Each provider part has private state, socket, log, and failure
+artifact roots. Parts run concurrently. Their parent writes scenario events in
+one order and fails the stage when any part fails. Tests do not use installed
+product state or ambient helpers.
 
 There are no quarantined tests. A future quarantine needs an owner, reason, and
 expiry. It cannot remove release evidence.
@@ -188,6 +195,7 @@ unknown path selects every functional stage and every release impact.
 | Quality policy or CI | static and gate self-contracts |
 | Swift source | Swift, metrics, app, packaged UI, and required dependencies |
 | CLI or session lifecycle | app, both providers, distribution, runtime, and dependencies |
+| One provider test | static and that provider; its shard verifies the exact app prerequisite |
 | Install or distribution | app, distribution, runtime, and dependencies |
 | Release or publication | app, preflights, workflow contracts, and dependencies |
 | Unknown path | full repository plan |

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -53,10 +53,9 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
   a capability, and a requirement. Each requirement links to a user journey
   and at least one automated scenario. Generated JSON and Markdown views must
   match the policy.
-- Retained gates are timing and quality history, not policy history, and cannot
-  restore old policy. An unsupported evidence schema is outside the telemetry
-  sample. Current-schema telemetry can span earlier policy identifiers without
-  dashboard-only fields. Malformed evidence remains an attention signal.
+- Retained gates are timing and quality history, not policy history. An
+  unsupported schema is outside telemetry. Current-schema data can span older
+  policy identifiers. Malformed evidence remains an attention signal.
 - `quality/evals.json` keeps expected outcomes for historical changes, escaped
   defects, policy mutations, and scope violations. Its graders compare stages,
   specs, capabilities, journeys, release gates, and ignored paths. Change an
@@ -67,12 +66,12 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - A local timing-budget failure creates performance work. Warm-cache or
   variance reruns cannot turn it into readiness; an unchanged rerun is allowed
   only for an evidenced unrelated external transient whose cause is recorded.
-- CI binds checks to tested merge and first parent. Level 0 is
-  plan and static work, level 1 is unit and contract work, and level 2 is
-  packaged and runtime work. All selected levels are required.
-- Shards revalidate merge identity but have no merge authority. The final
-  `quality-gates` job recomputes the plan and accepts only the shard set
-  and valid digests. Ambiguity fails closed.
+- CI binds checks to the tested merge and first parent. Linux runs level 0
+  planning and static work. Level 1 is unit and contract work. Level 2 is
+  packaged and runtime work on macOS. All selected levels are required.
+- Shards revalidate merge identity but have no merge authority. The final Linux
+  job recomputes the plan and accepts only exact digest-bound shard evidence.
+  Evidence roots are absolute. Ambiguity fails closed. A failed shard cancels peers.
 - CI keeps a ten-minute timing ratchet with no reference-Mac limit.
 - Gate contracts admit three heavy shards on eight CPUs and two on
   fewer CPUs. Light contracts stay concurrent. Budgets expose overload.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -153,26 +153,26 @@ Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
 session. They do not promise survival across logout or reboot, and an explicit
 kill of tmux/provider ends the live run. Recovery checkpoints remain available.
-Integration tests must preserve this close-client lifetime contract.
+Provider test parts can run concurrently only with private state, socket, and
+artifact roots. Their parent writes scenario events and requires every part.
+The tests preserve the close-client lifetime contract.
 
-Detach status options are session-local and use `@detach*`; never mutate a
-foreign tmux server's configuration. The status line tints its whole strip with
-a dense blend of the session identity color behind light plain-text labels,
-plus a solid painted-space left edge (no font-dependent partial blocks), and
-puts the power label and clock in `status-right`. Finished sessions keep a
-faint tint of the same hue; failures tint the strip with the reserved red. The
+Detach status options are session-local and use `@detach*`; they never change a
+foreign tmux server. The status strip uses a dense identity-color blend, light
+plain-text labels, a solid painted-space edge, and power and time on the right.
+Finished sessions keep a faint form of the hue. Failures use reserved red. The
 eight-hue identity palette omits pure red. Allocation scans both providers
 under the Start/Resume/Recover install lock. Known terminal history keeps its
 shown identity but does not reserve a hue; unknown state stays conservative.
 Keep an existing hue when unique among current state. Otherwise, walk from the
 stable provider/project preference to the first free hue, and duplicate only
 when all eight are occupied. The single `blend_session_color` formula makes
-every derived surface. The style snapshot saves and restores `status-right`
-and its length alongside the left side; a snapshot from an older Detach that never
-captured the right side must not clear the user's `status-right`. The text
-Plain text is the primary power signal: `MAC AWAKE`, `MAC CAN SLEEP`, `LOW
-BATTERY`, `MAC CAN SLEEP: TEMPERATURE`, `POWER UNAVAILABLE`, or a transition;
-app wording is equivalent and icons are secondary.
+every derived surface. The style snapshot saves and restores both sides and
+their lengths. An older snapshot without right-side data does not clear the
+user's `status-right`. Plain text is the primary power signal: `MAC AWAKE`,
+`MAC CAN SLEEP`, `LOW BATTERY`, `MAC CAN SLEEP: TEMPERATURE`,
+`POWER UNAVAILABLE`, or a transition. App wording is equivalent and icons are
+secondary.
 
 Managed input changes only the private server. `tmux-mouse` defaults on: wheel
 steps are one line; selection copies without clearing, exiting, or snapping;

--- a/quality/evals.json
+++ b/quality/evals.json
@@ -77,6 +77,37 @@
       }
     },
     {
+      "id": "historical-provider-test",
+      "category": "historical-task",
+      "grader": "impact",
+      "paths": [
+        "tests/run.sh"
+      ],
+      "expected": {
+        "status": "known",
+        "stages": [
+          "static",
+          "codex",
+          "release-budget"
+        ],
+        "specs": [
+          "runtime"
+        ],
+        "capabilities": [
+          "session-lifecycle"
+        ],
+        "journeys": [
+          "J-SESSION-CREATE",
+          "J-SESSION-PERSIST",
+          "J-SESSION-RECOVER",
+          "J-SESSION-STOP",
+          "J-SESSION-DELETE"
+        ],
+        "release_gates": [],
+        "unknown": false
+      }
+    },
+    {
       "id": "historical-provider-cli",
       "category": "historical-task",
       "grader": "impact",

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -659,7 +659,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 49,
+  "policy": 50,
   "release_domains": [
     {
       "gates": "-",
@@ -3247,12 +3247,12 @@
     {
       "capabilities": "session-lifecycle",
       "id": "codex-test",
-      "stages": "static,app,codex,release-budget"
+      "stages": "static,codex,release-budget"
     },
     {
       "capabilities": "session-lifecycle",
       "id": "claude-test",
-      "stages": "static,app,claude,release-budget"
+      "stages": "static,claude,release-budget"
     },
     {
       "capabilities": "installation",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	49
+policy	50
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -46,8 +46,8 @@ test-domain	install	static,app,distribution,tmux-runtime,release-budget	installa
 test-domain	tmux-build	static,app,codex,claude,tmux-runtime,release-budget	session-lifecycle
 test-domain	release-tool	static,app,release-preflight,publish-preflight,release-workflow,release-budget	update,publication
 test-domain	app-script	static,app,tmux-runtime,release-preflight,release-budget	installation
-test-domain	codex-test	static,app,codex,release-budget	session-lifecycle
-test-domain	claude-test	static,app,claude,release-budget	session-lifecycle
+test-domain	codex-test	static,codex,release-budget	session-lifecycle
+test-domain	claude-test	static,claude,release-budget	session-lifecycle
 test-domain	distribution-test	static,app,distribution,release-budget	installation
 test-domain	runtime-test	static,app,tmux-runtime,release-budget	session-lifecycle,power-protection
 test-domain	ui-test	static,app,release-budget	app-experience

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -23,6 +23,15 @@ grep -F 'run: scripts/quality-gate --mode repository --keep-going --without-rele
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'name: Validate and partition exact pull-request impact' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+quality_plan_job="$(sed -n '/^  quality-plan:/,/^  quality-shards:/p' \
+  "$ROOT/.github/workflows/quality-gates.yml")"
+printf '%s\n' "$quality_plan_job" | grep -F 'runs-on: ubuntu-latest' >/dev/null
+quality_gate_job="$(sed -n '/^  quality-gates:/,/^  quality-dashboard:/p' \
+  "$ROOT/.github/workflows/quality-gates.yml")"
+printf '%s\n' "$quality_gate_job" | \
+  grep -F "runs-on: \${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-26' }}" \
+  >/dev/null
+grep -F 'fail-fast: true' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'scripts/quality-shard plan --base "$BASE_SHA"' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'name: Run level-zero fail-fast contracts' \
@@ -267,6 +276,16 @@ setup_fixture docs-contract
 printf '%s\n' '# changed contract' >"$REPO/tests/docs-contract.sh"
 plan="$(gate --plan)"
 [[ "$plan" = *'stages=static' ]]
+
+setup_fixture codex-provider-test
+printf '%s\n' '#!/bin/bash' >"$REPO/tests/run.sh"
+plan="$(gate --plan)"
+[[ "$plan" = *'stages=static,codex,release-budget' ]]
+
+setup_fixture claude-provider-test
+printf '%s\n' '#!/bin/bash' >"$REPO/tests/run-claude.sh"
+plan="$(gate --plan)"
+[[ "$plan" = *'stages=static,claude,release-budget' ]]
 
 setup_fixture ignored-presentations
 clean_plan="$(gate --plan)"

--- a/tests/quality_care_contract.py
+++ b/tests/quality_care_contract.py
@@ -117,7 +117,8 @@ def main() -> int:
     result = json.loads(invoke(["evaluate", "--json"]).stdout)
     assert result["schema"] == 1
     assert result["status"] == "passed"
-    assert result["passed"] == result["total"] == 8
+    expected_total = len(json.loads(CORPUS.read_text(encoding="utf-8"))["cases"])
+    assert result["passed"] == result["total"] == expected_total
     assert set(result["categories"]) == {
         "escaped-defect", "historical-task", "policy-mutant", "scope-violation"
     }

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import sys
 import tempfile
@@ -23,7 +24,9 @@ from quality_gate import (  # noqa: E402
     gate_orchestrator_limit,
     include_gate_orchestrators,
     parse_name_status,
+    parse_options,
     run_app_stage,
+    run_provider_parts,
     split_quality_pipeline_jobs,
     split_swift_build_jobs,
     ui_coverage_binary,
@@ -32,6 +35,22 @@ from quality_policy import POLICY_FILE, Policy  # noqa: E402
 
 
 class QualityGateContract(unittest.TestCase):
+    def test_relative_result_root_becomes_absolute_evidence(self) -> None:
+        relative = Path("app/build/relative-quality-evidence")
+        with patch.dict(
+            "os.environ",
+            {"DETACH_QUALITY_GATE_RESULT_ROOT": str(relative)},
+            clear=False,
+        ), patch("quality_gate.git_text", return_value="a" * 40):
+            gate = QualityGate(parse_options([]))
+        self.assertEqual(gate.result_root, (Path.cwd() / relative).absolute())
+        self.assertTrue(gate.run_dir.is_absolute())
+
+    def test_environment_document_marks_an_unavailable_platform_tool(self) -> None:
+        gate = QualityGate.__new__(QualityGate)
+        with patch("quality_gate.run", side_effect=GateError("missing")):
+            self.assertEqual(gate.command_version(["missing-tool"]), "unavailable")
+
     def test_name_status_preserves_rename_and_unusual_paths(self) -> None:
         raw = b"R100\0old name\0new\nname\0A\0plain\0"
         self.assertEqual(
@@ -199,6 +218,115 @@ class QualityGateContract(unittest.TestCase):
         with patch.dict("os.environ", environment, clear=True):
             with self.assertRaisesRegex(GateError, "hosted CI authority"):
                 exact_products_enabled()
+
+    def test_codex_parts_get_private_artifact_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            suite = root / "tests/run.sh"
+            suite.parent.mkdir()
+            suite.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                "printf '%s\\t%s\\n' \"$DETACH_CODEX_TEST_PART\" "
+                "\"$DETACH_PROVIDER_TEST_ARTIFACT_DIR\"\n",
+                encoding="utf-8",
+            )
+            suite.chmod(0o755)
+            run_dir = root / "evidence"
+            run_dir.mkdir()
+            artifacts = run_dir / "codex-artifacts"
+            environment = {
+                "PATH": "/usr/bin:/bin",
+                "DETACH_PROVIDER_TEST_ARTIFACT_DIR": str(artifacts),
+            }
+            events = run_dir / "codex-events.jsonl"
+            with patch.dict(
+                "os.environ",
+                {
+                    "DETACH_QUALITY_SCENARIO_STAGE": "codex",
+                    "DETACH_QUALITY_SCENARIO_EVENTS": str(events),
+                },
+            ):
+                self.assertEqual(
+                    run_provider_parts(root, run_dir, "codex", environment),
+                    0,
+                )
+            for part in (
+                "preflight",
+                "lifecycle",
+                "recovery",
+                "resume",
+                "identity",
+                "crash",
+            ):
+                log = (run_dir / f"codex-parts/{part}.log").read_text(
+                    encoding="utf-8"
+                )
+                self.assertEqual(log, f"{part}\t{artifacts / part}\n")
+            records = [
+                json.loads(line)
+                for line in events.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(len(records), 10)
+            self.assertEqual(
+                {(record["kind"], record["id"]) for record in records},
+                {
+                    (kind, f"SC-SESSION-{scenario}-CODEX")
+                    for kind in ("begin", "pass")
+                    for scenario in ("CREATE", "PERSIST", "STOP", "RECOVER", "DELETE")
+                },
+            )
+
+    def test_claude_parts_get_private_artifact_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            suite = root / "tests/run-claude.sh"
+            suite.parent.mkdir()
+            suite.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                "printf '%s\\t%s\\n' \"$DETACH_CLAUDE_TEST_PART\" "
+                "\"$DETACH_PROVIDER_TEST_ARTIFACT_DIR\"\n",
+                encoding="utf-8",
+            )
+            suite.chmod(0o755)
+            run_dir = root / "evidence"
+            run_dir.mkdir()
+            artifacts = run_dir / "claude-artifacts"
+            environment = {
+                "PATH": "/usr/bin:/bin",
+                "DETACH_PROVIDER_TEST_ARTIFACT_DIR": str(artifacts),
+            }
+            events = run_dir / "claude-events.jsonl"
+            with patch.dict(
+                "os.environ",
+                {
+                    "DETACH_QUALITY_SCENARIO_STAGE": "claude",
+                    "DETACH_QUALITY_SCENARIO_EVENTS": str(events),
+                },
+            ):
+                self.assertEqual(
+                    run_provider_parts(root, run_dir, "claude", environment),
+                    0,
+                )
+            for part in ("lifecycle", "recovery", "history"):
+                log = (run_dir / f"claude-parts/{part}.log").read_text(
+                    encoding="utf-8"
+                )
+                self.assertEqual(log, f"{part}\t{artifacts / part}\n")
+            records = [
+                json.loads(line)
+                for line in events.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(len(records), 10)
+            self.assertEqual(
+                {(record["kind"], record["id"]) for record in records},
+                {
+                    (kind, f"SC-SESSION-{scenario}-CLAUDE")
+                    for kind in ("begin", "pass")
+                    for scenario in ("CREATE", "PERSIST", "STOP", "RECOVER", "DELETE")
+                },
+            )
 
 
 def main() -> int:

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -13,6 +13,24 @@ SOCKET="detach-claude-test-$$"
 SOCKET_PATH="$TMUX_SOCKET_ROOT/$SOCKET.sock"
 ARTIFACT_DIR="${DETACH_PROVIDER_TEST_ARTIFACT_DIR:-}"
 FAILURE_LINE=""
+CLAUDE_TEST_PART="${DETACH_CLAUDE_TEST_PART:-all}"
+
+case "$CLAUDE_TEST_PART" in
+  all|lifecycle|recovery|history) ;;
+  *)
+    printf 'unknown Claude test part: %s\n' "$CLAUDE_TEST_PART" >&2
+    exit 2
+    ;;
+esac
+
+claude_part_selected() {
+  [ "$CLAUDE_TEST_PART" = all ] || [ "$CLAUDE_TEST_PART" = "$1" ]
+}
+
+claude_scenario_event() {
+  [ "${DETACH_QUALITY_PARTITIONED_PROVIDER:-0}" = 1 ] || \
+    "$ROOT/scripts/quality-scenarios" event "$1" "$2"
+}
 
 if [ -n "${DETACH_TEST_STATE_BIN:-}" ]; then
   STATE_HELPER="$DETACH_TEST_STATE_BIN"
@@ -226,6 +244,41 @@ wait_for_file_text() {
   return 1
 }
 
+human_label='Rev (ai)'
+human_digest="$(printf '%s' "$human_label" | shasum -a 256 | \
+  awk '{print substr($1, 1, 12)}')"
+human_session="detach-claude-Rev-ai-$human_digest"
+
+bootstrap_claude_checkpoint() {
+  mkdir -p "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
+  export FAKE_CLAUDE_SLEEP=20
+  export FAKE_CLAUDE_EXIT=0
+  export FAKE_CLAUDE_EXPECT_RESTORED=0
+  reset_fake_claude_ready
+  "$SCRIPT" claude --name "$human_label" --detach -- \
+    --name display-name 'checkpoint fixture' \
+    --add-dir "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
+  wait_for_fake_claude_ready
+  session_id="$(awk 'previous == "--session-id" { print; exit } { previous = $0 }' \
+    "$FAKE_CLAUDE_ARGS_FILE")"
+  meta="$DETACH_CLAUDE_STATE_ROOT/sessions/$human_session/meta.json"
+  session="$human_session"
+  session_dir="$(dirname "$meta")"
+  checkpoint="$session_dir/checkpoint"
+  attempts=0
+  while { [ ! -s "$checkpoint/transcript.jsonl" ] || \
+          [ ! -s "$checkpoint/claude-session.tar" ]; } && \
+        [ "$attempts" -lt 100 ]; do
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  [ -s "$checkpoint/transcript.jsonl" ]
+  [ -s "$checkpoint/claude-session.tar" ]
+  "$SCRIPT" claude stop "$human_label"
+}
+
+if claude_part_selected lifecycle; then
+
 bash -n "$SCRIPT"
 bash -n "$ROOT/tests/fake-claude"
 [ "$($SCRIPT __version)" = "$(<"$ROOT/VERSION")" ]
@@ -287,21 +340,16 @@ current_codex_color="$("$SCRIPT" codex __allocate_session_color "$color_cwd")"
 [ "$current_codex_color" != "$current_claude_color" ]
 rm -rf "$codex_color_sessions" "$claude_color_sessions"
 
-human_label='Rev (ai)'
-human_digest="$(printf '%s' "$human_label" | shasum -a 256 | \
-  awk '{print substr($1, 1, 12)}')"
-human_session="detach-claude-Rev-ai-$human_digest"
-
 marker="$TMP_ROOT/must-not-exist"
 literal_prompt="spaces ; \$(touch $marker) * \"quotes\""
 mkdir -p "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
 # The display label stays out of tmux and filesystem identifiers, remains
 # usable for every lifecycle command, and survives resume/recovery.
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-CREATE-CLAUDE
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-PERSIST-CLAUDE
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-RECOVER-CLAUDE
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-STOP-CLAUDE
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-DELETE-CLAUDE
+claude_scenario_event begin SC-SESSION-CREATE-CLAUDE
+claude_scenario_event begin SC-SESSION-PERSIST-CLAUDE
+claude_scenario_event begin SC-SESSION-RECOVER-CLAUDE
+claude_scenario_event begin SC-SESSION-STOP-CLAUDE
+claude_scenario_event begin SC-SESSION-DELETE-CLAUDE
 reset_fake_claude_ready
 "$SCRIPT" claude --name "$human_label" --detach -- \
   --name display-name "$literal_prompt" --add-dir "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
@@ -330,7 +378,7 @@ session="$("$STATE_HELPER" meta get "$meta" session_name)"
 [ "$("$STATE_HELPER" meta get "$meta" display_name)" = "$human_label" ]
 "$SCRIPT" claude status "$human_label" | \
   grep -F "Name:           $human_label" >/dev/null
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-CREATE-CLAUDE
+claude_scenario_event pass SC-SESSION-CREATE-CLAUDE
 session_dir="$(dirname "$meta")"
 checkpoint="$session_dir/checkpoint"
 
@@ -349,7 +397,7 @@ live_pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_pane_
 [ "$(tmux -L "$SOCKET" display-message -p -t "$live_pane_id" '#{pane_dead}')" = "0" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -w -t "$live_pane_id" remain-on-exit)" = off ]
 [ "$(tmux -L "$SOCKET" show-options -qv -p -t "$live_pane_id" remain-on-exit)" = on ]
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-PERSIST-CLAUDE
+claude_scenario_event pass SC-SESSION-PERSIST-CLAUDE
 session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_color)"
 [[ "$session_color" =~ ^#[[:xdigit:]]{6}$ ]]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_status)" = "running" ]
@@ -583,10 +631,19 @@ stopped_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
 grep -Fx "release --session $session --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-STOP-CLAUDE
+claude_scenario_event pass SC-SESSION-STOP-CLAUDE
+
+if [ "$CLAUDE_TEST_PART" = lifecycle ]; then
+  "$SCRIPT" claude delete --force "$human_label"
+fi
+fi
 
 # Simulate losing primary metadata during a power failure. Recovery must use
 # checkpoint metadata and resume the exact Claude session UUID.
+if claude_part_selected recovery; then
+if [ "$CLAUDE_TEST_PART" = recovery ]; then
+  bootstrap_claude_checkpoint
+fi
 "$STATE_HELPER" meta patch "$checkpoint/meta.json" --string status running --null exit_status
 rm -f "$meta"
 printf '{damaged transcript\n' >"$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl"
@@ -671,7 +728,7 @@ grep -Fx -- "$TMP_ROOT/extra-b" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 [ -s "$CLAUDE_CONFIG_DIR/tasks/$session_id/task.json" ]
 [ -s "$CLAUDE_CONFIG_DIR/tasks/session-${session_id:0:8}/task.json" ]
 [ -s "$CLAUDE_CONFIG_DIR/teams/session-${session_id:0:8}/config.json" ]
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-RECOVER-CLAUDE
+claude_scenario_event pass SC-SESSION-RECOVER-CLAUDE
 
 "$SCRIPT" claude stop "$human_label"
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
@@ -717,8 +774,10 @@ reset_fake_claude_ready
 wait_for_fake_claude_ready
 "$SCRIPT" claude stop "$human_label"
 export FAKE_CLAUDE_EXPECT_RESTORED=0
-default_history_fixture="$TMP_ROOT/default-claude-history-fixture"
-cp -Rp "$DETACH_CLAUDE_STATE_ROOT/sessions/$session" "$default_history_fixture"
+if [ "$CLAUDE_TEST_PART" = all ]; then
+  default_history_fixture="$TMP_ROOT/default-claude-history-fixture"
+  cp -Rp "$DETACH_CLAUDE_STATE_ROOT/sessions/$session" "$default_history_fixture"
+fi
 
 mkdir -p "$CLAUDE_CONFIG_DIR/projects/copy"
 cp -p "$CLAUDE_CONFIG_DIR/projects/fake/$second_id.jsonl" \
@@ -740,6 +799,15 @@ grep -Fx 'outside sentinel' "$outside" >/dev/null
 "$SCRIPT" claude delete --force "$human_label"
 [ ! -d "$DETACH_CLAUDE_STATE_ROOT/sessions/$session" ]
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+fi
+
+if claude_part_selected history; then
+if [ "$CLAUDE_TEST_PART" = history ]; then
+  bootstrap_claude_checkpoint
+  default_history_fixture="$TMP_ROOT/default-claude-history-fixture"
+  cp -Rp "$DETACH_CLAUDE_STATE_ROOT/sessions/$session" "$default_history_fixture"
+  "$SCRIPT" claude delete --force "$human_label"
+fi
 
 # Claude uses the same default history-series contract as Codex: a completed
 # run remains intact while the next fresh conversation receives a new slot.
@@ -801,5 +869,6 @@ done
 "$SCRIPT" claude delete --force "$second_default_session"
 [ ! -e "$FAKE_GIT_MARKER" ]
 
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-DELETE-CLAUDE
-printf 'Claude detach integration tests passed\n'
+claude_scenario_event pass SC-SESSION-DELETE-CLAUDE
+fi
+printf 'Claude detach integration tests passed (%s)\n' "$CLAUDE_TEST_PART"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,6 +19,27 @@ OUTER_SOCKET_PATH="$TMUX_SOCKET_ROOT/$OUTER_SOCKET.sock"
 SESSION="detach-codex-integration"
 ARTIFACT_DIR="${DETACH_PROVIDER_TEST_ARTIFACT_DIR:-}"
 FAILURE_LINE=""
+CODEX_TEST_PART="${DETACH_CODEX_TEST_PART:-all}"
+
+case "$CODEX_TEST_PART" in
+  all|preflight|lifecycle|recovery|restart|resume|identity|crash|history) ;;
+  *)
+    printf 'unknown Codex test part: %s\n' "$CODEX_TEST_PART" >&2
+    exit 2
+    ;;
+esac
+
+codex_part_selected() {
+  [ "$CODEX_TEST_PART" = all ] || [ "$CODEX_TEST_PART" = "$1" ] || {
+    [ "$CODEX_TEST_PART" = preflight ] && [ "$1" = history ] ||
+    [ "$CODEX_TEST_PART" = recovery ] && [ "$1" = restart ]
+  }
+}
+
+codex_scenario_event() {
+  [ "${DETACH_QUALITY_PARTITIONED_PROVIDER:-0}" = 1 ] || \
+    "$ROOT/scripts/quality-scenarios" event "$1" "$2"
+}
 
 if [ -n "${DETACH_TEST_STATE_BIN:-}" ]; then
   STATE_HELPER="$DETACH_TEST_STATE_BIN"
@@ -365,9 +386,10 @@ test_sqlite() {
   sqlite3 -cmd '.timeout 5000' "$@"
 }
 
-bash -n "$SCRIPT"
-bash -n "$ROOT/bin/detach-core"
-[ "$($SCRIPT __version)" = "$(<"$ROOT/VERSION")" ]
+if codex_part_selected preflight; then
+  bash -n "$SCRIPT"
+  bash -n "$ROOT/bin/detach-core"
+  [ "$($SCRIPT __version)" = "$(<"$ROOT/VERSION")" ]
 
 if FAKE_POWER_STATE=unavailable run_codex --name power-preflight --detach -- \
   'must not start without power protection' >/dev/null 2>&1; then
@@ -542,6 +564,7 @@ legacy_style="$(tmux -L "$SOCKET" show-options -qv -t "=$legacy_session:" status
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$legacy_session:" status-left)" = "legacy user status" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$legacy_session:" status-left-length)" = "37" ]
 tmux -L "$SOCKET" kill-session -t "=$legacy_session"
+fi
 
 # The installed layout exposes only detach on PATH. The frontend must still
 # find its sibling core after resolving the public symlink.
@@ -563,22 +586,54 @@ fi
 SCRIPT="$install_root/bin/detach"
 DETACH="$SCRIPT"
 
-marker="$TMP_ROOT/must-not-exist"
-literal_prompt="spaces ; \$(touch $marker) * \"quotes\""
-export FAKE_CODEX_SLEEP=12
-integration_release="$TMP_ROOT/integration-provider-release"
-export FAKE_CODEX_RELEASE_FILE="$integration_release"
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-CREATE-CODEX
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-PERSIST-CODEX
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-RECOVER-CODEX
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-STOP-CODEX
-"$ROOT/scripts/quality-scenarios" event begin SC-SESSION-DELETE-CODEX
-run_codex --name integration --detach -- "$literal_prompt"
+bootstrap_codex_checkpoint() {
+  export FAKE_CODEX_SLEEP=20
+  export FAKE_CODEX_EXIT=0
+  export FAKE_CODEX_FOREIGN_FIRST=0
+  export FAKE_CODEX_INIT_DELAY=0.1
+  run_codex --name integration --detach -- 'recovery fixture'
+  wait_for_tmux_option "$SESSION" @detach_status running
+  meta="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/meta.json"
+  checkpoint="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint"
+  session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_color)"
+  expected_id="$("$STATE_HELPER" meta get "$meta" codex_session_id)"
+  attempts=0
+  while { [ ! -s "$checkpoint/rollout.jsonl" ] || \
+          [ ! -s "$checkpoint/codex-state.sqlite" ]; } && \
+        [ "$attempts" -lt 80 ]; do
+    attempts=$((attempts + 1))
+    sleep 0.1
+  done
+  [ -s "$checkpoint/rollout.jsonl" ]
+  [ -s "$checkpoint/codex-state.sqlite" ]
+  run_codex stop integration
+  upgraded_version="0.2.0"
+  upgraded_payload="$install_root/libexec/detach/versions/$upgraded_version-test"
+  install -d "$upgraded_payload"
+  install -m 0755 "$ROOT/bin/detach" "$ROOT/bin/detach-core" "$upgraded_payload/"
+  printf '%s\n' "$upgraded_version" >"$upgraded_payload/VERSION"
+  ln -s "$upgraded_payload/detach" "$install_root/bin/.detach-upgrade"
+  mv -f "$install_root/bin/.detach-upgrade" "$install_root/bin/detach"
+  failed_style="bg=$(expected_tint '#B91C1C' 55)"
+}
+
+if codex_part_selected lifecycle; then
+  marker="$TMP_ROOT/must-not-exist"
+  literal_prompt="spaces ; \$(touch $marker) * \"quotes\""
+  export FAKE_CODEX_SLEEP=12
+  integration_release="$TMP_ROOT/integration-provider-release"
+  export FAKE_CODEX_RELEASE_FILE="$integration_release"
+  codex_scenario_event begin SC-SESSION-CREATE-CODEX
+  codex_scenario_event begin SC-SESSION-PERSIST-CODEX
+  codex_scenario_event begin SC-SESSION-RECOVER-CODEX
+  codex_scenario_event begin SC-SESSION-STOP-CODEX
+  codex_scenario_event begin SC-SESSION-DELETE-CODEX
+  run_codex --name integration --detach -- "$literal_prompt"
 
 wait_for_tmux_option "$SESSION" @detach_status running
 tmux -L "$SOCKET" has-session -t "=$SESSION"
 "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-CREATE-CODEX
+codex_scenario_event pass SC-SESSION-CREATE-CODEX
 mkdir -p "$TMP_ROOT/unrelated-tmux-tmpdir"
 TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
   "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
@@ -592,7 +647,7 @@ pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_status)" = "running" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -w -t "$pane_id" remain-on-exit)" = off ]
 [ "$(tmux -L "$SOCKET" show-options -qv -p -t "$pane_id" remain-on-exit)" = on ]
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-PERSIST-CODEX
+codex_scenario_event pass SC-SESSION-PERSIST-CODEX
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_tmux_style)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_style_snapshot)" = "1" ]
 session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_color)"
@@ -912,10 +967,19 @@ run_codex stop integration
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
 grep -Fx "release --session $SESSION --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-STOP-CODEX
+codex_scenario_event pass SC-SESSION-STOP-CODEX
+
+if [ "$CODEX_TEST_PART" = lifecycle ]; then
+  run_codex delete --force integration
+fi
+fi
 
 # Simulate losing the primary metadata in a power failure. Auto-recovery must
 # use the checkpoint metadata and resume the exact saved UUID.
+if codex_part_selected recovery; then
+if [ "$CODEX_TEST_PART" = recovery ]; then
+  bootstrap_codex_checkpoint
+fi
 "$STATE_HELPER" meta patch "$checkpoint/meta.json" --string status running
 rm -f "$meta"
 
@@ -936,13 +1000,23 @@ case "$worker_pid" in
   ''|*[!0-9]*) printf 'recovered pane has invalid worker PID: %s\n' "$worker_pid" >&2; exit 1 ;;
 esac
 worker_pgid="$(wait_for_process_group_id "$worker_pid")"
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-RECOVER-CODEX
+codex_scenario_event pass SC-SESSION-RECOVER-CODEX
 
 run_codex stop integration
 ! kill -0 "$worker_pid" 2>/dev/null
 wait_for_process_group_exit "$worker_pgid"
 [ "$("$STATE_HELPER" meta get "$meta" status)" = "stopped" ]
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
+
+if [ "$CODEX_TEST_PART" = recovery ]; then
+  run_codex delete --force integration
+fi
+fi
+
+if codex_part_selected restart; then
+if [ "$CODEX_TEST_PART" = recovery ] || [ "$CODEX_TEST_PART" = restart ]; then
+  bootstrap_codex_checkpoint
+fi
 
 # A fresh run with the same name must never inherit the previous run's UUID.
 [ -s "$checkpoint/rollout.jsonl" ]
@@ -962,6 +1036,16 @@ if run_codex --name integration --detach -- 'must not replace a running task'; t
 fi
 [ "$("$STATE_HELPER" meta get "$meta" run_token)" = "$fresh_run_token" ]
 run_codex stop integration
+
+if [ "$CODEX_TEST_PART" != all ]; then
+  run_codex delete --force integration
+fi
+fi
+
+if codex_part_selected resume; then
+if [ "$CODEX_TEST_PART" = resume ]; then
+  bootstrap_codex_checkpoint
+fi
 
 # Explicit resume follows Codex semantics and accepts the exact thread UUID.
 export FAKE_CODEX_INIT_DELAY=0
@@ -1046,10 +1130,31 @@ json_line="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "working" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "turn-after-idle" ]
 
+if [ "$CODEX_TEST_PART" = resume ]; then
+  run_codex stop integration
+  run_codex delete --force integration
+fi
+fi
+
 # Codex /clear opens a successor thread inside the same provider process.
 # Discovery must rebind identity, turn state, and checkpoints to the newest
 # run-owned thread, refuse a creation-time tie, ignore subagent threads, and
 # consume superseded ids so the next switch is unambiguous again.
+if codex_part_selected identity; then
+if [ "$CODEX_TEST_PART" = identity ]; then
+  export FAKE_CODEX_SLEEP=60
+  export FAKE_CODEX_EXIT=0
+  export FAKE_CODEX_FOREIGN_FIRST=0
+  export FAKE_CODEX_INIT_DELAY=0.1
+  run_codex --name integration --detach -- 'identity fixture'
+  wait_for_tmux_option "$SESSION" @detach_status running
+  meta="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/meta.json"
+  checkpoint="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint"
+  session_color="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_color)"
+  json_line="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")"
+  turn_rollout="$("$STATE_HELPER" meta get "$meta" transcript_path)"
+  turn_id="$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)"
+fi
 switch_project_dir="$("$STATE_HELPER" meta get "$meta" project_dir)"
 switch_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 pre_switch_id="$("$STATE_HELPER" meta get "$meta" codex_session_id)"
@@ -1243,11 +1348,14 @@ wait "$checkpoint_holder"
 [ "$(<"$external_storage/keep")" = 'provider data' ]
 ! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
 ! run_codex list --json | grep -F "\"session_name\":\"$SESSION\"" >/dev/null
+codex_scenario_event pass SC-SESSION-DELETE-CODEX
+fi
 
 # Killing the worker can leave its provider alive in a retained pane. Detach
 # must expose that uncertainty, refuse every state-changing action, and keep
 # the session out of both cleanup plans until the whole managed process group
 # is gone.
+if codex_part_selected crash; then
 worker_crash_name=health-worker-crash
 worker_crash_session=detach-codex-health-worker-crash
 DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
@@ -1449,10 +1557,12 @@ tmux_loss_json="$(run_codex list --json | \
 [ "$(printf '%s' "$tmux_loss_json" | "$STATE_HELPER" meta get /dev/stdin reconcile_action)" = \
   mark_recoverable ]
 run_codex delete --force "$tmux_loss_name"
+fi
 
 # Default-history allocation is provider-root independent. Claude exercises
 # full preservation below in its integration; keep the Codex lane's mirror
 # bounded to exact monotonic slot selection.
+if codex_part_selected history; then
 default_slug="$(basename "$ROOT" | LC_ALL=C tr -cs 'A-Za-z0-9_-' '-' | \
   sed 's/^-*//; s/-*$//')"
 [ -n "$default_slug" ] || default_slug=project
@@ -1552,6 +1662,6 @@ if DETACH_CODEX_STATE_ROOT="$unsafe_state" run_codex __delete_locked "$SESSION";
 fi
 grep -Fx 'do not delete' "$unsafe_target/$SESSION/sentinel" >/dev/null
 [ ! -e "$FAKE_GIT_MARKER" ]
+fi
 
-"$ROOT/scripts/quality-scenarios" event pass SC-SESSION-DELETE-CODEX
-printf 'Codex detach integration tests passed\n'
+printf 'Codex detach integration tests passed (%s)\n' "$CODEX_TEST_PART"

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -87,6 +87,41 @@ QUALITY_TEST_BINARY = (
 QUALITY_UI_BINARY = Path(
     "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp"
 )
+PROVIDER_TEST_PARTS = {
+    "codex": (
+        "preflight",
+        "lifecycle",
+        "recovery",
+        "resume",
+        "identity",
+        "crash",
+    ),
+    "claude": (
+        "lifecycle",
+        "recovery",
+        "history",
+    ),
+}
+PROVIDER_PART_SCENARIOS = {
+    "codex": {
+        "lifecycle": (
+            "SC-SESSION-CREATE-CODEX",
+            "SC-SESSION-PERSIST-CODEX",
+            "SC-SESSION-STOP-CODEX",
+        ),
+        "recovery": ("SC-SESSION-RECOVER-CODEX",),
+        "identity": ("SC-SESSION-DELETE-CODEX",),
+    },
+    "claude": {
+        "lifecycle": (
+            "SC-SESSION-CREATE-CLAUDE",
+            "SC-SESSION-PERSIST-CLAUDE",
+            "SC-SESSION-STOP-CLAUDE",
+        ),
+        "recovery": ("SC-SESSION-RECOVER-CLAUDE",),
+        "history": ("SC-SESSION-DELETE-CLAUDE",),
+    },
+}
 
 
 class GateError(Exception):
@@ -310,7 +345,7 @@ class QualityGate:
         result_root = os.environ.get(
             "DETACH_QUALITY_GATE_RESULT_ROOT", str(ROOT / "app/build/quality-gates")
         )
-        self.result_root = Path(result_root)
+        self.result_root = Path(result_root).absolute()
         run_id = f"{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{os.getpid()}"
         self.run_dir = self.result_root / run_id
         self.summary = self.run_dir / "summary.tsv"
@@ -671,7 +706,10 @@ class QualityGate:
         self.write_static_files()
 
     def command_version(self, arguments: list[str], *, first_line: bool = False) -> str:
-        result = run(arguments, text=True, check=False)
+        try:
+            result = run(arguments, text=True, check=False)
+        except GateError:
+            return "unavailable"
         assert isinstance(result.stdout, str)
         value = result.stdout.strip()
         if first_line:
@@ -1870,6 +1908,95 @@ def run_exact_swift_stage(root: Path, run_dir: Path) -> int:
     )
 
 
+def run_provider_parts(
+    root: Path,
+    run_dir: Path,
+    stage: str,
+    environment: dict[str, str],
+) -> int:
+    parts = PROVIDER_TEST_PARTS.get(stage)
+    if parts is None:
+        print(f"quality-gate: no provider test partition for {stage}", file=sys.stderr)
+        return 2
+    part_root = run_dir / f"{stage}-parts"
+    if part_root.exists():
+        if not part_root.is_dir() or part_root.is_symlink():
+            print("quality-gate: provider part evidence root is unsafe", file=sys.stderr)
+            return 2
+        shutil.rmtree(part_root)
+    part_root.mkdir(mode=0o700)
+    artifact_value = environment.get("DETACH_PROVIDER_TEST_ARTIFACT_DIR", "")
+    artifact_root = Path(artifact_value) if artifact_value else None
+    variable = f"DETACH_{stage.upper()}_TEST_PART"
+    suite = root / ("tests/run.sh" if stage == "codex" else "tests/run-claude.sh")
+    scenario_owners = PROVIDER_PART_SCENARIOS.get(stage, {})
+    processes: list[
+        tuple[str, Path, subprocess.Popen[bytes], TextIO, float]
+    ] = []
+    try:
+        for part in parts:
+            for scenario_id in scenario_owners.get(part, ()):
+                record_scenario_event("begin", scenario_id)
+        for part in parts:
+            part_environment = environment.copy()
+            part_environment[variable] = part
+            part_environment["DETACH_QUALITY_PARTITIONED_PROVIDER"] = "1"
+            if artifact_root is not None:
+                part_environment["DETACH_PROVIDER_TEST_ARTIFACT_DIR"] = str(
+                    artifact_root / part
+                )
+            log = part_root / f"{part}.log"
+            output = log.open("w", encoding="utf-8")
+            log.chmod(0o600)
+            process = subprocess.Popen(
+                [str(suite)],
+                cwd=root,
+                env=part_environment,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+            )
+            processes.append((part, log, process, output, time.monotonic()))
+        pending = set(range(len(processes)))
+        statuses: dict[int, int] = {}
+        durations: dict[int, int] = {}
+        while pending:
+            for index in list(pending):
+                part, _, process, output, started = processes[index]
+                status = process.poll()
+                if status is None:
+                    continue
+                output.close()
+                statuses[index] = status
+                durations[index] = max(0, round(time.monotonic() - started))
+                if status == 0:
+                    for scenario_id in scenario_owners.get(part, ()):
+                        record_scenario_event("pass", scenario_id)
+                pending.remove(index)
+            if pending:
+                time.sleep(0.05)
+        for index, (part, log, _, _, _) in enumerate(processes):
+            status = statuses[index]
+            sys.stdout.write(log.read_text(encoding="utf-8", errors="replace"))
+            print(
+                f"quality-gate: {stage} part {part} completed in {durations[index]}s "
+                f"with exit {status}"
+            )
+        return next(
+            (statuses[index] for index in range(len(processes)) if statuses[index]),
+            0,
+        )
+    except OSError as error:
+        print(f"quality-gate: cannot run {stage} test parts: {error}", file=sys.stderr)
+        return 2
+    finally:
+        for _, _, process, output, _ in processes:
+            if process.poll() is None:
+                process.terminate()
+                process.wait()
+            if not output.closed:
+                output.close()
+
+
 def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -> int:
     static_file = run_dir / "static-files.z"
     try:
@@ -2515,8 +2642,9 @@ def run_stage_worker(stage: str) -> int:
                 ),
             }
         )
-        suite = "run.sh" if stage == "codex" else "run-claude.sh"
-        return child_run([str(root / "tests" / suite)], env=environment)
+        if stage in PROVIDER_TEST_PARTS:
+            return run_provider_parts(root, run_dir, stage, environment)
+        return child_run([str(root / "tests/run-claude.sh")], env=environment)
     commands = {
         "distribution": [[str(root / "tests/distribution.sh")]],
         "tmux-runtime": [[str(root / "tests/tmux-runtime.sh")]],


### PR DESCRIPTION
## Contract delta

- Run Codex and Claude integration partitions concurrently with private state, tmux, log, and artifact roots.
- Emit provider scenario evidence once from the partition parent and require every part.
- Run PR planning and final evidence aggregation on Linux while all product checks remain on macOS.
- Cancel peer matrix shards after a failure and omit the redundant standalone app stage for provider-test-only changes; each provider shard still verifies the exact packaged app prerequisite.

## Durable decisions

- Provider partitions preserve the direct sequential suite entry points.
- Linux control jobs only plan and validate digest-bound macOS evidence; they do not replace product evidence.
- Impact policy 50 maps each provider test to static, that provider, and release-budget.

## Evidence

- Local partitioned Codex stage: PASS, 28.15 s; all 10 required scenario events.
- Local partitioned Claude stage: PASS, 23.93 s; all 10 required scenario events.
- Direct sequential Codex and Claude suites: PASS.
- Policy generation/validation, quality-care 9/9, documentation contracts, quality gate orchestrator contracts, and git diff checks: PASS.
- Focused gate-contract stage after deterministic fixture fixes: PASS.
- One full local repository diagnostic passed static, Swift, app, provider, publication, release, distribution, preflight, and tmux stages. UI E2E reached the app accessibility tree but failed its local background-activation probe; hosted PR CI is the readiness authority for that environment-sensitive boundary.