### PR TITLE
Read terminal titles with a UTF-8 locale

### DIFF
--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -397,7 +397,8 @@ LC_ALL=C "$SCRIPT" claude --name "$human_label" --detach -- \
 wait_for_fake_claude_ready
 wait_for_tmux_option "$human_session" @detach_status running
 wait_for_tmux_option "$human_session" set-titles on
-wait_for_tmux_option "$human_session" set-titles-string "Detach · $PROJECT_LABEL"
+LC_ALL=C.UTF-8 wait_for_tmux_option \
+  "$human_session" set-titles-string "Detach · $PROJECT_LABEL"
 wait_for_tmux_option_text "$human_session" status-left RUNNING
 grep -Fx -- "$literal_prompt" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 grep -Fx -- '--session-id' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
@@ -435,9 +436,6 @@ run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 tmux -L "$SOCKET" has-session -t "=$session"
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_provider)" = "claude" ]
-[ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" set-titles)" = "on" ]
-[ "$(tmux -L "$SOCKET" show-options -qv -t "=$session:" set-titles-string)" = \
-  "Detach · $PROJECT_LABEL" ]
 live_pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$session:" @detach_pane_id)"
 # The start command (and therefore its creator process) has returned, yet the
 # private tmux server and provider worker continue without an attached client.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -671,7 +671,8 @@ if codex_part_selected lifecycle; then
 
 wait_for_tmux_option "$SESSION" @detach_status running
 wait_for_tmux_option "$SESSION" set-titles on
-wait_for_tmux_option "$SESSION" set-titles-string "Detach · $PROJECT_LABEL"
+LC_ALL=C.UTF-8 wait_for_tmux_option \
+  "$SESSION" set-titles-string "Detach · $PROJECT_LABEL"
 wait_for_tmux_option_text "$SESSION" status-left RUNNING
 tmux -L "$SOCKET" has-session -t "=$SESSION"
 "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
@@ -681,9 +682,6 @@ TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
   "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_provider)" = "codex" ]
-[ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" set-titles)" = "on" ]
-[ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" set-titles-string)" = \
-  "Detach · $PROJECT_LABEL" ]
 pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
 # The creator CLI has already exited. The tmux server and worker must remain
 # alive without an attached client (the same lifecycle as closing Terminal or


### PR DESCRIPTION
## Contract delta

- Read the Unicode terminal title through `C.UTF-8` even when the release workflow runs provider tests in `LC_ALL=C`.
- Keep one bounded assertion for title enablement and the exact `Detach · project` value.
- Remove the duplicate locale-sensitive title reads.

## Root cause

In release mode, tmux rendered the middle dot as `_` for a client using the C locale. The title stored by Detach remained correct.

## Evidence

- The failed release evidence reported `actual=Detach _ harness` for both providers.
- Focused Codex and Claude lifecycle tests passed in parallel with `LC_ALL=C`.
- `bash -n` passed for both suites.
- `git diff --check` passed.

Hosted `quality-gates` remains the readiness authority.