### PR TITLE
Retry a retained thermal safety release instead of wedging the run.

### DIFF
--- a/app/Sources/DetachKit/DetachPowerCommand.swift
+++ b/app/Sources/DetachKit/DetachPowerCommand.swift
@@ -533,6 +533,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         guard latch.isActive else { return }
         do {
             try reconcileLocked()
+            safetyReleaseFailure = nil
             transitionFailure = nil
         } catch {
             if latch.isActive {
@@ -551,6 +552,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         if latch.isActive {
             do {
                 try reconcileLocked()
+                safetyReleaseFailure = nil
             } catch {
                 if safetyReleaseFailure == nil { safetyReleaseFailure = error }
             }
@@ -573,6 +575,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         activityRequiresProtection = state.requiresProtection
         do {
             try reconcileLocked()
+            safetyReleaseFailure = nil
             transitionFailure = nil
         } catch {
             if latch.isActive {
@@ -586,13 +589,21 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
     func refresh() throws {
         lock.lock()
         defer { lock.unlock() }
-        if let safetyReleaseFailure { throw safetyReleaseFailure }
+        // Advance the cooldown and retry a retained safety release before
+        // surfacing it, so one transient failure cannot wedge lease renewals
+        // or protection recovery for the rest of the run.
         _ = latch.observe(lastState, now: now(), cooldown: cooldown)
         do {
             try reconcileLocked()
+            safetyReleaseFailure = nil
             transitionFailure = nil
         } catch {
-            transitionFailure = error
+            if latch.isActive {
+                // A still-failing safety release stays retained and surfaced.
+                if safetyReleaseFailure == nil { safetyReleaseFailure = error }
+            } else {
+                transitionFailure = error
+            }
             throw error
         }
     }

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -45,6 +45,7 @@ final class DetachPowerCommandTests: XCTestCase {
         let events: EventLog
         var acquireError: Error?
         var releaseError: Error?
+        var onRelease: (() -> Void)?
         var acquisitionActivates = true
         private(set) var isActive = false
 
@@ -63,6 +64,7 @@ final class DetachPowerCommandTests: XCTestCase {
 
         func release() throws -> Bool {
             events.append("assertion.release")
+            defer { onRelease?() }
             if let releaseError { throw releaseError }
             let changed = isActive
             isActive = false
@@ -745,6 +747,100 @@ final class DetachPowerCommandTests: XCTestCase {
         XCTAssertEqual(
             events.values.filter { $0 == "assertion.acquire" }.count,
             2)
+    }
+
+    func testTransientThermalReleaseFailureClearsAndProtectionReturns() throws {
+        let thermal = FakeThermalWatcher()
+        let clock = TestClock()
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            thermalWatcher: thermal,
+            thermalNow: { clock.date },
+            thermalCooldown: 30)
+        heartbeat.heartbeatCount = 3
+        assertion.releaseError = ExpectedFailure()
+        assertion.onRelease = { assertion.releaseError = nil }
+        var heartbeatIndex = 0
+        heartbeat.beforeHeartbeat = {
+            heartbeatIndex += 1
+            switch heartbeatIndex {
+            case 1:
+                thermal.emit(.critical)
+            case 2:
+                clock.date = Date(timeIntervalSince1970: 1_001)
+                thermal.emit(.nominal)
+            default:
+                clock.date = Date(timeIntervalSince1970: 1_032)
+            }
+        }
+        child.result = ChildCommandResult(exitCode: 7)
+
+        let result = try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])
+
+        XCTAssertEqual(result, .child(ChildCommandResult(exitCode: 7)))
+        XCTAssertEqual(helper.renewed.map(\.1), [false, false, false, false, true])
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.acquire" }.count,
+            2)
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.release" }.count,
+            3)
+        XCTAssertFalse(assertion.isActive)
+    }
+
+    func testStillFailingThermalReleaseStaysSurfaced() {
+        let thermal = FakeThermalWatcher()
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            thermalWatcher: thermal)
+        heartbeat.heartbeatCount = 1
+        assertion.releaseError = ExpectedFailure()
+        heartbeat.beforeHeartbeat = { thermal.emit(.critical) }
+
+        XCTAssertThrowsError(try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])) { error in
+            XCTAssertTrue(error is ExpectedFailure)
+        }
+
+        XCTAssertTrue(child.commands.isEmpty)
+        XCTAssertTrue(assertion.isActive)
+        XCTAssertFalse(helper.renewed.isEmpty)
+        XCTAssertTrue(helper.renewed.allSatisfy { $0.1 == false })
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.release" }.count,
+            3)
+    }
+
+    func testThermalLatchKeepsProtectionReleasedAcrossHeartbeats() throws {
+        let thermal = FakeThermalWatcher()
+        let clock = TestClock()
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            thermalWatcher: thermal,
+            thermalNow: { clock.date },
+            thermalCooldown: 30)
+        heartbeat.heartbeatCount = 3
+        var heartbeatIndex = 0
+        heartbeat.beforeHeartbeat = {
+            heartbeatIndex += 1
+            if heartbeatIndex == 1 { thermal.emit(.critical) }
+            clock.date = clock.date.addingTimeInterval(10)
+        }
+        child.result = ChildCommandResult(exitCode: 3)
+
+        let result = try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])
+
+        XCTAssertEqual(result, .child(ChildCommandResult(exitCode: 3)))
+        XCTAssertEqual(helper.renewed.map(\.1), [false, false, false, false])
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.acquire" }.count,
+            1)
+        XCTAssertFalse(assertion.isActive)
     }
 
     func testHeartbeatWithAlreadyReleasedAssertionReportsLowBatteryWithoutReacquire() throws {

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -715,6 +715,34 @@ final class DetachPowerCommandTests: XCTestCase {
         XCTAssertTrue(child.commands.isEmpty)
     }
 
+    func testThermalLatchDuringLeaseAttachStagesInactiveLeaseAndRefusesLaunch() {
+        let thermal = FakeThermalWatcher()
+        let (command, events, assertion, helper, child, _) = fixture(
+            thermalWatcher: thermal)
+        helper.onAcquire = { thermal.emit(.critical) }
+
+        XCTAssertThrowsError(try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])) { error in
+            XCTAssertEqual(
+                error as? DetachPowerCommandError,
+                .temperatureSafetyActive)
+        }
+
+        XCTAssertTrue(child.commands.isEmpty)
+        XCTAssertFalse(assertion.isActive)
+        XCTAssertEqual(helper.renewed.map(\.1), [false])
+        XCTAssertEqual(events.values, [
+            "assertion.acquire",
+            "helper.acquire",
+            "assertion.release",
+            "helper.renew",
+            "helper.release",
+            "assertion.release",
+        ])
+    }
+
     func testThermalProtectionReturnsOnlyAfterStableCooldown() throws {
         let thermal = FakeThermalWatcher()
         let clock = TestClock()

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -95,9 +95,12 @@ Thermal safety uses only public `ProcessInfo.thermalState`. `serious` and
 closed-lid sleep, the wrapper releases its IOKit assertion without waiting for
 a checkpoint, and initial acquisition is refused. A notification-time release
 failure is retained and surfaced by the next heartbeat or protected-run result;
-it must never disappear behind best-effort cleanup. `nominal` and `fair` must
-remain stable for 30 seconds before protection can return; the helper persists
-this cooldown across restart, and an unknown reading cannot clear it. The raw
+it must never disappear behind best-effort cleanup. Each heartbeat retries the
+safety release and advances the cooldown. Only a confirmed release clears the
+retained failure; a release that still fails stays surfaced. `nominal` and
+`fair` must remain stable for 30 seconds before protection can return; the
+helper persists this cooldown across restart, and an unknown reading cannot
+clear it. The raw
 `nominal|fair|serious|critical|unknown` value and latch cross helper status, CLI
 JSON, watchdog, tmux, and app. Low battery wins the combined reason when both
 guards are active, while the thermal fields remain visible. Borrowed external


### PR DESCRIPTION
Closes #116.

## Contract delta

`docs/specs/power.md` MODIFIED — the thermal fail-safe gains a recovery path:

- MODIFIED: each 30-second heartbeat now advances the thermal cooldown latch and retries a retained safety release before surfacing it. Previously one transient IOKit/XPC failure latched `safetyReleaseFailure` for the rest of the run: the heartbeat rethrew before reconciling, the helper lease expired at its 120-second TTL, and the cooldown never advanced without a thermal *change* event.
- ADDED: a confirmed reconcile clears the retained failure (all four paths: `observe`, `attachLease`, `observeActivity`, `refresh`), so protection returns once the Mac cools and a clean provider run no longer reports an error at `validateRelease()`.
- Unchanged invariant: while the latch is active, `reconcileLocked()` routes to `enforceSafetyReleaseLocked()` — protection stays released, and a still-failing release stays retained (first-wins) and thrown.

## Durable decisions

- `validateRelease()` stays a pure check (no final retry): with heartbeats retrying and clearing, a retained error at run end means the release was never confirmed, and surfacing it is the honest behavior.

## Acceptance evidence

- `swift test --filter DetachPowerCommandTests` — 39/39, including 3 new regression tests: transient release failure clears and protection returns via heartbeat alone; still-failing release stays surfaced with demonstrable retries and every renewal assertion-inactive; sustained critical latch keeps protection released across heartbeats.
- `swift test` (full DetachKitTests) — 494/494.
- `git diff --check` — clean.
- Environment caveat: tests ran on macOS 15.7.9 with a temporary manifest trim (Sparkle CDN unreachable, macOS-26 test bundles cannot load on this host), fully reverted before commit — the committed tree touches only the 3 files above. `DetachAppTests` did not run locally but does not reach this code; hosted macOS 26 CI is the readiness authority. Manual release gates not run.

Made with [Cursor](https://cursor.com)