### PR TITLE
Refresh onboarding heartbeat before decisions

### DIFF
--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -631,6 +631,7 @@ final class InstallationStore {
         // The user agent records an independently observable power heartbeat.
         watchdogError = nil
         do {
+            refreshPowerProtectionState()
             let watchdogStatusBeforeReconcile = watchdog.status
             let replaceSilentRegistration = watchdogStatusBeforeReconcile == .enabled
                 && !watchdogHeartbeat.healthy

--- a/app/Sources/DetachApp/OnboardingLivePoller.swift
+++ b/app/Sources/DetachApp/OnboardingLivePoller.swift
@@ -25,6 +25,7 @@ final class OnboardingLivePoller {
     private let providerCheckPassed: @MainActor () -> Bool
     private let reconcile: @MainActor () async -> Bool
     private let locate: () async -> ProviderAvailability
+    private let refreshHeartbeat: @MainActor () -> Void
     private let heartbeatIsHealthy: @MainActor () -> Bool
     private let installedCopyExists: () -> Bool
     private let sleep: (UInt64) async throws -> Void
@@ -41,6 +42,7 @@ final class OnboardingLivePoller {
             providerCheckPassed: { store.providerCheckPassed },
             reconcile: { await store.refreshContext() },
             locate: { await locator.locate() },
+            refreshHeartbeat: { store.refreshPowerProtectionState() },
             heartbeatIsHealthy: { store.watchdogHeartbeat.healthy },
             installedCopyExists: {
                 FileManager.default.fileExists(
@@ -55,6 +57,7 @@ final class OnboardingLivePoller {
         providerCheckPassed: @escaping @MainActor () -> Bool,
         reconcile: @escaping @MainActor () async -> Bool,
         locate: @escaping () async -> ProviderAvailability,
+        refreshHeartbeat: @escaping @MainActor () -> Void = {},
         heartbeatIsHealthy: @escaping @MainActor () -> Bool,
         installedCopyExists: @escaping () -> Bool,
         sleep: @escaping (UInt64) async throws -> Void = defaultSleep
@@ -65,6 +68,7 @@ final class OnboardingLivePoller {
         self.providerCheckPassed = providerCheckPassed
         self.reconcile = reconcile
         self.locate = locate
+        self.refreshHeartbeat = refreshHeartbeat
         self.heartbeatIsHealthy = heartbeatIsHealthy
         self.installedCopyExists = installedCopyExists
         self.sleep = sleep
@@ -151,6 +155,7 @@ final class OnboardingLivePoller {
             if heartbeatWaitStartedAt == nil {
                 heartbeatWaitStartedAt = Date()
             }
+            refreshHeartbeat()
             heartbeatHealthy = heartbeatIsHealthy()
             if heartbeatHealthy {
                 heartbeatWaitIsLong = false

--- a/app/Sources/DetachApp/OnboardingView.swift
+++ b/app/Sources/DetachApp/OnboardingView.swift
@@ -59,6 +59,7 @@ struct OnboardingView: View {
                 providerCheckPassed: { false },
                 reconcile: { false },
                 locate: { ProviderAvailability(codex: true) },
+                refreshHeartbeat: { store.refreshPowerProtectionState() },
                 heartbeatIsHealthy: { store.watchdogHeartbeat.healthy },
                 installedCopyExists: { false }))
         } else {

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -629,6 +629,37 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertEqual(watchdog.forceReplacementRequests, [false])
     }
 
+    func testSynchronizeDecidesForceReplacementFromFreshHeartbeatSnapshot()
+        async throws
+    {
+        let distribution = InstallationDistributionProbe(
+            synchronizeResults: [.success("repaired")],
+            doctorResults: [
+                .success(installedRuntimeReport()),
+                .success(installedRuntimeReport()),
+            ])
+        let watchdog = InstallationWatchdogProbe(status: .enabled)
+        let powerHelper = InstallationPowerHelperProbe(status: .enabled)
+        let fixture = try makePackagedInstallationFixture(
+            completedOnboarding: true,
+            distribution: distribution,
+            watchdog: watchdog,
+            powerHelper: powerHelper)
+        defer { fixture.cleanup() }
+
+        XCTAssertFalse(fixture.store.watchdogHeartbeat.healthy)
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp())"}"#,
+            to: fixture.stateRoot)
+        XCTAssertFalse(fixture.store.watchdogHeartbeat.healthy)
+
+        await fixture.store.repair()
+
+        XCTAssertTrue(fixture.store.watchdogHeartbeat.healthy)
+        XCTAssertEqual(watchdog.forceReplacementRequests, [false])
+        XCTAssertEqual(distribution.repairs, [true])
+    }
+
     func testRepairDefersHelperReplacementWhileActiveLeasesRemain()
         async throws
     {

--- a/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
+++ b/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
@@ -114,6 +114,22 @@ final class OnboardingLivePollerTests: XCTestCase {
         XCTAssertEqual(reconciles, 2)
     }
 
+    func testDoneTickUsesTheDefaultRefreshWhenNoneIsProvided() async {
+        let poller = OnboardingLivePoller(
+            refreshStatuses: {},
+            servicesEnabled: { false },
+            readinessConfirmed: { false },
+            providerCheckPassed: { false },
+            reconcile: { true },
+            locate: { ProviderAvailability() },
+            heartbeatIsHealthy: { true },
+            installedCopyExists: { false })
+
+        await poller.tick(.done)
+        XCTAssertTrue(poller.heartbeatHealthy)
+        XCTAssertFalse(poller.heartbeatWaitIsLong)
+    }
+
     func testHeartbeatGatePublishesHealth() async {
         var healthy = false
         let poller = makePoller(heartbeatIsHealthy: { healthy })

--- a/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
+++ b/app/Tests/DetachAppTests/OnboardingLivePollerTests.swift
@@ -127,6 +127,39 @@ final class OnboardingLivePollerTests: XCTestCase {
         XCTAssertFalse(poller.heartbeatWaitIsLong)
     }
 
+    func testDoneTickRereadsHeartbeatFileWithoutMenuBarTimer() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "detach-onboarding-heartbeat-\(UUID().uuidString)",
+                isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            powerStateRoot: root)
+        let poller = OnboardingLivePoller(store: store)
+
+        await poller.tick(.done)
+        XCTAssertFalse(poller.heartbeatHealthy)
+        XCTAssertFalse(store.watchdogHeartbeat.healthy)
+
+        let stamp = ISO8601DateFormatter().string(from: Date())
+        try Data(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp)"}"#
+                .utf8
+        ).write(
+            to: root.appendingPathComponent("watchdog-status.json"),
+            options: .atomic)
+        XCTAssertFalse(store.watchdogHeartbeat.healthy)
+
+        await poller.tick(.done)
+        XCTAssertTrue(store.watchdogHeartbeat.healthy)
+        XCTAssertTrue(poller.heartbeatHealthy)
+        XCTAssertFalse(poller.heartbeatWaitIsLong)
+    }
+
     func testInstalledCopyDetectionPublishes() async {
         var present = false
         let poller = makePoller(installedCopyExists: { present })
@@ -227,6 +260,7 @@ final class OnboardingLivePollerTests: XCTestCase {
         locate: @escaping () async -> ProviderAvailability = {
             ProviderAvailability()
         },
+        refreshHeartbeat: @escaping @MainActor () -> Void = {},
         heartbeatIsHealthy: @escaping @MainActor () -> Bool = { false },
         installedCopyExists: @escaping () -> Bool = { false },
         sleep: @escaping (UInt64) async throws -> Void = {
@@ -240,6 +274,7 @@ final class OnboardingLivePollerTests: XCTestCase {
             providerCheckPassed: providerCheckPassed,
             reconcile: reconcile,
             locate: locate,
+            refreshHeartbeat: refreshHeartbeat,
             heartbeatIsHealthy: heartbeatIsHealthy,
             installedCopyExists: installedCopyExists,
             sleep: sleep)

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -2,18 +2,17 @@
 
 ## Contract
 
-`app/` is a SwiftPM package containing `DetachKit`, `DetachApp`,
+`app/` is a SwiftPM package with `DetachKit`, `DetachApp`,
 `DetachWatchdog`, `DetachState`, `DetachPower`, and `DetachPowerHelper`. The app
-bundles and signs arm64-only executables, the immutable CLI
-payload, pinned tmux sources/licenses/provenance, Sparkle, SwiftTerm, and
-their license notices.
+bundles signed arm64-only executables, the immutable CLI payload, pinned tmux
+sources/licenses/provenance, Sparkle, SwiftTerm, and their license notices.
 
-`ANSIParser` is the single terminal-preview decoder. It strips non-SGR control
-sequences and preserves terminal foreground/background colors, bold, dim,
+`ANSIParser` is the terminal-preview decoder. It strips non-SGR sequences and
+keeps terminal foreground/background colors, bold, dim,
 italic, underline, strikethrough, and reverse video. Reverse video swaps
-against `ANSIParser.terminalBackground`, also the `LogTextView`
-background; do not duplicate that canvas color. Font-size scaling may replace
-only the font and must keep every ANSI attribute.
+against `ANSIParser.terminalBackground`, also the `LogTextView` background;
+keep one canvas color. Font scaling changes only the font and keeps every ANSI
+attribute.
 
 Onboarding uses the pure reducer in `SetupGuidance.step(for:)`; a setup failure
 outranks provider discovery. A bare
@@ -22,20 +21,18 @@ The live poller reads status without side effects and reconciles once when it
 becomes enabled. Only confirmed readiness (a
 finished helper journal and an open root gate) advances the step. Registration
 can stay in `requiresApproval`; do not treat it as enabled before macOS does.
-The success card waits for a fresh watchdog heartbeat. Each done-step poll
-reads the heartbeat file again. Its dashboard action stays disabled until then.
-After a long wait, it offers a monitor retry, not a bypass. The store records
-completion only after that action, exactly once. Repair and first-run
-synchronization read the heartbeat file again before they decide to replace a
-silent registration.
+Each done-step poll rereads the watchdog heartbeat. The success card disables
+its dashboard action until the heartbeat is fresh. After a long wait, it offers
+a monitor retry, not a bypass. The store records completion exactly once, only
+after that action. Repair and first-run synchronization also reread the
+heartbeat before replacing a silent registration.
 If a doctor refresh fails or detects another runtime identity, the app
 withdraws the earlier helper-readiness confirmation.
 
-After onboarding completes, `.idle`, `.syncing`, `.updateDeferred`, and
-`.ready` present `.mainApp`. Bootstrap, refresh, and an update held by active
-leases keep the dashboard mounted. Only a completed `.actionRequired` or
-`.failed` result shows setup again. A missing provider also shows the
-dashboard. Provider installation uses the official command,
+After onboarding, `.idle`, `.syncing`, `.updateDeferred`, and `.ready` present
+`.mainApp`. Bootstrap, refresh, and an update held by active leases keep the
+dashboard. Only a completed `.actionRequired` or `.failed` result shows setup;
+a missing provider keeps the dashboard. Provider installation uses the official command,
 launched visibly in the user's own terminal through the private `.command`
 mechanism; never claim a guided install failed (there is no outcome channel),
 only that the CLI is not detected yet. When helper/plist bytes change after an
@@ -50,25 +47,24 @@ signed marker. UI smoke uses a stripped private copy at
 power, state, and tmux. Injections stay below its root. An escape,
 unsafe identity, build mismatch, or payload fails closed.
 
-Smoke restores focus and the pointer. It sends ordered AppKit down/up
-pairs to measured SwiftUI controls; semantic locators have no actions. Row
-clicks select sessions even after preview text takes focus.
+Smoke restores focus and the pointer, then sends ordered AppKit down/up pairs to
+measured SwiftUI controls; semantic locators have no actions. Row clicks select
+sessions even after preview text takes focus.
 Each launch and stage stays within its deadline. Journeys cover main surfaces,
 Settings, onboarding, focus, Codex Recover, Claude Resume, and reconnect after
 an attach client exits. It disconnects Stop before the real control invokes it.
 Only visible controls complete onboarding.
 
 Coverage builds the normal bundle, instrumented binary, and Swift tests in
-isolated paths. UI waits for the bundle. Metrics wait for UI and Swift tests.
+isolated paths. UI waits for the bundle; metrics wait for UI and Swift tests.
 Only the copy gets it. The binary and profiles stay out of public artifacts.
 If an overlay scroller ignores a page event, the driver reveals the measured
 semantic control, then posts the action to it.
 
-The per-user watchdog has an additional launch-readiness rule. macOS can report
-an approved agent as enabled while no launchd job loaded after the approval
-transition. During first onboarding, or an explicit Repair, an enabled watchdog
-without a fresh heartbeat must be replaced through the same durable
-unregister/barrier/register transaction. Ordinary activation refreshes must not
+The per-user watchdog adds a launch-readiness rule: macOS can report an approved
+agent as enabled while no launchd job loaded after approval. During first
+onboarding or Repair, an enabled watchdog without a fresh heartbeat uses the
+durable unregister/barrier/register transaction. Ordinary activation does not
 replace it for a temporarily stale heartbeat.
 
 The menu bar item is display-only. Its Detach prompt mark uses a filled dot for

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -22,9 +22,12 @@ The live poller reads status without side effects and reconciles once when it
 becomes enabled. Only confirmed readiness (a
 finished helper journal and an open root gate) advances the step. Registration
 can stay in `requiresApproval`; do not treat it as enabled before macOS does.
-The success card waits for a fresh watchdog heartbeat. Its dashboard action
-stays disabled until then. After a long wait, it offers a monitor retry, not a
-bypass. The store records completion only after that action, exactly once.
+The success card waits for a fresh watchdog heartbeat. Each done-step poll
+reads the heartbeat file again. Its dashboard action stays disabled until then.
+After a long wait, it offers a monitor retry, not a bypass. The store records
+completion only after that action, exactly once. Repair and first-run
+synchronization read the heartbeat file again before they decide to replace a
+silent registration.
 If a doctor refresh fails or detects another runtime identity, the app
 withdraws the earlier helper-readiness confirmation.
 


### PR DESCRIPTION
## Problem

The onboarding success card read a cached watchdog heartbeat. It could remain
stale when the menu-bar timer was not active. Repair could also replace a silent
registration using an old snapshot.

## Contract delta

Every `.done` poll rereads the heartbeat before evaluating health. Repair and
first-run synchronization refresh the same snapshot before deciding whether an
enabled watchdog needs replacement. The app contract stays below its routed
12 KiB limit.

This preserves the two functional commits and their original authorship from
#130. Its obsolete docs-only compaction was replaced with a current semantic
compaction after #144.

Fixes #120.

## Evidence

- `cd app && swift test --filter 'OnboardingLivePollerTests|InstallationStorePowerStateTests'` — 54/54.
- `tests/docs-contract.sh`
- `git diff --check`
- `docs/specs/app.md` — 12,262 bytes.

Hosted `quality-gates` is readiness authority. Manual release and power gates
were not run.
