### PR TITLE
Reduce release quality-gate contention

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -438,7 +438,6 @@ enum UIE2ETestDriver {
                 NSApp.windows.allSatisfy(\.sheets.isEmpty)
             }
             try await activate(mainWindow)
-            try await Task.sleep(nanoseconds: 200_000_000)
 
             let newSession = try await element(identifier: "new-session-button")
             try requireSemanticControl(newSession, name: "new session action")
@@ -1073,7 +1072,7 @@ enum UIE2ETestDriver {
             mouseUp.post()
         }
         NSApp.postEvent(events[0], atStart: true)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: 60_000_000)
     }
 
     private static func moveCursor(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -438,6 +438,7 @@ enum UIE2ETestDriver {
                 NSApp.windows.allSatisfy(\.sheets.isEmpty)
             }
             try await activate(mainWindow)
+            try await Task.sleep(nanoseconds: 200_000_000)
 
             let newSession = try await element(identifier: "new-session-button")
             try requireSemanticControl(newSession, name: "new session action")
@@ -1072,7 +1073,7 @@ enum UIE2ETestDriver {
             mouseUp.post()
         }
         NSApp.postEvent(events[0], atStart: true)
-        try await Task.sleep(nanoseconds: 60_000_000)
+        try await Task.sleep(nanoseconds: 100_000_000)
     }
 
     private static func moveCursor(

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -166,7 +166,8 @@ not run a test twice.
 The gate-contract stage keeps lightweight contracts concurrent. It admits
 three process-heavy orchestrator shards on a host with at least eight logical
 CPUs, and two on a smaller host. This limit prevents process oversubscription
-without increasing the stage budget.
+without increasing the stage budget. At most four contract children run at one
+time, so lightweight contracts do not crowd adjacent preflights.
 
 Swift and Clang caches stay under `app/.build`. Their hosted key covers the
 compiler, package, sources, tests, build scripts, and version metadata. A
@@ -180,7 +181,8 @@ two Claude parts; larger hosts use finer parts. Compact layouts reuse
 checkpoints across recovery and restart, resume and identity, or Claude
 lifecycle and recovery. The parent writes scenario events in one order and
 fails the stage when any part fails. Tests do not use installed product state
-or ambient helpers.
+or ambient helpers. Distribution runs its runtime and shell-profile contracts
+as separate parts in private temporary homes.
 
 There are no quarantined tests. A future quarantine needs an owner, reason, and
 expiry. It cannot remove release evidence.

--- a/tests/distribution.sh
+++ b/tests/distribution.sh
@@ -4,6 +4,22 @@ set -eu
 set -o pipefail
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+DISTRIBUTION_TEST_PART="${DETACH_DISTRIBUTION_TEST_PART:-all}"
+case "$DISTRIBUTION_TEST_PART" in
+  all|runtime|shells) ;;
+  *) printf 'unknown distribution test part: %s\n' "$DISTRIBUTION_TEST_PART" >&2; exit 2 ;;
+esac
+
+distribution_part_selected() {
+  [ "$DISTRIBUTION_TEST_PART" = all ] || [ "$DISTRIBUTION_TEST_PART" = "$1" ]
+}
+
+distribution_scenario_event() {
+  [ "$DISTRIBUTION_TEST_PART" = all ] && \
+    [ "${DETACH_QUALITY_PARTITIONED_DISTRIBUTION:-0}" != 1 ] || return 0
+  "$ROOT/scripts/quality-scenarios" event "$1" "$2"
+}
+
 # Keep the synthetic home short enough that the production absolute tmux
 # socket remains within macOS's 103-byte sockaddr_un limit.
 TMP_ROOT="$(mktemp -d "/tmp/dt.XXXXXX")"
@@ -226,10 +242,12 @@ PLIST
   fi
 }
 
+if distribution_part_selected runtime; then
+
 # App launches inherit a synthetic PATH that already contains ~/.local/bin.
 # Shell setup must still configure every zsh startup mode and preserve a file
 # that existed before Detach, including its missing final newline.
-"$ROOT/scripts/quality-scenarios" event begin SC-INSTALL-CLEAN
+distribution_scenario_event begin SC-INSTALL-CLEAN
 printf '%s' 'export DETACH_ZSHENV_SENTINEL=all' >"$TEST_HOME/.zshenv"
 cp -p "$TEST_HOME/.zshenv" "$TMP_ROOT/zshenv.original"
 
@@ -499,11 +517,11 @@ fi
   --version-file "$payload_v2/VERSION"
 [ ! -e "$foreign_watchdog" ]
 [ ! -e "$LEGACY_WATCHDOG_STATE" ]
-"$ROOT/scripts/quality-scenarios" event pass SC-INSTALL-CLEAN
+distribution_scenario_event pass SC-INSTALL-CLEAN
 
 # Repair must restore from the pristine source recorded in the manifest, not
 # clone corrupted bytes from the active immutable directory.
-"$ROOT/scripts/quality-scenarios" event begin SC-INSTALL-REPAIR
+distribution_scenario_event begin SC-INSTALL-REPAIR
 active_dir="$(cd -P "$(dirname "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")")" && pwd)"
 printf '\n# corruption\n' >>"$active_dir/detach-core"
 PATH="$DETACH_INSTALL_BIN_DIR:/usr/bin:/bin" \
@@ -518,7 +536,7 @@ grep -F '# corruption' "$active_dir/detach-core" >/dev/null
 "$DETACH_INSTALL_BIN_DIR/detach" repair
 [ "$(shasum -a 256 "$active_dir/detach-core" | awk '{print $1}')" = \
   "$(shasum -a 256 "$payload_v2/detach-core" | awk '{print $1}')" ]
-"$ROOT/scripts/quality-scenarios" event pass SC-INSTALL-REPAIR
+distribution_scenario_event pass SC-INSTALL-REPAIR
 
 # BUILD participates in downgrade prevention even when semver is unchanged.
 payload_v2_build2="$(make_payload v2-build2 0.2.0 2)"
@@ -538,7 +556,7 @@ payload_old="$(make_payload old 0.1.5)"
 # The installed runtime is self-contained: doctor resolves immutable sibling
 # helpers even from a sparse PATH and does not ask for the dependencies Detach
 # now owns itself.
-"$ROOT/scripts/quality-scenarios" event begin SC-DOCTOR-REPORT
+distribution_scenario_event begin SC-DOCTOR-REPORT
 active_dir="$(cd -P "$(dirname "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")")" && pwd)"
 doctor_json="$TMP_ROOT/doctor.json"
 env -u DETACH_TMUX_BIN -u DETACH_STATE_BIN -u DETACH_POWER_BIN \
@@ -612,11 +630,11 @@ plutil -extract state raw -o - - <<<"$power_json" | grep -qx allowed
 plutil -extract helper_reachable raw -o - - <<<"$power_json" | grep -qx true
 plutil -extract thermal_state raw -o - - <<<"$power_json" | grep -qx nominal
 plutil -extract thermal_safety_active raw -o - - <<<"$power_json" | grep -qx false
-"$ROOT/scripts/quality-scenarios" event pass SC-DOCTOR-REPORT
+distribution_scenario_event pass SC-DOCTOR-REPORT
 
 # Direct CLI uninstall must not strand the app-owned SMAppService without its
 # executable. Detach.app unregisters the helper before invoking the installer.
-"$ROOT/scripts/quality-scenarios" event begin SC-INSTALL-UNINSTALL
+distribution_scenario_event begin SC-INSTALL-UNINSTALL
 export FAKE_APP_WATCHDOG=1
 if "$DETACH_INSTALL_BIN_DIR/detach" uninstall --keep-state; then
   printf 'uninstall unexpectedly ignored the app-owned watchdog\n' >&2
@@ -673,6 +691,13 @@ DETACH_CODEX_STATE_ROOT="$HOME/.local/state/../../.codex" \
 cmp -s "$TMP_ROOT/zshenv.original" "$TEST_HOME/.zshenv"
 grep -Fx provider-sentinel "$HOME/.codex/must-survive" >/dev/null
 ! grep -F 'bootout' "$LAUNCHCTL_LOG" >/dev/null
+
+fi
+
+if distribution_part_selected shells; then
+if [ "$DISTRIBUTION_TEST_PART" = shells ]; then
+  payload_v2="$(make_payload v2 0.2.0)"
+fi
 
 # Exercise every supported shell adapter in isolated homes so profile ownership
 # cannot leak between cases or into the developer's real shell configuration.
@@ -1070,5 +1095,6 @@ for shell_case_pid in "${shell_case_pids[@]}"; do
 done
 [ "$shell_case_status" -eq 0 ]
 
-"$ROOT/scripts/quality-scenarios" event pass SC-INSTALL-UNINSTALL
-printf 'Detach distribution tests passed\n'
+distribution_scenario_event pass SC-INSTALL-UNINSTALL
+fi
+printf 'Detach distribution tests passed (%s)\n' "$DISTRIBUTION_TEST_PART"

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -20,6 +20,7 @@ from quality_gate import (  # noqa: E402
     GateError,
     QualityGate,
     exact_products_enabled,
+    gate_contract_process_limit,
     gate_contract_definitions,
     gate_orchestrator_limit,
     include_gate_orchestrators,
@@ -27,6 +28,7 @@ from quality_gate import (  # noqa: E402
     parse_options,
     provider_test_parts,
     run_app_stage,
+    run_distribution_parts,
     run_provider_parts,
     run_static_contracts,
     split_quality_pipeline_jobs,
@@ -109,6 +111,8 @@ class QualityGateContract(unittest.TestCase):
         self.assertEqual(gate_orchestrator_limit(10), 3)
         self.assertEqual(gate_orchestrator_limit(8), 3)
         self.assertEqual(gate_orchestrator_limit(4), 2)
+        self.assertEqual(gate_contract_process_limit(10), 4)
+        self.assertEqual(gate_contract_process_limit(4), 4)
 
     def test_public_shell_entry_point_is_thin(self) -> None:
         wrapper = (ROOT / "scripts/quality-gate").read_text(encoding="utf-8")
@@ -278,7 +282,15 @@ class QualityGateContract(unittest.TestCase):
             with patch("quality_gate.os.cpu_count", return_value=10):
                 self.assertEqual(
                     provider_test_parts("codex"),
-                    ("preflight", "lifecycle", "recovery", "resume", "identity", "crash"),
+                    (
+                        "preflight",
+                        "lifecycle",
+                        "recovery",
+                        "resume",
+                        "identity",
+                        "delete",
+                        "crash",
+                    ),
                 )
 
     def test_static_contracts_keep_separate_deterministic_logs(self) -> None:
@@ -365,8 +377,58 @@ class QualityGateContract(unittest.TestCase):
             with patch("quality_gate.os.cpu_count", return_value=10):
                 self.assertEqual(
                     provider_test_parts("claude"),
-                    ("lifecycle", "recovery", "history"),
+                    ("lifecycle-guardrails", "recovery", "history"),
                 )
+
+    def test_distribution_parts_keep_separate_logs_and_scenario_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            suite = root / "tests/distribution.sh"
+            suite.parent.mkdir()
+            suite.write_text(
+                "#!/bin/bash\n"
+                "set -eu\n"
+                "[ \"$DETACH_QUALITY_PARTITIONED_DISTRIBUTION\" = 1 ]\n"
+                "printf '%s\\n' \"$DETACH_DISTRIBUTION_TEST_PART\"\n",
+                encoding="utf-8",
+            )
+            suite.chmod(0o755)
+            run_dir = root / "evidence"
+            run_dir.mkdir()
+            events = run_dir / "distribution-events.jsonl"
+            with patch.dict(
+                "os.environ",
+                {
+                    "DETACH_QUALITY_SCENARIO_STAGE": "distribution",
+                    "DETACH_QUALITY_SCENARIO_EVENTS": str(events),
+                },
+            ):
+                self.assertEqual(run_distribution_parts(root, run_dir), 0)
+            for part in ("runtime", "shells"):
+                self.assertEqual(
+                    (run_dir / f"distribution-parts/{part}.log").read_text(
+                        encoding="utf-8"
+                    ),
+                    f"{part}\n",
+                )
+            records = [
+                json.loads(line)
+                for line in events.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(len(records), 8)
+            self.assertEqual(
+                {(record["kind"], record["id"]) for record in records},
+                {
+                    (kind, scenario)
+                    for kind in ("begin", "pass")
+                    for scenario in (
+                        "SC-INSTALL-CLEAN",
+                        "SC-INSTALL-REPAIR",
+                        "SC-DOCTOR-REPORT",
+                        "SC-INSTALL-UNINSTALL",
+                    )
+                },
+            )
 
 
 def main() -> int:

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -18,7 +18,7 @@ FAILURE_COMMAND=""
 CLAUDE_TEST_PART="${DETACH_CLAUDE_TEST_PART:-all}"
 
 case "$CLAUDE_TEST_PART" in
-  all|session|lifecycle|recovery|history) ;;
+  all|session|lifecycle|lifecycle-guardrails|recovery-guardrails|recovery|history) ;;
   *)
     printf 'unknown Claude test part: %s\n' "$CLAUDE_TEST_PART" >&2
     exit 2
@@ -27,6 +27,7 @@ esac
 
 claude_part_selected() {
   [ "$CLAUDE_TEST_PART" = all ] || [ "$CLAUDE_TEST_PART" = "$1" ] || {
+    [ "$CLAUDE_TEST_PART" = lifecycle-guardrails ] && [ "$1" = lifecycle ] ||
     [ "$CLAUDE_TEST_PART" = session ] && {
       case "$1" in lifecycle|recovery) return 0 ;; esac
       return 1
@@ -685,10 +686,13 @@ fi
 
 # Simulate losing primary metadata during a power failure. Recovery must use
 # checkpoint metadata and resume the exact Claude session UUID.
-if claude_part_selected recovery; then
-if [ "$CLAUDE_TEST_PART" = recovery ]; then
+if claude_part_selected recovery || [ "$CLAUDE_TEST_PART" = recovery-guardrails ] || \
+   [ "$CLAUDE_TEST_PART" = lifecycle-guardrails ]; then
+case "$CLAUDE_TEST_PART" in
+recovery|recovery-guardrails)
   bootstrap_claude_checkpoint
-fi
+  ;;
+esac
 "$STATE_HELPER" meta patch "$checkpoint/meta.json" --string status running --null exit_status
 rm -f "$meta"
 printf '{damaged transcript\n' >"$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl"
@@ -707,6 +711,9 @@ export FAKE_CLAUDE_EXPECT_RESTORED=1
 # CLAUDE_CONFIG_DIR itself may be a symlink, but no descendant on a restore
 # destination may be one. Recovery must validate every destination before it
 # replaces even the transcript, and it must never write through that symlink.
+if [ "$CLAUDE_TEST_PART" = all ] || [ "$CLAUDE_TEST_PART" = session ] || \
+   [ "$CLAUDE_TEST_PART" = recovery-guardrails ] || \
+   [ "$CLAUDE_TEST_PART" = lifecycle-guardrails ]; then
 unsafe_claude_outside="$TMP_ROOT/unsafe-claude-restore-target"
 mkdir -p "$unsafe_claude_outside"
 printf 'outside sentinel\n' >"$unsafe_claude_outside/sentinel"
@@ -742,6 +749,10 @@ grep -Fx '{damaged transcript' \
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
 mv -f "$good_claude_archive" "$checkpoint/claude-session.tar"
 rm -rf "$malicious_claude_stage"
+fi
+
+if [ "$CLAUDE_TEST_PART" != recovery-guardrails ] && \
+   [ "$CLAUDE_TEST_PART" != lifecycle-guardrails ]; then
 
 # Stable publish siblings make an interrupted directory replacement
 # recoverable. `.old` is rolled back first and `.tmp` is discarded safely;
@@ -844,6 +855,7 @@ grep -Fx 'outside sentinel' "$outside" >/dev/null
 "$SCRIPT" claude delete --force "$human_label"
 [ ! -d "$DETACH_CLAUDE_STATE_ROOT/sessions/$session" ]
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+fi
 fi
 
 if claude_part_selected history; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -24,7 +24,7 @@ FAILURE_COMMAND=""
 CODEX_TEST_PART="${DETACH_CODEX_TEST_PART:-all}"
 
 case "$CODEX_TEST_PART" in
-  all|guardrails|preflight|configuration|lifecycle-recovery|resume-identity|lifecycle|recovery|restart|resume|identity|crash|history) ;;
+  all|guardrails|preflight|configuration|lifecycle-recovery|resume-identity|lifecycle|recovery|restart|resume|identity|delete|crash|history) ;;
   *)
     printf 'unknown Codex test part: %s\n' "$CODEX_TEST_PART" >&2
     exit 2
@@ -46,7 +46,7 @@ codex_part_selected() {
       return 1
     } ||
     [ "$CODEX_TEST_PART" = resume-identity ] && {
-      case "$1" in resume|identity) return 0 ;; esac
+      case "$1" in resume|identity|delete) return 0 ;; esac
       return 1
     }
   }
@@ -1345,7 +1345,11 @@ printf '%s' "$json_line" | grep -F '"session_color":null' >/dev/null
 # safety assertion does not pass merely because the saved value is malformed.
 "$STATE_HELPER" meta patch "$meta" --string session_color "$session_color"
 
-# delete refuses a live session and removes a stopped one.
+# Delete refuses a live session and removes a stopped one. The fine-grained
+# local layout gives its intentional held-lock wait a separate parallel lane.
+fi
+
+if codex_part_selected delete; then
 run_codex --name integration --detach -- 'delete refusal coverage'
 wait_for_tmux_option "$SESSION" @detach_status running
 live_storage_plan="$("$DETACH" storage cleanup --dry-run --json)"

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -139,7 +139,7 @@ UI_E2E_DEADLINE=$((SECONDS + 38))
 
 mkdir -p "$TEST_HOME/.local/bin" "$TEST_HOME/Library/Preferences" \
   "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
-ditto "$SOURCE_APP" "$TEST_APP"
+cp -cR "$SOURCE_APP" "$TEST_APP"
 
 if [ -n "$COVERAGE_BINARY" ]; then
   install -m 0755 "$COVERAGE_BINARY" "$TEST_APP/Contents/MacOS/Detach"
@@ -238,7 +238,7 @@ run_app_scenario() {
       && [ "$SECONDS" -lt "$UI_E2E_DEADLINE" ]; do
     [ ! -f "$RESULT" ] || break
     if ! kill -0 "$APP_PID" 2>/dev/null; then break; fi
-    sleep 0.1
+    sleep 0.05
   done
   if [ ! -f "$RESULT" ]; then
     kill -TERM "$APP_PID" 2>/dev/null || true
@@ -255,7 +255,7 @@ run_app_scenario() {
   for _ in $(seq 1 10); do
     if ! kill -0 "$APP_PID" 2>/dev/null; then break; fi
     [ "$SECONDS" -lt "$UI_E2E_DEADLINE" ] || break
-    sleep 0.1
+    sleep 0.05
   done
   if kill -0 "$APP_PID" 2>/dev/null; then
     kill -TERM "$APP_PID" 2>/dev/null || true

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -95,14 +95,22 @@ PROVIDER_TEST_PARTS = {
         "recovery",
         "resume",
         "identity",
+        "delete",
         "crash",
     ),
     "claude": (
-        "lifecycle",
+        "lifecycle-guardrails",
         "recovery",
         "history",
     ),
 }
+DISTRIBUTION_TEST_PARTS = ("runtime", "shells")
+DISTRIBUTION_SCENARIOS = (
+    "SC-INSTALL-CLEAN",
+    "SC-INSTALL-REPAIR",
+    "SC-DOCTOR-REPORT",
+    "SC-INSTALL-UNINSTALL",
+)
 COMPACT_CODEX_TEST_PARTS = (
     "guardrails",
     "lifecycle-recovery",
@@ -120,7 +128,7 @@ PROVIDER_PART_SCENARIOS = {
             "SC-SESSION-STOP-CODEX",
         ),
         "recovery": ("SC-SESSION-RECOVER-CODEX",),
-        "identity": ("SC-SESSION-DELETE-CODEX",),
+        "delete": ("SC-SESSION-DELETE-CODEX",),
         "lifecycle-recovery": (
             "SC-SESSION-CREATE-CODEX",
             "SC-SESSION-PERSIST-CODEX",
@@ -139,6 +147,11 @@ PROVIDER_PART_SCENARIOS = {
             "SC-SESSION-RECOVER-CLAUDE",
         ),
         "lifecycle": (
+            "SC-SESSION-CREATE-CLAUDE",
+            "SC-SESSION-PERSIST-CLAUDE",
+            "SC-SESSION-STOP-CLAUDE",
+        ),
+        "lifecycle-guardrails": (
             "SC-SESSION-CREATE-CLAUDE",
             "SC-SESSION-PERSIST-CLAUDE",
             "SC-SESSION-STOP-CLAUDE",
@@ -1985,29 +1998,33 @@ def run_provider_parts(
         for part in parts:
             for scenario_id in scenario_owners.get(part, ()):
                 record_scenario_event("begin", scenario_id)
-        for part in parts:
-            part_environment = environment.copy()
-            part_environment[variable] = part
-            part_environment["DETACH_QUALITY_PARTITIONED_PROVIDER"] = "1"
-            if artifact_root is not None:
-                part_environment["DETACH_PROVIDER_TEST_ARTIFACT_DIR"] = str(
-                    artifact_root / part
-                )
-            log = part_root / f"{part}.log"
-            output = log.open("w", encoding="utf-8")
-            log.chmod(0o600)
-            process = subprocess.Popen(
-                [str(suite)],
-                cwd=root,
-                env=part_environment,
-                stdout=output,
-                stderr=subprocess.STDOUT,
-            )
-            processes.append((part, log, process, output, time.monotonic()))
-        pending = set(range(len(processes)))
+        waiting = list(parts)
+        part_limit = min(len(parts), 3 if stage == "codex" else len(parts))
+        pending: set[int] = set()
         statuses: dict[int, int] = {}
         durations: dict[int, int] = {}
-        while pending:
+        while waiting or pending:
+            while waiting and len(pending) < part_limit:
+                part = waiting.pop(0)
+                part_environment = environment.copy()
+                part_environment[variable] = part
+                part_environment["DETACH_QUALITY_PARTITIONED_PROVIDER"] = "1"
+                if artifact_root is not None:
+                    part_environment["DETACH_PROVIDER_TEST_ARTIFACT_DIR"] = str(
+                        artifact_root / part
+                    )
+                log = part_root / f"{part}.log"
+                output = log.open("w", encoding="utf-8")
+                log.chmod(0o600)
+                process = subprocess.Popen(
+                    [str(suite)],
+                    cwd=root,
+                    env=part_environment,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                )
+                processes.append((part, log, process, output, time.monotonic()))
+                pending.add(len(processes) - 1)
             for index in list(pending):
                 part, _, process, output, started = processes[index]
                 status = process.poll()
@@ -2035,6 +2052,76 @@ def run_provider_parts(
         )
     except OSError as error:
         print(f"quality-gate: cannot run {stage} test parts: {error}", file=sys.stderr)
+        return 2
+    finally:
+        for _, _, process, output, _ in processes:
+            if process.poll() is None:
+                process.terminate()
+                process.wait()
+            if not output.closed:
+                output.close()
+
+
+def run_distribution_parts(root: Path, run_dir: Path) -> int:
+    part_root = run_dir / "distribution-parts"
+    if part_root.exists():
+        if not part_root.is_dir() or part_root.is_symlink():
+            print(
+                "quality-gate: distribution part evidence root is unsafe",
+                file=sys.stderr,
+            )
+            return 2
+        shutil.rmtree(part_root)
+    part_root.mkdir(mode=0o700)
+    suite = root / "tests/distribution.sh"
+    processes: list[
+        tuple[str, Path, subprocess.Popen[bytes], TextIO, float]
+    ] = []
+    try:
+        for scenario_id in DISTRIBUTION_SCENARIOS:
+            record_scenario_event("begin", scenario_id)
+        statuses: dict[int, int] = {}
+        durations: dict[int, int] = {}
+        for part in DISTRIBUTION_TEST_PARTS:
+            environment = os.environ.copy()
+            environment["DETACH_DISTRIBUTION_TEST_PART"] = part
+            environment["DETACH_QUALITY_PARTITIONED_DISTRIBUTION"] = "1"
+            log = part_root / f"{part}.log"
+            output = log.open("w", encoding="utf-8")
+            log.chmod(0o600)
+            process = subprocess.Popen(
+                [str(suite)],
+                cwd=root,
+                env=environment,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+            )
+            processes.append((part, log, process, output, time.monotonic()))
+            index = len(processes) - 1
+            statuses[index] = process.wait()
+            durations[index] = max(
+                0, round(time.monotonic() - processes[index][4])
+            )
+            output.close()
+        status = next(
+            (statuses[index] for index in range(len(processes)) if statuses[index]),
+            0,
+        )
+        if status == 0:
+            for scenario_id in DISTRIBUTION_SCENARIOS:
+                record_scenario_event("pass", scenario_id)
+        for index, (part, log, _, _, _) in enumerate(processes):
+            sys.stdout.write(log.read_text(encoding="utf-8", errors="replace"))
+            print(
+                f"quality-gate: distribution part {part} completed in "
+                f"{durations[index]}s with exit {statuses[index]}"
+            )
+        return status
+    except OSError as error:
+        print(
+            f"quality-gate: cannot run distribution test parts: {error}",
+            file=sys.stderr,
+        )
         return 2
     finally:
         for _, _, process, output, _ in processes:
@@ -2330,12 +2417,18 @@ def gate_orchestrator_limit(logical_cpus: int | None = None) -> int:
     return 3 if (available or 0) >= 8 else 2
 
 
+def gate_contract_process_limit(logical_cpus: int | None = None) -> int:
+    available = logical_cpus if logical_cpus is not None else os.cpu_count()
+    return max(2, min(4, available or 2))
+
+
 def include_gate_orchestrators(mode: str, diagnostic_stage: str) -> bool:
     return mode != "change" or bool(diagnostic_stage)
 
 
 def run_gate_contract_stage(root: Path, *, include_orchestrators: bool) -> int:
     orchestrator_limit = gate_orchestrator_limit()
+    process_limit = gate_contract_process_limit()
     contracts = gate_contract_definitions(
         root, include_orchestrators=include_orchestrators
     )
@@ -2349,6 +2442,8 @@ def run_gate_contract_stage(root: Path, *, include_orchestrators: bool) -> int:
         running_orchestrators = 0
         while waiting or running:
             for contract in list(waiting):
+                if len(running) >= process_limit:
+                    break
                 filename, command, additions, expected = contract
                 is_orchestrator = filename.startswith("orchestrator-")
                 if is_orchestrator and running_orchestrators >= orchestrator_limit:
@@ -2745,8 +2840,9 @@ def run_stage_worker(stage: str) -> int:
         if stage in PROVIDER_TEST_PARTS:
             return run_provider_parts(root, run_dir, stage, environment)
         return child_run([str(root / "tests/run-claude.sh")], env=environment)
+    if stage == "distribution":
+        return run_distribution_parts(root, run_dir)
     commands = {
-        "distribution": [[str(root / "tests/distribution.sh")]],
         "tmux-runtime": [[str(root / "tests/tmux-runtime.sh")]],
         "release-preflight": [[str(root / "tests/release-preflight.sh")]],
         "publish-preflight": [[str(root / "tests/publish-preflight.sh")]],


### PR DESCRIPTION
## Contract delta

- Keep provider and distribution coverage, but partition slow suites so their work is balanced.
- Limit gate-contract execution to four child processes while retaining the existing heavy-orchestrator cap.
- Use an APFS clone and tighter shell polling for the private UI test app without changing app-side UI waits.
- Document the bounded concurrency and private distribution homes.

## Evidence

- `scripts/quality-gate` diagnostic PASS
- Fingerprint: `5162f46d007fc1b480ccb70035996d0e1d631bff74aa2402115039f740e98af5`
- Release budget PASS: UI 13s, Claude 37s, Codex 55s, distribution 45s, publish-preflight 11s, release-workflow 56s
- UI coverage: 74.72% (8487/11358)
- `python3 tests/quality_gate_contract.py`: 16 tests PASS
- `tests/docs-contract.sh`: PASS
- `git diff --check`: PASS

Hosted `quality-gates` remains readiness authority.