### PR TITLE
Scope lease acquire and renewal confirmation to the requesting identity.

### DIFF
--- a/app/Sources/DetachKit/PowerHelperLeaseService.swift
+++ b/app/Sources/DetachKit/PowerHelperLeaseService.swift
@@ -277,7 +277,9 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
                         identity, previousLease: previousLease)
                     throw PowerHelperLeaseServiceError.requestExpired
                 }
-                guard status.state == .protected else {
+                let confirmation = Self.confirmationStatus(
+                    for: identity, liveLeases: state.leases, status: status)
+                guard confirmation.state == .protected else {
                     let rollbackStatus = try rollbackInitialAcquireLocked(
                         identity, previousLease: previousLease)
                     // Usually the rollback snapshot is the most truthful
@@ -302,7 +304,7 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
                         thermalSafetyActive:
                             rollbackStatus.thermalSafetyActive)
                 }
-                return status
+                return confirmation
             }
         }
     }
@@ -324,7 +326,9 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
                 try upsertLeaseLocked(
                     identity, renewedAt: instant,
                     assertionActive: assertionActive)
-                return try reconcileAndCacheLocked()
+                let status = try reconcileAndCacheLocked()
+                return Self.confirmationStatus(
+                    for: identity, liveLeases: state.leases, status: status)
             }
         }
     }
@@ -510,6 +514,44 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
             throw PowerHelperLeaseServiceError.closedLidRestorationFailed
         }
         return status
+    }
+
+    /// Confirmation view of a reconcile result for one acquiring or renewing
+    /// identity.
+    ///
+    /// The global aggregate requires every live lease to hold its idle-sleep
+    /// assertion, so one session's staged assertion-inactive lease — a
+    /// waiting transition, or a failed release that survives until its TTL —
+    /// would otherwise fail an unrelated identity's acquire or renewal even
+    /// though that identity's own lease and the machine-wide setting are both
+    /// active. The scoped aggregate keeps every assertion-active lease plus
+    /// the requesting identity and drops unrelated staged-inactive leases.
+    /// The fail-safes are preserved: `derive` never reports `.protected`
+    /// while low battery or thermal safety is active, the requesting
+    /// identity's own staged-inactive lease still blocks its confirmation,
+    /// and the read-only cached status keeps the honest global aggregate.
+    private static func confirmationStatus(
+        for identity: PowerLeaseIdentity,
+        liveLeases: [PowerLease],
+        status: PowerProtectionStatus
+    ) -> PowerProtectionStatus {
+        let scopedLeases = liveLeases.filter {
+            $0.assertionActive
+                || ($0.sessionName == identity.sessionName
+                    && $0.runToken == identity.runToken)
+        }
+        let assertionActive = !scopedLeases.isEmpty
+            && scopedLeases.allSatisfy(\.assertionActive)
+        guard assertionActive != status.assertionActive else { return status }
+        return PowerProtectionStatus.derive(
+            leaseCount: status.leaseCount,
+            assertionActive: assertionActive,
+            closedLidProtectionActive: status.closedLidProtectionActive,
+            helperReachable: status.helperReachable,
+            transitionInProgress: status.transitionInProgress,
+            lowBattery: status.lowBattery,
+            thermalState: status.thermalState,
+            thermalSafetyActive: status.thermalSafetyActive)
     }
 
     private func reconcileAndCacheLocked(

--- a/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
@@ -405,6 +405,113 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
         XCTAssertTrue(backend.writes.isEmpty)
     }
 
+    func testAcquireIgnoresAnotherSessionsStagedInactiveLease() throws {
+        let stagedLease = PowerLease(
+            id: "staged", sessionName: "claude-review", runToken: "run-9",
+            renewedAt: now, assertionActive: false)
+        let store = FakeStore(state: PowerHelperPersistentState(
+            leases: [stagedLease], bootSessionIdentifier: "test-boot"))
+        let backend = FakeBackend(enabled: false)
+        let service = try makeService(store: store, backend: backend)
+
+        let status = try service.acquireLease(identity, assertionActive: true)
+
+        XCTAssertEqual(status.state, .protected)
+        XCTAssertEqual(status.leaseCount, 2)
+        XCTAssertEqual(backend.writes, [true])
+        XCTAssertEqual(store.state?.leases.count, 2)
+        // The read-only snapshot keeps the honest global aggregate; only the
+        // acquire confirmation is scoped to the requesting identity.
+        let cached = try service.status()
+        XCTAssertEqual(cached.state, .unavailable)
+        XCTAssertFalse(cached.assertionActive)
+    }
+
+    func testRenewalIgnoresAnotherSessionsStagedInactiveLease() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let service = try makeService(store: store, backend: backend)
+        let other = PowerLeaseIdentity(
+            sessionName: "claude-review", runToken: "run-9")
+        _ = try service.acquireLease(identity, assertionActive: true)
+        _ = try service.acquireLease(other, assertionActive: true)
+
+        // The wrapper stages its lease assertion-inactive before a waiting
+        // release; the staging report itself stays honest.
+        let staged = try service.renewLease(other, assertionActive: false)
+        XCTAssertEqual(staged.state, .unavailable)
+
+        let renewed = try service.renewLease(identity, assertionActive: true)
+
+        XCTAssertEqual(renewed.state, .protected)
+        XCTAssertEqual(renewed.leaseCount, 2)
+        XCTAssertEqual(backend.writes, [true])
+        XCTAssertEqual(store.state?.leases.count, 2)
+    }
+
+    func testLowBatteryStillRefusesAcquireDespiteAnotherStagedInactiveLease() throws {
+        let stagedLease = PowerLease(
+            id: "staged", sessionName: "claude-review", runToken: "run-9",
+            renewedAt: now, assertionActive: false)
+        let store = FakeStore(state: PowerHelperPersistentState(
+            leases: [stagedLease], bootSessionIdentifier: "test-boot"))
+        let backend = FakeBackend(enabled: false)
+        let service = try makeService(
+            store: store, backend: backend,
+            battery: FakeBatteryReader(lowBattery: true))
+
+        let status = try service.acquireLease(identity, assertionActive: true)
+
+        XCTAssertEqual(status.state, .lowBattery)
+        XCTAssertEqual(store.state?.leases, [stagedLease])
+        XCTAssertFalse(backend.enabled)
+        XCTAssertTrue(backend.writes.isEmpty)
+    }
+
+    func testThermalSafetyStillRefusesAcquireDespiteAnotherStagedInactiveLease() throws {
+        let stagedLease = PowerLease(
+            id: "staged", sessionName: "claude-review", runToken: "run-9",
+            renewedAt: now, assertionActive: false)
+        let store = FakeStore(state: PowerHelperPersistentState(
+            leases: [stagedLease], bootSessionIdentifier: "test-boot"))
+        let backend = FakeBackend(enabled: false)
+        let service = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: FakeBatteryReader(lowBattery: false),
+            thermalReader: MutableThermalReader(.serious),
+            bootSessionReader: FakeBootSessionReader(identifier: "test-boot"),
+            now: { self.now })
+
+        let status = try service.acquireLease(identity, assertionActive: true)
+
+        XCTAssertEqual(status.state, .temperature)
+        XCTAssertTrue(status.thermalSafetyActive)
+        XCTAssertEqual(store.state?.leases, [stagedLease])
+        XCTAssertTrue(backend.writes.isEmpty)
+    }
+
+    func testLowBatteryStillRefusesRenewalConfirmation() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let battery = MutableBatteryReader()
+        let service = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: battery,
+            bootSessionReader: FakeBootSessionReader(identifier: "test-boot"),
+            now: { self.now },
+            leaseTimeout: 120)
+        _ = try service.acquireLease(identity, assertionActive: true)
+        battery.lowBattery = true
+
+        let status = try service.renewLease(identity, assertionActive: true)
+
+        XCTAssertEqual(status.state, .unavailable)
+        XCTAssertTrue(status.lowBattery)
+        XCTAssertEqual(backend.writes, [true, false])
+    }
+
     func testReleaseRestoresNormalSleepOnlyWhenDetachOwnedTheMutation() throws {
         let store = FakeStore()
         let backend = FakeBackend(enabled: false)

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -26,7 +26,11 @@ Each working session owns a separate helper lease. Outside the low-battery and
 thermal fail-safe states, the helper keeps the machine-wide closed-lid setting
 active while at least one working lease exists. Detach can permit normal sleep
 only after every live session is waiting or stopped. One waiting session must
-never release another working session's protection.
+never release another working session's protection. Acquire and renewal
+confirmation are scoped to the requesting lease. A staged assertion-inactive
+lease from another session must not fail an unrelated acquire or renewal. The
+low-battery and thermal fail-safe refusals still fail closed for every
+request.
 
 The root helper installs a listener-level Foundation code-signing requirement
 before accepting XPC or reconciling power state. It accepts only valid code


### PR DESCRIPTION
Closes #117.

## Contract delta

`docs/specs/power.md` MODIFIED:

- ADDED: lease acquire/renewal confirmation is scoped to the requesting lease. A staged assertion-inactive lease from another session must not fail an unrelated acquire or renewal. Low-battery and thermal refusals still fail closed and return the honest global status.

## Durable decisions

- Identity-scoped confirmation instead of a wrapper retry: a bounded retry cannot reliably outlive a staged lease that persists until the 120-second TTL without delaying session starts, and it would do nothing for `renew(true)` confirmation of already-running sessions. The root cause was the confirmation predicate reusing the global `allSatisfy(\.assertionActive)` aggregate.
- Fail-safes preserved: `derive` never reports `.protected` while low battery or thermal safety is active; the identity's own staged-inactive lease still blocks its own confirmation; the read-only cached status keeps the honest global aggregate for UI/watchdog/tmux consumers.

## Acceptance evidence

- `swift test --filter PowerHelperLeaseServiceTests` — 39 tests, 0 failures (5 new: staged-inactive neighbor does not fail acquire or renewal; low-battery and thermal acquire refusals with a staged neighbor still return `.lowBattery`/`.temperature` with rollback; low-battery renewal still refuses)
- `swift test --filter Power` — 213 tests, 0 failures
- `swift test --filter DetachKitTests` — 496 tests, 0 failures
- Changed-line coverage measured locally with `swift test --enable-code-coverage` + `llvm-cov`: 26/26 changed executable lines covered (100%; gate minimum 90%)
- `git diff --check` — clean
- Real power/hardware gates not run (unit-level change).

Note: the suite coverage ratchet currently fails all PRs on unchanged code by one environment-sensitive line — tracked in #136.

Made with [Cursor](https://cursor.com)