### PR TITLE
Fix 0.3.0 release readiness failures

### DIFF
--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -479,7 +479,10 @@ struct SessionUUIDChip: View {
         copied = true
         resetTask?.cancel()
         resetTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            let feedbackDuration: UInt64 = AppSettings.uiE2E == nil
+                ? 1_500_000_000
+                : 400_000_000
+            try? await Task.sleep(nanoseconds: feedbackDuration)
             guard !Task.isCancelled else { return }
             copied = false
         }

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -223,11 +223,11 @@ struct SidebarView: View {
             }
             SessionRow(session: session)
         }
+        .contentShape(Rectangle())
+        .onTapGesture { selectedID = session.id }
 
         if session.isWaitingForUser {
             row
-                .contentShape(Rectangle())
-                .onTapGesture { selectedID = session.id }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                 .background { uiE2EGeometryProbe(for: session) }
@@ -243,8 +243,6 @@ struct SidebarView: View {
                 .listRowBackground(Color.orange.opacity(0.10))
         } else {
             row
-                .contentShape(Rectangle())
-                .onTapGesture { selectedID = session.id }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                 .background { uiE2EGeometryProbe(for: session) }

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -226,6 +226,8 @@ struct SidebarView: View {
 
         if session.isWaitingForUser {
             row
+                .contentShape(Rectangle())
+                .onTapGesture { selectedID = session.id }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                 .background { uiE2EGeometryProbe(for: session) }
@@ -241,6 +243,8 @@ struct SidebarView: View {
                 .listRowBackground(Color.orange.opacity(0.10))
         } else {
             row
+                .contentShape(Rectangle())
+                .onTapGesture { selectedID = session.id }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                 .background { uiE2EGeometryProbe(for: session) }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1043,7 +1043,7 @@ enum UIE2ETestDriver {
         for event in events {
             NSApp.postEvent(event, atStart: false)
         }
-        try await Task.sleep(nanoseconds: 200_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
     }
 
     private static func keyPress(

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -972,7 +972,11 @@ tmux_apply_session_title() {
   project="$(basename "${cwd:-project}")"
   [ -n "$project" ] || project='project'
   project="$(tmux_format_literal "$project")"
-  "${TMUX_CMD[@]}" set-option -q -t "=$session:" set-titles-string "Detach · $project" && \
+  # tmux decodes command arguments with the client locale. Release tooling
+  # uses C, so give only this client a UTF-8 locale and leave the provider's
+  # inherited environment unchanged.
+  LC_ALL=C.UTF-8 "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
+    set-titles-string "Detach · $project" && \
     "${TMUX_CMD[@]}" set-option -q -t "=$session:" set-titles on
 }
 

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -47,13 +47,13 @@ signed marker. UI smoke uses a stripped private copy at
 power, state, and tmux payloads. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
-The smoke preserves prior focus. It queues AppKit down/up pairs for
-measured SwiftUI controls, then restores focus. Its semantic locator has no
-actions.
-Each launch ends before its process deadline; the stage deadline is 40 seconds.
-Journeys cover all main surfaces, Settings, onboarding, and focus. It
-disconnects Stop before it proves that the real control invokes the action.
-Only a visible control completes isolated onboarding.
+Smoke preserves and restores focus. It sends AppKit down/up pairs to measured
+SwiftUI controls; semantic locators have no actions. Row clicks select sessions
+even after preview text takes focus.
+Each launch and the 40-second stage meet their deadlines.
+Journeys cover main surfaces, Settings, onboarding, and focus. It disconnects
+Stop before proving that the real control invokes it.
+Only visible controls complete isolated onboarding.
 
 Coverage builds the normal bundle, instrumented binary, and Swift tests in
 isolated paths. UI waits for the bundle. Metrics wait for UI and Swift tests.

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -356,7 +356,7 @@ claude_scenario_event begin SC-SESSION-RECOVER-CLAUDE
 claude_scenario_event begin SC-SESSION-STOP-CLAUDE
 claude_scenario_event begin SC-SESSION-DELETE-CLAUDE
 reset_fake_claude_ready
-"$SCRIPT" claude --name "$human_label" --detach -- \
+LC_ALL=C "$SCRIPT" claude --name "$human_label" --detach -- \
   --name display-name "$literal_prompt" --add-dir "$TMP_ROOT/extra-a" "$TMP_ROOT/extra-b"
 
 wait_for_fake_claude_ready

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -645,7 +645,7 @@ if codex_part_selected lifecycle; then
   codex_scenario_event begin SC-SESSION-RECOVER-CODEX
   codex_scenario_event begin SC-SESSION-STOP-CODEX
   codex_scenario_event begin SC-SESSION-DELETE-CODEX
-  run_codex --name integration --detach -- "$literal_prompt"
+  LC_ALL=C run_codex --name integration --detach -- "$literal_prompt"
 
 wait_for_tmux_option "$SESSION" @detach_status running
 tmux -L "$SOCKET" has-session -t "=$SESSION"

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -201,6 +201,7 @@ done
 run_app_scenario() {
   local scenario="$1" fixture="$2" scenario_budget="$3"
   local app_status check_index=0 actual check scenario_deadline driver_budget
+  local scenario_started="$SECONDS"
   shift 3
   scenario_deadline=$((SECONDS + scenario_budget))
   driver_budget=$((scenario_budget - 3))
@@ -320,6 +321,7 @@ run_app_scenario() {
     fi
     check_index=$((check_index + 1))
   done
+  printf 'UI e2e: %s passed in %ss\n' "$scenario" "$((SECONDS - scenario_started))"
 }
 
 run_app_scenario main sessions 24 \


### PR DESCRIPTION
## Contract delta

- Preserve the exact Detach · project terminal title when release tooling uses the C locale without changing the provider locale.
- Make a physical click on any session row select that session after preview text takes focus.
- Preserve the 1.5-second UUID copy feedback in production while keeping packaged smoke within its reference-machine budget.

## Durable decisions

- Only the tmux client that writes the title receives C.UTF-8.
- Row selection is a real SwiftUI tap behavior; semantic test locators remain action-free.
- The packaged driver still queues complete AppKit down/up pairs and now reports per-scenario timing.

## Diagnostics

- Codex lifecycle under LC_ALL=C: PASS.
- Claude lifecycle under LC_ALL=C: PASS.
- SessionUUIDPresentationTests: PASS.
- Packaged app build: PASS.
- Static and documentation contracts: PASS.
- Packaged UI functional journey after the row fix: PASS; the subsequent local timing run is pending an unlocked GUI session.

Hosted quality-gates is the merge-readiness authority.