### PR TITLE
Reread the watchdog heartbeat on the onboarding success card.

### DIFF
--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -631,6 +631,7 @@ final class InstallationStore {
         // The user agent records an independently observable power heartbeat.
         watchdogError = nil
         do {
+            refreshPowerProtectionState()
             let watchdogStatusBeforeReconcile = watchdog.status
             let replaceSilentRegistration = watchdogStatusBeforeReconcile == .enabled
                 && !watchdogHeartbeat.healthy

--- a/app/Sources/DetachApp/OnboardingLivePoller.swift
+++ b/app/Sources/DetachApp/OnboardingLivePoller.swift
@@ -25,6 +25,7 @@ final class OnboardingLivePoller {
     private let providerCheckPassed: @MainActor () -> Bool
     private let reconcile: @MainActor () async -> Bool
     private let locate: () async -> ProviderAvailability
+    private let refreshHeartbeat: @MainActor () -> Void
     private let heartbeatIsHealthy: @MainActor () -> Bool
     private let installedCopyExists: () -> Bool
     private let sleep: (UInt64) async throws -> Void
@@ -41,6 +42,7 @@ final class OnboardingLivePoller {
             providerCheckPassed: { store.providerCheckPassed },
             reconcile: { await store.refreshContext() },
             locate: { await locator.locate() },
+            refreshHeartbeat: { store.refreshPowerProtectionState() },
             heartbeatIsHealthy: { store.watchdogHeartbeat.healthy },
             installedCopyExists: {
                 FileManager.default.fileExists(
@@ -55,6 +57,7 @@ final class OnboardingLivePoller {
         providerCheckPassed: @escaping @MainActor () -> Bool,
         reconcile: @escaping @MainActor () async -> Bool,
         locate: @escaping () async -> ProviderAvailability,
+        refreshHeartbeat: @escaping @MainActor () -> Void = {},
         heartbeatIsHealthy: @escaping @MainActor () -> Bool,
         installedCopyExists: @escaping () -> Bool,
         sleep: @escaping (UInt64) async throws -> Void = {
@@ -67,6 +70,7 @@ final class OnboardingLivePoller {
         self.providerCheckPassed = providerCheckPassed
         self.reconcile = reconcile
         self.locate = locate
+        self.refreshHeartbeat = refreshHeartbeat
         self.heartbeatIsHealthy = heartbeatIsHealthy
         self.installedCopyExists = installedCopyExists
         self.sleep = sleep
@@ -146,6 +150,7 @@ final class OnboardingLivePoller {
             if heartbeatWaitStartedAt == nil {
                 heartbeatWaitStartedAt = Date()
             }
+            refreshHeartbeat()
             heartbeatHealthy = heartbeatIsHealthy()
             if heartbeatHealthy {
                 heartbeatWaitIsLong = false

--- a/app/Sources/DetachApp/OnboardingView.swift
+++ b/app/Sources/DetachApp/OnboardingView.swift
@@ -59,6 +59,7 @@ struct OnboardingView: View {
                 providerCheckPassed: { false },
                 reconcile: { false },
                 locate: { ProviderAvailability(codex: true) },
+                refreshHeartbeat: { store.refreshPowerProtectionState() },
                 heartbeatIsHealthy: { store.watchdogHeartbeat.healthy },
                 installedCopyExists: { false }))
         } else {

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -629,6 +629,37 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertEqual(watchdog.forceReplacementRequests, [false])
     }
 
+    func testSynchronizeDecidesForceReplacementFromFreshHeartbeatSnapshot()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("repaired")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            completedOnboarding: true,
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+
+        XCTAssertFalse(fixture.store.watchdogHeartbeat.healthy)
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp())"}"#,
+            to: fixture.stateRoot)
+        XCTAssertFalse(fixture.store.watchdogHeartbeat.healthy)
+
+        await fixture.store.repair()
+
+        XCTAssertTrue(fixture.store.watchdogHeartbeat.healthy)
+        XCTAssertEqual(watchdog.forceReplacementRequests, [false])
+        XCTAssertEqual(distribution.repairs, [true])
+    }
+
     func testRepairDefersHelperReplacementWhileActiveLeasesRemain()
         async throws
     {

--- a/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
+++ b/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
@@ -107,6 +107,22 @@ final class OnboardingLivePollerTests: XCTestCase {
         XCTAssertEqual(reconciles, 2)
     }
 
+    func testDoneTickUsesTheDefaultRefreshWhenNoneIsProvided() async {
+        let poller = OnboardingLivePoller(
+            refreshStatuses: {},
+            servicesEnabled: { false },
+            readinessConfirmed: { false },
+            providerCheckPassed: { false },
+            reconcile: { true },
+            locate: { ProviderAvailability() },
+            heartbeatIsHealthy: { true },
+            installedCopyExists: { false })
+
+        await poller.tick(.done)
+        XCTAssertTrue(poller.heartbeatHealthy)
+        XCTAssertFalse(poller.heartbeatWaitIsLong)
+    }
+
     func testHeartbeatGatePublishesHealth() async {
         var healthy = false
         let poller = makePoller(heartbeatIsHealthy: { healthy })

--- a/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
+++ b/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
@@ -120,6 +120,39 @@ final class OnboardingLivePollerTests: XCTestCase {
         XCTAssertFalse(poller.heartbeatWaitIsLong)
     }
 
+    func testDoneTickRereadsHeartbeatFileWithoutMenuBarTimer() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "detach-onboarding-heartbeat-\(UUID().uuidString)",
+                isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            powerStateRoot: root)
+        let poller = OnboardingLivePoller(store: store)
+
+        await poller.tick(.done)
+        XCTAssertFalse(poller.heartbeatHealthy)
+        XCTAssertFalse(store.watchdogHeartbeat.healthy)
+
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        try Data(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp)"}"#
+                .utf8
+        ).write(
+            to: root.appendingPathComponent("watchdog-status.json"),
+            options: .atomic)
+        XCTAssertFalse(store.watchdogHeartbeat.healthy)
+
+        await poller.tick(.done)
+        XCTAssertTrue(store.watchdogHeartbeat.healthy)
+        XCTAssertTrue(poller.heartbeatHealthy)
+        XCTAssertFalse(poller.heartbeatWaitIsLong)
+    }
+
     func testInstalledCopyDetectionPublishes() async {
         var present = false
         let poller = makePoller(installedCopyExists: { present })
@@ -199,6 +232,7 @@ final class OnboardingLivePollerTests: XCTestCase {
         locate: @escaping () async -> ProviderAvailability = {
             ProviderAvailability()
         },
+        refreshHeartbeat: @escaping @MainActor () -> Void = {},
         heartbeatIsHealthy: @escaping @MainActor () -> Bool = { false },
         installedCopyExists: @escaping () -> Bool = { false },
         sleep: @escaping (UInt64) async throws -> Void = {
@@ -212,6 +246,7 @@ final class OnboardingLivePollerTests: XCTestCase {
             providerCheckPassed: providerCheckPassed,
             reconcile: reconcile,
             locate: locate,
+            refreshHeartbeat: refreshHeartbeat,
             heartbeatIsHealthy: heartbeatIsHealthy,
             installedCopyExists: installedCopyExists,
             sleep: sleep)

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -22,13 +22,12 @@ The live poller reads status without side effects and reconciles once when it
 becomes enabled. Only confirmed readiness (a
 finished helper journal and an open root gate) advances the step. Registration
 can stay in `requiresApproval`; do not treat it as enabled before macOS does.
-The success card waits for a fresh watchdog heartbeat. Each done-step poll
-reads the heartbeat file again. Its dashboard action stays disabled until then.
-After a long wait, it offers a monitor retry, not a bypass. The store records
+The success card waits for a fresh watchdog heartbeat; each done-step poll
+rereads it, and its dashboard action stays disabled until then.
+After a long wait it offers a monitor retry, not a bypass. The store records
 completion only after that action, exactly once. Repair and first-run
-synchronization read the heartbeat file again before they decide to replace a
-silent registration.
-If a doctor refresh fails or detects another runtime identity, the app
+synchronization reread the heartbeat before replacing a silent registration.
+If a doctor refresh fails or finds another runtime identity, the app
 withdraws the earlier helper-readiness confirmation.
 
 After onboarding completes, `.idle`, `.syncing`, `.updateDeferred`, and
@@ -46,11 +45,11 @@ app activation.
 
 Each readiness build stores one `detach-app-build:<UUID>` in its executable and
 signed marker. UI smoke uses a stripped private copy at
-`/private/tmp/detach-ui-e2e.*`. It excludes production CLI, watchdog, helper,
+`/private/tmp/detach-ui-e2e.*` that excludes production CLI, watchdog, helper,
 power, state, and tmux. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
-Smoke restores focus and the pointer. It sends ordered AppKit down/up
+Smoke restores focus and the pointer, and sends ordered AppKit down/up
 pairs to measured SwiftUI controls; semantic locators have no actions. Row
 clicks select sessions even after preview text takes focus.
 Each launch and stage stays within its deadline.
@@ -59,23 +58,23 @@ Stop before proving that the real control invokes it.
 Only visible controls complete onboarding.
 
 Coverage builds the normal bundle, instrumented binary, and Swift tests in
-isolated paths. UI waits for the bundle. Metrics wait for UI and Swift tests.
+isolated paths. UI waits for the bundle; metrics wait for UI and Swift tests.
 Only the copy gets it. The binary and profiles stay out of public artifacts.
 If an overlay scroller ignores a page event, the driver reveals the measured
-semantic control, then posts the action to it.
+semantic control and posts the action to it.
 
-The per-user watchdog has an additional launch-readiness rule. macOS can report
+The per-user watchdog has an added launch-readiness rule: macOS can report
 an approved agent as enabled while no launchd job was loaded after the approval
-transition. During first onboarding, or an explicit Repair, an enabled watchdog
-without a fresh heartbeat must be replaced through the same durable
+transition. During first onboarding or an explicit Repair, an enabled watchdog
+without a fresh heartbeat must be replaced through the durable
 unregister/barrier/register transaction. Ordinary activation refreshes must not
-force replacement merely because a heartbeat is temporarily stale.
+force replacement over a temporarily stale heartbeat.
 
 The menu bar item is display-only. Its Detach prompt mark uses a filled dot for
 protected, a dim mark for sleep allowed, an exclamation badge for attention,
 and an outline for unknown. With active sessions, green means working and
-orange means waiting. Waiting outranks working. A badge suppresses both tints
-so a power warning stays visible. Monochrome states remain template. Tinted
+orange means waiting; waiting outranks working. A badge suppresses both tints
+so a power warning stays visible. Monochrome states remain template; tinted
 states use label or system colors resolved at composite time. VoiceOver names
 the session state. The first menu line is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
@@ -83,7 +82,7 @@ working session and never claims no sessions. The shared `checked_at` heartbeat
 reader and session poller supply the glyph and words. UI never calls `pmset` or
 root XPC. Freshness uses the document timestamp, not file mtime. One
 `detach list --json` poller serves the window, notifications, and menu. It runs
-faster with a window and slower without one. It never stops. Closing the last
+faster with a window, slower without, and never stops. Closing the last
 window keeps the app and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
@@ -91,16 +90,16 @@ Mac Power status and approval controls. The Settings window follows the hosting
 screen; System scrolls. Temperature safety has its own warning shape and the
 text **Mac can sleep: temperature**.
 
-The dashboard shows identity, status, and Mac Power separately. Identity is a
-thin tmux-colored capsule. Status is a filled circle. Power has a neutral
-surface and semantic color. The UUID chip is one copy control. Any click copies
+The dashboard shows identity, status, and Mac Power separately: identity is a
+thin tmux-colored capsule, status is a filled circle, and power has a neutral
+surface and semantic color. The UUID chip is one copy control; any click copies
 the full UUID and shows **Copied**.
 
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
 
 Every app CLI invocation runs in a fresh process group that drains stdout and
-stderr. Its deadline sends TERM then KILL to the group. A pipe-only descendant
+stderr; its deadline sends TERM then KILL to the group. A pipe-only descendant
 cannot hold the caller past the drain deadline. GUI PATH orders NVM and mise
 Node directories by semantic version.
 
@@ -108,29 +107,29 @@ Helper replacement is a durable fail-closed transaction. One versioned JSON
 journal records `preparing`, `unregisterSubmitted`, `removed`, or `registering`,
 the install/remove goal, target digest, boot UUID, and lifetime-barrier contract.
 Each transition uses atomic rename and file/directory fsync before its side
-effect. A per-user `flock` protects the journal. In addition, the root helper
+effect. A per-user `flock` protects the journal. The root helper also
 creates a stable root-owned `0644` inode
 under `/var/run`; every app user opens it read-only and holds one exclusive
-kernel `flock` across the complete asynchronous SMAppService transaction. This
-is the machine-wide single-writer barrier across Fast User Switching, and the
+kernel `flock` for the whole asynchronous SMAppService transaction. It
+is the machine-wide single-writer barrier across Fast User Switching; the
 kernel releases it if the app crashes. Only the current non-root console user's
-app may perform register or unregister mutations, checked again immediately
+app may perform register or unregister mutations, rechecked immediately
 before each mutation. Root persists `unregistration_pending`, blocks
 acquire/renew without a wall-clock expiry, and restores and reads back only the
 setting Detach owns.
 
 The helper takes an exclusive, root-owned lifetime `flock` before its listener
-can answer prepare and holds it until process exit. An enabled job with no
+can answer prepare and holds it until exit. An enabled job with no
 lifetime barrier this boot is dead; unregister may proceed. The app writes
 `unregisterSubmitted` only after observing that lock. A fresh successful async
 SMAppService callback is the normal process-reaped barrier. If a crash loses the
-callback, exact `notRegistered` status plus acquisition of the released lifetime
+callback, exact `notRegistered` status plus the released lifetime
 lock (or a changed boot UUID) is required before registration; generic
-`unavailable` is not sufficient. An unregister error keeps the journal and root
-gate closed for retry rather than reopening it while a callback may still be
-pending. If a different user acquires the system lock after the original app
-crashed and has no local journal, the existing root-created lock/lifetime files
-prove this is not a pristine install: it bootstraps at `unregisterSubmitted`,
+`unavailable` is insufficient. An unregister error keeps the journal and root
+gate closed for retry rather than reopening it while a callback may be
+pending. If another user acquires the system lock after the original app
+crashed and has no local journal, the root-created lock/lifetime files
+prove the install is not pristine: it bootstraps at `unregisterSubmitted`,
 replays asynchronous unregister, and cannot register until that fresh callback
 or the exact absent-job plus released-lifetime recovery barrier completes.
 
@@ -143,24 +142,24 @@ termination gate and must not create this persistent update state.
 
 Settings → System owns one **Mac Power** block. It shows the sleep state,
 component health, the 10% battery rule, and the correct action. Helper Ready
-requires a doctor-confirmed live XPC connection. Registration alone is Needs
+requires a doctor-confirmed live XPC connection; registration alone is Needs
 attention. Power state comes from a healthy watchdog heartbeat no older than
 three minutes. A missing, stale, or malformed snapshot means `unknown`. Refresh
 the installation context when Settings appears or the app becomes active.
 While this tab is visible, publish a heartbeat snapshot every ten seconds so
-the state does not remain stale when SwiftUI does not re-render.
+the state stays fresh when SwiftUI does not re-render.
 
 The watchdog heartbeat carries both the effective power state and typed raw
 thermal state/latch. When notifications are enabled, the app emits one
 localized temperature-safety warning on each inactive-to-active latch
 transition, including when borrowed external protection makes the effective
-power state unavailable; repeated polls never duplicate the warning.
+power state unavailable; repeated polls never duplicate it.
 
 The watchdog is a signed per-user LaunchAgent with its own embedded
 `__TEXT,__info_plist`. It resolves `~/.local/bin/detach` at runtime, calls
 `detach power status --json` through the same process-group runner with a
 five-second deadline, and writes private health state. The privileged
-daemon is a distinct demand-launched LaunchDaemon. Neither plist may contain a
+daemon is a distinct demand-launched LaunchDaemon; neither plist may contain a
 user-specific path. Native power protection requires no Apple Events or
 Automation entitlement.
 
@@ -168,15 +167,15 @@ Distribution bootstrap runs only from `/Applications`, never a DMG or App
 Translocation path. Terminal actions use `NSWorkspace`, not Apple Events. They
 open a private self-deleting `.command` file and reuse a running terminal app.
 If none runs, the launch environment sets a private `.zshenv` as outer
-`ZDOTDIR`. It blocks startup prompts until payload removal, then restores the
+`ZDOTDIR`, blocks startup prompts until payload removal, then restores the
 original `ZDOTDIR` for that process. Open, Resume, and Recover use the selected
 terminal, with Terminal as fallback.
-The new-session sheet accepts an optional UTF-8 name up to 100 bytes. It rejects
+The new-session sheet accepts an optional UTF-8 name up to 100 bytes, rejects
 control characters, blocks launch, and passes one `--name`. The launch button
 names the selected terminal. Advanced holds terminal choice and the prompt and
 grows down, top fixed. The app uses `display_name` as the title, with
 the project/internal name fallback for old records.
-Notifications are opt-in. One poller deduplicates baseline and transitions.
+Notifications are opt-in; one poller deduplicates baseline and transitions.
 
 Sparkle 2 is pinned in `Package.resolved`, embedded with its symlink layout
 intact, and signed inside-out before the outer app. Ad-hoc development builds
@@ -188,10 +187,10 @@ requirement so Intel clients are never offered the update.
 A Sparkle update replaces only the app; bootstrap atomically activates its new
 immutable CLI payload without rewriting live-session binaries. Sparkle errors
 for a disk image or App Translocation tell the user to move Detach to
-`/Applications`. Temporary-directory and download errors tell the user to
+`/Applications`; temporary-directory and download errors tell the user to
 check the network and free disk space, then try again. Archive, signature,
 validation, and installation errors provide the manual DMG path and the
-Settings > System Repair path. These errors state that the active CLI did not
+Settings > System Repair path; each states that the active CLI did not
 change. If replacement completes but CLI or helper sync fails, the prior CLI
 stays active and Repair remains available. Background sync keeps
-the dashboard. A later activation retries it.
+the dashboard; a later activation retries it.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -22,9 +22,12 @@ The live poller reads status without side effects and reconciles once when it
 becomes enabled. Only confirmed readiness (a
 finished helper journal and an open root gate) advances the step. Registration
 can stay in `requiresApproval`; do not treat it as enabled before macOS does.
-The success card waits for a fresh watchdog heartbeat. Its dashboard action
-stays disabled until then. After a long wait, it offers a monitor retry, not a
-bypass. The store records completion only after that action, exactly once.
+The success card waits for a fresh watchdog heartbeat. Each done-step poll
+reads the heartbeat file again. Its dashboard action stays disabled until then.
+After a long wait, it offers a monitor retry, not a bypass. The store records
+completion only after that action, exactly once. Repair and first-run
+synchronization read the heartbeat file again before they decide to replace a
+silent registration.
 If a doctor refresh fails or detects another runtime identity, the app
 withdraws the earlier helper-readiness confirmation.
 


### PR DESCRIPTION
Closes #120.

## Contract delta

`docs/specs/app.md` MODIFIED:

- MODIFIED: the onboarding success card rereads the watchdog heartbeat file on each done-step poll (`refreshPowerProtectionState()` before `heartbeatIsHealthy`), instead of copying a stale in-memory snapshot. The card no longer depends on the menu-bar label's 5-second timer to unlock "Open Dashboard".
- MODIFIED: `synchronize()` (Repair / first-run) refreshes the heartbeat snapshot before the silent-registration force-replacement decision.

## Durable decisions

- The poller takes `refreshHeartbeat` as an injectable hook (default no-op in the designated init) so the behavior is unit-testable without the app store.

## Acceptance evidence

- `swift test --filter OnboardingLivePollerTests` — 11/11, including `testDoneTickRereadsHeartbeatFileWithoutMenuBarTimer` and `testDoneTickUsesTheDefaultRefreshWhenNoneIsProvided`
- `swift test --filter InstallationStorePowerStateTests` — 42/42, including `testSynchronizeDecidesForceReplacementFromFreshHeartbeatSnapshot`
- Changed-line coverage of the diff: 5/5 = 100% locally (gate minimum 90%), verified with the repo's `tools/quality_metrics.py` semantics; the one unmappable View-body closure is inside the existing `ui-e2e-instrumentation` exclusion
- `git diff --check` — clean
- Environment caveat: tests ran on macOS 15.7.9 with explicit target/availability flags (package targets macOS 26; Sparkle CDN unreachable, local stub used and reverted). Hosted macOS 26 CI is the readiness authority. Manual release gates not run.

Made with [Cursor](https://cursor.com)