### PR TITLE
Route the release orchestrator to the lid gate.

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -34,9 +34,10 @@ change real power state, upload assets, or claim publication.
 - Developer ID signing, notarization, and the real signed power smoke are
   mandatory for every release. `scripts/release-impact` compares the last
   published tag with the release source. It selects supervised closed-lid
-  testing only for power, helper, watchdog, lease, assertion, or lid-probe
-  impact. An unknown product path selects the closed-lid gate. Test-only,
-  documentation-only, and known unrelated product paths do not select it.
+  testing only for power, helper, watchdog, lease, assertion, lid-probe, or
+  `scripts/release-version` impact. An unknown product path selects the
+  closed-lid gate. Test-only, documentation-only, and known unrelated product
+  paths do not select it.
 - Notary credential preflight gives `notarytool` a private PTY and captures its
   output in private workflow evidence. This supports protected Keychain
   profiles without exposing submission history in the release log.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -687,7 +687,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 50,
+  "policy": 51,
   "release_domains": [
     {
       "gates": "-",
@@ -1767,7 +1767,7 @@
     {
       "pattern": "scripts/release-version",
       "priority": 900,
-      "release_domain": "safe",
+      "release_domain": "lid",
       "spec": "docs/specs/release.md",
       "test_domain": "release-tool"
     },

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	50
+policy	51
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -206,7 +206,7 @@ route	900	app/scripts/bundle-modes.sh	app-script	unknown	docs/specs/release.md
 route	890	app/scripts/publish-release.sh	release-tool	safe	docs/specs/release.md
 route	890	app/scripts/verify-appcast.sh	release-tool	safe	docs/specs/release.md
 route	880	app/scripts/*	app-script	safe	docs/specs/release.md
-route	900	scripts/release-version	release-tool	safe	docs/specs/release.md
+route	900	scripts/release-version	release-tool	lid	docs/specs/release.md
 route	900	scripts/release-impact	release-tool	safe	docs/specs/release.md
 route	800	scripts/*	unknown	unknown	docs/specs/documentation.md
 route	900	tests/run.sh	codex-test	safe	docs/specs/runtime.md

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -78,6 +78,7 @@ expect_route app/Sources/DetachKit/TerminalLauncher.swift runtime-source safe fa
 expect_route app/Sources/DetachApp/OnboardingView.swift onboarding-source install false
 expect_route app/Sources/DetachApp/FutureFlow.swift swift-source unknown true
 expect_route scripts/release-lid-probe release-tool lid false
+expect_route scripts/release-version release-tool lid false
 expect_route scripts/quality-metrics policy safe false
 expect_route scripts/quality-mutation policy safe false
 

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -154,6 +154,14 @@ assert_value "$TMP_ROOT/new-app.tsv" unknown_impact true
 grep -F $'unknown_reason\tapp/Sources/DetachApp/FutureFlow.swift' \
   "$TMP_ROOT/new-app.tsv" >/dev/null
 
+ORCHESTRATOR_HEAD="$(commit_path scripts/release-version lid-orchestrator)"
+"$REPO/scripts/release-impact" "$NEW_APP_HEAD" "$ORCHESTRATOR_HEAD" \
+  >"$TMP_ROOT/orchestrator.tsv"
+assert_value "$TMP_ROOT/orchestrator.tsv" lid_test_required true
+assert_value "$TMP_ROOT/orchestrator.tsv" unknown_impact false
+grep -F $'lid_test_reason\tscripts/release-version' \
+  "$TMP_ROOT/orchestrator.tsv" >/dev/null
+
 git -C "$REPO" checkout -qb unrelated "$BASE"
 UNRELATED_HEAD="$(commit_path docs/note.md unrelated)"
 if "$REPO/scripts/release-impact" "$NEW_APP_HEAD" "$UNRELATED_HEAD" \


### PR DESCRIPTION
Closes #121.

## Contract delta

`docs/specs/release.md` MODIFIED: supervised closed-lid testing is now also selected for `scripts/release-version` impact. Policy routes are path-only (priority + glob), so the whole orchestrator file is lid-gated rather than only `run_lid_test`.

- `quality/policy.tsv`: `scripts/release-version` route `safe` → `lid`; policy version 50 → 51.
- `quality/generated/policy.json`: regenerated.

A release whose only diff from the previous tag touches the lid-test acceptance logic now requires the hardware closed-lid test it controls, instead of recording the lid stage as done.

## Durable decisions

- Whole-file gating is deliberate: the policy has no path+content granularity, and the orchestrator's lid logic (`run_lid_test`) is interleaved with stage flow, so a narrower route would be fragile.

## Acceptance evidence

- `tests/quality-policy.sh` — passed (includes the new `expect_route scripts/release-version release-tool lid false`)
- `tests/release-impact.sh` — passed (a `scripts/release-version` change now requires `lid_test_required=true`)
- `tests/docs-contract.sh` — passed
- `git diff --check` — clean
- No app/Sources changes — the changed-line coverage gate is not applicable. The hardware closed-lid test itself is a supervised release-only gate and was not run.

Made with [Cursor](https://cursor.com)