### PR TITLE
Scope transcript watches and bound screen lock

### DIFF
--- a/app/Sources/DetachKit/ClamshellLockRunner.swift
+++ b/app/Sources/DetachKit/ClamshellLockRunner.swift
@@ -205,33 +205,76 @@ private let clamshellInterestCallback: IOServiceInterestCallback = {
 
 public enum PMSetScreenLockError: LocalizedError, Equatable {
     case failed(exitCode: Int32)
+    case timedOut
 
     public var errorDescription: String? {
         switch self {
         case let .failed(exitCode):
             "pmset displaysleepnow exited with status \(exitCode)"
+        case .timedOut:
+            "pmset displaysleepnow did not exit before its timeout"
         }
     }
 }
 
 /// `pmset displaysleepnow` is a documented, unprivileged macOS operation. It
 /// turns the displays off immediately; macOS then applies the user's normal
-/// Lock Screen policy, including Touch ID and Apple Watch unlock.
+/// Lock Screen policy, including Touch ID and Apple Watch unlock. The command
+/// runs with the same bounded execution as the root command runner: a timeout
+/// with SIGTERM-to-SIGKILL escalation, so a hung `pmset` cannot block the
+/// clamshell queue or delay wrapper cleanup.
 public struct PMSetScreenLockRequester: ScreenLockRequesting {
-    public init() {}
+    public static let defaultTimeout: TimeInterval = 2
+    public static let defaultTerminationGrace: TimeInterval = 1
+
+    private let executableURL: URL
+    private let arguments: [String]
+    private let timeout: TimeInterval
+    private let terminationGrace: TimeInterval
+    private let runner: BoundedProcessRunner
+
+    public init(
+        timeout: TimeInterval = PMSetScreenLockRequester.defaultTimeout,
+        terminationGrace: TimeInterval =
+            PMSetScreenLockRequester.defaultTerminationGrace
+    ) {
+        self.init(
+            executableURL: URL(fileURLWithPath: "/usr/bin/pmset"),
+            arguments: ["displaysleepnow"],
+            timeout: timeout,
+            terminationGrace: terminationGrace)
+    }
+
+    init(
+        executableURL: URL,
+        arguments: [String],
+        timeout: TimeInterval,
+        terminationGrace: TimeInterval,
+        runner: BoundedProcessRunner = BoundedProcessRunner()
+    ) {
+        self.executableURL = executableURL
+        self.arguments = arguments
+        self.timeout = timeout
+        self.terminationGrace = terminationGrace
+        self.runner = runner
+    }
 
     public func requestLock() throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
-        process.arguments = ["displaysleepnow"]
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            throw PMSetScreenLockError.failed(
-                exitCode: process.terminationStatus)
+        let result = try runner.run(BoundedProcessRequest(
+            executableURL: executableURL,
+            arguments: arguments,
+            environment: [
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "LC_ALL": "C",
+            ],
+            timeout: timeout,
+            terminationGrace: terminationGrace,
+            maximumOutputBytes: 1_024))
+        if result.timedOut {
+            throw PMSetScreenLockError.timedOut
+        }
+        guard result.exitCode == 0 else {
+            throw PMSetScreenLockError.failed(exitCode: result.exitCode)
         }
     }
 }

--- a/app/Sources/DetachKit/PowerRunActivity.swift
+++ b/app/Sources/DetachKit/PowerRunActivity.swift
@@ -209,9 +209,7 @@ public final class FilePowerRunActivityWatcher:
                 eventMask: [.write, .delete, .rename, .revoke],
                 queue: eventQueue)
             sourceEvents.setEventHandler {
-                guard sourceWatch.consumeEvent(from: sourceEvents) else {
-                    return
-                }
+                guard sourceWatch.consumeEvent(from: sourceEvents) else { return }
                 onStateChange(.working)
                 sourceEvents.cancel()
             }

--- a/app/Sources/DetachKit/PowerRunActivity.swift
+++ b/app/Sources/DetachKit/PowerRunActivity.swift
@@ -138,9 +138,21 @@ private struct FilePowerRunActivitySourceReader {
     }
 }
 
-private final class PowerRunActivitySourceWatchBox: @unchecked Sendable {
+final class PowerRunActivitySourceWatchBox: @unchecked Sendable {
     var source: (any DispatchSourceFileSystemObject)?
     var waiting = false
+
+    /// A transcript event applies only to the watch generation that delivered
+    /// it. An event from a cancelled generation can still run after its
+    /// replacement is installed; it must not consume the current watch.
+    func consumeEvent(
+        from eventSource: any DispatchSourceFileSystemObject
+    ) -> Bool {
+        guard waiting, source === eventSource else { return false }
+        waiting = false
+        source = nil
+        return true
+    }
 }
 
 public final class FilePowerRunActivityWatcher:
@@ -197,11 +209,11 @@ public final class FilePowerRunActivityWatcher:
                 eventMask: [.write, .delete, .rename, .revoke],
                 queue: eventQueue)
             sourceEvents.setEventHandler {
-                guard sourceWatch.waiting else { return }
-                sourceWatch.waiting = false
+                guard sourceWatch.consumeEvent(from: sourceEvents) else {
+                    return
+                }
                 onStateChange(.working)
-                sourceWatch.source?.cancel()
-                sourceWatch.source = nil
+                sourceEvents.cancel()
             }
             sourceEvents.setCancelHandler {
                 Darwin.close(source.descriptor)

--- a/app/Tests/DetachKitTests/ClamshellLockRunnerTests.swift
+++ b/app/Tests/DetachKitTests/ClamshellLockRunnerTests.swift
@@ -122,4 +122,39 @@ final class ClamshellLockRunnerTests: XCTestCase {
         XCTAssertTrue(messages.values[0].contains(
             "could not lock the screen after the lid closed"))
     }
+
+    func testScreenLockRequestHonorsTimeoutAndEscalatesToKill() {
+        let requester = PMSetScreenLockRequester(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "trap '' TERM; exec /bin/sleep 5"],
+            timeout: 0.05,
+            terminationGrace: 0.05)
+
+        XCTAssertThrowsError(try requester.requestLock()) { error in
+            XCTAssertEqual(error as? PMSetScreenLockError, .timedOut)
+        }
+    }
+
+    func testScreenLockRequestSucceedsForPromptCommand() {
+        let requester = PMSetScreenLockRequester(
+            executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+            arguments: [],
+            timeout: 2,
+            terminationGrace: 1)
+
+        XCTAssertNoThrow(try requester.requestLock())
+    }
+
+    func testScreenLockRequestReportsNonzeroExitStatus() {
+        let requester = PMSetScreenLockRequester(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "exit 7"],
+            timeout: 2,
+            terminationGrace: 1)
+
+        XCTAssertThrowsError(try requester.requestLock()) { error in
+            XCTAssertEqual(
+                error as? PMSetScreenLockError, .failed(exitCode: 7))
+        }
+    }
 }

--- a/app/Tests/DetachKitTests/PowerRunActivityTests.swift
+++ b/app/Tests/DetachKitTests/PowerRunActivityTests.swift
@@ -21,6 +21,23 @@ final class PowerRunActivityTests: XCTestCase {
         }
     }
 
+    private final class FlagBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var set = false
+
+        func arm() {
+            lock.lock()
+            set = true
+            lock.unlock()
+        }
+
+        var isArmed: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return set
+        }
+    }
+
     func testReaderPermitsSleepOnlyForExactOwnedRegularWaitingRecord() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("detach-power-activity-\(UUID().uuidString)")
@@ -102,6 +119,161 @@ final class PowerRunActivityTests: XCTestCase {
             })
 
         XCTAssertEqual(result.exitCode, 17)
+    }
+
+    func testStaleTranscriptEventDoesNotConsumeReplacementWatch() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-box-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let transcript = directory.appendingPathComponent("transcript.jsonl")
+        try Data("initial\n".utf8).write(to: transcript)
+        let queue = DispatchQueue(
+            label: "dev.tsarev.detach.test.power-activity-box")
+
+        func makeSource() -> (any DispatchSourceFileSystemObject)? {
+            let descriptor = Darwin.open(
+                transcript.path, O_EVTONLY | O_CLOEXEC | O_NOFOLLOW)
+            guard descriptor >= 0 else { return nil }
+            let source = DispatchSource.makeFileSystemObjectSource(
+                fileDescriptor: descriptor,
+                eventMask: [.write],
+                queue: queue)
+            source.setCancelHandler { Darwin.close(descriptor) }
+            return source
+        }
+
+        guard let stale = makeSource(), let current = makeSource() else {
+            XCTFail("could not open transcript descriptors")
+            return
+        }
+        let box = PowerRunActivitySourceWatchBox()
+        box.source = current
+        box.waiting = true
+
+        // An event from a cancelled previous generation must not consume
+        // the replacement watch.
+        XCTAssertFalse(box.consumeEvent(from: stale))
+        XCTAssertTrue(box.waiting)
+        XCTAssertTrue(box.source === current)
+
+        // The current generation consumes its own event exactly once.
+        XCTAssertTrue(box.consumeEvent(from: current))
+        XCTAssertFalse(box.waiting)
+        XCTAssertNil(box.source)
+        XCTAssertFalse(box.consumeEvent(from: current))
+
+        stale.cancel()
+        current.cancel()
+        stale.resume()
+        current.resume()
+        queue.sync {}
+    }
+
+    func testReplacementWatchSurvivesQueuedTranscriptEvent() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-stale-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let activity = directory.appendingPathComponent("activity")
+        let activitySource = directory.appendingPathComponent("activity-source")
+        let transcript = directory.appendingPathComponent("transcript.jsonl")
+        try Data("waiting\n".utf8).write(to: activity)
+        try Data("initial\n".utf8).write(to: transcript)
+
+        @Sendable func writeHandoff() throws {
+            var information = stat()
+            XCTAssertEqual(Darwin.lstat(transcript.path, &information), 0)
+            let signature = "\(information.st_ino):\(information.st_mtimespec.tv_sec):\(information.st_size)"
+            try Data("\(signature)\n\(transcript.path)".utf8).write(
+                to: activitySource)
+        }
+
+        // A same-size in-place rewrite fires a transcript event while the
+        // recorded inode/mtime-second/size snapshot can still match.
+        @Sendable func overwriteTranscript() throws {
+            let handle = try FileHandle(forWritingTo: transcript)
+            try handle.write(contentsOf: Data("initial\n".utf8))
+            try handle.synchronize()
+            try handle.close()
+        }
+
+        try writeHandoff()
+
+        let queue = DispatchQueue(
+            label: "dev.tsarev.detach.test.power-activity")
+        let watcher = FilePowerRunActivityWatcher(queue: queue)
+        let observedWaiting = DispatchSemaphore(value: 0)
+        let observedWorking = DispatchSemaphore(value: 0)
+        let workingArmed = FlagBox()
+        let gate = DispatchSemaphore(value: 0)
+        let gateEntered = DispatchSemaphore(value: 0)
+
+        let result = try watcher.run(
+            activityFile: activity.path,
+            activitySourceFile: activitySource.path,
+            onStateChange: { state in
+                switch state {
+                case .waiting:
+                    observedWaiting.signal()
+                case .working:
+                    if workingArmed.isArmed { observedWorking.signal() }
+                }
+            },
+            operation: {
+                // The initial watch reports waiting before the operation.
+                XCTAssertEqual(
+                    observedWaiting.wait(timeout: .now() + 2),
+                    .success)
+
+                // Occupy the watch queue so file events pile up behind the
+                // gate instead of running immediately.
+                queue.async {
+                    gateEntered.signal()
+                    _ = gate.wait(timeout: .now() + 10)
+                }
+                XCTAssertEqual(
+                    gateEntered.wait(timeout: .now() + 2),
+                    .success)
+
+                // Queue the activity rewrite first so its re-watch runs
+                // before the stale transcript event queued after it.
+                let activityHandle = try FileHandle(forWritingTo: activity)
+                try activityHandle.truncate(atOffset: 0)
+                try activityHandle.write(contentsOf: Data("waiting\n".utf8))
+                try activityHandle.synchronize()
+                try activityHandle.close()
+                Thread.sleep(forTimeInterval: 0.5)
+
+                // Queue a transcript event against the current watch, then
+                // refresh the handoff so the re-watch accepts the transcript.
+                try overwriteTranscript()
+                try writeHandoff()
+                Thread.sleep(forTimeInterval: 0.5)
+
+                // Release the queue: the re-watch installs a new transcript
+                // watch, then the stale event from the cancelled watch runs.
+                gate.signal()
+                XCTAssertEqual(
+                    observedWaiting.wait(timeout: .now() + 2),
+                    .success)
+                queue.sync {}
+
+                // The stale event must not have cancelled the replacement
+                // watch: a new transcript write still reports working.
+                workingArmed.arm()
+                try overwriteTranscript()
+                XCTAssertEqual(
+                    observedWorking.wait(timeout: .now() + 2),
+                    .success)
+                return ChildCommandResult(exitCode: 31)
+            })
+
+        XCTAssertEqual(result.exitCode, 31)
     }
 
     func testWatcherRejectsWaitingWithMismatchedTranscriptSnapshot() throws {

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -116,7 +116,10 @@ While the wrapper holds a confirmed protected run, it observes the documented
 IOPMrootDomain clamshell notification. Each physical open-to-closed transition
 requests `/usr/bin/pmset displaysleepnow` as the unprivileged console user so
 macOS follows the user's normal Lock Screen policy without Apple Events,
-Automation, or synthetic input. The initial clamshell state is only a baseline:
+Automation, or synthetic input. The lock request has bounded execution: a
+two-second timeout with SIGTERM-to-SIGKILL escalation. A hung `pmset` must not
+block the clamshell monitor or delay wrapper cleanup. The initial clamshell
+state is only a baseline:
 starting a run while the lid is already closed must not lock an external-display
 workflow. Repeated closed notifications lock only once until the lid reopens.
 This does not rewrite the user's password-delay setting. A MacBook run must

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -18,9 +18,11 @@ validates a recorded inode/mtime/size snapshot and starts an event watcher on th
 exact provider transcript. It then stages the helper lease as
 assertion-inactive, releases the IOKit assertion, and releases the helper lease.
 Any transcript change immediately means `working` and reacquires both layers;
-it does not wait for the idle runtime heartbeat. Missing, changed, or malformed
-handoff state stays `working`. Transition failures are surfaced and must not
-claim that sleep is safe. The provider continues while waiting.
+it does not wait for the idle runtime heartbeat. A transcript event belongs to
+the watch generation that delivered it: an event from a cancelled watch must
+not cancel its replacement or change the reported state. Missing, changed, or
+malformed handoff state stays `working`. Transition failures are surfaced and
+must not claim that sleep is safe. The provider continues while waiting.
 
 Each working session owns a separate helper lease. Outside the low-battery and
 thermal fail-safe states, the helper keeps the machine-wide closed-lid setting


### PR DESCRIPTION
Closes #118.

This successor preserves all three contributor commits from #133.

Contract delta:

- a transcript event can consume only the watch generation that delivered it;
- a queued event from a cancelled source cannot cancel its replacement or report a false working transition;
- `pmset displaysleepnow` has a two-second timeout and process-group TERM-to-KILL escalation;
- a hung screen-lock request cannot block the clamshell queue or delay wrapper cleanup.

Local evidence:

- `cd app && swift test --filter ClamshellLockRunnerTests --filter PowerRunActivityTests` — 12/12 PASS;
- `tests/docs-contract.sh` PASS;
- `git diff --check` PASS.

No real power, signed smoke, closed-lid, signing, notarization, tagging, upload, or publication gate was run. Hosted `quality-gates` is readiness authority.
