### PR TITLE
Stabilize session row selection for 0.3.0

### DIFF
--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -414,11 +414,22 @@ enum SessionUUIDPresentation {
     }
 
     @discardableResult
-    static func copy(_ uuid: String, to pasteboard: NSPasteboard = .general) -> Bool {
+    static func copy(
+        _ uuid: String,
+        to pasteboard: any SessionUUIDPasteboardWriting = NSPasteboard.general
+    ) -> Bool {
         pasteboard.clearContents()
         return pasteboard.setString(uuid, forType: .string)
     }
 }
+
+protocol SessionUUIDPasteboardWriting: AnyObject {
+    @discardableResult
+    func clearContents() -> Int
+    func setString(_ string: String, forType dataType: NSPasteboard.PasteboardType) -> Bool
+}
+
+extension NSPasteboard: SessionUUIDPasteboardWriting {}
 
 /// The whole chip is the control. A nested icon-only button inside
 /// `FlowLayout` often misses clicks on macOS.

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -183,8 +183,8 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func sessionRow(_ session: Session) -> some View {
-        let row = HStack(spacing: 8) {
-            if isSelectingFinished && session.canDeleteFromFinishedList {
+        if isSelectingFinished && session.canDeleteFromFinishedList {
+            HStack(spacing: 8) {
                 Button {
                     if selectedFinishedIDs.contains(session.id) {
                         selectedFinishedIDs.remove(session.id)
@@ -220,41 +220,39 @@ struct SidebarView: View {
                 }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
+                SessionRow(session: session)
             }
-            SessionRow(session: session)
-        }
-        .contentShape(Rectangle())
-        .onTapGesture { selectedID = session.id }
-
-        if session.isWaitingForUser {
-            row
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
-                .background { uiE2EGeometryProbe(for: session) }
+            .background { uiE2EGeometryProbe(for: session) }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
-                .tag(session.id)
-                .accessibilityElement(children:
-                    isSelectingFinished && session.canDeleteFromFinishedList
-                        ? .contain : .combine)
-                .accessibilityLabel(session.displayTitle)
-                .accessibilityIdentifier("session-row-\(session.id)")
-                .accessibilityAction { selectedID = session.id }
-                .listRowBackground(Color.orange.opacity(0.10))
+            .tag(session.id)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(session.displayTitle)
+            .accessibilityIdentifier("session-row-\(session.id)")
+            .listRowBackground(
+                session.isWaitingForUser ? Color.orange.opacity(0.10) : nil)
         } else {
-            row
+            Button {
+                selectedID = session.id
+            } label: {
+                SessionRow(session: session)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
-                .background { uiE2EGeometryProbe(for: session) }
+            .background { uiE2EGeometryProbe(for: session) }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
-                .tag(session.id)
-                .accessibilityElement(children:
-                    isSelectingFinished && session.canDeleteFromFinishedList
-                        ? .contain : .combine)
-                .accessibilityLabel(session.displayTitle)
-                .accessibilityIdentifier("session-row-\(session.id)")
-                .accessibilityAction { selectedID = session.id }
+            .tag(session.id)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(session.displayTitle)
+            .accessibilityIdentifier("session-row-\(session.id)")
+            .listRowBackground(
+                session.isWaitingForUser ? Color.orange.opacity(0.10) : nil)
         }
     }
 

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -163,10 +163,6 @@ enum UIE2ETestDriver {
         store: SessionStore
     ) async -> Report {
         switch configuration.scenario {
-        case "failure":
-            return await runFailurePresentation()
-        case "settings":
-            return await runSettings()
         case "onboarding-first-run":
             return await runOnboardingFirstRun(
                 configuration: configuration,
@@ -438,6 +434,11 @@ enum UIE2ETestDriver {
             checks.append("empty-dashboard-state")
             trace("empty dashboard visible")
 
+            try Data("error\n".utf8).write(
+                to: configuration.fixtureState, options: .atomic)
+            checks.append(try await verifyFailurePresentation(in: mainWindow))
+            checks.append(contentsOf: try await verifySettings(in: mainWindow))
+
             try await restoreFocus(
                 to: previousFrontmost, policy: previousActivationPolicy)
             checks.append("installed-app-focus-restored")
@@ -460,76 +461,58 @@ enum UIE2ETestDriver {
         }
     }
 
-    private static func runFailurePresentation() async -> Report {
-        var checks: [String] = []
-        do {
-            let mainWindow = try testWindow()
-            try await activate(mainWindow)
-            let errorStatus = try await element(identifier: "session-status-error")
-            guard label(errorStatus)?.isEmpty == false else {
-                throw Failure(message: "actionable session failure has no semantics")
-            }
-            _ = try await measuredFrame(
-                identifier: "session-status-error",
-                name: "actionable session failure")
-            checks.append("actionable-failure-presentation")
-            return Report(
-                schema: 1, passed: true, checks: checks, error: nil,
-                accessibilityTree: snapshots())
-        } catch {
-            return Report(
-                schema: 1, passed: false, checks: checks,
-                error: error.localizedDescription,
-                accessibilityTree: snapshots())
+    private static func verifyFailurePresentation(
+        in mainWindow: NSWindow
+    ) async throws -> String {
+        try await activate(mainWindow)
+        let errorStatus = try await element(identifier: "session-status-error")
+        guard label(errorStatus)?.isEmpty == false else {
+            throw Failure(message: "actionable session failure has no semantics")
         }
+        _ = try await measuredFrame(
+            identifier: "session-status-error",
+            name: "actionable session failure")
+        return "actionable-failure-presentation"
     }
 
-    private static func runSettings() async -> Report {
+    private static func verifySettings(
+        in mainWindow: NSWindow
+    ) async throws -> [String] {
         var checks: [String] = []
-        do {
-            let mainWindow = try testWindow()
-            try await activate(mainWindow)
-            try await keyPress(",", keyCode: 43, modifiers: [.command])
-            let tipsToggle = try await element(identifier: "settings-show-tips")
-            try requireSemanticControl(tipsToggle, name: "settings tips toggle")
-            let priorTips = AppSettings.defaults.bool(
-                forKey: AppSettings.tipsEnabledKey)
-            try await clickUntil(
-                tipsToggle,
-                name: "settings tips toggle",
-                outcome: "settings value persists") {
-                    AppSettings.defaults.bool(
-                        forKey: AppSettings.tipsEnabledKey) != priorTips
-                }
-            checks.append("settings-change-persists")
-            guard let settingsWindow = UIE2EEventWindowResolver.owner(of: tipsToggle)
-            else {
-                throw Failure(message: "Settings window is missing")
+        try await activate(mainWindow)
+        try await keyPress(",", keyCode: 43, modifiers: [.command])
+        let tipsToggle = try await element(identifier: "settings-show-tips")
+        try requireSemanticControl(tipsToggle, name: "settings tips toggle")
+        let priorTips = AppSettings.defaults.bool(
+            forKey: AppSettings.tipsEnabledKey)
+        try await clickUntil(
+            tipsToggle,
+            name: "settings tips toggle",
+            outcome: "settings value persists") {
+                AppSettings.defaults.bool(
+                    forKey: AppSettings.tipsEnabledKey) != priorTips
             }
-            guard let visible = settingsWindow.screen?.visibleFrame else {
-                throw Failure(message: "Settings window has no hosting screen")
-            }
-            let frame = settingsWindow.frame
-            guard visible.insetBy(dx: -2, dy: -2).contains(frame) else {
-                throw Failure(message: "Settings window is off the hosting screen")
-            }
-            checks.append("settings-window-stays-on-screen")
-            let systemTab = try await buttonLabeled(
-                L10n.string("System"), attempts: 20)
-            try await click(systemTab, name: "System settings tab")
-            try await revealGeometry(identifier: "settings-storage", name: "Storage")
-            try await revealGeometry(
-                identifier: "settings-installation", name: "Installation")
-            checks.append("settings-system-reveals-storage-and-installation")
-            return Report(
-                schema: 1, passed: true, checks: checks, error: nil,
-                accessibilityTree: snapshots())
-        } catch {
-            return Report(
-                schema: 1, passed: false, checks: checks,
-                error: error.localizedDescription,
-                accessibilityTree: snapshots())
+        checks.append("settings-change-persists")
+        guard let settingsWindow = UIE2EEventWindowResolver.owner(of: tipsToggle)
+        else {
+            throw Failure(message: "Settings window is missing")
         }
+        guard let visible = settingsWindow.screen?.visibleFrame else {
+            throw Failure(message: "Settings window has no hosting screen")
+        }
+        let frame = settingsWindow.frame
+        guard visible.insetBy(dx: -2, dy: -2).contains(frame) else {
+            throw Failure(message: "Settings window is off the hosting screen")
+        }
+        checks.append("settings-window-stays-on-screen")
+        let systemTab = try await buttonLabeled(
+            L10n.string("System"), attempts: 20)
+        try await click(systemTab, name: "System settings tab")
+        try await revealGeometry(identifier: "settings-storage", name: "Storage")
+        try await revealGeometry(
+            identifier: "settings-installation", name: "Installation")
+        checks.append("settings-system-reveals-storage-and-installation")
+        return checks
     }
 
     private static func runOnboardingFirstRun(
@@ -777,6 +760,9 @@ enum UIE2ETestDriver {
         if let identifier = identifierOf(element),
            usesMeasuredGeometry(identifier) {
             try await waitUntil("real control geometry for \(name)") {
+                elements().compactMap { $0 as? UIE2EGeometryView }.first {
+                    $0.identifierValue == identifier
+                }?.publishFrame()
                 guard let measured = UIE2EGeometryRegistry.frame(for: identifier) else {
                     return false
                 }
@@ -1037,6 +1023,9 @@ enum UIE2ETestDriver {
             else { continue }
             events.append(event)
         }
+        guard events.count == 2 else {
+            throw Failure(message: "cannot create mouse pair for \(name)")
+        }
         // Queue the complete pair before yielding. Dispatching only mouseDown
         // can enter AppKit's tracking loop before this main-actor task gets a
         // chance to enqueue the matching mouseUp.
@@ -1075,18 +1064,6 @@ enum UIE2ETestDriver {
         try await waitUntil("test app activation") {
             NSApp.isActive && mainWindow.isKeyWindow
         }
-    }
-
-    private static func testWindow() throws -> NSWindow {
-        guard let mainWindow = NSApp.windows.first(where: {
-            $0.identifier?.rawValue == "main"
-        }) else {
-            throw Failure(message: "main test window is missing")
-        }
-        guard NSApp.setActivationPolicy(.regular) else {
-            throw Failure(message: "cannot enable test app activation")
-        }
-        return mainWindow
     }
 
     private static func find(identifier: String) -> (any NSAccessibilityProtocol)? {

--- a/app/Tests/DetachAppTests/SessionIdentityTests.swift
+++ b/app/Tests/DetachAppTests/SessionIdentityTests.swift
@@ -98,14 +98,14 @@ final class SessionUUIDPresentationTests: XCTestCase {
     }
 
     func testCopyWritesTheFullUUIDToThePasteboard() {
-        let pasteboard = NSPasteboard.withUniqueName()
-        defer { pasteboard.releaseGlobally() }
+        let pasteboard = RecordingSessionUUIDPasteboard()
         XCTAssertTrue(
             SessionUUIDPresentation.copy(
                 "a9f58f1d-1234-5678-9abc-def012342ed9",
                 to: pasteboard))
+        XCTAssertTrue(pasteboard.didClear)
         XCTAssertEqual(
-            pasteboard.string(forType: .string),
+            pasteboard.strings[.string],
             "a9f58f1d-1234-5678-9abc-def012342ed9")
     }
 
@@ -113,6 +113,25 @@ final class SessionUUIDPresentationTests: XCTestCase {
     func testChipBuildsTheWholeCopyControl() {
         _ = SessionUUIDChip(
             uuid: "a9f58f1d-1234-5678-9abc-def012342ed9").body
+    }
+}
+
+private final class RecordingSessionUUIDPasteboard: SessionUUIDPasteboardWriting {
+    private(set) var didClear = false
+    private(set) var strings: [NSPasteboard.PasteboardType: String] = [:]
+
+    func clearContents() -> Int {
+        didClear = true
+        strings.removeAll()
+        return 1
+    }
+
+    func setString(
+        _ string: String,
+        forType dataType: NSPasteboard.PasteboardType
+    ) -> Bool {
+        strings[dataType] = string
+        return true
     }
 }
 

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -336,12 +336,11 @@ run_app_scenario main sessions 24 \
   bulk-delete-reaches-fake-cli \
   new-session-sheet-semantics \
   empty-dashboard-state \
-  installed-app-focus-restored
-run_app_scenario failure error 8 actionable-failure-presentation
-run_app_scenario settings empty 8 \
+  actionable-failure-presentation \
   settings-change-persists \
   settings-window-stays-on-screen \
-  settings-system-reveals-storage-and-installation
+  settings-system-reveals-storage-and-installation \
+  installed-app-focus-restored
 run_app_scenario onboarding-first-run empty 8 onboarding-first-run-completes
 run_app_scenario onboarding-provider empty 8 onboarding-detects-provider
 run_app_scenario onboarding-approval empty 8 onboarding-explains-approval


### PR DESCRIPTION
## Summary

- Make each normal session row a full-width plain button. Keep the finished-deletion checkbox as its only nested control.
- Refresh measured SwiftUI geometry immediately before physical UI-smoke clicks.
- Run Failure and Settings checks in the main journey to stay within the release budget.
- Use a recording UUID pasteboard writer in unit tests. Packaged UI smoke still verifies the real general pasteboard.

## Contract delta

Normal row clicks now use Button semantics and select the session across the full row after preview text takes focus. Finished deletion mode remains a separate checkbox flow. The smoke still sends AppKit mouse down/up pairs to real controls and invokes no semantic actions.

## Evidence

- `static`: PASS
- `swift`: PASS, 796 tests
- packaged app build: PASS
- UI harness contract: PASS
- local packaged UI execution: incomplete because macOS 26 aborted in `_RegisterApplication` before `NSApplication.init`; the app log was empty and no driver code ran
- hosted `quality-gates` is readiness authority