### PR TITLE
Wait for in-flight checkpoints before delete

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -4553,7 +4553,7 @@ delete_session() {
       *) die "aborted" ;;
     esac
   fi
-  "$LOCKF_BIN" -k -t 10 "$(checkpoint_lock_path "$session")" \
+  "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
     "$SELF" __delete_locked "$session"
 }
 

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -83,12 +83,12 @@ conversations. Public operations reject symlinked or foreign-owned mutable
 roots before traversal. Codex's integrity-checked SQLite backup is never
 restored automatically.
 
-Bulk cleanup may select only fully scanned `stopped` or `orphaned` sessions.
-Before deletion the app must re-read and match the displayed status and byte
-counts. Actual deletion continues through the provider command, holds the
-checkpoint lock, rechecks managed tmux liveness/ownership under that lock, and
-refuses symlinked or foreign-owned state/session directories. A partial failure
-must leave every failed session in place and continue reporting it explicitly.
+Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
+Before deletion, the app re-reads and matches the displayed status and byte
+counts. The provider command waits up to 30 seconds for the checkpoint lock,
+then rechecks managed tmux liveness and ownership. It rejects symlinked or
+foreign-owned state/session directories. A partial failure keeps each failed
+session and reports it explicitly.
 
 ### Session lifecycle and tmux
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1352,7 +1352,7 @@ printf '%s' "$storage_report" | grep -F '"symlink_count":1' >/dev/null
 checkpoint_lock="$DETACH_LOCKS_ROOT/checkpoint-$SESSION.lock"
 checkpoint_ready="$TMP_ROOT/checkpoint-lock-ready"
 /usr/bin/lockf -k "$checkpoint_lock" /bin/sh -c \
-  'touch "$1"; sleep 1; test -d "$2"' sh \
+  'touch "$1"; sleep 12; test -d "$2"' sh \
   "$checkpoint_ready" "$DETACH_CODEX_STATE_ROOT/sessions/$SESSION" &
 checkpoint_holder=$!
 attempts=0


### PR DESCRIPTION
## Summary

- Align the Delete checkpoint-lock wait with the existing 30-second checkpoint acquisition bound.
- Keep the existing operation/checkpoint lock order and all fail-closed ownership checks.
- Extend the held-lock regression to 12 seconds, beyond the previous Delete limit.

## Evidence

Release-mode run 20260828T093137Z-66649 showed Codex and Claude lifecycle Delete both exhausting the old 10-second wait during full provider fan-out. All other provider parts passed. The two lifecycle suites pass together when isolated from the remaining fan-out.

- Parallel focused Codex / Claude stages: PASS, 44s / 41s
- Impact-aware diagnostic PASS: fingerprint 1b6f5983afbe1f8804b0ba5ac17cf970917342a26ecfdf28a75f4549b3a6202a
- Impact timings: UI 13s, Codex 47s, Claude 45s, distribution 51s
- Aggregate release budget: PASS
- Documentation contracts and git diff --check: PASS

Hosted pull-request quality-gates remains merge-readiness authority.