### PR TITLE
Fix coverage evidence parity for Swift tests

### DIFF
--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -15,7 +15,9 @@ final class PowerHelperPlatformTests: XCTestCase {
 
     func testRootCommandRunnerTerminatesHungProcess() {
         let runner = RootProcessCommandRunner(
-            timeout: 0.05, terminationGrace: 0.05)
+            // Give the child time to install its ignored-TERM handler before
+            // the runner starts the TERM-to-KILL escalation.
+            timeout: 0.5, terminationGrace: 0.05)
 
         XCTAssertThrowsError(try runner.run(RootCommand(
             executable: "/bin/sh",

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -221,6 +221,8 @@ reads a manual floor file.
 
 The metric artifact records exact UI and business test identities, aggregate
 line coverage, critical-source coverage, and changed executable Swift lines.
+Swift-test changes run the packaged-app journeys before metrics so the current
+and baseline coverage inputs are equivalent.
 CI rejects a removed test or a lower aggregate or critical-source ratio.
 Changed executable lines need at least 90 percent coverage. A new critical
 source needs 100 percent coverage for its first baseline. Missing, stale,

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -44,11 +44,11 @@ Hosted CI is the merge-readiness authority.
 - Resume evidence retains stage timing and digest-bound logs, binds its parent,
   requires the same authority, and cannot turn a prior time-budget regression
   into authoritative evidence.
-- Quality policy files contain only current version and state; Git is history.
+- Quality policy files contain current version and state; Git is history.
   Runtime tools do not decode old policy schemas. A last-green metrics artifact
-  can use an earlier policy number only with the current evidence schema. This
-  preserves continuity without old-policy decoding.
-- The quality policy registers each tracked durable spec exactly once. It has
+  can use an earlier policy number only with the current evidence schema,
+  preserving continuity without old-policy decoding.
+- Quality policy registers each tracked durable spec exactly once. It has
   no spec-history or lifecycle-status field. Each registered spec owns a route,
   a capability, and a requirement. Each requirement links to a user journey
   and at least one automated scenario. Generated JSON and Markdown views must
@@ -71,27 +71,28 @@ Hosted CI is the merge-readiness authority.
   packaged and runtime work on macOS. All selected levels are required.
 - Shards revalidate merge identity but have no merge authority. The final Linux
   job recomputes the plan and accepts only exact digest-bound shard evidence.
-  Evidence roots are absolute. Ambiguity fails closed. A failed shard cancels peers.
+  Evidence roots are absolute; ambiguity fails closed and a failed shard cancels peers.
 - CI keeps a ten-minute timing ratchet with no reference-Mac limit.
-- Gate contracts admit three heavy shards on eight CPUs and two on
-  fewer CPUs. Light contracts stay concurrent. Budgets expose overload.
-- Swift and release builds use separate caches and split at three CPUs.
-  Smaller hosts run in order. UI waits for app; metrics for both.
+- Gate contracts admit three heavy shards on eight CPUs and two on smaller
+  hosts; light contracts stay concurrent and budgets expose overload.
+- Swift and release builds use separate caches and split at three CPUs;
+  smaller hosts run in order. UI waits for app; metrics require both.
   Gate-contract and release-workflow exclude heavy peers. Gate-contract permits
   preflight and gates distribution. Other work uses two heavy and one
   integration lane.
 - Exact keys bind code, resources, scripts, version, and toolchain. `main` warms
-  only a missing app or executable product. CI verifies hits and rebuilds
-  misses. Warming is not evidence.
-- CI uses the newest green `main` artifact with measured metrics. A later run
-  without metrics does not replace it. Test identities, aggregate coverage,
-  and critical-source coverage cannot decrease. Changed Swift lines need 90
-  percent coverage. A person cannot raise floors. Policy-owned exclusions need
+  only missing products; CI verifies hits and rebuilds misses. Warming is not
+  evidence.
+- CI uses the newest green `main` artifact with metrics; a later run without
+  them does not replace it. Test identities and aggregate or critical-source
+  coverage cannot decrease. Changed Swift lines need 90 percent coverage; a
+  person cannot raise floors. Policy exclusions need
   scenario evidence and cannot cover critical sources. Named test-only regions
   stay in aggregate coverage but not changed-line metrics.
-- Authoritative coverage combines Swift tests and packaged-app journeys. CI
-  resolves one shared cache, then three builds use isolated paths. The
-  gate splits workers and verifies the normal bundle. Only the stripped private
+- Authoritative coverage combines Swift and packaged-app tests. Swift-test
+  changes run both, so metrics match the baseline. CI resolves one shared
+  cache, then three builds use isolated paths. The gate splits workers and
+  verifies the normal bundle. Only a stripped private
   copy gets the instrumented executable. Metrics merge profiles without a
   second test run.
 - `coverage-opportunities.json` is a separate digest-bound advisory artifact.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -705,7 +705,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 50,
+  "policy": 51,
   "release_domains": [
     {
       "gates": "-",
@@ -3266,7 +3266,7 @@
     {
       "capabilities": "quality-system",
       "id": "swift-test",
-      "stages": "static,swift,quality-contracts,release-budget"
+      "stages": "static,swift,quality-contracts,app,release-budget"
     },
     {
       "capabilities": "installation,update",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	50
+policy	51
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -39,7 +39,7 @@ test-domain	update-source	static,swift,quality-contracts,app,release-budget	upda
 test-domain	diagnostics-source	static,swift,quality-contracts,app,release-budget	diagnostics
 test-domain	runtime-source	static,swift,quality-contracts,app,release-budget	session-lifecycle
 test-domain	session-ui-source	static,swift,quality-contracts,app,release-budget	session-lifecycle,app-experience
-test-domain	swift-test	static,swift,quality-contracts,release-budget	quality-system
+test-domain	swift-test	static,swift,quality-contracts,app,release-budget	quality-system
 test-domain	package	static,swift,quality-contracts,app,tmux-runtime,release-budget	installation,update
 test-domain	cli	static,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
 test-domain	install	static,app,distribution,tmux-runtime,release-budget	installation

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -318,6 +318,13 @@ printf '%s\n' 'struct Changed {}' >"$REPO/app/Sources/DetachKit/Changed.swift"
 plan="$(gate --plan)"
 [[ "$plan" = *'stages=static,swift,quality-contracts,app,ui-e2e,release-budget' ]]
 
+setup_fixture swift-test
+mkdir -p "$REPO/app/Tests/DetachKitTests"
+printf '%s\n' 'final class ChangedTests {}' \
+  >"$REPO/app/Tests/DetachKitTests/ChangedTests.swift"
+plan="$(gate --plan)"
+[[ "$plan" = *'stages=static,swift,quality-contracts,app,ui-e2e,release-budget' ]]
+
 setup_fixture typed-state-impact
 mkdir -p "$REPO/app/Sources/DetachKit"
 printf '%s\n' 'struct ChangedState {}' >"$REPO/app/Sources/DetachKit/DetachStateCommand.swift"


### PR DESCRIPTION
Closes #136

This keeps the coverage ratchet strict and makes both sides comparable:

- Swift-test changes now select the packaged app and UI journeys before quality metrics, matching the last-green baseline inputs.
- The power runner test gives its child enough time to install the ignored-TERM handler before TERM-to-KILL escalation, removing the remaining timing-sensitive covered line.

No production timeout or product behavior changes.

Evidence:
- quality policy and orchestrator contracts passed
- documentation and test-suite contracts passed
- focused PowerHelperPlatform test passed
- full coverage-enabled Swift suite passed: 841 tests
- PowerHelperPlatform.swift remained at 520/608 lines (85.53%)
- git diff --check passed

Hosted quality-gates is readiness authority.