### PR TITLE
Pass downloaded artifact paths through env in dashboard workflows.

### DIFF
--- a/.github/workflows/quality-care.yml
+++ b/.github/workflows/quality-care.yml
@@ -117,37 +117,60 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           baseline_root="$(scripts/quality-baseline)"
-          printf 'root=%s\n' "$baseline_root" >>"$GITHUB_OUTPUT"
-          printf 'run_id=%s\n' "${baseline_root##*/}" >>"$GITHUB_OUTPUT"
+          {
+            echo 'root<<EOF'
+            printf '%s\n' "$baseline_root"
+            echo 'EOF'
+            echo 'run_id<<EOF'
+            printf '%s\n' "${baseline_root##*/}"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: mutation-evidence
         name: Restore latest mutation score when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-mutation latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: security-evidence
         name: Restore latest security result when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-security latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - name: Generate dashboard with care evidence
+        env:
+          MUTATION_SUMMARY: ${{ steps.mutation-evidence.outputs.summary }}
+          SECURITY_SUMMARY: ${{ steps.security-evidence.outputs.summary }}
+          MAIN_EVIDENCE_ROOT: ${{ steps.main-evidence.outputs.root }}
+          DASHBOARD_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}
         run: |
           mutation_args=()
           security_args=()
-          if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
-            mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          if [ -n "$MUTATION_SUMMARY" ]; then
+            mutation_args+=(--mutation-summary "$MUTATION_SUMMARY")
           fi
-          if [ -n "${{ steps.security-evidence.outputs.summary }}" ]; then
-            security_args+=(--security-summary "${{ steps.security-evidence.outputs.summary }}")
+          if [ -n "$SECURITY_SUMMARY" ]; then
+            security_args+=(--security-summary "$SECURITY_SUMMARY")
           fi
           scripts/quality-dashboard generate \
-            --result-root "${{ steps.main-evidence.outputs.root }}" \
+            --result-root "$MAIN_EVIDENCE_ROOT" \
             --output app/build/quality-dashboard \
             --care-summary app/build/quality-care/summary.json \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
+            --run-url "$DASHBOARD_RUN_URL" \
             "${mutation_args[@]}" \
             "${security_args[@]}"
       - name: Configure Pages

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -378,47 +378,75 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           root="$(scripts/quality-baseline)"
-          printf 'root=%s\n' "$root" >>"$GITHUB_OUTPUT"
+          {
+            echo 'root<<EOF'
+            printf '%s\n' "$root"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: mutation-evidence
         name: Restore latest mutation score when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-mutation latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: care-evidence
         name: Restore latest quality-care summary when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-care latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: security-evidence
         name: Restore latest security result when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-security latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - name: Generate quality dashboard
+        env:
+          MUTATION_SUMMARY: ${{ steps.mutation-evidence.outputs.summary }}
+          CARE_SUMMARY: ${{ steps.care-evidence.outputs.summary }}
+          SECURITY_SUMMARY: ${{ steps.security-evidence.outputs.summary }}
+          METRICS_BASELINE: ${{ steps.metrics-baseline.outputs.root }}
+          DASHBOARD_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           mutation_args=()
           care_args=()
           security_args=()
-          if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
-            mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          if [ -n "$MUTATION_SUMMARY" ]; then
+            mutation_args+=(--mutation-summary "$MUTATION_SUMMARY")
           fi
-          if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
-            care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
+          if [ -n "$CARE_SUMMARY" ]; then
+            care_args+=(--care-summary "$CARE_SUMMARY")
           fi
-          if [ -n "${{ steps.security-evidence.outputs.summary }}" ]; then
-            security_args+=(--security-summary "${{ steps.security-evidence.outputs.summary }}")
+          if [ -n "$SECURITY_SUMMARY" ]; then
+            security_args+=(--security-summary "$SECURITY_SUMMARY")
           fi
           scripts/quality-dashboard generate \
             --result-root app/build/quality-gates \
             --output app/build/quality-dashboard \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --metrics-baseline "${{ steps.metrics-baseline.outputs.root }}" \
+            --run-url "$DASHBOARD_RUN_URL" \
+            --metrics-baseline "$METRICS_BASELINE" \
             "${mutation_args[@]}" \
             "${care_args[@]}" \
             "${security_args[@]}"

--- a/.github/workflows/quality-mutations.yml
+++ b/.github/workflows/quality-mutations.yml
@@ -94,37 +94,60 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           baseline_root="$(scripts/quality-baseline)"
-          printf 'root=%s\n' "$baseline_root" >>"$GITHUB_OUTPUT"
-          printf 'run_id=%s\n' "${baseline_root##*/}" >>"$GITHUB_OUTPUT"
+          {
+            echo 'root<<EOF'
+            printf '%s\n' "$baseline_root"
+            echo 'EOF'
+            echo 'run_id<<EOF'
+            printf '%s\n' "${baseline_root##*/}"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: care-evidence
         name: Restore latest quality-care summary when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-care latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: security-evidence
         name: Restore latest security result when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-security latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - name: Generate dashboard with mutation score
+        env:
+          CARE_SUMMARY: ${{ steps.care-evidence.outputs.summary }}
+          SECURITY_SUMMARY: ${{ steps.security-evidence.outputs.summary }}
+          MAIN_EVIDENCE_ROOT: ${{ steps.main-evidence.outputs.root }}
+          DASHBOARD_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}
         run: |
           care_args=()
           security_args=()
-          if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
-            care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
+          if [ -n "$CARE_SUMMARY" ]; then
+            care_args+=(--care-summary "$CARE_SUMMARY")
           fi
-          if [ -n "${{ steps.security-evidence.outputs.summary }}" ]; then
-            security_args+=(--security-summary "${{ steps.security-evidence.outputs.summary }}")
+          if [ -n "$SECURITY_SUMMARY" ]; then
+            security_args+=(--security-summary "$SECURITY_SUMMARY")
           fi
           scripts/quality-dashboard generate \
-            --result-root "${{ steps.main-evidence.outputs.root }}" \
+            --result-root "$MAIN_EVIDENCE_ROOT" \
             --output app/build/quality-dashboard \
             --mutation-summary app/build/quality-mutations/summary.json \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
+            --run-url "$DASHBOARD_RUN_URL" \
             "${care_args[@]}" \
             "${security_args[@]}"
       - name: Configure Pages

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -142,37 +142,60 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           baseline_root="$(scripts/quality-baseline)"
-          printf 'root=%s\n' "$baseline_root" >>"$GITHUB_OUTPUT"
-          printf 'run_id=%s\n' "${baseline_root##*/}" >>"$GITHUB_OUTPUT"
+          {
+            echo 'root<<EOF'
+            printf '%s\n' "$baseline_root"
+            echo 'EOF'
+            echo 'run_id<<EOF'
+            printf '%s\n' "${baseline_root##*/}"
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: mutation-evidence
         name: Restore latest mutation score when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-mutation latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - id: care-evidence
         name: Restore latest quality-care summary when available
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           summary="$(scripts/quality-care latest --optional)"
-          printf 'summary=%s\n' "$summary" >>"$GITHUB_OUTPUT"
+          {
+            echo 'summary<<EOF'
+            if [ -n "$summary" ]; then
+              printf '%s\n' "$summary"
+            fi
+            echo 'EOF'
+          } >>"$GITHUB_OUTPUT"
       - name: Generate dashboard with security result
+        env:
+          MUTATION_SUMMARY: ${{ steps.mutation-evidence.outputs.summary }}
+          CARE_SUMMARY: ${{ steps.care-evidence.outputs.summary }}
+          MAIN_EVIDENCE_ROOT: ${{ steps.main-evidence.outputs.root }}
+          DASHBOARD_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}
         run: |
           mutation_args=()
           care_args=()
-          if [ -n "${{ steps.mutation-evidence.outputs.summary }}" ]; then
-            mutation_args+=(--mutation-summary "${{ steps.mutation-evidence.outputs.summary }}")
+          if [ -n "$MUTATION_SUMMARY" ]; then
+            mutation_args+=(--mutation-summary "$MUTATION_SUMMARY")
           fi
-          if [ -n "${{ steps.care-evidence.outputs.summary }}" ]; then
-            care_args+=(--care-summary "${{ steps.care-evidence.outputs.summary }}")
+          if [ -n "$CARE_SUMMARY" ]; then
+            care_args+=(--care-summary "$CARE_SUMMARY")
           fi
           scripts/quality-dashboard generate \
-            --result-root "${{ steps.main-evidence.outputs.root }}" \
+            --result-root "$MAIN_EVIDENCE_ROOT" \
             --output app/build/quality-dashboard \
             --security-summary app/build/quality-security/summary.json \
-            --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ steps.main-evidence.outputs.run_id }}" \
+            --run-url "$DASHBOARD_RUN_URL" \
             "${mutation_args[@]}" \
             "${care_args[@]}"
       - name: Configure Pages

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -272,7 +272,10 @@ that policy. The bounded care workflow can publish a validated attention
 result, then marks its run failed and opens one issue. A later deploy restores
 the newest valid care artifact for the current policy. The next healthy care
 run closes the issue. No workflow publishes pull request or local gate
-evidence.
+evidence. Hosted dashboard jobs pass downloaded summary and baseline paths
+through environment variables. They do not expand those paths with workflow
+expressions inside the shell. Producing steps write those paths with
+multiline-safe output delimiters.
 
 ## Definition of done
 

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -145,6 +145,20 @@ grep -F 'scripts/quality-care latest --optional' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'care_args+=(--care-summary' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'MUTATION_SUMMARY:' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'summary<<EOF' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+if grep -F 'if [ -n "${{' \
+    "$ROOT/.github/workflows/quality-gates.yml" >/dev/null; then
+  printf 'quality dashboard interpolates step outputs into the shell\n' >&2
+  exit 1
+fi
+if grep -F "printf 'summary=%s\\n'" \
+    "$ROOT/.github/workflows/quality-gates.yml" >/dev/null; then
+  printf 'quality dashboard writes summary outputs without a delimiter\n' >&2
+  exit 1
+fi
 
 prepare_template() {
   local stage

--- a/tests/quality_care_contract.py
+++ b/tests/quality_care_contract.py
@@ -82,6 +82,14 @@ def assert_workflows() -> None:
     ):
         if required not in docs:
             raise AssertionError(f"documentation-care workflow is missing: {required}")
+    if "MUTATION_SUMMARY:" not in care or "summary<<EOF" not in care:
+        raise AssertionError(
+            "quality-care dashboard does not pass downloaded paths through env"
+        )
+    if 'if [ -n "${{' in care or "printf 'summary=%s\\n'" in care:
+        raise AssertionError(
+            "quality-care dashboard interpolates downloaded paths into the shell"
+        )
     for workflow in (care, docs):
         if re.search(r"uses:\s+\S+@v[0-9]", workflow):
             raise AssertionError("care workflow contains a mutable Action tag")

--- a/tests/quality_mutation_contract.py
+++ b/tests/quality_mutation_contract.py
@@ -106,9 +106,13 @@ def main() -> int:
         "if: github.ref == 'refs/heads/main'",
         "scripts/quality-care latest --optional",
         "care_args+=(--care-summary",
+        "CARE_SUMMARY:",
+        "summary<<EOF",
     ):
         if required not in workflow:
             fail(f"mutation workflow is missing: {required}")
+    if 'if [ -n "${{' in workflow or "printf 'summary=%s\\n'" in workflow:
+        fail("mutation dashboard interpolates downloaded paths into the shell")
     if re.search(r"uses:\s+\S+@v[0-9]", workflow):
         fail("mutation workflow contains a mutable Action tag")
     with tempfile.TemporaryDirectory(prefix="detach-quality-mutation-") as raw:

--- a/tests/security_contract.py
+++ b/tests/security_contract.py
@@ -118,12 +118,19 @@ def main() -> None:
             "the security dashboard does not consume the exact current artifact")
     require("timeout-minutes: 3" in dashboard_zone,
             "security dashboard deadline is missing")
-    for path in PAGES_WORKFLOWS:
+    dashboard_workflows = (WORKFLOW, *PAGES_WORKFLOWS)
+    for path in dashboard_workflows:
         pages_workflow = path.read_text(encoding="utf-8")
-        require("scripts/quality-security latest --optional" in pages_workflow,
-                f"{path.name} does not preserve the latest security result")
+        if path in PAGES_WORKFLOWS:
+            require("scripts/quality-security latest --optional" in pages_workflow,
+                    f"{path.name} does not preserve the latest security result")
         require("--security-summary" in pages_workflow,
                 f"{path.name} does not pass security evidence to the dashboard")
+        require("summary<<EOF" in pages_workflow,
+                f"{path.name} writes summary outputs without a delimiter")
+        require('if [ -n "${{' not in pages_workflow
+                and "printf 'summary=%s\\n'" not in pages_workflow,
+                f"{path.name} interpolates downloaded paths into the shell")
     require("release-version" not in workflow and "notary" not in workflow,
             "security care can enter a release path")
     require("version: 2" in dependabot, "Dependabot schema is missing")


### PR DESCRIPTION
Closes #125.

## Contract delta

`docs/quality-gates.md` MODIFIED: hosted dashboard jobs pass downloaded paths through environment variables and write them with multiline-safe output delimiters.

- All four dashboard workflows (`quality-gates.yml`, `quality-care.yml`, `security.yml`, `quality-mutations.yml`) no longer expand step outputs via `${{ }}` inside shell scripts; values flow through `env:` (`MUTATION_SUMMARY`, `CARE_SUMMARY`, `SECURITY_SUMMARY`, `METRICS_BASELINE`/`MAIN_EVIDENCE_ROOT`, `DASHBOARD_RUN_URL`).
- Producing steps write `summary`, `root`, and `run_id` outputs with the `<<EOF` delimiter pattern instead of newline-unsafe `printf 'key=%s\n'`.

A crafted path in a green main artifact can no longer execute as shell in a job holding `pages: write`.

## Durable decisions

- Contract tests now assert the `${{ }}`-in-shell and `printf 'summary=%s\n'` sinks cannot return (`tests/quality-gate.sh`, `tests/security_contract.py`, `tests/quality_care_contract.py`, `tests/quality_mutation_contract.py`).

## Acceptance evidence

- `python3 tests/security_contract.py`, `tests/quality_care_contract.py`, `tests/quality_mutation_contract.py` — passed
- Workflow-structure prefix of `tests/quality-gate.sh` — `QUALITY_GATES_WORKFLOW_CONTRACTS_OK`
- YAML parse of all workflow files (PyYAML + Ruby) — OK
- `tests/docs-contract.sh` — passed; `git diff --check` — clean
- No app/Sources changes — the changed-line coverage gate is not applicable.

Made with [Cursor](https://cursor.com)