### PR TITLE
Refuse test-mode publication and enumerate remote assets in verify.

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -49,10 +49,13 @@ change real power state, upload assets, or claim publication.
   bounded ten-second launch window before owner confirmation is accepted.
   Automated release tests cover install, repair, uninstall, update, CLI
   synchronization, and helper replacement paths.
+- `DETACH_RELEASE_TEST_MODE=1` relaxes selected local production-path checks
+  for hermetic tests. It refuses the push and publication stages.
 - The release entry point supplies the low-level publication confirmation after
-  all selected gates pass. After upload, every remote asset is downloaded and
-  its digest is independently matched. Missing, extra, changed, or mismatched
-  assets fail closed.
+  all selected gates pass. After upload, verification lists every remote asset
+  name. A name outside the expected set fails closed. Every expected remote
+  asset is downloaded and its digest is independently matched. Missing, extra,
+  changed, or mismatched assets fail closed.
 - Each release includes a deterministic SPDX 2.3 SBOM. It lists the exact
   Swift resolution and the checksummed tmux, libevent, and utf8proc sources.
   The SBOM names the exact tag and commit. The release manifest binds its

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,7 +149,8 @@
   and explicit publication-confirmation guards.
 - `tests/release-workflow.sh` — hermetic end-to-end orchestration, including
   resume after every durable stage, dirty/diverged source rejection, duplicate
-  tag/release rejection, hardware-gate failure, and remote hash mismatch.
+  tag/release rejection, hardware-gate failure, remote hash mismatch,
+  test-mode publication refusal, and unexpected remote assets.
 - `cd app && swift test --enable-code-coverage --disable-sandbox`, followed by
   `tests/quality-contracts.sh` — unit tests plus measured UI and business test
   identities, aggregate coverage, and coverage for the 13 critical sources.
@@ -217,7 +218,7 @@ matching temporary branch. It does not push release metadata directly to
 `main`. It then reuses the
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
 the signed candidate, runs the real power smoke, publishes, and independently
-downloads and hashes every remote asset. `scripts/release-impact` compares the
+lists, downloads, and hashes every remote asset. `scripts/release-impact` compares the
 last published tag with the release source. It selects the supervised
 closed-lid probe only for power, helper, watchdog, lease, assertion, or
 lid-probe impact. Unknown product paths select the closed-lid gate. Its private

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -203,6 +203,9 @@ validate_configuration() {
     die 'DETACH_RELEASE_TEST_MODE must be 0 or 1'
   [ "$IGNORE_TIMING" = 0 ] || [ "$IGNORE_TIMING" = 1 ] || \
     die 'DETACH_RELEASE_IGNORE_TIMING must be 0 or 1'
+  [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 0 ] || \
+    [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 1 ] || \
+    die 'DETACH_RELEASE_TEST_ALLOW_PUBLISH must be 0 or 1'
   if [ "$TEST_MODE" = 1 ]; then
     printf 'release-version: TEST MODE — production path checks are relaxed\n' >&2
   fi
@@ -490,7 +493,7 @@ download_latest_manifest() {
     "https://github.com/$REPOSITORY/releases/latest/download/release-manifest.json" \
     --output "$destination"
   chmod 0600 "$destination"
-  plutil -p "$destination" >/dev/null
+  plutil -convert json -o /dev/null "$destination"
 }
 
 manifest_value() {
@@ -713,9 +716,16 @@ remove_release_ci_branch() {
     die 'remote release CI branch still exists after cleanup'
 }
 
+refuse_test_mode_publication() {
+  [ "$TEST_MODE" = 1 ] || return 0
+  [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 1 ] || \
+    die 'DETACH_RELEASE_TEST_MODE refuses push and publication'
+}
+
 push_release_source() {
   local remote_ci remote_main remote_tag merge_output parents tag_commit tag_type
   local -a release_pr_args
+  refuse_test_mode_publication
   if has_stage pushed; then
     RELEASE_HEAD="$(read_state_value release-head)" || die 'release head is missing'
     RELEASE_COMMIT="$(read_state_value release-commit)" || die 'release commit is missing'
@@ -1021,6 +1031,7 @@ run_publish_preflight() {
 }
 
 publish_release() {
+  refuse_test_mode_publication
   if ! has_stage published; then
     release_api_status "$STATE_DIR/release-before-publish.json" >/dev/null
     run_publish_preflight
@@ -1045,7 +1056,7 @@ download_remote_asset() {
 
 verify_published_release() {
   local remote_root="$STATE_DIR/remote-assets" latest_tag http_status
-  local local_asset remote_asset name
+  local local_asset remote_asset name remote_assets remote_name expected
   local -a assets
 
   rm -rf "$remote_root"
@@ -1066,8 +1077,23 @@ verify_published_release() {
     "$APP_ROOT/build/update-assets/release-manifest.json"
     "$APP_ROOT/build/update-assets/release-manifest.json.sha256"
   )
+  remote_assets="$(gh release view "$TAG" --repo "$REPOSITORY" \
+    --json assets --jq '.assets[].name')"
+  while IFS= read -r remote_name; do
+    [ -n "$remote_name" ] || continue
+    expected=0
+    for local_asset in "${assets[@]}"; do
+      if [ "$remote_name" = "$(basename "$local_asset")" ]; then
+        expected=1
+        break
+      fi
+    done
+    [ "$expected" = 1 ] || die "published release has unexpected asset: $remote_name"
+  done <<<"$remote_assets"
   for local_asset in "${assets[@]}"; do
     name="$(basename "$local_asset")"
+    grep -Fx "$name" <<<"$remote_assets" >/dev/null || \
+      die "published release is missing asset: $name"
     remote_asset="$remote_root/$name"
     download_remote_asset "$name" "$remote_asset"
     [ "$(shasum -a 256 "$local_asset" | awk '{print $1}')" = \

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -392,6 +392,12 @@ case "${1:-} ${2:-}" in
     [ -f "${FAKE_RELEASE_EXISTS:?}" ] || exit 1
     case " $* " in
       *' --json tagName '*) printf '%s\n' "${FAKE_TARGET_TAG:?}" ;;
+      *' --json assets '*)
+        for path in "${FAKE_REMOTE_ASSETS:?}"/*; do
+          [ -f "$path" ] || continue
+          basename "$path"
+        done
+        ;;
     esac
     ;;
   *) exit 64 ;;
@@ -484,6 +490,7 @@ run_workflow() {
       FAKE_TARGET_TAG="$TARGET_TAG" \
       FAKE_DMG_APP="$REPO/app/build/fake-dmg/Detach.app" \
       DETACH_RELEASE_TEST_MODE=1 \
+      DETACH_RELEASE_TEST_ALLOW_PUBLISH="${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-1}" \
       DETACH_QUALITY_GATE_TEST_MODE=1 \
       DETACH_RELEASE_TEST_APPLICATIONS_DIR="$APPS" \
       DETACH_RELEASE_TEST_LID_MIN_SECONDS=0 \
@@ -672,6 +679,32 @@ run_remote_hash_case() {
   [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
 }
 
+run_test_mode_refuses_publish_case() {
+  setup_fixture test-mode-refuses-publish
+  export DETACH_RELEASE_TEST_ALLOW_PUBLISH=0
+  expect_failure test-mode-refuses-publish \
+    'DETACH_RELEASE_TEST_MODE refuses push and publication' \
+    run_workflow
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-prepared" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-pushed" ]
+  [ ! -f "$RELEASE_EXISTS" ]
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/tags/$TARGET_TAG")" ]
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
+  ! grep -q '^publish$' "$ACTION_LOG"
+}
+
+run_unexpected_remote_asset_case() {
+  setup_fixture unexpected-remote-asset
+  expect_failure unexpected-remote-asset-prep \
+    'injected safe failure after published' run_workflow published
+  printf '%s\n' extra >"$REMOTE_ASSETS/unexpected-notes.txt"
+  expect_failure unexpected-remote-asset \
+    'published release has unexpected asset: unexpected-notes.txt' \
+    run_workflow
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-published" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
+}
+
 run_post_push_main_rejection_case() {
   setup_fixture post-push-main
   expect_failure post-push-artifacts 'injected safe failure after artifacts' \
@@ -696,6 +729,8 @@ for release_case in \
   run_preflight_rejection_cases \
   run_hardware_rejection_case \
   run_remote_hash_case \
+  run_test_mode_refuses_publish_case \
+  run_unexpected_remote_asset_case \
   run_post_push_main_rejection_case \
   run_invalid_resume_artifact_credentials_case; do
   "$release_case" &


### PR DESCRIPTION
Closes #122.

## Contract delta

`docs/specs/release.md` and `docs/testing.md` MODIFIED:

- ADDED: `DETACH_RELEASE_TEST_MODE=1` now dies at `push_release_source` and `publish_release` ("refuses push and publication") unless the explicit test-only hook `DETACH_RELEASE_TEST_ALLOW_PUBLISH=1` is set. A leftover test-mode export in a shell with real credentials can no longer reach a public release; hermetic workflow tests set the hook to exercise the fake publish path.
- ADDED: `verify_published_release` enumerates the remote release's assets via `gh release view --json assets` and fails closed on any unexpected name, and on any missing expected name — matching the AGENTS.md requirement that every asset is independently verified (previously only a fixed allowlist was downloaded).

## Durable decisions

- The allow-publish escape hatch is a separate variable (not implied by test mode) so the dangerous combination is always a deliberate two-flag choice.
- `download_latest_manifest` validates the manifest with `plutil -convert json -o /dev/null` instead of `plutil -p` — same parse validation, works on both macOS 15 and 26 (`plutil -p` rejects JSON input on older hosts).

## Acceptance evidence

- `tests/release-workflow.sh` (includes new cases: test mode refuses publish without the hook; verify fails on an unexpected remote asset), `tests/release-preflight.sh`, `tests/publish-preflight.sh`, `tests/release-impact.sh`, `tests/release-sbom.sh`, `tests/release-pr.sh`, `tests/release-budget-ratchet.sh`, `tests/release-budget-ratchet-contract.sh`, `tests/docs-contract.sh` — all green
- `git diff --check` — clean
- No app/Sources changes — the changed-line coverage gate is not applicable. Real signing, notarization, tagging, upload, and publication not run (release-only gates).

Made with [Cursor](https://cursor.com)