### PR TITLE
Reject unexpected release assets safely

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -50,10 +50,13 @@ change real power state, upload assets, or claim publication.
   bounded ten-second launch window before owner confirmation is accepted.
   Automated release tests cover install, repair, uninstall, update, CLI
   synchronization, and helper replacement paths.
+- `DETACH_RELEASE_TEST_MODE=1` relaxes selected local production-path checks
+  for hermetic tests. It refuses the push and publication stages.
 - The release entry point supplies the low-level publication confirmation after
-  all selected gates pass. After upload, every remote asset is downloaded and
-  its digest is independently matched. Missing, extra, changed, or mismatched
-  assets fail closed.
+  all selected gates pass. After upload, verification lists every remote asset
+  name. A name outside the expected set fails closed. Every expected remote
+  asset is downloaded and its digest is independently matched. Missing, extra,
+  changed, or mismatched assets fail closed.
 - Each release includes a deterministic SPDX 2.3 SBOM. It lists the exact
   Swift resolution, including SwiftTerm, and the checksummed tmux, libevent,
   and utf8proc sources.

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -51,7 +51,9 @@ change real power state, upload assets, or claim publication.
   Automated release tests cover install, repair, uninstall, update, CLI
   synchronization, and helper replacement paths.
 - `DETACH_RELEASE_TEST_MODE=1` relaxes selected local production-path checks
-  for hermetic tests. It refuses the push and publication stages.
+  for hermetic tests. It can simulate push and publication only after it proves
+  the exact fixture repository, local origin, empty hooks, placeholder name,
+  and fake external tools. This boundary never authorizes an external release.
 - The release entry point supplies the low-level publication confirmation after
   all selected gates pass. After upload, verification lists every remote asset
   name. A name outside the expected set fails closed. Every expected remote

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,7 +149,8 @@
   and explicit publication-confirmation guards.
 - `tests/release-workflow.sh` — hermetic end-to-end orchestration, including
   resume after every durable stage, dirty/diverged source rejection, duplicate
-  tag/release rejection, hardware-gate failure, and remote hash mismatch.
+  tag/release rejection, hardware-gate failure, remote hash mismatch,
+  test-mode publication refusal, and unexpected remote assets.
 - `cd app && swift test --enable-code-coverage --disable-sandbox`, followed by
   `tests/quality-contracts.sh` — unit tests plus measured UI and business test
   identities, aggregate coverage, and coverage for the 13 critical sources.
@@ -217,7 +218,7 @@ matching temporary branch. It does not push release metadata directly to
 `main`. It then reuses the
 strict `app/scripts/release.sh` and `app/scripts/publish-release.sh`, installs
 the signed candidate, runs the real power smoke, publishes, and independently
-downloads and hashes every remote asset. `scripts/release-impact` compares the
+lists, downloads, and hashes every remote asset. `scripts/release-impact` compares the
 last published tag with the release source. It selects the supervised
 closed-lid probe only for power, helper, watchdog, lease, assertion, or
 lid-probe impact. Unknown product paths select the closed-lid gate. Its private

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -150,7 +150,7 @@
 - `tests/release-workflow.sh` — hermetic end-to-end orchestration, including
   resume after every durable stage, dirty/diverged source rejection, duplicate
   tag/release rejection, hardware-gate failure, remote hash mismatch,
-  test-mode publication refusal, and unexpected remote assets.
+  hermetic publication-boundary rejection, and unexpected remote assets.
 - `cd app && swift test --enable-code-coverage --disable-sandbox`, followed by
   `tests/quality-contracts.sh` — unit tests plus measured UI and business test
   identities, aggregate coverage, and coverage for the 13 critical sources.

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -203,6 +203,9 @@ validate_configuration() {
     die 'DETACH_RELEASE_TEST_MODE must be 0 or 1'
   [ "$IGNORE_TIMING" = 0 ] || [ "$IGNORE_TIMING" = 1 ] || \
     die 'DETACH_RELEASE_IGNORE_TIMING must be 0 or 1'
+  [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 0 ] || \
+    [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 1 ] || \
+    die 'DETACH_RELEASE_TEST_ALLOW_PUBLISH must be 0 or 1'
   if [ "$TEST_MODE" = 1 ]; then
     printf 'release-version: TEST MODE — production path checks are relaxed\n' >&2
   fi
@@ -490,7 +493,7 @@ download_latest_manifest() {
     "https://github.com/$REPOSITORY/releases/latest/download/release-manifest.json" \
     --output "$destination"
   chmod 0600 "$destination"
-  plutil -p "$destination" >/dev/null
+  plutil -convert json -o /dev/null "$destination"
 }
 
 manifest_value() {
@@ -713,9 +716,16 @@ remove_release_ci_branch() {
     die 'remote release CI branch still exists after cleanup'
 }
 
+refuse_test_mode_publication() {
+  [ "$TEST_MODE" = 1 ] || return 0
+  [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 1 ] || \
+    die 'DETACH_RELEASE_TEST_MODE refuses push and publication'
+}
+
 push_release_source() {
   local remote_ci remote_main remote_tag merge_output parents tag_commit tag_type
   local -a release_pr_args
+  refuse_test_mode_publication
   if has_stage pushed; then
     RELEASE_HEAD="$(read_state_value release-head)" || die 'release head is missing'
     RELEASE_COMMIT="$(read_state_value release-commit)" || die 'release commit is missing'
@@ -1021,6 +1031,7 @@ run_publish_preflight() {
 }
 
 publish_release() {
+  refuse_test_mode_publication
   if ! has_stage published; then
     release_api_status "$STATE_DIR/release-before-publish.json" >/dev/null
     run_publish_preflight
@@ -1045,7 +1056,7 @@ download_remote_asset() {
 
 verify_published_release() {
   local remote_root="$STATE_DIR/remote-assets" latest_tag http_status
-  local local_asset remote_asset name
+  local local_asset remote_asset name remote_assets remote_name expected
   local -a assets
 
   rm -rf "$remote_root"
@@ -1066,8 +1077,23 @@ verify_published_release() {
     "$APP_ROOT/build/update-assets/release-manifest.json"
     "$APP_ROOT/build/update-assets/release-manifest.json.sha256"
   )
+  remote_assets="$(gh release view "$TAG" --repo "$REPOSITORY" \
+    --json assets --jq '.assets[].name')"
+  while IFS= read -r remote_name; do
+    [ -n "$remote_name" ] || continue
+    expected=0
+    for local_asset in "${assets[@]}"; do
+      if [ "$remote_name" = "$(basename "$local_asset")" ]; then
+        expected=1
+        break
+      fi
+    done
+    [ "$expected" = 1 ] || die "published release has unexpected asset: $remote_name"
+  done <<<"$remote_assets"
   for local_asset in "${assets[@]}"; do
     name="$(basename "$local_asset")"
+    grep -Fx "$name" <<<"$remote_assets" >/dev/null || \
+      die "published release is missing asset: $name"
     remote_asset="$remote_root/$name"
     download_remote_asset "$name" "$remote_asset"
     [ "$(shasum -a 256 "$local_asset" | awk '{print $1}')" = \

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -203,9 +203,6 @@ validate_configuration() {
     die 'DETACH_RELEASE_TEST_MODE must be 0 or 1'
   [ "$IGNORE_TIMING" = 0 ] || [ "$IGNORE_TIMING" = 1 ] || \
     die 'DETACH_RELEASE_IGNORE_TIMING must be 0 or 1'
-  [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 0 ] || \
-    [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 1 ] || \
-    die 'DETACH_RELEASE_TEST_ALLOW_PUBLISH must be 0 or 1'
   if [ "$TEST_MODE" = 1 ]; then
     printf 'release-version: TEST MODE — production path checks are relaxed\n' >&2
   fi
@@ -716,16 +713,69 @@ remove_release_ci_branch() {
     die 'remote release CI branch still exists after cleanup'
 }
 
-refuse_test_mode_publication() {
+verify_test_mode_publication_boundary() {
+  local fixture_root fixture_repo fixture_origin fixture_bin fixture_hooks
+  local remote_url remote_push_url configured_hooks tool tool_path hook
+
   [ "$TEST_MODE" = 1 ] || return 0
-  [ "${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-0}" = 1 ] || \
-    die 'DETACH_RELEASE_TEST_MODE refuses push and publication'
+  fixture_root="${DETACH_RELEASE_TEST_FIXTURE_ROOT:-}"
+  [ -n "$fixture_root" ] && [[ "$fixture_root" = /* ]] || \
+    die 'test-mode push and publication require an absolute hermetic fixture root'
+  [ -d "$fixture_root" ] && [ ! -L "$fixture_root" ] || \
+    die 'test-mode fixture root must be a non-symlink directory'
+  fixture_root="$(cd -P "$fixture_root" && pwd)"
+  fixture_repo="$fixture_root/repo"
+  fixture_origin="$fixture_root/origin.git"
+  fixture_bin="$fixture_root/bin"
+  fixture_hooks="$fixture_root/hooks"
+
+  [ -d "$fixture_repo" ] && [ ! -L "$fixture_repo" ] && \
+    [ "$(cd -P "$fixture_repo" && pwd)" = "$ROOT" ] || \
+    die 'test-mode fixture repository does not match the release root'
+  [ -d "$fixture_origin" ] && [ ! -L "$fixture_origin" ] && \
+    [ "$(cd -P "$fixture_origin" && pwd)" = "$fixture_origin" ] || \
+    die 'test-mode fixture origin must be a local non-symlink directory'
+  remote_url="$(git -C "$ROOT" remote get-url origin)"
+  remote_push_url="$(git -C "$ROOT" remote get-url --push origin)"
+  [[ "$remote_url" = /* ]] && [[ "$remote_push_url" = /* ]] && \
+    [ -d "$remote_url" ] && [ ! -L "$remote_url" ] && \
+    [ -d "$remote_push_url" ] && [ ! -L "$remote_push_url" ] && \
+    [ "$(cd -P "$remote_url" && pwd)" = "$fixture_origin" ] && \
+    [ "$(cd -P "$remote_push_url" && pwd)" = "$fixture_origin" ] || \
+    die 'test-mode fixture origin does not match the Git remote'
+  [ "$REPOSITORY" = example/detach ] || \
+    die 'test-mode publication requires the placeholder repository'
+
+  configured_hooks="$(git -C "$ROOT" config --get core.hooksPath || true)"
+  [ -d "$fixture_hooks" ] && [ ! -L "$fixture_hooks" ] && \
+    [ -z "$(find "$fixture_hooks" -mindepth 1 -maxdepth 1 -print -quit)" ] && \
+    [[ "$configured_hooks" = /* ]] && [ -d "$configured_hooks" ] && \
+    [ ! -L "$configured_hooks" ] && \
+    [ "$(cd -P "$configured_hooks" && pwd)" = "$fixture_hooks" ] || \
+    die 'test-mode fixture must use its empty hooks directory'
+  for hook in "$fixture_origin"/hooks/*; do
+    [ -e "$hook" ] || continue
+    case "$hook" in
+      *.sample) ;;
+      *) die 'test-mode fixture origin contains an active hook' ;;
+    esac
+  done
+
+  [ -d "$fixture_bin" ] && [ ! -L "$fixture_bin" ] || \
+    die 'test-mode fixture tool directory must be a non-symlink directory'
+  for tool in gh curl security xcrun hdiutil ditto open swift; do
+    tool_path="$(type -P "$tool" || true)"
+    [ -x "$tool_path" ] && [ ! -L "$tool_path" ] && \
+      [ "$(basename "$tool_path")" = "$tool" ] && \
+      [ "$(cd -P "$(dirname "$tool_path")" && pwd)" = "$fixture_bin" ] || \
+      die "test-mode fixture does not own the $tool command"
+  done
 }
 
 push_release_source() {
   local remote_ci remote_main remote_tag merge_output parents tag_commit tag_type
   local -a release_pr_args
-  refuse_test_mode_publication
+  verify_test_mode_publication_boundary
   if has_stage pushed; then
     RELEASE_HEAD="$(read_state_value release-head)" || die 'release head is missing'
     RELEASE_COMMIT="$(read_state_value release-commit)" || die 'release commit is missing'
@@ -1031,7 +1081,7 @@ run_publish_preflight() {
 }
 
 publish_release() {
-  refuse_test_mode_publication
+  verify_test_mode_publication_boundary
   if ! has_stage published; then
     release_api_status "$STATE_DIR/release-before-publish.json" >/dev/null
     run_publish_preflight

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -39,7 +39,7 @@ setup_fixture() {
   PUBLISHED_MANIFEST="$FIXTURE/published-manifest.json"
   mkdir -p "$REPO/scripts" "$REPO/tests/quality-gate-fixtures" "$REPO/app/scripts" \
     "$REPO/app/.build/artifacts/sparkle/Sparkle/bin" "$REPO/quality" "$REPO/tools" \
-    "$BIN" "$APPS" \
+    "$BIN" "$APPS" "$FIXTURE/hooks" \
     "$REMOTE_ASSETS"
 
   install -m 0755 "$ROOT/scripts/release-version" "$REPO/scripts/release-version"
@@ -471,6 +471,7 @@ SH
   git -C "$REPO" tag -a v1.2.3 -m 'published fixture'
   git init -q --bare "$ORIGIN"
   git -C "$REPO" remote add origin "$ORIGIN"
+  git -C "$REPO" config core.hooksPath "$FIXTURE/hooks"
   git -C "$REPO" push -q -u origin main
   git -C "$REPO" push -q origin v1.2.3
 }
@@ -490,7 +491,7 @@ run_workflow() {
       FAKE_TARGET_TAG="$TARGET_TAG" \
       FAKE_DMG_APP="$REPO/app/build/fake-dmg/Detach.app" \
       DETACH_RELEASE_TEST_MODE=1 \
-      DETACH_RELEASE_TEST_ALLOW_PUBLISH="${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-1}" \
+      DETACH_RELEASE_TEST_FIXTURE_ROOT="${DETACH_RELEASE_TEST_FIXTURE_ROOT-$FIXTURE}" \
       DETACH_QUALITY_GATE_TEST_MODE=1 \
       DETACH_RELEASE_TEST_APPLICATIONS_DIR="$APPS" \
       DETACH_RELEASE_TEST_LID_MIN_SECONDS=0 \
@@ -679,11 +680,11 @@ run_remote_hash_case() {
   [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
 }
 
-run_test_mode_refuses_publish_case() {
-  setup_fixture test-mode-refuses-publish
-  export DETACH_RELEASE_TEST_ALLOW_PUBLISH=0
-  expect_failure test-mode-refuses-publish \
-    'DETACH_RELEASE_TEST_MODE refuses push and publication' \
+run_test_mode_rejects_unproven_fixture_case() {
+  setup_fixture test-mode-rejects-unproven-fixture
+  export DETACH_RELEASE_TEST_FIXTURE_ROOT=
+  expect_failure test-mode-rejects-unproven-fixture \
+    'test-mode push and publication require an absolute hermetic fixture root' \
     run_workflow
   [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-prepared" ]
   [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-pushed" ]
@@ -729,7 +730,7 @@ for release_case in \
   run_preflight_rejection_cases \
   run_hardware_rejection_case \
   run_remote_hash_case \
-  run_test_mode_refuses_publish_case \
+  run_test_mode_rejects_unproven_fixture_case \
   run_unexpected_remote_asset_case \
   run_post_push_main_rejection_case \
   run_invalid_resume_artifact_credentials_case; do

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -392,6 +392,12 @@ case "${1:-} ${2:-}" in
     [ -f "${FAKE_RELEASE_EXISTS:?}" ] || exit 1
     case " $* " in
       *' --json tagName '*) printf '%s\n' "${FAKE_TARGET_TAG:?}" ;;
+      *' --json assets '*)
+        for path in "${FAKE_REMOTE_ASSETS:?}"/*; do
+          [ -f "$path" ] || continue
+          basename "$path"
+        done
+        ;;
     esac
     ;;
   *) exit 64 ;;
@@ -484,6 +490,7 @@ run_workflow() {
       FAKE_TARGET_TAG="$TARGET_TAG" \
       FAKE_DMG_APP="$REPO/app/build/fake-dmg/Detach.app" \
       DETACH_RELEASE_TEST_MODE=1 \
+      DETACH_RELEASE_TEST_ALLOW_PUBLISH="${DETACH_RELEASE_TEST_ALLOW_PUBLISH:-1}" \
       DETACH_QUALITY_GATE_TEST_MODE=1 \
       DETACH_RELEASE_TEST_APPLICATIONS_DIR="$APPS" \
       DETACH_RELEASE_TEST_LID_MIN_SECONDS=0 \
@@ -672,6 +679,32 @@ run_remote_hash_case() {
   [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
 }
 
+run_test_mode_refuses_publish_case() {
+  setup_fixture test-mode-refuses-publish
+  export DETACH_RELEASE_TEST_ALLOW_PUBLISH=0
+  expect_failure test-mode-refuses-publish \
+    'DETACH_RELEASE_TEST_MODE refuses push and publication' \
+    run_workflow
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-prepared" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-pushed" ]
+  [ ! -f "$RELEASE_EXISTS" ]
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/tags/$TARGET_TAG")" ]
+  [ -z "$(git -C "$REPO" ls-remote origin "refs/heads/detach-release/$TARGET_TAG")" ]
+  ! grep -q '^publish$' "$ACTION_LOG"
+}
+
+run_unexpected_remote_asset_case() {
+  setup_fixture unexpected-remote-asset
+  expect_failure unexpected-remote-asset-prep \
+    'injected safe failure after published' run_workflow published
+  printf '%s\n' extra >"$REMOTE_ASSETS/unexpected-notes.txt"
+  expect_failure unexpected-remote-asset \
+    'published release has unexpected asset: unexpected-notes.txt' \
+    run_workflow
+  [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-published" ]
+  [ ! -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
+}
+
 run_post_push_main_rejection_case() {
   setup_fixture post-push-main
   expect_failure post-push-artifacts 'injected safe failure after artifacts' \
@@ -696,6 +729,8 @@ for release_case in \
   run_preflight_rejection_cases \
   run_hardware_rejection_case \
   run_remote_hash_case \
+  run_test_mode_refuses_publish_case \
+  run_unexpected_remote_asset_case \
   run_post_push_main_rejection_case \
   run_invalid_resume_artifact_credentials_case; do
   "$release_case" &


### PR DESCRIPTION
Closes #122.

This successor keeps the contributor change from #131 as its first task commit. It also repairs the test-mode publication boundary before integration.

Contract delta:

- enumerate every remote release asset before download and fail on missing or unexpected names;
- keep independent digest verification for every expected asset;
- permit simulated test-mode push and publication only after proving the exact temporary repository, local bare origin, empty hooks directory, placeholder repository name, and fake external tools;
- reject an unproven fixture before any tag, branch push, or publication action.

Local evidence:

- `tests/release-workflow.sh` PASS;
- `tests/docs-contract.sh` PASS;
- `bash -n scripts/release-version tests/release-workflow.sh` PASS;
- `git diff --check` PASS;
- impact-aware repository diagnostic: release-workflow, release-preflight, publish-preflight, distribution, app, static, and gate-contract passed. Unrelated tmux/UI stages could not create local sandbox sockets, and two concurrent clipboard tests failed. Hosted `quality-gates` remains readiness authority.

No signing, notarization, real power, closed-lid, tagging, upload, or publication gate was run.
