### PR TITLE
Raise the install-lock timeout and harden delete and stop mutations.

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -4496,10 +4496,19 @@ stop_session() {
     if [ -n "$pane" ] && [ "$(tmux_pane_dead "$session")" = "0" ]; then
       pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
       if [ -n "$pane_pid" ]; then
-        pgid="$(ps -o pgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]')"
+        pgid="$(/bin/ps -o pgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]')"
+        case "$pgid" in ''|*[!0-9]*) pgid="" ;; esac
       fi
       if [ -n "$pgid" ]; then
-        kill -TERM -- "-$pgid" 2>/dev/null || true
+        # A group signal reaches every process in the group. Revalidate the
+        # pane immediately before the TERM: it must still be alive, still run
+        # the same owned process, and still lead the same process group.
+        if [ "$(tmux_pane_dead "$session")" = "0" ] && \
+           [ "$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)" = "$pane_pid" ] && \
+           process_is_owned_alive "$pane_pid" && \
+           [ "$(/bin/ps -o pgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]')" = "$pgid" ]; then
+          kill -TERM -- "-$pgid" 2>/dev/null || true
+        fi
       elif [ -n "$pane_pid" ]; then
         kill -TERM "$pane_pid" 2>/dev/null || true
       fi
@@ -4576,9 +4585,13 @@ delete_locked() {
   [ -d "$SESSIONS_ROOT" ] && [ ! -L "$SESSIONS_ROOT" ] && \
     [ "$(/usr/bin/stat -f '%u' "$SESSIONS_ROOT" 2>/dev/null || true)" = "$owner_uid" ] || \
     die "refusing unsafe sessions root: $SESSIONS_ROOT"
-  [ -d "$dir" ] && [ ! -L "$dir" ] && \
-    [ "$(/usr/bin/stat -f '%u' "$dir" 2>/dev/null || true)" = "$owner_uid" ] || \
-    die "refusing unsafe session directory: $dir"
+  # A tmux-only remnant has no state directory left to validate; the retained
+  # tmux session must still be removed below.
+  if [ -e "$dir" ] || [ -L "$dir" ]; then
+    [ -d "$dir" ] && [ ! -L "$dir" ] && \
+      [ "$(/usr/bin/stat -f '%u' "$dir" 2>/dev/null || true)" = "$owner_uid" ] || \
+      die "refusing unsafe session directory: $dir"
+  fi
   # Re-check under the lock: a concurrent start may have revived the session.
   refuse_runtime_without_managed_tmux "$session"
   if tmux_has_session "$session"; then
@@ -4590,7 +4603,7 @@ delete_locked() {
   if tmux_has_session "$session"; then
     "${TMUX_CMD[@]}" kill-session -t "=$session" || die "could not remove tmux session '$session'"
   fi
-  rm -rf -- "$dir"
+  rm -rf -- "$dir" || die "could not completely remove session state: $dir"
   printf 'Deleted %s\n' "$session"
 }
 

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -77,6 +77,11 @@ CONFIG_ROOT="${DETACH_CONFIG_ROOT:-${XDG_CONFIG_HOME:-$HOME/.config}/detach}"
 CONFIG_FILE="$CONFIG_ROOT/config"
 INSTALL_STATE_ROOT="${DETACH_INSTALL_STATE_ROOT:-$STATE_BASE_ROOT}"
 INSTALL_LOCK="$INSTALL_STATE_ROOT/install.lock"
+# A start holds the install lock through the provider readiness wait (up to
+# 350 x 0.1 seconds) plus bounded session-creation work. Size the acquisition
+# timeout above that worst-case hold so a concurrent start or config write
+# waits for the holder instead of failing spuriously.
+INSTALL_LOCK_TIMEOUT=90
 
 config_value() {
   local key="$1"
@@ -1476,7 +1481,8 @@ write_config_key_under_lock() {
   else
     mkdir -p "$INSTALL_STATE_ROOT" || die "cannot create install lock directory"
   fi
-  "$LOCKF_BIN" -k -t 30 "$INSTALL_LOCK" "$SELF" __write_config_key_locked "$key" "$value" || \
+  "$LOCKF_BIN" -k -t "$INSTALL_LOCK_TIMEOUT" "$INSTALL_LOCK" \
+    "$SELF" __write_config_key_locked "$key" "$value" || \
     die "could not update $label setting"
 }
 
@@ -3691,7 +3697,7 @@ start_under_install_lock() {
 
 start_under_project_lock() {
   mkdir -p "$INSTALL_STATE_ROOT" || die "cannot create install lock directory"
-  "$LOCKF_BIN" -k -t 30 "$INSTALL_LOCK" "$SELF" __start_under_install_lock "$@"
+  "$LOCKF_BIN" -k -t "$INSTALL_LOCK_TIMEOUT" "$INSTALL_LOCK" "$SELF" __start_under_install_lock "$@"
 }
 
 read_meta_field() {

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -32,7 +32,7 @@ CLI LaunchAgent stays removed.
 - **`bin/detach`** is the only command on PATH. It resolves owned executables as
   immutable siblings and selects `codex` or `claude`. It owns cross-provider
   `list`, UUID-aware `resume`, storage and reconcile previews, `power status`,
-  config, doctor, repair, and uninstall. Then it invokes the core.
+  config, doctor, repair, and uninstall.
 - **`bin/detach-core`** owns the provider-neutral session lifecycle, inline
   provider adaptations, checkpoint/recovery policy, tmux status, and internal
   self-reinvocation commands. It rejects direct invocation unless the frontend
@@ -40,28 +40,26 @@ CLI LaunchAgent stays removed.
 
 Tests may inject binary and state paths with `DETACH_*` variables. Production
 must default tmux, `detach-state`, and `detach-power` to the immutable sibling
-payload, never to Homebrew or another ambient installation. Provider binaries
-remain user-owned and are discovered through `PATH` or provider-specific test
-overrides. macOS-supplied `sqlite3`, `tar`, `env`, and `lockf` remain explicit,
+payload, never Homebrew or another ambient installation. Provider binaries
+remain user-owned and are found through `PATH` or provider-specific test
+overrides. macOS-supplied `sqlite3`, `tar`, `env`, and `lockf` stay explicit,
 injectable platform utilities.
 
-Critical shared-state operations run by self-reinvoking the core under `lockf`,
-for example `__checkpoint_once_locked`, `__delete_locked`, and
-`__start_tmux_session_locked`. Start, Resume, Stop, Recover, and Delete also
+Critical shared-state operations self-reinvoke the core under `lockf`
+(`__checkpoint_once_locked`, `__delete_locked`, `__start_tmux_session_locked`). Start, Resume, Stop, Recover, and Delete also
 share a per-session operation lock so their whole state transitions serialize
 before narrower install/project/checkpoint locks. New shared mutations should
 keep the lock around the whole child process and preserve that lock order.
-The install lock covers the full start readiness wait. Its acquisition timeout
-stays above the worst-case wait, so an unrelated operation waits for the
-holder instead of failing spuriously.
+The install lock covers the full start readiness wait; its acquisition
+timeout stays above the worst-case hold.
 
 ### Typed state boundary
 
 `detach-state` is the JSON boundary. Do not edit JSON in shell. It owns typed
 metadata, JSONL, health, reconcile, storage, and emit operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
-descriptors. It accepts no path stream. It rejects unsafe session or checkpoint
-directories and opens only owned regular files of at most 1 MiB with
+descriptors, accepts no path stream, rejects unsafe session or checkpoint
+directories, and opens only owned regular files of at most 1 MiB with
 `O_NOFOLLOW`.
 Integer conversion must not trap. Storage reports allocated and logical bytes,
 excludes provider storage, does not follow symlinks, and authorizes cleanup
@@ -76,9 +74,9 @@ state, run token, PID ownership and ancestry, valid metadata, heartbeat, and
 checkpoint freshness. Stale data alone cannot classify a proven live provider
 as hung. A recorded live runtime without managed tmux permits no signal,
 replacement, recovery, or deletion. Wait for the exact processes to exit.
-Anything restored into provider storage must pass canonical path, symlink,
-session-ID, and JSONL validation, be written to a temporary file, validated
-again, and only then be moved into place.
+Anything restored into provider storage passes canonical path, symlink,
+session-ID, and JSONL validation, is written to a temporary file, validated
+again, and only then moved into place.
 
 State is private (`umask 077`) under
 `~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
@@ -89,7 +87,7 @@ restored automatically.
 Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
 Before deletion, the app re-reads and matches the displayed status and byte
 counts. The provider command waits up to 30 seconds for the checkpoint lock,
-then rechecks managed tmux liveness and ownership. It rejects symlinked or
+then rechecks managed tmux liveness and ownership, rejecting symlinked or
 foreign-owned state/session directories. A partial failure keeps each failed
 session and reports it explicitly.
 
@@ -104,20 +102,20 @@ successors use a monotonic `-r<12-hex>` suffix and persist the unsuffixed
 `default_session_base`. An explicit human-readable
 name is 1–100 UTF-8 bytes of printable text. Legacy-safe names retain the exact
 `detach-<provider>-<name>` identifier; all other names derive a deterministic
-ASCII slug plus a 12-hex content hash. A valid full
-`detach-<provider>-<safe-name>` is reserved as an explicit internal identifier
-for backward compatibility. User input never becomes a tmux name or state path
-unless it already satisfies that legacy-safe grammar.
+ASCII slug plus a 12-hex content hash. A full
+`detach-<provider>-<safe-name>` stays reserved as an explicit internal
+identifier for backward compatibility; user input never becomes a tmux name or
+state path unless it already satisfies that legacy-safe grammar.
 
 The optional display name is persisted separately, emitted through typed state,
 preserved across resume/recovery, and accepted by later lifecycle commands,
-which deterministically resolve it back to the same internal identifier. The
+which resolve it deterministically to the same internal identifier. The
 shared tmux daemon is anchored in persistent install state, not the first
-project directory. It is addressed only through the private absolute
+project directory, and is addressed only through the private
 `$DETACH_INSTALL_STATE_ROOT/tmux/tmux.sock`, never ambient `TMUX_TMPDIR`.
-Install migration checks both the older default socket and the historical
+Install migration checks the older default socket and the historical
 `-L dev.tsarev.detach` socket before switching payloads. Each worker starts
-from stable install state and then enters the canonical project beneath its
+from stable install state, then enters the canonical project beneath its
 cleanup trap.
 
 Tmux environment arguments stay in memory; provider credentials are never
@@ -126,7 +124,7 @@ session scratch data.
 Default starts form a provider/project history series. A fresh start refuses a
 live member or second writer; otherwise it allocates a successor without
 reusing saved state. No-`NAME` commands select the live member, then the highest
-suffix. Older `session_name` values stay addressable, and their metadata, logs,
+suffix. Older `session_name` values stay addressable; their metadata, logs,
 and checkpoints remain until Delete or typed storage cleanup. Explicit names
 stay deterministic and obey the same project lock and cleanup policy.
 
@@ -140,46 +138,41 @@ detach-power run --session <name> --run-token <token>
   -- <provider> ...
 ```
 
-The power wrapper must confirm both protection layers and atomically mark the
+The power wrapper must confirm both protection layers, atomically mark the
 ready file before launching the provider, then atomically publish the exact
 spawned provider PID. The starter waits for both handshakes and one forced
-runtime heartbeat and must never print `Started` before they arrive.
-HUP/INT/TERM are forwarded to the provider while the wrapper remains alive long
-enough to release its lease and assertion; explicit `detach stop` also performs
-an idempotent release by session/run token. The provider must inherit the
-wrapper's tmux foreground process group; launching it in a separate group makes
-interactive Codex or Claude stop on terminal I/O. On provider exit, the worker
-records status, attempts a final checkpoint, and leaves the pane retained for
-logs and diagnosis.
+runtime heartbeat and never prints `Started` before they arrive.
+HUP/INT/TERM forward to the provider while the wrapper stays alive to release
+its lease and assertion; explicit `detach stop` also releases idempotently by
+session/run token. The provider must inherit the
+wrapper's tmux foreground process group; a separate group makes interactive
+Codex or Claude stop on terminal I/O. On provider exit, the worker records
+status, attempts a final checkpoint, and leaves the pane retained for logs.
 
-Stop resolves the pane process group through `/bin/ps` and revalidates the
-live pane identity immediately before it signals that group. Delete removes
-the retained tmux session and the state directory. A missing state directory
-does not prevent the removal of a retained tmux session. If state removal
-does not complete, the delete fails; Delete never reports success over
-leftover state.
+Stop resolves the pane group through `/bin/ps` and revalidates pane identity
+immediately before signaling. Delete removes a retained tmux session even
+without a state directory and never reports success over leftover state.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
-session. They do not promise survival across logout or reboot, and an explicit
+session. They do not promise survival across logout or reboot; an explicit
 kill of tmux/provider ends the live run. Recovery checkpoints remain available.
-Provider test parts need private state, socket, and artifact roots. Their parent
-orders events and requires every part. Small hosts reuse lifecycle checkpoints
-in three Codex and two Claude parts. Larger hosts use finer parts.
+Provider test parts need private state, socket, and artifact roots; their
+parent orders events and requires every part. Small hosts reuse lifecycle
+checkpoints in three Codex and two Claude parts; larger hosts use finer parts.
 
-Detach status options use session-local `@detach*` keys and never change a
+Detach status options use session-local `@detach*` keys and never touch a
 foreign tmux server. The strip blends an identity color, uses light text and a
 solid edge, and shows power and time on the right.
-Each managed session sets `Detach · <project basename>` as the terminal title.
-It follows the active tmux session, independent of styling.
+Each managed session sets `Detach · <project basename>` as the terminal title,
+following the active tmux session independent of styling.
 Finished sessions keep a faint hue. Failures use reserved red, which the
 eight-hue identity palette omits. Allocation scans both providers
 under the Start/Resume/Recover install lock. Known terminal history keeps its
 identity but reserves no hue. Unknown state stays conservative. Keep a
-current unique hue. Otherwise, choose the first free hue from the stable
-provider/project preference, and duplicate only after all eight are used.
-`blend_session_color` makes every surface. Style snapshots save and restore
-both sides and lengths. An old snapshot without right-side data preserves the
+current unique hue; otherwise choose the first free hue from the stable
+provider/project preference, duplicating only after all eight are used.
+Style snapshots save and restore both sides and lengths. An old snapshot without right-side data preserves the
 user's `status-right`. Plain text is the primary power signal: `MAC AWAKE`,
 `MAC CAN SLEEP`, `LOW BATTERY`, `MAC CAN SLEEP: TEMPERATURE`,
 `POWER UNAVAILABLE`, or a transition. App wording is equivalent and icons are
@@ -200,8 +193,7 @@ state, opaque turn ID, PIDs, health, reconcile, freshness, ownership,
 and cleanup fields. Keep the emitter and Swift `Session` decoder synchronized.
 Provider lifecycle records, never terminal text, supply turn state
 and the private run-token activity file defined in `power.md`.
-Typed cleanup uses `cleanup_eligible`. List batches metadata, health, and JSON
-in two helpers.
+Typed cleanup uses `cleanup_eligible`.
 
 ### Provider identity and checkpoints
 
@@ -212,8 +204,8 @@ after launch by matching the run-token originator in rollout files and SQLite;
 an ambiguous first binding fails. If the provider switches to another run-owned
 user thread (for example `/clear`), discovery rebinds identity, transcript, and
 checkpoints to the newest originator-matched thread within one heartbeat or
-checkpoint tick. It records superseded thread IDs so the next switch stays
-unambiguous, and it keeps the current binding on a creation-time tie. Subagent
+checkpoint tick, records superseded thread IDs so the next switch stays
+unambiguous, and keeps the current binding on a creation-time tie. Subagent
 threads never rebind a session. Wrapper-owned provider flags are rejected;
 policy defaults apply only without an allowed override.
 
@@ -221,9 +213,9 @@ Every 300 seconds by default, a per-session lock protects checkpoint creation.
 A checkpoint contains metadata, validated provider JSONL, pane capture, and a
 repository root from a real `.git` ancestor. Codex adds an integrity-checked
 SQLite backup. Claude archives its matching project session and companions.
-Provider-created hard links become independent regular files in staging.
-Archives and restore destinations still reject hard links and non-plain
+Provider-created hard links become independent regular files in staging;
+archives and restore destinations still reject hard links and non-plain
 entries. A provider test override can disable the final `/bin/sync`.
 
-Only allowlisted provider flags are serialized to `resume-args.bin`. A provider
-flag that should survive Resume or Recover must be added deliberately.
+Only allowlisted provider flags are serialized to `resume-args.bin`; a flag
+that should survive Resume or Recover must be added deliberately.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -152,6 +152,13 @@ interactive Codex or Claude stop on terminal I/O. On provider exit, the worker
 records status, attempts a final checkpoint, and leaves the pane retained for
 logs and diagnosis.
 
+Stop resolves the pane process group through `/bin/ps` and revalidates the
+live pane identity immediately before it signals that group. Delete removes
+the retained tmux session and the state directory. A missing state directory
+does not prevent the removal of a retained tmux session. If state removal
+does not complete, the delete fails; Delete never reports success over
+leftover state.
+
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
 session. They do not promise survival across logout or reboot, and an explicit

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -51,6 +51,9 @@ for example `__checkpoint_once_locked`, `__delete_locked`, and
 share a per-session operation lock so their whole state transitions serialize
 before narrower install/project/checkpoint locks. New shared mutations should
 keep the lock around the whole child process and preserve that lock order.
+The install lock covers the full start readiness wait. Its acquisition timeout
+stays above the worst-case wait, so an unrelated operation waits for the
+holder instead of failing spuriously.
 
 ### Typed state boundary
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1398,6 +1398,28 @@ wait "$checkpoint_holder"
 ! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
 ! run_codex list --json | grep -F "\"session_name\":\"$SESSION\"" >/dev/null
 codex_scenario_event pass SC-SESSION-DELETE-CODEX
+
+# A start holds the install lock through its readiness wait (up to 35
+# seconds). A concurrent config write must wait for that holder instead of
+# failing spuriously on a shorter acquisition timeout.
+install_lock_ready="$TMP_ROOT/install-lock-ready"
+/usr/bin/lockf -k "$TEST_INSTALL_STATE_ROOT/install.lock" /bin/sh -c \
+  'touch "$1"; sleep 35' sh "$install_lock_ready" &
+install_holder=$!
+attempts=0
+while [ ! -f "$install_lock_ready" ]; do
+  attempts=$((attempts + 1))
+  [ "$attempts" -lt 40 ] || {
+    printf 'install lock holder did not start\n' >&2
+    exit 1
+  }
+  sleep 0.05
+done
+"$SCRIPT" config tmux-mouse off
+wait "$install_holder"
+[ "$("$SCRIPT" config tmux-mouse)" = "off" ]
+"$SCRIPT" config tmux-mouse on
+[ "$("$SCRIPT" config tmux-mouse)" = "on" ]
 fi
 
 # Killing the worker can leave its provider alive in a retained pane. Detach

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1399,6 +1399,62 @@ wait "$checkpoint_holder"
 ! run_codex list --json | grep -F "\"session_name\":\"$SESSION\"" >/dev/null
 codex_scenario_event pass SC-SESSION-DELETE-CODEX
 
+# A managed tmux session whose state directory was removed by hand is a
+# tmux-only remnant. Delete must still remove the remnant instead of dying
+# on the missing directory.
+remnant_name=delete-remnant
+remnant_session=detach-codex-delete-remnant
+FAKE_CODEX_INIT_DELAY=0 FAKE_CODEX_SLEEP=1 FAKE_CODEX_EXIT=0 \
+  run_codex --name "$remnant_name" --detach -- 'tmux-only remnant delete coverage'
+remnant_pane="$(tmux -L "$SOCKET" show-options -qv -t "=$remnant_session:" @detach_pane_id)"
+wait_for_pane_dead "$remnant_pane"
+tmux -L "$SOCKET" has-session -t "=$remnant_session"
+rm -rf "$DETACH_CODEX_STATE_ROOT/sessions/$remnant_session"
+run_codex delete --force "$remnant_name"
+! tmux -L "$SOCKET" has-session -t "=$remnant_session" 2>/dev/null
+
+# A delete that cannot remove every byte must fail loudly instead of
+# printing a misleading success over leftover state.
+stubborn_name=delete-stubborn
+stubborn_session=detach-codex-delete-stubborn
+FAKE_CODEX_INIT_DELAY=0 FAKE_CODEX_SLEEP=1 FAKE_CODEX_EXIT=0 \
+  run_codex --name "$stubborn_name" --detach -- 'partial delete failure coverage'
+stubborn_pane="$(tmux -L "$SOCKET" show-options -qv -t "=$stubborn_session:" @detach_pane_id)"
+wait_for_pane_dead "$stubborn_pane"
+stubborn_dir="$DETACH_CODEX_STATE_ROOT/sessions/$stubborn_session"
+mkdir -p "$stubborn_dir/nested"
+printf 'undeletable\n' >"$stubborn_dir/nested/keep"
+chmod 0555 "$stubborn_dir/nested"
+if run_codex delete --force "$stubborn_name" >"$TMP_ROOT/delete-stubborn.out" 2>&1; then
+  printf 'delete unexpectedly succeeded over an undeletable nested file\n' >&2
+  exit 1
+fi
+grep -F 'could not completely remove session state' "$TMP_ROOT/delete-stubborn.out" >/dev/null
+! grep -F "Deleted $stubborn_session" "$TMP_ROOT/delete-stubborn.out" >/dev/null
+grep -Fx 'undeletable' "$stubborn_dir/nested/keep" >/dev/null
+chmod 0755 "$stubborn_dir/nested"
+rm -rf "$stubborn_dir"
+! tmux -L "$SOCKET" has-session -t "=$stubborn_session" 2>/dev/null
+
+# Stop resolves the pane process group through /bin/ps. A failing ps first
+# on PATH must not replace it: a single-pid fallback TERM would leave the
+# HUP-ignoring provider running after kill-session and fail the stop, while
+# the revalidated group TERM still stops the whole managed group cleanly.
+shadow_name=delete-stop-shadow-ps
+shadow_session=detach-codex-delete-stop-shadow-ps
+shadow_bin="$TMP_ROOT/shadow-bin"
+mkdir -p "$shadow_bin"
+printf '%s\n' '#!/bin/bash' 'exit 1' >"$shadow_bin/ps"
+chmod 0755 "$shadow_bin/ps"
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name "$shadow_name" --detach -- 'stop PATH ps coverage'
+wait_for_tmux_option "$shadow_session" @detach_status running
+PATH="$shadow_bin:$PATH" run_codex stop "$shadow_name"
+! tmux -L "$SOCKET" has-session -t "=$shadow_session" 2>/dev/null
+[ "$("$STATE_HELPER" meta get \
+  "$DETACH_CODEX_STATE_ROOT/sessions/$shadow_session/meta.json" status)" = stopped ]
+run_codex delete --force "$shadow_name"
+
 # A start holds the install lock through its readiness wait (up to 35
 # seconds). A concurrent config write must wait for that holder instead of
 # failing spuriously on a shorter acquisition timeout.


### PR DESCRIPTION
Closes #123. Closes #124.

## Contract delta

`docs/specs/runtime.md` MODIFIED:

- MODIFIED (#123): the install lock covers the full start readiness wait, and its acquisition timeout (now 90s, was 30s) stays above the worst-case hold (35s readiness wait + bounded creation work). A concurrent start or `detach config tmux-*` write now waits for the holder instead of failing spuriously. Lock order (operation → install → project → checkpoint) is unchanged.
- ADDED (#124): Stop resolves the pane group through `/bin/ps`, rejects non-numeric pgids, and revalidates pane identity (alive, same `pane_pid`, owned, same pgid) immediately before the group TERM. The pane-dead re-check before the KILL is unchanged.
- ADDED (#124): Delete removes a retained tmux session even when the state directory is missing (present symlink/foreign-owned directories are still refused), and `rm -rf` failure now fails loudly instead of printing `Deleted` over leftover state.

## Durable decisions

- #123 raises the timeout rather than moving the readiness wait out of the lock: the wait sits inside the self-reinvoked process boundary that owns the failure-cleanup trap and the readiness handshake (`Started` must never print before handshakes); splitting it would restructure the most safety-critical path for no correctness gain.

## Acceptance evidence

- `tests/run.sh` lanes `delete`, `configuration`, `crash`, `lifecycle`, `guardrails`, `lifecycle-recovery`, `resume-identity` — all PASS (four new regression tests in the delete lane)
- Each new test verified to fail against pre-fix code (held-lock timeout at 30s, remnant delete refusal, stubborn delete false success, shadow-`ps` stop)
- `git diff --check` — clean
- No app/Sources changes — the changed-line coverage gate is not applicable. `tests/run-claude.sh` not run (provider-neutral change); real power/release gates not run.

Made with [Cursor](https://cursor.com)