### PR TITLE
Preserve UI smoke mouse event order

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -19,7 +19,7 @@ private final class UIE2EDeferredMouseUp: @unchecked Sendable {
     }
 
     func post() {
-        application.postEvent(event, atStart: true)
+        application.postEvent(event, atStart: false)
     }
 }
 
@@ -1063,7 +1063,9 @@ enum UIE2ETestDriver {
             throw Failure(message: "cannot create mouse pair for \(name)")
         }
         // AppKit permits postEvent from a subthread. Delay mouseUp so SwiftUI
-        // receives a physical-duration click even inside a tracking loop.
+        // receives a physical-duration click even inside a tracking loop. Put
+        // mouseUp at the queue tail so a busy main thread cannot process it
+        // before the mouseDown event at the queue head.
         let mouseUp = UIE2EDeferredMouseUp(application: NSApp, event: events[1])
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + clickInterval

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -47,9 +47,9 @@ signed marker. UI smoke uses a stripped private copy at
 power, state, and tmux payloads. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
-Smoke restores focus and pointer position. It sends AppKit down/up pairs to measured
-SwiftUI controls; semantic locators have no actions. Row clicks select sessions
-even after preview text takes focus.
+Smoke restores focus and the pointer. It sends ordered AppKit down/up
+pairs to measured SwiftUI controls; semantic locators have no actions. Row
+clicks select sessions even after preview text takes focus.
 Each launch and stage stays within its deadline.
 Journeys cover main surfaces, Settings, onboarding, and focus. It disconnects
 Stop before proving that the real control invokes it.


### PR DESCRIPTION
## Contract delta

- Keep delayed AppKit `mouseUp` behind the already queued `mouseDown` event.
- Preserve the physical-duration click without allowing a busy main thread to observe up before down.
- Record ordered UI smoke clicks in the app specification.

## Root cause

Both events were inserted at the queue head. If the main thread did not consume `mouseDown` within 30 ms, the delayed `mouseUp` overtook it and the SwiftUI UUID button did not fire.

## Evidence

- Failed release evidence stopped at the UUID copy confirmation after the click was posted.
- Fresh release app build passed.
- Packaged UI E2E passed in 14s with the real UUID-chip click.
- `docs/specs/app.md` remains below 12 KiB at 12,286 bytes.
- `git diff --check` passed.

Hosted `quality-gates` remains the readiness authority.