### PR TITLE
Stabilize release readiness gates

### DIFF
--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -35,41 +35,40 @@ struct SidebarView: View {
     }
 
     var body: some View {
-        List(selection: $selectedID) {
-            ForEach(SessionSection.allCases, id: \.self) { section in
-                let items = sessions(in: section)
-                if !items.isEmpty {
-                    Section {
-                        ForEach(items) { session in
-                            sessionRow(session)
+        VStack(spacing: 0) {
+            List(selection: $selectedID) {
+                ForEach(SessionSection.allCases, id: \.self) { section in
+                    let items = sessions(in: section)
+                    if !items.isEmpty {
+                        Section {
+                            ForEach(items) { session in
+                                sessionRow(session)
+                            }
+                        } header: {
+                            sectionHeader(section, count: items.count)
                         }
-                    } header: {
-                        sectionHeader(section, count: items.count)
                     }
                 }
             }
-        }
-        .overlay {
-            if store.sessions.isEmpty && store.state == .ok {
-                ContentUnavailableView {
-                    Label {
-                        Text(L10n.string("No sessions yet"))
-                    } icon: {
-                        Image(systemName: "terminal").foregroundStyle(Brand.gradient)
+            .overlay {
+                if store.sessions.isEmpty && store.state == .ok {
+                    ContentUnavailableView {
+                        Label {
+                            Text(L10n.string("No sessions yet"))
+                        } icon: {
+                            Image(systemName: "terminal")
+                                .foregroundStyle(Brand.gradient)
+                        }
+                    } description: {
+                        Text(L10n.string("Launch Codex or Claude in Terminal"))
                     }
-                } description: {
-                    Text(L10n.string("Launch Codex or Claude in Terminal"))
                 }
             }
-        }
-        .safeAreaInset(edge: .bottom) {
-            VStack(spacing: 0) {
-                if isSelectingFinished {
-                    finishedSelectionBar
-                    Divider()
-                }
-                StatusBar(store: store)
+            if isSelectingFinished {
+                finishedSelectionBar
+                Divider()
             }
+            StatusBar(store: store)
         }
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -454,7 +453,7 @@ struct StatusBar: View {
         .padding(.horizontal, 12)
         .padding(.top, 4)
         .padding(.bottom, 8)
-        // No backing material: the sidebar List already ends above this inset,
+        // No backing material: the sidebar List already ends above this bar,
         // and an opaque bar reads as a stray strip over the sidebar glass.
     }
 }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -9,6 +9,32 @@ enum UIE2EControlFault {
     static var stopActionAttempts = 0
 }
 
+private final class UIE2EDeferredMouseUp: @unchecked Sendable {
+    private let application: NSApplication
+    private let event: NSEvent
+
+    init(application: NSApplication, event: NSEvent) {
+        self.application = application
+        self.event = event
+    }
+
+    func post() {
+        application.postEvent(event, atStart: true)
+    }
+}
+
+enum UIE2ECursorPositionResolver {
+    static func quartzPoint(
+        for appKitPoint: CGPoint,
+        screenFrame: CGRect,
+        displayBounds: CGRect
+    ) -> CGPoint {
+        CGPoint(
+            x: displayBounds.minX + appKitPoint.x - screenFrame.minX,
+            y: displayBounds.minY + screenFrame.maxY - appKitPoint.y)
+    }
+}
+
 @MainActor
 enum UIE2EEventWindowResolver {
     static func owner(
@@ -128,6 +154,7 @@ enum UIE2ETestDriver {
     private static var scenarioDeadline = TimeInterval.greatestFiniteMagnitude
     private static var nextMouseEventNumber = Int(
         ProcessInfo.processInfo.systemUptime * 1_000)
+    private static var cursorRestorePoint: CGPoint?
 
     static func runIfRequested(
         installation: InstallationStore,
@@ -162,6 +189,13 @@ enum UIE2ETestDriver {
         installation: InstallationStore,
         store: SessionStore
     ) async -> Report {
+        cursorRestorePoint = CGEvent(source: nil)?.location
+        defer {
+            if let cursorRestorePoint {
+                CGWarpMouseCursorPosition(cursorRestorePoint)
+            }
+            cursorRestorePoint = nil
+        }
         switch configuration.scenario {
         case "onboarding-first-run":
             return await runOnboardingFirstRun(
@@ -994,6 +1028,7 @@ enum UIE2ETestDriver {
         trace(
             "clicking \(name) at \(screenPoint.x),\(screenPoint.y) "
                 + "in window \(windowName)")
+        try moveCursor(to: screenPoint, name: name)
         let windowPoint = window.convertPoint(fromScreen: screenPoint)
         if let contentView = window.contentView {
             let contentPoint = contentView.convert(windowPoint, from: nil)
@@ -1007,6 +1042,7 @@ enum UIE2ETestDriver {
         }
         var events: [NSEvent] = []
         let timestamp = ProcessInfo.processInfo.systemUptime
+        let clickInterval: TimeInterval = 0.03
         for type in [NSEvent.EventType.leftMouseDown, .leftMouseUp] {
             let eventNumber = nextMouseEventNumber
             nextMouseEventNumber += 1
@@ -1014,7 +1050,7 @@ enum UIE2ETestDriver {
                 with: type,
                 location: windowPoint,
                 modifierFlags: [],
-                timestamp: timestamp + Double(events.count) / 1_000,
+                timestamp: timestamp + Double(events.count) * clickInterval,
                 windowNumber: window.windowNumber,
                 context: nil,
                 eventNumber: eventNumber,
@@ -1026,11 +1062,41 @@ enum UIE2ETestDriver {
         guard events.count == 2 else {
             throw Failure(message: "cannot create mouse pair for \(name)")
         }
-        // Put the complete pair at the front in delivery order. The main event
-        // loop dispatches mouseDown and can consume mouseUp while it tracks.
-        NSApp.postEvent(events[1], atStart: true)
+        // AppKit permits postEvent from a subthread. Delay mouseUp so SwiftUI
+        // receives a physical-duration click even inside a tracking loop.
+        let mouseUp = UIE2EDeferredMouseUp(application: NSApp, event: events[1])
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + clickInterval
+        ) {
+            mouseUp.post()
+        }
         NSApp.postEvent(events[0], atStart: true)
         try await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    private static func moveCursor(
+        to screenPoint: CGPoint,
+        name: String
+    ) throws {
+        guard cursorRestorePoint != nil else {
+            throw Failure(message: "cannot preserve pointer position for \(name)")
+        }
+        guard let screen = NSScreen.screens.first(where: {
+            $0.frame.contains(screenPoint)
+        }),
+        let screenNumber = screen.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? NSNumber
+        else {
+            throw Failure(message: "cannot resolve the display for \(name)")
+        }
+        let quartzPoint = UIE2ECursorPositionResolver.quartzPoint(
+            for: screenPoint,
+            screenFrame: screen.frame,
+            displayBounds: CGDisplayBounds(CGDirectDisplayID(screenNumber.uint32Value)))
+        guard CGWarpMouseCursorPosition(quartzPoint) == .success else {
+            throw Failure(message: "cannot position the pointer for \(name)")
+        }
     }
 
     private static func keyPress(
@@ -1057,10 +1123,11 @@ enum UIE2ETestDriver {
     }
 
     private static func activate(_ mainWindow: NSWindow) async throws {
-        NSApp.activate(ignoringOtherApps: true)
-        mainWindow.makeKeyAndOrderFront(nil)
         try await waitUntil("test app activation") {
-            NSApp.isActive && mainWindow.isKeyWindow
+            if NSApp.isActive && mainWindow.isKeyWindow { return true }
+            NSApp.activate(ignoringOtherApps: true)
+            mainWindow.makeKeyAndOrderFront(nil)
+            return false
         }
     }
 

--- a/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
@@ -4,6 +4,18 @@ import XCTest
 
 @MainActor
 final class UIE2EEventWindowResolverTests: XCTestCase {
+    func testCursorPointMapsBetweenOffsetDisplayCoordinateSystems() {
+        let screenFrame = CGRect(x: -800, y: 200, width: 800, height: 600)
+        let displayBounds = CGRect(x: 1_600, y: 900, width: 800, height: 600)
+
+        XCTAssertEqual(
+            UIE2ECursorPositionResolver.quartzPoint(
+                for: CGPoint(x: -600, y: 350),
+                screenFrame: screenFrame,
+                displayBounds: displayBounds),
+            CGPoint(x: 1_800, y: 1_350))
+    }
+
     func testViewResolvesItsOwningWindowWhenWindowsOverlap() {
         let behind = NSWindow(
             contentRect: NSRect(x: 100, y: 100, width: 300, height: 300),

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -47,13 +47,13 @@ signed marker. UI smoke uses a stripped private copy at
 power, state, and tmux payloads. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
-Smoke preserves and restores focus. It sends AppKit down/up pairs to measured
+Smoke restores focus and pointer position. It sends AppKit down/up pairs to measured
 SwiftUI controls; semantic locators have no actions. Row clicks select sessions
 even after preview text takes focus.
-Each launch and the 40-second stage meet their deadlines.
+Each launch and stage stays within its deadline.
 Journeys cover main surfaces, Settings, onboarding, and focus. It disconnects
 Stop before proving that the real control invokes it.
-Only visible controls complete isolated onboarding.
+Only visible controls complete onboarding.
 
 Coverage builds the normal bundle, instrumented binary, and Swift tests in
 isolated paths. UI waits for the bundle. Metrics wait for UI and Swift tests.
@@ -93,8 +93,8 @@ thin tmux-colored capsule. Status is a filled circle. Power has a neutral
 surface and semantic color. The UUID chip is one copy control. Any click copies
 the full UUID and shows **Copied**.
 
-**Finished** bulk Delete uses typed Delete, asks once, tolerates failures, and
-keeps provider transcripts. Select/Done has 12-point scroll clearance.
+**Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
+tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
 
 Every app CLI invocation runs in a fresh process group that drains stdout and
 stderr. Its deadline sends TERM then KILL to the group. A pipe-only descendant

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -4,7 +4,7 @@
 
 Codex and Claude Code receive the same small durable instruction core, discover
 only task-relevant detailed specs, and use focused tests while iterating.
-Hosted pull-request CI is the deterministic merge-readiness authority.
+Hosted CI is the merge-readiness authority.
 
 ## Invariants
 
@@ -75,10 +75,11 @@ Hosted pull-request CI is the deterministic merge-readiness authority.
 - CI keeps a ten-minute timing ratchet with no reference-Mac limit.
 - Gate contracts admit three heavy shards on eight CPUs and two on
   fewer CPUs. Light contracts stay concurrent. Budgets expose overload.
-- Swift tests and both release builds use separate caches and split three or
-  more CPUs. Smaller hosts run them in order. UI waits for the app; metrics
-  wait for Swift and UI. Later work uses two heavy lanes and one integration
-  lane. Distribution waits for gate-contract.
+- Swift and release builds use separate caches and split at three CPUs.
+  Smaller hosts run in order. UI waits for app; metrics for both.
+  Gate-contract and release-workflow exclude heavy peers. Gate-contract permits
+  preflight and gates distribution. Other work uses two heavy and one
+  integration lane.
 - Exact keys bind code, resources, scripts, version, and toolchain. `main` warms
   only a missing app or executable product. CI verifies hits and rebuilds
   misses. Warming is not evidence.

--- a/tests/publish-preflight.sh
+++ b/tests/publish-preflight.sh
@@ -289,11 +289,13 @@ chmod 0755 \
 
 assert_local_validation_rejected() {
   local failure="$1"
-  : >"$TMP_ROOT/validation.log"
-  rm -f "$GH_LOG"
+  local validation_log="$TMP_ROOT/$failure.validation.log"
+  local gh_log="$TMP_ROOT/$failure.gh.log"
+  : >"$validation_log"
+  rm -f "$gh_log"
   if PATH="$FAKE_BIN:/usr/bin:/bin" \
-      FAKE_GH_LOG="$GH_LOG" \
-      FAKE_VALIDATION_LOG="$TMP_ROOT/validation.log" \
+      FAKE_GH_LOG="$gh_log" \
+      FAKE_VALIDATION_LOG="$validation_log" \
       FAIL_VALIDATION="$failure" \
       DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
       DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
@@ -303,12 +305,12 @@ assert_local_validation_rejected() {
       "$failure" >&2
     exit 1
   fi
-  [ ! -e "$GH_LOG" ] || {
+  [ ! -e "$gh_log" ] || {
     printf 'publish contacted GitHub before rejecting: %s\n' "$failure" >&2
     exit 1
   }
   if [ "$failure" = hdiutil_attach ]; then
-    grep -F 'hdiutil|detach ' "$TMP_ROOT/validation.log" >/dev/null || {
+    grep -F 'hdiutil|detach ' "$validation_log" >/dev/null || {
       printf 'failed DMG attach was not cleaned up with detach\n' >&2
       exit 1
     }
@@ -355,6 +357,8 @@ printf '%s\n' dirty >"$TEST_REPO/local-note.txt"
 assert_dirty_worktree_rejected dirty-untracked
 rm "$TEST_REPO/local-note.txt"
 
+validation_case_pids=()
+validation_case_names=()
 for failed_validation in \
   hdiutil_verify \
   hdiutil_attach \
@@ -366,8 +370,19 @@ for failed_validation in \
   stapler_dmg \
   gatekeeper_app \
   gatekeeper_dmg; do
-  assert_local_validation_rejected "$failed_validation"
+  assert_local_validation_rejected "$failed_validation" &
+  validation_case_pids+=("$!")
+  validation_case_names+=("$failed_validation")
 done
+validation_case_status=0
+for validation_case_index in "${!validation_case_pids[@]}"; do
+  if ! wait "${validation_case_pids[$validation_case_index]}"; then
+    printf 'publish validation lane failed: %s\n' \
+      "${validation_case_names[$validation_case_index]}" >&2
+    validation_case_status=1
+  fi
+done
+[ "$validation_case_status" -eq 0 ] || exit 1
 
 : >"$TMP_ROOT/validation.log"
 rm -f "$GH_LOG"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -953,6 +953,11 @@ cat >"$REPO/tests/quality-gate-fixtures/distribution" <<'SH'
 #!/bin/bash
 set -eu
 [ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/codex-started" ] && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
 [ -f "$GATE_ORDER_ROOT/codex-started" ]
 [ ! -f "$GATE_ORDER_ROOT/codex" ]
 : >"$GATE_ORDER_ROOT/integration-after-contract"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -929,6 +929,7 @@ set -eu
 [ -f "${GATE_ORDER_ROOT:?}/app" ]
 [ -f "$GATE_ORDER_ROOT/ui-e2e" ]
 [ -f "$GATE_ORDER_ROOT/quality-contracts" ]
+[ -f "$GATE_ORDER_ROOT/gate-contract" ]
 : >"$GATE_ORDER_ROOT/codex-started"
 attempt=0
 while [ ! -f "$GATE_ORDER_ROOT/integration-after-contract" ] && \
@@ -960,20 +961,22 @@ cat >"$REPO/tests/quality-gate-fixtures/publish-preflight" <<'SH'
 #!/bin/bash
 set -eu
 attempt=0
-while { [ ! -f "${GATE_ORDER_ROOT:?}/gate-contract-started" ] || \
-        [ ! -f "$GATE_ORDER_ROOT/codex-started" ]; } && [ "$attempt" -lt 50 ]; do
+while [ ! -f "${GATE_ORDER_ROOT:?}/gate-contract-started" ] && \
+    [ "$attempt" -lt 50 ]; do
   attempt=$((attempt + 1))
   sleep 0.1
 done
 [ -f "$GATE_ORDER_ROOT/gate-contract-started" ]
-[ -f "$GATE_ORDER_ROOT/codex-started" ]
 [ ! -f "$GATE_ORDER_ROOT/gate-contract" ]
+[ ! -f "$GATE_ORDER_ROOT/codex-started" ]
 : >"$GATE_ORDER_ROOT/short-preflight-during-contract"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/release-workflow" <<'SH'
 #!/bin/bash
 set -eu
 [ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
+[ -f "$GATE_ORDER_ROOT/codex" ]
+[ -f "$GATE_ORDER_ROOT/claude" ]
 : >"$GATE_ORDER_ROOT/release-workflow-started"
 sleep 1
 : >"$GATE_ORDER_ROOT/release-workflow"
@@ -981,8 +984,17 @@ SH
 cat >"$REPO/tests/quality-gate-fixtures/claude" <<'SH'
 #!/bin/bash
 set -eu
-[ -f "${GATE_ORDER_ROOT:?}/release-workflow" ] || [ -f "$GATE_ORDER_ROOT/codex" ]
-: >"$GATE_ORDER_ROOT/third-heavy-waited"
+[ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
+[ ! -f "$GATE_ORDER_ROOT/release-workflow-started" ]
+: >"$GATE_ORDER_ROOT/claude-started"
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/codex-started" ] && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/codex-started" ]
+sleep 1
+: >"$GATE_ORDER_ROOT/claude"
 SH
 for ordered_stage in tmux-runtime release-preflight; do
   cat >"$REPO/tests/quality-gate-fixtures/$ordered_stage" <<'SH'
@@ -1017,8 +1029,8 @@ grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/resource-order.out" >/dev/null
   printf 'bounded scheduler did not use the safe preflight lane\n' >&2
   exit 1
 }
-[ -f "$ORDER_ROOT/third-heavy-waited" ] || {
-  printf 'bounded scheduler admitted a third process-heavy lane\n' >&2
+[ -f "$ORDER_ROOT/release-workflow" ] || {
+  printf 'bounded scheduler overlapped the nested release workflow with a heavy peer\n' >&2
   exit 1
 }
 

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -70,6 +70,7 @@ POST_UI_STAGES = (
 PROCESS_HEAVY_LIMIT = 2
 INTEGRATION_LANE_LIMIT = 1
 PROCESS_HEAVY_STAGES = {"gate-contract", "codex", "claude", "release-workflow"}
+EXCLUSIVE_PROCESS_HEAVY_STAGES = {"gate-contract", "release-workflow"}
 GATE_COMPATIBLE_INTEGRATION_STAGES = {
     "tmux-runtime",
     "release-preflight",
@@ -1410,7 +1411,13 @@ class QualityGate:
                 raise GateError(f"release stage budget must rank scheduled stage: {stage}")
             return int(value)
 
-        pending.sort(key=lambda stage: (-expected_seconds(stage), self.all_stages.index(stage)))
+        pending.sort(
+            key=lambda stage: (
+                stage != "gate-contract",
+                -expected_seconds(stage),
+                self.all_stages.index(stage),
+            )
+        )
         while pending or any(stage in self.active for stage in POST_UI_STAGES):
             while pending:
                 active_heavy = sum(
@@ -1426,6 +1433,14 @@ class QualityGate:
                         stage for stage in pending
                         if (
                             active_heavy < PROCESS_HEAVY_LIMIT
+                            and (
+                                active_heavy == 0
+                                if stage in EXCLUSIVE_PROCESS_HEAVY_STAGES
+                                else not any(
+                                    peer in self.active
+                                    for peer in EXCLUSIVE_PROCESS_HEAVY_STAGES
+                                )
+                            )
                             if stage in PROCESS_HEAVY_STAGES
                             else (
                                 active_integration < INTEGRATION_LANE_LIMIT


### PR DESCRIPTION
## Summary

- Keep the Finished bulk-selection bar outside the SwiftUI List event boundary.
- Make packaged UI clicks pointer-aware, preserve the user pointer, and retry app activation within the existing deadline.
- Isolate recursive gate-contract and release-workflow process load while keeping provider and integration lanes concurrent.
- Run independent negative publication validations in parallel.

## Contract delta

Finished bulk Delete keeps the same typed confirmation and transcript-preservation behavior. The UI smoke now restores both focus and pointer position. Gate-contract and release-workflow exclude heavy peers; other post-UI work keeps two heavy lanes and one integration lane.

## Evidence

- Full local diagnostic PASS: fingerprint 5b4782bbb66fc7fc760dca56aefd91eb137a0a70b10dc0a3798c5310efd5a219
- UI E2E: 14s
- Codex / Claude: 38s / 43s
- publish-preflight: 21s
- release-workflow: 63s
- aggregate release budget: PASS
- git diff --check and documentation contracts: PASS

Hosted pull-request quality-gates remains merge-readiness authority.