### PR TITLE
Fix pull request merge-base selection

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -31,9 +31,9 @@ jobs:
       - id: impact
         name: Validate and partition exact pull-request impact
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DETACH_QUALITY_AUTHORITY: ci-merge
         run: |
+          BASE_SHA="$(git rev-parse HEAD^1)"
           plan="$RUNNER_TEMP/quality-impact.json"
           scripts/quality-shard plan --base "$BASE_SHA" >"$plan"
           python3 - "$plan" "$GITHUB_OUTPUT" <<'PY'
@@ -55,9 +55,9 @@ jobs:
               output.write(f"has_shards={str(bool(later)).lower()}\n")
           PY
       - name: Run level-zero fail-fast contracts
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: scripts/quality-shard run --base "$BASE_SHA" --shard static --result-root app/build/quality-shards/static
+        run: |
+          BASE_SHA="$(git rev-parse HEAD^1)"
+          scripts/quality-shard run --base "$BASE_SHA" --shard static --result-root app/build/quality-shards/static
       - name: Upload level-zero evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -141,9 +141,9 @@ jobs:
           DETACH_QUALITY_APP_SCRATCH: 1
         run: app/scripts/make-app.sh
       - name: Run exact quality shard
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: scripts/quality-shard run --base "$BASE_SHA" --shard "${{ matrix.id }}" --result-root "app/build/quality-shards/${{ matrix.id }}"
+        run: |
+          BASE_SHA="$(git rev-parse HEAD^1)"
+          scripts/quality-shard run --base "$BASE_SHA" --shard "${{ matrix.id }}" --result-root "app/build/quality-shards/${{ matrix.id }}"
       - name: Upload shard evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -194,9 +194,9 @@ jobs:
           path: ${{ runner.temp }}/quality-shards
       - name: Aggregate authoritative pull-request evidence
         if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: scripts/quality-shard aggregate --base "$BASE_SHA" --input-root "$RUNNER_TEMP/quality-shards" --result-root app/build/quality-gates
+        run: |
+          BASE_SHA="$(git rev-parse HEAD^1)"
+          scripts/quality-shard aggregate --base "$BASE_SHA" --input-root "$RUNNER_TEMP/quality-shards" --result-root app/build/quality-gates
       - id: promoted-main
         name: Promote exact pull-request evidence
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -34,9 +34,19 @@ printf '%s\n' "$quality_gate_job" | \
 grep -F 'fail-fast: true' "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'scripts/quality-shard plan --base "$BASE_SHA"' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+if grep -F 'github.event.pull_request.base.sha' \
+    "$ROOT/.github/workflows/quality-gates.yml" >/dev/null; then
+  printf 'quality workflow used the event base instead of the tested merge first parent\n' >&2
+  exit 1
+fi
+if [ "$(grep -Fc 'BASE_SHA="$(git rev-parse HEAD^1)"' \
+    "$ROOT/.github/workflows/quality-gates.yml")" -ne 4 ]; then
+  printf 'quality workflow did not derive every pull-request base from the tested merge\n' >&2
+  exit 1
+fi
 grep -F 'name: Run level-zero fail-fast contracts' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
-grep -F 'run: scripts/quality-shard run --base "$BASE_SHA" --shard static' \
+grep -F 'scripts/quality-shard run --base "$BASE_SHA" --shard static' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'name: Aggregate authoritative pull-request evidence' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null


### PR DESCRIPTION
Fixes #106.

Contract delta:
- Pull-request planning, shards, and aggregation derive the base from the tested merge first parent.
- Merge identity validation remains fail closed.
- No user-facing or durable contract changes; this restores the existing CI invariant.

Local diagnostics:
- DETACH_QUALITY_GATE_CONTRACT_SHARD=selection tests/quality-gate.sh
- git diff --check