### PR TITLE
Stabilize release gate event ordering

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1026,12 +1026,10 @@ enum UIE2ETestDriver {
         guard events.count == 2 else {
             throw Failure(message: "cannot create mouse pair for \(name)")
         }
-        // Queue the complete pair before yielding. Dispatching only mouseDown
-        // can enter AppKit's tracking loop before this main-actor task gets a
-        // chance to enqueue the matching mouseUp.
-        for event in events {
-            NSApp.postEvent(event, atStart: false)
-        }
+        // Put the complete pair at the front in delivery order. The main event
+        // loop dispatches mouseDown and can consume mouseUp while it tracks.
+        NSApp.postEvent(events[1], atStart: true)
+        NSApp.postEvent(events[0], atStart: true)
         try await Task.sleep(nanoseconds: 100_000_000)
     }
 

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -930,7 +930,13 @@ set -eu
 [ -f "$GATE_ORDER_ROOT/ui-e2e" ]
 [ -f "$GATE_ORDER_ROOT/quality-contracts" ]
 : >"$GATE_ORDER_ROOT/codex-started"
-sleep 3
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/integration-after-contract" ] && \
+    [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/integration-after-contract" ]
 : >"$GATE_ORDER_ROOT/codex"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/gate-contract" <<'SH'


### PR DESCRIPTION
## Summary
- enqueue each AppKit mouse pair at the front in down/up delivery order
- replace the scheduler fixture's fixed delay with a bounded marker handshake

## Contract delta
No user-facing product contract changes. Packaged UI smoke still uses physical AppKit events on measured SwiftUI controls. The scheduler contract still proves that distribution starts after gate-contract while Codex remains active.

## Evidence
- impact-aware local diagnostic PASS, policy 50, fingerprint `05e662279956b4a657b322b019cbc2fd7fb307f042ee1422fc6df6873c292e3c`
- packaged UI E2E PASS in 14 seconds
- gate-contract PASS
- docs and test-suite contracts PASS