### PR TITLE
Count active Mac Power sessions consistently

### DIFF
--- a/app/Sources/DetachApp/MenuBarPresentation.swift
+++ b/app/Sources/DetachApp/MenuBarPresentation.swift
@@ -55,14 +55,14 @@ struct MenuBarPresentation: Equatable {
         now: Date = Date()
     ) {
         let state = heartbeat.effectivePowerState
-        let live = MacPowerLiveSessions.live(in: allSessions)
-        let working = live.filter { !$0.isWaitingForUser }
+        let active = MacPowerActiveSessions.active(in: allSessions)
+        let working = active.filter { !$0.isWaitingForUser }
         power = MacPowerSettingsPresentation(
             state: state,
             helperStatus: helperStatus,
             watchdogStatus: watchdogStatus,
             distributionMatchesBundle: distributionMatchesBundle,
-            activeSessionCount: live.count,
+            activeSessionCount: active.count,
             workingSessionCount: working.count)
         ageSeconds = heartbeat.healthy
             ? heartbeat.age(relativeTo: now).map { max(0, Int($0)) }
@@ -104,9 +104,9 @@ struct MenuBarPresentation: Equatable {
         case .attention, .lowBattery, .temperature:
             sessionDot = .none
         case .active, .canSleep, .unknown:
-            if live.contains(where: { $0.isWaitingForUser }) {
+            if active.contains(where: { $0.isWaitingForUser }) {
                 sessionDot = .answerReady
-            } else if live.isEmpty {
+            } else if active.isEmpty {
                 sessionDot = .none
             } else {
                 sessionDot = .working
@@ -114,7 +114,7 @@ struct MenuBarPresentation: Equatable {
         }
 
         // Sessions awaiting a reply outrank ones that are still working.
-        let ordered = live.sorted {
+        let ordered = active.sorted {
             if $0.isWaitingForUser != $1.isWaitingForUser {
                 return $0.isWaitingForUser
             }

--- a/app/Sources/DetachApp/MenuBarPresentation.swift
+++ b/app/Sources/DetachApp/MenuBarPresentation.swift
@@ -55,7 +55,7 @@ struct MenuBarPresentation: Equatable {
         now: Date = Date()
     ) {
         let state = heartbeat.effectivePowerState
-        let live = allSessions.filter(\.isLive)
+        let live = MacPowerLiveSessions.live(in: allSessions)
         let working = live.filter { !$0.isWaitingForUser }
         power = MacPowerSettingsPresentation(
             state: state,

--- a/app/Sources/DetachApp/MenuBarPresentation.swift
+++ b/app/Sources/DetachApp/MenuBarPresentation.swift
@@ -55,14 +55,14 @@ struct MenuBarPresentation: Equatable {
         now: Date = Date()
     ) {
         let state = heartbeat.effectivePowerState
-        let running = allSessions.filter { $0.effectiveStatus == .running }
-        let working = running.filter { !$0.isWaitingForUser }
+        let live = allSessions.filter(\.isLive)
+        let working = live.filter { !$0.isWaitingForUser }
         power = MacPowerSettingsPresentation(
             state: state,
             helperStatus: helperStatus,
             watchdogStatus: watchdogStatus,
             distributionMatchesBundle: distributionMatchesBundle,
-            activeSessionCount: running.count,
+            activeSessionCount: live.count,
             workingSessionCount: working.count)
         ageSeconds = heartbeat.healthy
             ? heartbeat.age(relativeTo: now).map { max(0, Int($0)) }
@@ -104,9 +104,9 @@ struct MenuBarPresentation: Equatable {
         case .attention, .lowBattery, .temperature:
             sessionDot = .none
         case .active, .canSleep, .unknown:
-            if running.contains(where: { $0.isWaitingForUser }) {
+            if live.contains(where: { $0.isWaitingForUser }) {
                 sessionDot = .answerReady
-            } else if running.isEmpty {
+            } else if live.isEmpty {
                 sessionDot = .none
             } else {
                 sessionDot = .working
@@ -114,7 +114,7 @@ struct MenuBarPresentation: Equatable {
         }
 
         // Sessions awaiting a reply outrank ones that are still working.
-        let ordered = running.sorted {
+        let ordered = live.sorted {
             if $0.isWaitingForUser != $1.isWaitingForUser {
                 return $0.isWaitingForUser
             }

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -64,7 +64,7 @@ struct MacPowerSettingsPresentation: Equatable {
             }
         case .allowed:
             // The heartbeat wins, but never claim "no sessions" while the
-            // session poller can see running ones.
+            // session poller can see live ones.
             if let activeSessionCount, activeSessionCount > 0 {
                 if workingSessionCount == 0 {
                     reason = .waitingSessions(activeSessionCount)
@@ -295,15 +295,18 @@ struct SettingsView: View {
         }
         .task(id: navigation.selectedTab) {
             guard navigation.selectedTab == .system else { return }
-            await storageStore.refresh()
+            installation.refreshPowerProtectionState()
+            async let storageRefresh: Void = storageStore.refresh()
             while !Task.isCancelled {
-                installation.refreshPowerProtectionState()
                 do {
                     try await Task.sleep(nanoseconds: 10_000_000_000)
                 } catch {
+                    await storageRefresh
                     return
                 }
+                installation.refreshPowerProtectionState()
             }
+            await storageRefresh
         }
         .onChange(of: fontPointSize) { _, value in
             let clamped = AppFontSize.clamped(value)
@@ -989,16 +992,14 @@ struct SettingsView: View {
     }
 
     private var macPowerPresentation: MacPowerSettingsPresentation {
-        let running = sessionStore.sessions.filter {
-            $0.effectiveStatus == .running
-        }
+        let live = sessionStore.sessions.filter(\.isLive)
         return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,
-            activeSessionCount: running.count,
-            workingSessionCount: running.filter { !$0.isWaitingForUser }.count)
+            activeSessionCount: live.count,
+            workingSessionCount: live.filter { !$0.isWaitingForUser }.count)
     }
 
     private var macPowerHeroRow: some View {

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -100,15 +100,21 @@ struct MacPowerSettingsPresentation: Equatable {
     }
 }
 
-/// Live sessions that Settings and the menu bar count as active.
-enum MacPowerLiveSessions {
-    static func live(in sessions: [Session]) -> [Session] {
-        sessions.filter(\.isLive)
+/// Sessions that Settings and the menu bar count as active work.
+enum MacPowerActiveSessions {
+    static func active(in sessions: [Session]) -> [Session] {
+        sessions.filter {
+            switch $0.effectiveStatus {
+            case .starting, .running, .recovering: true
+            case .hung, .completed, .failed, .interrupted, .stopped,
+                 .recoverable, .orphaned, .corrupt, .collision, .unknown: false
+            }
+        }
     }
 
     static func counts(in sessions: [Session]) -> (active: Int, working: Int) {
-        let live = live(in: sessions)
-        return (live.count, live.filter { !$0.isWaitingForUser }.count)
+        let active = active(in: sessions)
+        return (active.count, active.filter { !$0.isWaitingForUser }.count)
     }
 }
 
@@ -1019,7 +1025,7 @@ struct SettingsView: View {
     }
 
     var macPowerPresentation: MacPowerSettingsPresentation {
-        let counts = MacPowerLiveSessions.counts(in: sessionStore.sessions)
+        let counts = MacPowerActiveSessions.counts(in: sessionStore.sessions)
         return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -100,6 +100,40 @@ struct MacPowerSettingsPresentation: Equatable {
     }
 }
 
+/// Live sessions that Settings and the menu bar count as active.
+enum MacPowerLiveSessions {
+    static func live(in sessions: [Session]) -> [Session] {
+        sessions.filter(\.isLive)
+    }
+
+    static func counts(in sessions: [Session]) -> (active: Int, working: Int) {
+        let live = live(in: sessions)
+        return (live.count, live.filter { !$0.isWaitingForUser }.count)
+    }
+}
+
+/// Heartbeat refresh for Settings → System. The SwiftUI `.task` wrapper
+/// only calls this; XCTest cannot map that modifier.
+enum SystemTabHeartbeatRefresh {
+    static func run(
+        refreshPower: () -> Void,
+        refreshStorage: () async -> Void,
+        sleepNanoseconds: UInt64 = 10_000_000_000
+    ) async {
+        refreshPower()
+        async let storageRefresh: Void = refreshStorage()
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(nanoseconds: sleepNanoseconds)
+            } catch {
+                break
+            }
+            refreshPower()
+        }
+        await storageRefresh
+    }
+}
+
 struct PowerHelperSettingsPresentation: Equatable {
     let status: DiagnosticCheck.Status
     let detailLocalizationKey: String?
@@ -294,19 +328,12 @@ struct SettingsView: View {
             await extendedKeys.load(detachPath: activeDetachPath)
         }
         .task(id: navigation.selectedTab) {
+// quality-coverage:begin system-heartbeat
             guard navigation.selectedTab == .system else { return }
-            installation.refreshPowerProtectionState()
-            async let storageRefresh: Void = storageStore.refresh()
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(nanoseconds: 10_000_000_000)
-                } catch {
-                    await storageRefresh
-                    return
-                }
-                installation.refreshPowerProtectionState()
-            }
-            await storageRefresh
+            await SystemTabHeartbeatRefresh.run(
+                refreshPower: { installation.refreshPowerProtectionState() },
+                refreshStorage: { await storageStore.refresh() })
+// quality-coverage:end system-heartbeat
         }
         .onChange(of: fontPointSize) { _, value in
             let clamped = AppFontSize.clamped(value)
@@ -991,15 +1018,15 @@ struct SettingsView: View {
         }
     }
 
-    private var macPowerPresentation: MacPowerSettingsPresentation {
-        let live = sessionStore.sessions.filter(\.isLive)
+    var macPowerPresentation: MacPowerSettingsPresentation {
+        let counts = MacPowerLiveSessions.counts(in: sessionStore.sessions)
         return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,
-            activeSessionCount: live.count,
-            workingSessionCount: live.filter { !$0.isWaitingForUser }.count)
+            activeSessionCount: counts.active,
+            workingSessionCount: counts.working)
     }
 
     private var macPowerHeroRow: some View {

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -178,19 +178,21 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
 }
 
 @MainActor
-final class MacPowerLiveSessionTests: XCTestCase {
-    func testCountsTreatStartingAndRecoveringAsActive() {
+final class MacPowerActiveSessionTests: XCTestCase {
+    func testCountsTreatStartingRunningAndRecoveringAsActiveButNotHung() {
         let sessions = [
             session(status: "starting"),
+            session(status: "running"),
             session(status: "recovering"),
+            session(status: "hung"),
             session(status: "completed"),
         ]
         XCTAssertEqual(
-            MacPowerLiveSessions.live(in: sessions).map(\.effectiveStatus),
-            [.starting, .recovering])
-        let counts = MacPowerLiveSessions.counts(in: sessions)
-        XCTAssertEqual(counts.active, 2)
-        XCTAssertEqual(counts.working, 2)
+            MacPowerActiveSessions.active(in: sessions).map(\.effectiveStatus),
+            [.starting, .running, .recovering])
+        let counts = MacPowerActiveSessions.counts(in: sessions)
+        XCTAssertEqual(counts.active, 3)
+        XCTAssertEqual(counts.working, 3)
     }
 
     func testCountsSeparateWaitingRunningSessions() {
@@ -198,7 +200,7 @@ final class MacPowerLiveSessionTests: XCTestCase {
             session(status: "running", turnState: "waiting"),
             session(status: "starting"),
         ]
-        let counts = MacPowerLiveSessions.counts(in: sessions)
+        let counts = MacPowerActiveSessions.counts(in: sessions)
         XCTAssertEqual(counts.active, 2)
         XCTAssertEqual(counts.working, 1)
     }

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -1,4 +1,5 @@
 import DetachKit
+import SwiftUI
 import XCTest
 @testable import DetachApp
 
@@ -174,4 +175,126 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
             activeSessionCount: activeSessionCount,
             workingSessionCount: workingSessionCount)
     }
+}
+
+@MainActor
+final class MacPowerLiveSessionTests: XCTestCase {
+    func testCountsTreatStartingAndRecoveringAsActive() {
+        let sessions = [
+            session(status: "starting"),
+            session(status: "recovering"),
+            session(status: "completed"),
+        ]
+        XCTAssertEqual(
+            MacPowerLiveSessions.live(in: sessions).map(\.effectiveStatus),
+            [.starting, .recovering])
+        let counts = MacPowerLiveSessions.counts(in: sessions)
+        XCTAssertEqual(counts.active, 2)
+        XCTAssertEqual(counts.working, 2)
+    }
+
+    func testCountsSeparateWaitingRunningSessions() {
+        let sessions = [
+            session(status: "running", turnState: "waiting"),
+            session(status: "starting"),
+        ]
+        let counts = MacPowerLiveSessions.counts(in: sessions)
+        XCTAssertEqual(counts.active, 2)
+        XCTAssertEqual(counts.working, 1)
+    }
+
+    func testHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
+        var events: [String] = []
+        let task = Task {
+            await SystemTabHeartbeatRefresh.run(
+                refreshPower: { events.append("power") },
+                refreshStorage: {
+                    events.append("storage-start")
+                    try? await Task.sleep(nanoseconds: 40_000_000)
+                    events.append("storage-end")
+                },
+                sleepNanoseconds: 1_000_000_000)
+        }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        XCTAssertEqual(events.first, "power")
+        XCTAssertTrue(events.contains("storage-start"))
+        XCTAssertFalse(events.contains("storage-end"))
+        task.cancel()
+        await task.value
+        XCTAssertTrue(events.contains("storage-end"))
+    }
+
+    func testHeartbeatRepeatsAfterTheSleepInterval() async {
+        var powerCount = 0
+        let task = Task {
+            await SystemTabHeartbeatRefresh.run(
+                refreshPower: { powerCount += 1 },
+                refreshStorage: {},
+                sleepNanoseconds: 8_000_000)
+        }
+        try? await Task.sleep(nanoseconds: 25_000_000)
+        task.cancel()
+        await task.value
+        XCTAssertGreaterThanOrEqual(powerCount, 2)
+    }
+
+    func testSettingsSystemPaneCountsAStartingSession() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let checkedAt = ISO8601DateFormatter().string(from: Date())
+        try Data(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(checkedAt)"}"#
+                .utf8
+        ).write(to: root.appendingPathComponent("watchdog-status.json"))
+
+        let cli = LiveSessionListCLI(stdout: sessionJSON(status: "starting"))
+        let sessionStore = SessionStore(cli: cli)
+        await sessionStore.refresh()
+
+        let view = SettingsView(
+            installation: InstallationStore(
+                detachPath: "/tmp/detach-test",
+                powerStateRoot: root),
+            sessionStore: sessionStore,
+            storageStore: StorageStore(cli: cli),
+            updater: UpdaterService(),
+            notifications: SessionNotificationService(
+                center: SilentNotificationCenter(),
+                identifierProvider: { "settings-test" }),
+            navigation: SettingsNavigation(selectedTab: .system))
+
+        XCTAssertNotEqual(view.macPowerPresentation.reason, .noActiveSessions)
+        XCTAssertEqual(view.macPowerPresentation.reason, .sessionsNotHolding(1))
+    }
+}
+
+private struct SilentNotificationCenter: SessionNotificationCenterBackend {
+    func authorizationStatus() async -> SessionNotificationAuthorizationStatus { .denied }
+    func requestAuthorization() async throws -> Bool { false }
+    func deliver(_ payload: SessionNotificationPayload) async throws {}
+}
+
+private struct LiveSessionListCLI: DetachCLIRunning {
+    let stdout: String
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        CLIResult(exitCode: 0, stdout: stdout, stderr: "", timedOut: false)
+    }
+}
+
+private func session(status: String, turnState: String? = nil) -> Session {
+    SessionListParser.parse(sessionJSON(status: status, turnState: turnState)).sessions[0]
+}
+
+private func sessionJSON(status: String, turnState: String? = nil) -> String {
+    let turnField = turnState.map { #","agent_turn_state":"\#($0)""# } ?? ""
+    return """
+    {"schema":1,"provider":"codex","session_name":"detach-codex-\(status)",\
+    "name":"\(status)","effective_status":"\(status)","meta_status":"\(status)",\
+    "agent_session_id":"\(status)","project_dir":"/tmp/p",\
+    "created_at":"2026-07-15T10:00:00Z","last_checkpoint_at":null,\
+    "exit_status":null,"finished_at":null\(turnField)}
+    """
 }

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -129,7 +129,7 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
         XCTAssertEqual(
             presentation(state: .unknown, activeSessionCount: 3).reason,
             .noFreshReport)
-        // An allowed heartbeat with visible running sessions must not claim
+        // An allowed heartbeat with visible live sessions must not claim
         // there are none; it names the mismatch instead.
         XCTAssertEqual(
             presentation(state: .allowed, activeSessionCount: 2).reason,

--- a/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
@@ -123,13 +123,57 @@ final class MenuBarPresentationTests: XCTestCase {
 
     func testAllowedStateWithRunningSessionsNamesTheMismatch() {
         // Heartbeat lag right after a session starts: the menu must not say
-        // "No active agent sessions" above a listed running session.
+        // "No active agent sessions" above a listed live session.
         let presentation = makePresentation(
             powerState: "allowed",
             sessions: [runningSession(id: "a")])
 
         XCTAssertEqual(presentation.power.reason, .sessionsNotHolding(1))
         XCTAssertEqual(presentation.sessions.count, 1)
+    }
+
+    func testStartingAndRecoveringSessionsCountAsActive() {
+        for status in ["starting", "recovering"] {
+            let liveSession = session(
+                id: status,
+                status: status,
+                createdAt: "2026-07-15T10:00:00Z",
+                turnState: nil)
+
+            let allowed = makePresentation(
+                powerState: "allowed",
+                sessions: [liveSession])
+            XCTAssertEqual(allowed.sessions.map(\.id), ["detach-codex-\(status)"], status)
+            XCTAssertEqual(allowed.power.reason, .sessionsNotHolding(1), status)
+            XCTAssertNotEqual(allowed.power.reason, .noActiveSessions, status)
+            XCTAssertEqual(allowed.sessionDot, .working, status)
+
+            let protected = makePresentation(
+                powerState: "protected",
+                sessions: [liveSession])
+            XCTAssertEqual(protected.icon, .active(sessionCount: 1), status)
+            XCTAssertEqual(protected.power.reason, .activeSessions(1), status)
+            XCTAssertEqual(protected.sessionDot, .working, status)
+        }
+    }
+
+    func testAllowedStateNeverClaimsNoSessionsWhileALiveSessionExists() {
+        for status in ["starting", "running", "recovering", "hung"] {
+            let presentation = makePresentation(
+                powerState: "allowed",
+                sessions: [
+                    session(
+                        id: status,
+                        status: status,
+                        createdAt: "2026-07-15T10:00:00Z",
+                        turnState: nil),
+                ])
+            XCTAssertNotEqual(
+                presentation.power.reason,
+                .noActiveSessions,
+                "live status \(status) must not be worded as empty")
+            XCTAssertEqual(presentation.sessions.count, 1, status)
+        }
     }
 
     func testHeaderTextJoinsStateReasonAndFreshness() {

--- a/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MenuBarPresentationTests.swift
@@ -123,7 +123,7 @@ final class MenuBarPresentationTests: XCTestCase {
 
     func testAllowedStateWithRunningSessionsNamesTheMismatch() {
         // Heartbeat lag right after a session starts: the menu must not say
-        // "No active agent sessions" above a listed live session.
+        // "No active agent sessions" above a listed active session.
         let presentation = makePresentation(
             powerState: "allowed",
             sessions: [runningSession(id: "a")])
@@ -157,8 +157,8 @@ final class MenuBarPresentationTests: XCTestCase {
         }
     }
 
-    func testAllowedStateNeverClaimsNoSessionsWhileALiveSessionExists() {
-        for status in ["starting", "running", "recovering", "hung"] {
+    func testAllowedStateNeverClaimsNoSessionsWhileAnActiveSessionExists() {
+        for status in ["starting", "running", "recovering"] {
             let presentation = makePresentation(
                 powerState: "allowed",
                 sessions: [
@@ -171,9 +171,25 @@ final class MenuBarPresentationTests: XCTestCase {
             XCTAssertNotEqual(
                 presentation.power.reason,
                 .noActiveSessions,
-                "live status \(status) must not be worded as empty")
+                "active status \(status) must not be worded as empty")
             XCTAssertEqual(presentation.sessions.count, 1, status)
         }
+    }
+
+    func testHungSessionIsAProblemNotActiveWork() {
+        let presentation = makePresentation(
+            powerState: "allowed",
+            sessions: [
+                session(
+                    id: "hung",
+                    status: "hung",
+                    createdAt: "2026-07-15T10:00:00Z",
+                    turnState: nil),
+            ])
+
+        XCTAssertEqual(presentation.power.reason, .noActiveSessions)
+        XCTAssertTrue(presentation.sessions.isEmpty)
+        XCTAssertEqual(presentation.sessionDot, .none)
     }
 
     func testHeaderTextJoinsStateReasonAndFreshness() {

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -68,12 +68,12 @@ without a fresh heartbeat must be replaced through the same durable
 unregister/barrier/register transaction. Ordinary activation refreshes must not
 replace it for a temporarily stale heartbeat.
 
-The menu bar item is display-only. Its Detach prompt mark uses a filled dot for
-protected, a dim mark for sleep allowed, an exclamation badge for attention,
-and an outline for unknown. With active sessions, green means working and
-orange means waiting. Waiting outranks working. A badge suppresses both tints
-so a power warning stays visible. Monochrome states remain template. Tinted
-states use label or system colors resolved at composite time. VoiceOver names
+The menu bar is display-only. Its prompt mark is filled for protected, dim for
+sleep allowed, badged for attention, and outlined for unknown. Starting,
+running, and recovering sessions are active; hung sessions are not. Green means
+working and orange means waiting. Waiting outranks working. A badge hides both
+tints so power warnings stay visible. Monochrome states remain template; tints
+resolve from label or system colors. VoiceOver names
 the session state. The first menu line is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. The shared `checked_at` heartbeat

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -714,7 +714,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 51,
+  "policy": 53,
   "release_domains": [
     {
       "gates": "-",

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -286,6 +286,15 @@
     },
     {
       "group": "ui",
+      "path": "app/Sources/DetachApp/SettingsView.swift",
+      "region": "system-heartbeat",
+      "scenarios": [
+        "SC-UI-SETTINGS"
+      ],
+      "summary": "XCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop."
+    },
+    {
+      "group": "ui",
       "path": "app/Sources/DetachApp/SidebarView.swift",
       "region": "ui-e2e-instrumentation",
       "scenarios": [

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -76,6 +76,7 @@ coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrume
 coverage-region	ui	app/Sources/DetachApp/SessionAttachTerminalView.swift	swiftterm-metal	SC-UI-SESSION-DETAIL	XCTest cannot host LocalProcessTerminalView. HeadlessTerminal owns the process proof.
 coverage-region	ui	app/Sources/DetachApp/SessionAttachTerminalView.swift	swiftterm-host	SC-UI-SESSION-DETAIL	XCTest cannot construct the SwiftTerm representable. The packaged journey hosts it.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	ui-e2e-instrumentation	SC-UI-SETTINGS	The packaged Settings journey covers its semantic control.
+coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	system-heartbeat	SC-UI-SETTINGS	XCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.
 coverage-region	ui	app/Sources/DetachApp/SidebarView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-FAILURE	Packaged journeys cover sidebar control geometry, bulk Delete, and failure status.
 route	1100	quality/policy.tsv	quality-core	safe	docs/specs/documentation.md
 route	1000	quality/*	policy	safe	docs/specs/documentation.md

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	51
+policy	53
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -56,7 +56,7 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'scenario inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" coverage-exclusions | wc -l | tr -d ' ')" = 4 ] || \
   fail 'coverage exclusion inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 11 ] || \
+[ "$("$ROOT/scripts/quality-policy" coverage-regions | wc -l | tr -d ' ')" = 12 ] || \
   fail 'coverage region inventory is incomplete'
 first_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"
 second_json="$("$ROOT/scripts/quality-policy" render-json | shasum -a 256 | awk '{print $1}')"

--- a/tests/quality_policy_contract.py
+++ b/tests/quality_policy_contract.py
@@ -123,6 +123,10 @@ def main() -> None:
             "\tSC-UI-SETTINGS\tThe packaged Settings journey covers its semantic control.",
             "\tSC-UI-DASHBOARD\tThe packaged Settings journey covers its semantic control.",
             1,
+        ).replace(
+            "\tSC-UI-SETTINGS\tXCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.",
+            "\tSC-UI-DASHBOARD\tXCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.",
+            1,
         ),
         "requirement has no automated verification scenario: QC-APP-SETTINGS",
     )


### PR DESCRIPTION
## Problem

Settings and the menu bar counted only `.running` sessions. They omitted
`.starting` and `.recovering`, while the broad `Session.isLive` alternative
would also count `.hung`. The System-tab heartbeat loop also waited for storage
refresh before it could publish its first power heartbeat.

## Contract delta

One explicit classifier treats only `.starting`, `.running`, and `.recovering`
as active Mac Power work. Hung and terminal states are excluded. Settings and
the menu bar use the same counts. The System tab publishes power immediately,
runs storage refresh concurrently, and continues its ten-second heartbeat until
cancellation.

The two original commits from #129 retain their authorship. The repair adds the
negative hung regression, deterministic heartbeat-loop coverage, and policy 53.

Fixes #119.

## Evidence

- `cd app && swift test --filter 'MacPowerActiveSessionTests|MenuBarPresentationTests'` — 32/32.
- `tests/quality-policy.sh`
- `tests/release-impact.sh`
- `tests/docs-contract.sh`
- `git diff --check`
- `docs/specs/app.md` — 12,268 bytes.

Hosted `quality-gates` is readiness authority. Manual power and release gates
were not run.
