### PR TITLE
Retry retained thermal safety releases

### DIFF
--- a/app/Sources/DetachKit/DetachPowerCommand.swift
+++ b/app/Sources/DetachKit/DetachPowerCommand.swift
@@ -533,6 +533,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         guard latch.isActive else { return }
         do {
             try reconcileLocked()
+            safetyReleaseFailure = nil
             transitionFailure = nil
         } catch {
             if latch.isActive {
@@ -551,6 +552,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         if latch.isActive {
             do {
                 try reconcileLocked()
+                safetyReleaseFailure = nil
             } catch {
                 if safetyReleaseFailure == nil { safetyReleaseFailure = error }
             }
@@ -573,6 +575,7 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
         activityRequiresProtection = state.requiresProtection
         do {
             try reconcileLocked()
+            safetyReleaseFailure = nil
             transitionFailure = nil
         } catch {
             if latch.isActive {
@@ -586,13 +589,21 @@ private final class PowerRunThermalSafetyController: @unchecked Sendable {
     func refresh() throws {
         lock.lock()
         defer { lock.unlock() }
-        if let safetyReleaseFailure { throw safetyReleaseFailure }
+        // Advance the cooldown and retry a retained safety release before
+        // surfacing it, so one transient failure cannot wedge lease renewals
+        // or protection recovery for the rest of the run.
         _ = latch.observe(lastState, now: now(), cooldown: cooldown)
         do {
             try reconcileLocked()
+            safetyReleaseFailure = nil
             transitionFailure = nil
         } catch {
-            transitionFailure = error
+            if latch.isActive {
+                // A still-failing safety release stays retained and surfaced.
+                if safetyReleaseFailure == nil { safetyReleaseFailure = error }
+            } else {
+                transitionFailure = error
+            }
             throw error
         }
     }

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -177,6 +177,30 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
     }
 }
 
+private actor StorageRefreshGate {
+    private var entered = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func waitForRelease() async {
+        entered = true
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        await withCheckedContinuation { releaseContinuation = $0 }
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
 @MainActor
 final class MacPowerActiveSessionTests: XCTestCase {
     func testCountsTreatStartingRunningAndRecoveringAsActiveButNotHung() {
@@ -207,22 +231,27 @@ final class MacPowerActiveSessionTests: XCTestCase {
 
     func testHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
         var events: [String] = []
+        var runFinished = false
+        let storageGate = StorageRefreshGate()
         let task = Task {
             await SystemTabHeartbeatRefresh.run(
                 refreshPower: { events.append("power") },
                 refreshStorage: {
                     events.append("storage-start")
-                    try? await Task.sleep(nanoseconds: 40_000_000)
+                    await storageGate.waitForRelease()
                     events.append("storage-end")
                 },
                 sleepNanoseconds: 1_000_000_000)
+            runFinished = true
         }
-        try? await Task.sleep(nanoseconds: 10_000_000)
-        XCTAssertEqual(events.first, "power")
-        XCTAssertTrue(events.contains("storage-start"))
-        XCTAssertFalse(events.contains("storage-end"))
+        await storageGate.waitUntilEntered()
+        XCTAssertEqual(events, ["power", "storage-start"])
         task.cancel()
+        await Task.yield()
+        XCTAssertFalse(runFinished)
+        await storageGate.release()
         await task.value
+        XCTAssertTrue(runFinished)
         XCTAssertTrue(events.contains("storage-end"))
     }
 

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -45,6 +45,7 @@ final class DetachPowerCommandTests: XCTestCase {
         let events: EventLog
         var acquireError: Error?
         var releaseError: Error?
+        var onRelease: (() -> Void)?
         var acquisitionActivates = true
         private(set) var isActive = false
 
@@ -63,6 +64,7 @@ final class DetachPowerCommandTests: XCTestCase {
 
         func release() throws -> Bool {
             events.append("assertion.release")
+            defer { onRelease?() }
             if let releaseError { throw releaseError }
             let changed = isActive
             isActive = false
@@ -745,6 +747,100 @@ final class DetachPowerCommandTests: XCTestCase {
         XCTAssertEqual(
             events.values.filter { $0 == "assertion.acquire" }.count,
             2)
+    }
+
+    func testTransientThermalReleaseFailureClearsAndProtectionReturns() throws {
+        let thermal = FakeThermalWatcher()
+        let clock = TestClock()
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            thermalWatcher: thermal,
+            thermalNow: { clock.date },
+            thermalCooldown: 30)
+        heartbeat.heartbeatCount = 3
+        assertion.releaseError = ExpectedFailure()
+        assertion.onRelease = { assertion.releaseError = nil }
+        var heartbeatIndex = 0
+        heartbeat.beforeHeartbeat = {
+            heartbeatIndex += 1
+            switch heartbeatIndex {
+            case 1:
+                thermal.emit(.critical)
+            case 2:
+                clock.date = Date(timeIntervalSince1970: 1_001)
+                thermal.emit(.nominal)
+            default:
+                clock.date = Date(timeIntervalSince1970: 1_032)
+            }
+        }
+        child.result = ChildCommandResult(exitCode: 7)
+
+        let result = try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])
+
+        XCTAssertEqual(result, .child(ChildCommandResult(exitCode: 7)))
+        XCTAssertEqual(helper.renewed.map(\.1), [false, false, false, false, true])
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.acquire" }.count,
+            2)
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.release" }.count,
+            3)
+        XCTAssertFalse(assertion.isActive)
+    }
+
+    func testStillFailingThermalReleaseStaysSurfaced() {
+        let thermal = FakeThermalWatcher()
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            thermalWatcher: thermal)
+        heartbeat.heartbeatCount = 1
+        assertion.releaseError = ExpectedFailure()
+        heartbeat.beforeHeartbeat = { thermal.emit(.critical) }
+
+        XCTAssertThrowsError(try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])) { error in
+            XCTAssertTrue(error is ExpectedFailure)
+        }
+
+        XCTAssertTrue(child.commands.isEmpty)
+        XCTAssertTrue(assertion.isActive)
+        XCTAssertFalse(helper.renewed.isEmpty)
+        XCTAssertTrue(helper.renewed.allSatisfy { $0.1 == false })
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.release" }.count,
+            3)
+    }
+
+    func testThermalLatchKeepsProtectionReleasedAcrossHeartbeats() throws {
+        let thermal = FakeThermalWatcher()
+        let clock = TestClock()
+        let (command, events, assertion, helper, child, heartbeat) = fixture(
+            thermalWatcher: thermal,
+            thermalNow: { clock.date },
+            thermalCooldown: 30)
+        heartbeat.heartbeatCount = 3
+        var heartbeatIndex = 0
+        heartbeat.beforeHeartbeat = {
+            heartbeatIndex += 1
+            if heartbeatIndex == 1 { thermal.emit(.critical) }
+            clock.date = clock.date.addingTimeInterval(10)
+        }
+        child.result = ChildCommandResult(exitCode: 3)
+
+        let result = try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])
+
+        XCTAssertEqual(result, .child(ChildCommandResult(exitCode: 3)))
+        XCTAssertEqual(helper.renewed.map(\.1), [false, false, false, false])
+        XCTAssertEqual(
+            events.values.filter { $0 == "assertion.acquire" }.count,
+            1)
+        XCTAssertFalse(assertion.isActive)
     }
 
     func testHeartbeatWithAlreadyReleasedAssertionReportsLowBatteryWithoutReacquire() throws {

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -715,6 +715,34 @@ final class DetachPowerCommandTests: XCTestCase {
         XCTAssertTrue(child.commands.isEmpty)
     }
 
+    func testThermalLatchDuringLeaseAttachStagesInactiveLeaseAndRefusesLaunch() {
+        let thermal = FakeThermalWatcher()
+        let (command, events, assertion, helper, child, _) = fixture(
+            thermalWatcher: thermal)
+        helper.onAcquire = { thermal.emit(.critical) }
+
+        XCTAssertThrowsError(try command.execute(arguments: [
+            "run", "--session", "session", "--run-token", "token",
+            "--", "/fixture/provider",
+        ])) { error in
+            XCTAssertEqual(
+                error as? DetachPowerCommandError,
+                .temperatureSafetyActive)
+        }
+
+        XCTAssertTrue(child.commands.isEmpty)
+        XCTAssertFalse(assertion.isActive)
+        XCTAssertEqual(helper.renewed.map(\.1), [false])
+        XCTAssertEqual(events.values, [
+            "assertion.acquire",
+            "helper.acquire",
+            "assertion.release",
+            "helper.renew",
+            "helper.release",
+            "assertion.release",
+        ])
+    }
+
     func testThermalProtectionReturnsOnlyAfterStableCooldown() throws {
         let thermal = FakeThermalWatcher()
         let clock = TestClock()

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -101,9 +101,12 @@ Thermal safety uses only public `ProcessInfo.thermalState`. `serious` and
 closed-lid sleep, the wrapper releases its IOKit assertion without waiting for
 a checkpoint, and initial acquisition is refused. A notification-time release
 failure is retained and surfaced by the next heartbeat or protected-run result;
-it must never disappear behind best-effort cleanup. `nominal` and `fair` must
-remain stable for 30 seconds before protection can return; the helper persists
-this cooldown across restart, and an unknown reading cannot clear it. The raw
+it must never disappear behind best-effort cleanup. Each heartbeat retries the
+safety release and advances the cooldown. Only a confirmed release clears the
+retained failure; a release that still fails stays surfaced. `nominal` and
+`fair` must remain stable for 30 seconds before protection can return; the
+helper persists this cooldown across restart, and an unknown reading cannot
+clear it. The raw
 `nominal|fair|serious|critical|unknown` value and latch cross helper status, CLI
 JSON, watchdog, tmux, and app. Low battery wins the combined reason when both
 guards are active, while the thermal fields remain visible. Borrowed external


### PR DESCRIPTION
Closes #116.

This successor preserves both contributor commits from #128.

Contract delta:

- each heartbeat advances the thermal cooldown and retries a retained safety release;
- only a confirmed reconcile clears the retained failure;
- a release that still fails remains surfaced;
- protection stays released while the thermal latch is active;
- a transient release failure no longer stops lease renewals for the rest of the run.

Integration repair:

- replace the System tab heartbeat concurrency test timer race with an explicit async gate after the first current-main CI run exposed it under runner load;
- keep the same ordering, cancellation, and storage-await assertions without wall-clock assumptions.

Local evidence:

- `cd app && swift test --disable-sandbox --filter DetachPowerCommandTests` — 40/40 PASS;
- `cd app && swift test --disable-sandbox --filter MacPowerActiveSessionTests` — 5/5 PASS;
- `cd app && swift test --disable-sandbox` — 887/887 PASS;
- `tests/docs-contract.sh` PASS;
- `git diff --check` PASS.

No real power, signed smoke, closed-lid, signing, notarization, tagging, upload, or publication gate was run. Hosted `quality-gates` is readiness authority.