### PR TITLE
Count live sessions, not only running ones, in the menu bar and Settings.

### DIFF
--- a/app/Sources/DetachApp/MenuBarPresentation.swift
+++ b/app/Sources/DetachApp/MenuBarPresentation.swift
@@ -55,7 +55,7 @@ struct MenuBarPresentation: Equatable {
         now: Date = Date()
     ) {
         let state = heartbeat.effectivePowerState
-        let live = allSessions.filter(\.isLive)
+        let live = MacPowerLiveSessions.live(in: allSessions)
         let working = live.filter { !$0.isWaitingForUser }
         power = MacPowerSettingsPresentation(
             state: state,

--- a/app/Sources/DetachApp/MenuBarPresentation.swift
+++ b/app/Sources/DetachApp/MenuBarPresentation.swift
@@ -55,14 +55,14 @@ struct MenuBarPresentation: Equatable {
         now: Date = Date()
     ) {
         let state = heartbeat.effectivePowerState
-        let running = allSessions.filter { $0.effectiveStatus == .running }
-        let working = running.filter { !$0.isWaitingForUser }
+        let live = allSessions.filter(\.isLive)
+        let working = live.filter { !$0.isWaitingForUser }
         power = MacPowerSettingsPresentation(
             state: state,
             helperStatus: helperStatus,
             watchdogStatus: watchdogStatus,
             distributionMatchesBundle: distributionMatchesBundle,
-            activeSessionCount: running.count,
+            activeSessionCount: live.count,
             workingSessionCount: working.count)
         ageSeconds = heartbeat.healthy
             ? heartbeat.age(relativeTo: now).map { max(0, Int($0)) }
@@ -104,9 +104,9 @@ struct MenuBarPresentation: Equatable {
         case .attention, .lowBattery, .temperature:
             sessionDot = .none
         case .active, .canSleep, .unknown:
-            if running.contains(where: { $0.isWaitingForUser }) {
+            if live.contains(where: { $0.isWaitingForUser }) {
                 sessionDot = .answerReady
-            } else if running.isEmpty {
+            } else if live.isEmpty {
                 sessionDot = .none
             } else {
                 sessionDot = .working
@@ -114,7 +114,7 @@ struct MenuBarPresentation: Equatable {
         }
 
         // Sessions awaiting a reply outrank ones that are still working.
-        let ordered = running.sorted {
+        let ordered = live.sorted {
             if $0.isWaitingForUser != $1.isWaitingForUser {
                 return $0.isWaitingForUser
             }

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -64,7 +64,7 @@ struct MacPowerSettingsPresentation: Equatable {
             }
         case .allowed:
             // The heartbeat wins, but never claim "no sessions" while the
-            // session poller can see running ones.
+            // session poller can see live ones.
             if let activeSessionCount, activeSessionCount > 0 {
                 if workingSessionCount == 0 {
                     reason = .waitingSessions(activeSessionCount)
@@ -295,15 +295,18 @@ struct SettingsView: View {
         }
         .task(id: navigation.selectedTab) {
             guard navigation.selectedTab == .system else { return }
-            await storageStore.refresh()
+            installation.refreshPowerProtectionState()
+            async let storageRefresh: Void = storageStore.refresh()
             while !Task.isCancelled {
-                installation.refreshPowerProtectionState()
                 do {
                     try await Task.sleep(nanoseconds: 10_000_000_000)
                 } catch {
+                    await storageRefresh
                     return
                 }
+                installation.refreshPowerProtectionState()
             }
+            await storageRefresh
         }
         .onChange(of: fontPointSize) { _, value in
             let clamped = AppFontSize.clamped(value)
@@ -989,16 +992,14 @@ struct SettingsView: View {
     }
 
     private var macPowerPresentation: MacPowerSettingsPresentation {
-        let running = sessionStore.sessions.filter {
-            $0.effectiveStatus == .running
-        }
+        let live = sessionStore.sessions.filter(\.isLive)
         return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,
-            activeSessionCount: running.count,
-            workingSessionCount: running.filter { !$0.isWaitingForUser }.count)
+            activeSessionCount: live.count,
+            workingSessionCount: live.filter { !$0.isWaitingForUser }.count)
     }
 
     private var macPowerHeroRow: some View {

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -100,6 +100,40 @@ struct MacPowerSettingsPresentation: Equatable {
     }
 }
 
+/// Live sessions that Settings and the menu bar count as active.
+enum MacPowerLiveSessions {
+    static func live(in sessions: [Session]) -> [Session] {
+        sessions.filter(\.isLive)
+    }
+
+    static func counts(in sessions: [Session]) -> (active: Int, working: Int) {
+        let live = live(in: sessions)
+        return (live.count, live.filter { !$0.isWaitingForUser }.count)
+    }
+}
+
+/// Heartbeat refresh for Settings → System. The SwiftUI `.task` wrapper
+/// only calls this; XCTest cannot map that modifier.
+enum SystemTabHeartbeatRefresh {
+    static func run(
+        refreshPower: () -> Void,
+        refreshStorage: () async -> Void,
+        sleepNanoseconds: UInt64 = 10_000_000_000
+    ) async {
+        refreshPower()
+        async let storageRefresh: Void = refreshStorage()
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(nanoseconds: sleepNanoseconds)
+            } catch {
+                break
+            }
+            refreshPower()
+        }
+        await storageRefresh
+    }
+}
+
 struct PowerHelperSettingsPresentation: Equatable {
     let status: DiagnosticCheck.Status
     let detailLocalizationKey: String?
@@ -294,19 +328,12 @@ struct SettingsView: View {
             await extendedKeys.load(detachPath: activeDetachPath)
         }
         .task(id: navigation.selectedTab) {
+// quality-coverage:begin system-heartbeat
             guard navigation.selectedTab == .system else { return }
-            installation.refreshPowerProtectionState()
-            async let storageRefresh: Void = storageStore.refresh()
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(nanoseconds: 10_000_000_000)
-                } catch {
-                    await storageRefresh
-                    return
-                }
-                installation.refreshPowerProtectionState()
-            }
-            await storageRefresh
+            await SystemTabHeartbeatRefresh.run(
+                refreshPower: { installation.refreshPowerProtectionState() },
+                refreshStorage: { await storageStore.refresh() })
+// quality-coverage:end system-heartbeat
         }
         .onChange(of: fontPointSize) { _, value in
             let clamped = AppFontSize.clamped(value)
@@ -991,15 +1018,15 @@ struct SettingsView: View {
         }
     }
 
-    private var macPowerPresentation: MacPowerSettingsPresentation {
-        let live = sessionStore.sessions.filter(\.isLive)
+    var macPowerPresentation: MacPowerSettingsPresentation {
+        let counts = MacPowerLiveSessions.counts(in: sessionStore.sessions)
         return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,
-            activeSessionCount: live.count,
-            workingSessionCount: live.filter { !$0.isWaitingForUser }.count)
+            activeSessionCount: counts.active,
+            workingSessionCount: counts.working)
     }
 
     private var macPowerHeroRow: some View {

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -1,4 +1,5 @@
 import DetachKit
+import SwiftUI
 import XCTest
 @testable import DetachApp
 
@@ -174,4 +175,126 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
             activeSessionCount: activeSessionCount,
             workingSessionCount: workingSessionCount)
     }
+}
+
+@MainActor
+final class MacPowerLiveSessionTests: XCTestCase {
+    func testCountsTreatStartingAndRecoveringAsActive() {
+        let sessions = [
+            session(status: "starting"),
+            session(status: "recovering"),
+            session(status: "completed"),
+        ]
+        XCTAssertEqual(
+            MacPowerLiveSessions.live(in: sessions).map(\.effectiveStatus),
+            [.starting, .recovering])
+        let counts = MacPowerLiveSessions.counts(in: sessions)
+        XCTAssertEqual(counts.active, 2)
+        XCTAssertEqual(counts.working, 2)
+    }
+
+    func testCountsSeparateWaitingRunningSessions() {
+        let sessions = [
+            session(status: "running", turnState: "waiting"),
+            session(status: "starting"),
+        ]
+        let counts = MacPowerLiveSessions.counts(in: sessions)
+        XCTAssertEqual(counts.active, 2)
+        XCTAssertEqual(counts.working, 1)
+    }
+
+    func testHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
+        var events: [String] = []
+        let task = Task {
+            await SystemTabHeartbeatRefresh.run(
+                refreshPower: { events.append("power") },
+                refreshStorage: {
+                    events.append("storage-start")
+                    try? await Task.sleep(nanoseconds: 40_000_000)
+                    events.append("storage-end")
+                },
+                sleepNanoseconds: 1_000_000_000)
+        }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        XCTAssertEqual(events.first, "power")
+        XCTAssertTrue(events.contains("storage-start"))
+        XCTAssertFalse(events.contains("storage-end"))
+        task.cancel()
+        await task.value
+        XCTAssertTrue(events.contains("storage-end"))
+    }
+
+    func testHeartbeatRepeatsAfterTheSleepInterval() async {
+        var powerCount = 0
+        let task = Task {
+            await SystemTabHeartbeatRefresh.run(
+                refreshPower: { powerCount += 1 },
+                refreshStorage: {},
+                sleepNanoseconds: 8_000_000)
+        }
+        try? await Task.sleep(nanoseconds: 25_000_000)
+        task.cancel()
+        await task.value
+        XCTAssertGreaterThanOrEqual(powerCount, 2)
+    }
+
+    func testSettingsSystemPaneCountsAStartingSession() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let checkedAt = ISO8601DateFormatter().string(from: Date())
+        try Data(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(checkedAt)"}"#
+                .utf8
+        ).write(to: root.appendingPathComponent("watchdog-status.json"))
+
+        let cli = LiveSessionListCLI(stdout: sessionJSON(status: "starting"))
+        let sessionStore = SessionStore(cli: cli)
+        await sessionStore.refresh()
+
+        let view = SettingsView(
+            installation: InstallationStore(
+                detachPath: "/tmp/detach-test",
+                powerStateRoot: root),
+            sessionStore: sessionStore,
+            storageStore: StorageStore(cli: cli),
+            updater: UpdaterService(),
+            notifications: SessionNotificationService(
+                center: SilentNotificationCenter(),
+                identifierProvider: { "settings-test" }),
+            navigation: SettingsNavigation(selectedTab: .system))
+
+        XCTAssertNotEqual(view.macPowerPresentation.reason, .noActiveSessions)
+        XCTAssertEqual(view.macPowerPresentation.reason, .sessionsNotHolding(1))
+    }
+}
+
+private struct SilentNotificationCenter: SessionNotificationCenterBackend {
+    func authorizationStatus() async -> SessionNotificationAuthorizationStatus { .denied }
+    func requestAuthorization() async throws -> Bool { false }
+    func deliver(_ payload: SessionNotificationPayload) async throws {}
+}
+
+private struct LiveSessionListCLI: DetachCLIRunning {
+    let stdout: String
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        CLIResult(exitCode: 0, stdout: stdout, stderr: "", timedOut: false)
+    }
+}
+
+private func session(status: String, turnState: String? = nil) -> Session {
+    SessionListParser.parse(sessionJSON(status: status, turnState: turnState)).sessions[0]
+}
+
+private func sessionJSON(status: String, turnState: String? = nil) -> String {
+    let turnField = turnState.map { #","agent_turn_state":"\#($0)""# } ?? ""
+    return """
+    {"schema":1,"provider":"codex","session_name":"detach-codex-\(status)",\
+    "name":"\(status)","effective_status":"\(status)","meta_status":"\(status)",\
+    "agent_session_id":"\(status)","project_dir":"/tmp/p",\
+    "created_at":"2026-07-15T10:00:00Z","last_checkpoint_at":null,\
+    "exit_status":null,"finished_at":null\(turnField)}
+    """
 }

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -129,7 +129,7 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
         XCTAssertEqual(
             presentation(state: .unknown, activeSessionCount: 3).reason,
             .noFreshReport)
-        // An allowed heartbeat with visible running sessions must not claim
+        // An allowed heartbeat with visible live sessions must not claim
         // there are none; it names the mismatch instead.
         XCTAssertEqual(
             presentation(state: .allowed, activeSessionCount: 2).reason,

--- a/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
@@ -123,13 +123,57 @@ final class MenuBarPresentationTests: XCTestCase {
 
     func testAllowedStateWithRunningSessionsNamesTheMismatch() {
         // Heartbeat lag right after a session starts: the menu must not say
-        // "No active agent sessions" above a listed running session.
+        // "No active agent sessions" above a listed live session.
         let presentation = makePresentation(
             powerState: "allowed",
             sessions: [runningSession(id: "a")])
 
         XCTAssertEqual(presentation.power.reason, .sessionsNotHolding(1))
         XCTAssertEqual(presentation.sessions.count, 1)
+    }
+
+    func testStartingAndRecoveringSessionsCountAsActive() {
+        for status in ["starting", "recovering"] {
+            let liveSession = session(
+                id: status,
+                status: status,
+                createdAt: "2026-07-15T10:00:00Z",
+                turnState: nil)
+
+            let allowed = makePresentation(
+                powerState: "allowed",
+                sessions: [liveSession])
+            XCTAssertEqual(allowed.sessions.map(\.id), ["detach-codex-\(status)"], status)
+            XCTAssertEqual(allowed.power.reason, .sessionsNotHolding(1), status)
+            XCTAssertNotEqual(allowed.power.reason, .noActiveSessions, status)
+            XCTAssertEqual(allowed.sessionDot, .working, status)
+
+            let protected = makePresentation(
+                powerState: "protected",
+                sessions: [liveSession])
+            XCTAssertEqual(protected.icon, .active(sessionCount: 1), status)
+            XCTAssertEqual(protected.power.reason, .activeSessions(1), status)
+            XCTAssertEqual(protected.sessionDot, .working, status)
+        }
+    }
+
+    func testAllowedStateNeverClaimsNoSessionsWhileALiveSessionExists() {
+        for status in ["starting", "running", "recovering", "hung"] {
+            let presentation = makePresentation(
+                powerState: "allowed",
+                sessions: [
+                    session(
+                        id: status,
+                        status: status,
+                        createdAt: "2026-07-15T10:00:00Z",
+                        turnState: nil),
+                ])
+            XCTAssertNotEqual(
+                presentation.power.reason,
+                .noActiveSessions,
+                "live status \(status) must not be worded as empty")
+            XCTAssertEqual(presentation.sessions.count, 1, status)
+        }
     }
 
     func testHeaderTextJoinsStateReasonAndFreshness() {

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -268,6 +268,15 @@
     },
     {
       "group": "ui",
+      "path": "app/Sources/DetachApp/SettingsView.swift",
+      "region": "system-heartbeat",
+      "scenarios": [
+        "SC-UI-SETTINGS"
+      ],
+      "summary": "XCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop."
+    },
+    {
+      "group": "ui",
       "path": "app/Sources/DetachApp/SidebarView.swift",
       "region": "ui-e2e-instrumentation",
       "scenarios": [

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -74,6 +74,7 @@ coverage-region	ui	app/Sources/DetachApp/OnboardingView.swift	ui-e2e-instrumenta
 coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged journeys cover the test-only semantic bridge and route.
 coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE,SC-UI-SESSION-DETAIL	The packaged journey covers action geometry, UUID copy, and its negative control.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	ui-e2e-instrumentation	SC-UI-SETTINGS	The packaged Settings journey covers its semantic control.
+coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	system-heartbeat	SC-UI-SETTINGS	XCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.
 coverage-region	ui	app/Sources/DetachApp/SidebarView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-FAILURE	Packaged journeys cover sidebar control geometry, bulk Delete, and failure status.
 route	1100	quality/policy.tsv	quality-core	safe	docs/specs/documentation.md
 route	1000	quality/*	policy	safe	docs/specs/documentation.md

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -56,7 +56,7 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'scenario inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" coverage-exclusions | wc -l | tr -d ' ')" = 4 ] || \
   fail 'coverage exclusion inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 9 ] || \
+[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 10 ] || \
   fail 'coverage region inventory is incomplete'
 first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"

--- a/tests/quality_policy_contract.py
+++ b/tests/quality_policy_contract.py
@@ -123,6 +123,10 @@ def main() -> None:
             "\tSC-UI-SETTINGS\tThe packaged Settings journey covers its semantic control.",
             "\tSC-UI-DASHBOARD\tThe packaged Settings journey covers its semantic control.",
             1,
+        ).replace(
+            "\tSC-UI-SETTINGS\tXCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.",
+            "\tSC-UI-DASHBOARD\tXCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.",
+            1,
         ),
         "requirement has no automated verification scenario: QC-APP-SETTINGS",
     )


### PR DESCRIPTION
Closes #119.

## Contract delta

No spec change — `docs/specs/app.md` already states the wording contract (the `.allowed` state must never claim there are no sessions while a working session exists); this change makes the code honor it.

- MODIFIED: `MenuBarPresentation` and the Settings System pane derive the active count, working count, session list, and status dot from `Session.isLive` (`starting`, `running`, `recovering`, `hung`) instead of `effectiveStatus == .running`. A session that is starting or recovering (windows up to ~35s) no longer produces a false "No active agent sessions" claim.
- MODIFIED: the System tab publishes the heartbeat snapshot immediately and refreshes it every 10s concurrently with `storageStore.refresh()`, instead of starting the loop only after the up-to-30s storage scan returns.

## Durable decisions

- Reused the existing `Session.isLive` concept rather than a second filter; it also covers `.hung`, which is still a live session and must not produce a "no sessions" claim either.

## Acceptance evidence

- `swift test --filter MenuBarPresentationTests` — 26/26, including new `testStartingAndRecoveringSessionsCountAsActive` and `testAllowedStateNeverClaimsNoSessionsWhileALiveSessionExists`
- `swift test --filter MacPowerSettingsPresentationTests` — 9/9
- `git diff --check` — clean
- Environment caveat: tests ran on macOS 15.7.9 with explicit target/availability flags and a local Sparkle xcframework (CDN unreachable); `Package.swift`/`Package.resolved` unchanged in the commit. Hosted macOS 26 CI is the readiness authority. Manual release gates not run.

Made with [Cursor](https://cursor.com)