### PR TITLE
Set terminal title from active project

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -939,13 +939,14 @@ blend_session_color() {
   printf '#%02X%02X%02X\n' "$red" "$green" "$blue"
 }
 
-tmux_status_literal() {
+tmux_format_literal() {
   local value="$1"
+  local limit="${2:-${#value}}"
   local result=""
   local character
   local index
 
-  for ((index = 0; index < ${#value} && index < 48; index++)); do
+  for ((index = 0; index < ${#value} && index < limit; index++)); do
     character="${value:index:1}"
     if [[ "$character" == [[:cntrl:]] ]]; then
       result+='?'
@@ -957,6 +958,22 @@ tmux_status_literal() {
     fi
   done
   printf '%s' "$result"
+}
+
+tmux_status_literal() {
+  tmux_format_literal "$1" 48
+}
+
+tmux_apply_session_title() {
+  local session="$1"
+  local cwd project
+
+  cwd="$(tmux_option "$session" '@detach_cwd')"
+  project="$(basename "${cwd:-project}")"
+  [ -n "$project" ] || project='project'
+  project="$(tmux_format_literal "$project")"
+  "${TMUX_CMD[@]}" set-option -q -t "=$session:" set-titles-string "Detach · $project" && \
+    "${TMUX_CMD[@]}" set-option -q -t "=$session:" set-titles on
 }
 
 tmux_forget_session_style_snapshot() {
@@ -1522,6 +1539,8 @@ attach_session() {
 
   tmux_has_session "$session" || die "tmux session '$session' is not running"
   tmux_is_managed "$session" || die "refusing to attach to unmanaged tmux session '$session'"
+  tmux_apply_session_title "$session" || \
+    error "warning: could not configure the terminal title for this session"
   tmux_configure_server || \
     error "warning: could not configure Detach server input options for this session"
   if [ -n "$INSIDE_TMUX" ]; then
@@ -3538,6 +3557,8 @@ start_tmux_session() {
   "${TMUX_CMD[@]}" set-option -q -t "=$session:" @detach_power_state "$(power_protection_state)"
   "${TMUX_CMD[@]}" set-option -q -t "=$session:" @detach_cli_version "$(release_version 2>/dev/null || printf 'unknown')"
   "${TMUX_CMD[@]}" set-option -q -t "=$session:" @detach_core_path "$SELF"
+  tmux_apply_session_title "$session" || \
+    error "warning: could not configure the terminal title for this session"
   # Retain only the managed provider pane for logs and exit status. User-created
   # splits inherit the window-level off value and disappear normally on exit.
   "${TMUX_CMD[@]}" set-option -q -w -t "$pane_id" remain-on-exit off

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -157,18 +157,19 @@ Provider test parts need private state, socket, and artifact roots. Their parent
 orders events and requires every part. Small hosts reuse lifecycle checkpoints
 in three Codex and two Claude parts. Larger hosts use finer parts.
 
-Detach status options are session-local and use `@detach*`; they never change a
-foreign tmux server. The status strip uses a dense identity-color blend, light
-plain-text labels, a solid painted-space edge, and power and time on the right.
-Finished sessions keep a faint form of the hue. Failures use reserved red. The
-eight-hue identity palette omits pure red. Allocation scans both providers
+Detach status options use session-local `@detach*` keys and never change a
+foreign tmux server. The strip blends an identity color, uses light text and a
+solid edge, and shows power and time on the right.
+Each managed session sets `Detach · <project basename>` as the terminal title.
+It follows the active tmux session, independent of styling.
+Finished sessions keep a faint hue. Failures use reserved red, which the
+eight-hue identity palette omits. Allocation scans both providers
 under the Start/Resume/Recover install lock. Known terminal history keeps its
-shown identity but does not reserve a hue; unknown state stays conservative.
-Keep an existing hue when unique among current state. Otherwise, walk from the
-stable provider/project preference to the first free hue, and duplicate only
-when all eight are occupied. The single `blend_session_color` formula makes
-every derived surface. The style snapshot saves and restores both sides and
-their lengths. An older snapshot without right-side data does not clear the
+identity but reserves no hue. Unknown state stays conservative. Keep a
+current unique hue. Otherwise, choose the first free hue from the stable
+provider/project preference, and duplicate only after all eight are used.
+`blend_session_color` makes every surface. Style snapshots save and restore
+both sides and lengths. An old snapshot without right-side data preserves the
 user's `status-right`. Plain text is the primary power signal: `MAC AWAKE`,
 `MAC CAN SLEEP`, `LOW BATTERY`, `MAC CAN SLEEP: TEMPERATURE`,
 `POWER UNAVAILABLE`, or a transition. App wording is equivalent and icons are

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -396,6 +396,9 @@ run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 tmux -L "$SOCKET" has-session -t "=$session"
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_provider)" = "claude" ]
+[ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" set-titles)" = "on" ]
+[ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" set-titles-string)" = \
+  "Detach · $PROJECT_LABEL" ]
 live_pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_pane_id)"
 # The start command (and therefore its creator process) has returned, yet the
 # private tmux server and provider worker continue without an attached client.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -656,6 +656,9 @@ TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
   "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_provider)" = "codex" ]
+[ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" set-titles)" = "on" ]
+[ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" set-titles-string)" = \
+  "Detach · $PROJECT_LABEL" ]
 pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
 # The creator CLI has already exited. The tmux server and worker must remain
 # alive without an attached client (the same lifecycle as closing Terminal or


### PR DESCRIPTION
## Summary

- set each managed tmux session title to Detach · <project basename>
- refresh the title on session creation and attach, including sessions created before this update
- keep title ownership independent of the Detach status style

## Contract delta

docs/specs/runtime.md: the outer terminal title follows the active managed tmux session and identifies its project.

## Durable decisions

- tmux owns the title, so switching the active session also switches the project name.
- The app still launches terminals through NSWorkspace and needs no Apple Events or Automation permission.
- Project names retain their full basename. Control characters are neutralized and tmux format markers are escaped.

## Acceptance evidence

- Codex lifecycle integration: pass
- Claude lifecycle integration: pass
- scripts/quality-gate --stage static: pass
- tests/docs-contract.sh: pass
- git diff --check: pass

Hosted quality-gates is the readiness authority.