### PR TITLE
Start new sessions inside Detach

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ process ownership, recovery, power protection, and operations around them.
 ## The everyday workflow
 
 1. Click **＋** in Detach. Choose a project, provider, and optional session name.
-2. Expand **Advanced** only when you want to change the launch terminal or add
-   an initial prompt. The launch button names the selected terminal.
-3. Select the live session and work in its embedded terminal. The external
-   terminal remains available as a fallback.
-4. Close either terminal or Detach.app whenever you want. The managed agent
+2. Expand **Advanced** only when you want to add an initial prompt. Click
+   **Start**. Detach starts the run in the background and selects it.
+3. Work in the embedded terminal. An external terminal remains available as a
+   fallback.
+4. Close Detach.app whenever you want. The managed agent
    keeps running.
 5. Reopen Detach to answer the agent, inspect progress, stop the run, Resume a
    conversation, or Recover an interrupted managed run.
@@ -109,18 +109,18 @@ detach claude --detach -- "run the test suite and fix failures"
 The app and CLI operate on the same sessions. Start in one and continue in the
 other.
 
-New sessions start through the selected terminal application. Detach uses a
-private startup guard until the temporary command starts. A startup prompt,
-such as an oh-my-zsh update, cannot consume the command path. Detach then
-restores the user's shell startup files for that process. Live work, Resume,
-and Recover are available in the app after the managed session exists.
+New sessions start inside Detach. The app runs the CLI with `--detach` in the
+selected project and refreshes the session list. When Detach identifies one
+new match, it selects the session and opens the embedded terminal. A start
+error stays in the sheet. The selected external terminal remains a fallback
+for Attach, Resume, and Recover.
 
 ## The terminal and control center in one window
 
-Detach.app owns the session lifecycle. A live session is interactive inside
-Detach. Resume and Recover also start inside the app and do not require an
-outer terminal. The selected Terminal, iTerm2, Warp, or other shell-script
-runner remains available from the named fallback button.
+Detach.app owns the session lifecycle. Start, Resume, and Recover run inside
+the app and do not require an outer terminal. The selected Terminal, iTerm2,
+Warp, or other shell-script runner remains available from the named fallback
+button.
 
 The dashboard gives every managed session:
 

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "The session has no provider UUID to resume." = "The session has no provider UUID to resume.";
 "detach resume timed out" = "detach resume timed out";
 "detach recover timed out" = "detach recover timed out";
+"detach start timed out" = "detach start timed out";
 "detach exited with status %d" = "detach exited with status %d";
 "Could not run detach: %@" = "Could not run detach: %@";
 "Session is not eligible for deletion from Finished." = "Session is not eligible for deletion from Finished.";
@@ -116,10 +117,8 @@
 "Install Manifest" = "Install Manifest";
 "Install and authenticate Codex CLI or Claude CLI, then retry setup." = "Install and authenticate Codex CLI or Claude CLI, then retry setup.";
 "Installation" = "Installation";
-"Launch Codex or Claude in Terminal" = "Launch Codex or Claude in Terminal";
 "Launch in %@" = "Launch in %@";
-"Launching…" = "Launching…";
-"Leave empty and type in the terminal." = "Leave empty and type in the terminal.";
+"Leave empty and type in the embedded terminal." = "Leave empty and type in the embedded terminal.";
 "Live session terminal" = "Live session terminal";
 "Model context used" = "Model context used";
 "Move Detach to Applications" = "Move Detach to Applications";
@@ -177,7 +176,10 @@
 "Setting Up Detach…" = "Setting Up Detach…";
 "Something went wrong" = "Something went wrong";
 "Sparkle checks in the background on its own schedule." = "Sparkle checks in the background on its own schedule.";
-"Start a managed run in your terminal." = "Start a managed run in your terminal.";
+"Start a managed run in Detach." = "Start a managed run in Detach.";
+"Start Codex or Claude in Detach" = "Start Codex or Claude in Detach";
+"Start" = "Start";
+"Starting…" = "Starting…";
 "Start your first session" = "Start your first session";
 "Stop" = "Stop";
 "Technical Details" = "Technical Details";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "The session has no provider UUID to resume." = "У сессии нет UUID провайдера для продолжения.";
 "detach resume timed out" = "Истекло время ожидания detach resume";
 "detach recover timed out" = "Истекло время ожидания detach recover";
+"detach start timed out" = "Истекло время ожидания detach start";
 "detach exited with status %d" = "detach завершился с кодом %d";
 "Could not run detach: %@" = "Не удалось запустить detach: %@";
 "Session is not eligible for deletion from Finished." = "Сессию нельзя удалить из раздела «Завершены».";
@@ -116,10 +117,8 @@
 "Install Manifest" = "Манифест установки";
 "Install and authenticate Codex CLI or Claude CLI, then retry setup." = "Установите и авторизуйте Codex CLI или Claude CLI, затем повторите настройку.";
 "Installation" = "Установка";
-"Launch Codex or Claude in Terminal" = "Запустить Codex или Claude в терминале";
 "Launch in %@" = "Запустить в %@";
-"Launching…" = "Запуск…";
-"Leave empty and type in the terminal." = "Можно оставить пустым и писать в терминале.";
+"Leave empty and type in the embedded terminal." = "Можно оставить пустым и писать во встроенном терминале.";
 "Live session terminal" = "Интерактивный терминал сессии";
 "Model context used" = "Занятый контекст модели";
 "Move Detach to Applications" = "Переместите Detach в Applications";
@@ -177,7 +176,10 @@
 "Setting Up Detach…" = "Настраиваем Detach…";
 "Something went wrong" = "Не получилось";
 "Sparkle checks in the background on its own schedule." = "Проверки выполняет Sparkle в фоне по собственному расписанию.";
-"Start a managed run in your terminal." = "Запустите управляемый сеанс в терминале.";
+"Start a managed run in Detach." = "Запустите управляемую сессию в Detach.";
+"Start Codex or Claude in Detach" = "Запустить Codex или Claude в Detach";
+"Start" = "Запустить";
+"Starting…" = "Запуск…";
 "Start your first session" = "Запустите первую сессию";
 "Stop" = "Остановить";
 "Technical Details" = "Технические детали";

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -4,11 +4,9 @@ import DetachKit
 struct NewSessionSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appFontPointSize) private var fontPointSize
-    @AppStorage(AppSettings.terminalBundleIdentifierKey, store: AppSettings.defaults)
-    private var terminalBundleIdentifier =
-        TerminalCatalog.defaultBundleIdentifier
 
-    let detachPath: String
+    let store: SessionStore
+    @Binding var selectedID: String?
 
     @State private var projectDir: URL?
     @State private var provider: Provider = .claude
@@ -16,17 +14,19 @@ struct NewSessionSheet: View {
     @State private var prompt = ""
     @State private var showAdvanced = false
     @FocusState private var promptFocused: Bool
-    @State private var launchFailure: TerminalLaunchFailure?
+    @State private var launchFailure: String?
     @State private var isLaunching = false
 
     init(
-        detachPath: String,
+        store: SessionStore,
+        selectedID: Binding<String?> = .constant(nil),
         initialName: String = "",
         showsAdvanced: Bool = false,
         initialProjectDir: URL? = nil,
-        initialLaunchFailure: TerminalLaunchFailure? = nil
+        initialLaunchFailure: String? = nil
     ) {
-        self.detachPath = detachPath
+        self.store = store
+        _selectedID = selectedID
         _name = State(initialValue: initialName)
         _showAdvanced = State(initialValue: showsAdvanced)
         _projectDir = State(initialValue: initialProjectDir)
@@ -76,7 +76,7 @@ struct NewSessionSheet: View {
         VStack(alignment: .leading, spacing: 4) {
             Text(L10n.string("New session"))
                 .appFont(.title3, weight: .bold)
-            Text(L10n.string("Start a managed run in your terminal."))
+            Text(L10n.string("Start a managed run in Detach."))
                 .appFont(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -120,10 +120,6 @@ struct NewSessionSheet: View {
             }
             .buttonStyle(.plain)
         }
-    }
-
-    private var selectedTerminalDisplayName: String {
-        TerminalLaunchPresentation.displayName(for: terminalBundleIdentifier)
     }
 
     private var providerAndName: some View {
@@ -183,55 +179,40 @@ struct NewSessionSheet: View {
 // quality-coverage:end ui-e2e-instrumentation
 
             if showAdvanced {
-                VStack(alignment: .leading, spacing: 14) {
-                    VStack(alignment: .leading, spacing: 5) {
-                        fieldLabel(L10n.string("Terminal"))
-                        TerminalPreferencePicker(
-                            bundleIdentifier: $terminalBundleIdentifier,
-                            accessibilityIdentifier: "new-session-terminal")
+                VStack(alignment: .leading, spacing: 5) {
+                    fieldLabel(L10n.string("Initial prompt (optional)"))
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $prompt)
+                            .appFont(.body)
+                            .scrollContentBackground(.hidden)
+                            .focused($promptFocused)
+                            .padding(.horizontal, 6)
+                            .padding(.top, 6)
+                            .padding(.bottom, 10)
+                            .frame(height: max(84, fontPointSize * 5.4))
+                            .accessibilityIdentifier("new-session-prompt")
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                             .background {
-                                uiE2EGeometryProbe(identifier: "new-session-terminal")
+                                uiE2EGeometryProbe(identifier: "new-session-prompt")
                             }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
-                    }
-                    VStack(alignment: .leading, spacing: 5) {
-                        fieldLabel(L10n.string("Initial prompt (optional)"))
-                        ZStack(alignment: .topLeading) {
-                            TextEditor(text: $prompt)
+                        if prompt.isEmpty && !promptFocused {
+                            Text(L10n.string("Leave empty and type in the embedded terminal."))
                                 .appFont(.body)
-                                .scrollContentBackground(.hidden)
-                                .focused($promptFocused)
-                                .padding(.horizontal, 6)
-                                .padding(.top, 6)
-                                .padding(.bottom, 10)
-                                .frame(height: max(84, fontPointSize * 5.4))
-                                .accessibilityIdentifier("new-session-prompt")
-// quality-coverage:begin ui-e2e-instrumentation
-#if !DEBUG
-                                .background {
-                                    uiE2EGeometryProbe(identifier: "new-session-prompt")
-                                }
-#endif
-// quality-coverage:end ui-e2e-instrumentation
-                            if prompt.isEmpty && !promptFocused {
-                                Text(L10n.string("Leave empty and type in the terminal."))
-                                    .appFont(.body)
-                                    .foregroundStyle(.tertiary)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 8)
-                                    .allowsHitTesting(false)
-                            }
+                                .foregroundStyle(.tertiary)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 8)
+                                .allowsHitTesting(false)
                         }
-                        .background(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(Color(nsColor: .textBackgroundColor)))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(.quaternary, lineWidth: 1)
-                        }
+                    }
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color(nsColor: .textBackgroundColor)))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .strokeBorder(.quaternary, lineWidth: 1)
                     }
                 }
             }
@@ -241,20 +222,12 @@ struct NewSessionSheet: View {
     @ViewBuilder
     private var launchFailureBanner: some View {
         if let launchFailure {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(launchFailure.message).appFont(.caption).foregroundStyle(.red)
-                if launchFailure.requiresTerminalSelection {
-                    SettingsLink {
-                        Text(L10n.string("Choose another terminal"))
-                    }
-                    .appFont(.caption)
-                }
-            }
-            .padding(10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.red.opacity(0.08)))
+            Text(launchFailure).appFont(.caption).foregroundStyle(.red)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.red.opacity(0.08)))
         }
     }
 
@@ -281,8 +254,7 @@ struct NewSessionSheet: View {
                     Task { await launch() }
                 } label: {
                     NewSessionLaunch.label(
-                        isLaunching: isLaunching,
-                        terminalDisplayName: selectedTerminalDisplayName)
+                        isLaunching: isLaunching)
                 }
                     .buttonStyle(.borderedProminent)
                     .tint(Brand.tint(for: provider))
@@ -293,8 +265,7 @@ struct NewSessionSheet: View {
                     .background {
                         uiE2EGeometryProbe(
                             identifier: "new-session-launch",
-                            semanticLabel: TerminalLaunchPresentation.title(
-                                terminalDisplayName: selectedTerminalDisplayName),
+                            semanticLabel: L10n.string("Start"),
                             semanticRole: .button,
                             semanticEnabled: canLaunch)
                     }
@@ -347,19 +318,16 @@ struct NewSessionSheet: View {
         guard !isLaunching, isNameValid, let projectDir else { return }
         isLaunching = true
         defer { isLaunching = false }
-        let command = NewSessionLaunch.command(
-            detachPath: detachPath,
+        let result = await store.startDetached(
             provider: provider,
-            projectDir: projectDir.path,
+            projectDirectory: projectDir,
             name: normalizedName,
-            prompt: prompt)
+            prompt: NewSessionLaunch.trimmedPrompt(prompt))
         launchFailure = nil
-        let failure = await TerminalLauncher.open(
-            command: command,
-            terminalBundleIdentifier: terminalBundleIdentifier)
-        if let failure {
-            launchFailure = failure
+        if let message = result.message {
+            launchFailure = message
         } else {
+            if let sessionID = result.sessionID { selectedID = sessionID }
             dismiss()
         }
     }
@@ -372,32 +340,16 @@ enum NewSessionLaunch {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    static func command(
-        detachPath: String,
-        provider: Provider,
-        projectDir: String,
-        name: String?,
-        prompt: String
-    ) -> String {
-        TerminalCommand.start(
-            detachPath: detachPath,
-            provider: provider,
-            projectDir: projectDir,
-            name: name,
-            prompt: trimmedPrompt(prompt))
-    }
-
     @ViewBuilder
-    static func label(isLaunching: Bool, terminalDisplayName: String) -> some View {
+    static func label(isLaunching: Bool) -> some View {
         HStack(spacing: 7) {
             if isLaunching {
                 ProgressView()
                     .controlSize(.small)
-                Text(L10n.string("Launching…"))
+                Text(L10n.string("Starting…"))
             } else {
                 Image(systemName: "terminal")
-                Text(TerminalLaunchPresentation.title(
-                    terminalDisplayName: terminalDisplayName))
+                Text(L10n.string("Start"))
             }
         }
     }

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -314,8 +314,9 @@ struct NewSessionSheet: View {
     }
 
     @MainActor
-    private func launch() async {
-        guard !isLaunching, isNameValid, let projectDir else { return }
+    @discardableResult
+    func launch() async -> SessionStartResult? {
+        guard !isLaunching, isNameValid, let projectDir else { return nil }
         isLaunching = true
         defer { isLaunching = false }
         let result = await store.startDetached(
@@ -330,6 +331,7 @@ struct NewSessionSheet: View {
             if let sessionID = result.sessionID { selectedID = sessionID }
             dismiss()
         }
+        return result
     }
 }
 // quality-coverage:end sheet-appkit

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -46,7 +46,6 @@ struct RootView: View {
                     NavigationSplitView {
                         SidebarView(
                             store: store,
-                            detachPath: detachPath,
                             selectedID: $selectedID,
                             navigation: navigation)
                     } detail: {

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -12,7 +12,6 @@ enum FinishedDeletionPresentation {
 struct SidebarView: View {
     @Environment(\.appFontPointSize) private var fontPointSize
     let store: SessionStore
-    let detachPath: String
     @Binding var selectedID: String?
     @ObservedObject var navigation: MainNavigation
     @State private var showNewSession = false
@@ -60,7 +59,7 @@ struct SidebarView: View {
                                 .foregroundStyle(Brand.gradient)
                         }
                     } description: {
-                        Text(L10n.string("Launch Codex or Claude in Terminal"))
+                        Text(L10n.string("Start Codex or Claude in Detach"))
                     }
                 }
             }
@@ -91,7 +90,7 @@ struct SidebarView: View {
             }
         }
         .sheet(isPresented: $showNewSession) {
-            NewSessionSheet(detachPath: detachPath)
+            NewSessionSheet(store: store, selectedID: $selectedID)
         }
         .confirmationDialog(
             L10n.format(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -538,9 +538,7 @@ enum UIE2ETestDriver {
                 throw Failure(message: "Advanced prompt is visible while collapsed")
             }
             let launchControl = try await element(identifier: "new-session-launch")
-            let expectedLaunch = TerminalLaunchPresentation.title(
-                terminalDisplayName: TerminalLaunchPresentation.displayName(
-                    for: TerminalCatalog.defaultBundleIdentifier))
+            let expectedLaunch = L10n.string("Start")
             guard label(launchControl) == expectedLaunch else {
                 throw Failure(
                     message: "launch button is \(label(launchControl) ?? "nil"), expected \(expectedLaunch)")
@@ -559,9 +557,10 @@ enum UIE2ETestDriver {
             try await click(advanced, name: "new session Advanced")
             _ = try await measuredFrame(
                 identifier: "new-session-prompt", name: "new session prompt")
-            _ = try await measuredFrame(
-                identifier: "new-session-terminal", name: "new session terminal")
-            checks.append("new-session-hosts-terminal-picker")
+            guard UIE2EGeometryRegistry.frame(for: "new-session-terminal") == nil else {
+                throw Failure(message: "new-session sheet still hosts a terminal picker")
+            }
+            checks.append("new-session-starts-without-outer-terminal")
             var lastMaxY = pinnedTop
             var lastFrame = sheet.frame
             do {

--- a/app/Sources/DetachKit/DetachCLI.swift
+++ b/app/Sources/DetachKit/DetachCLI.swift
@@ -110,6 +110,21 @@ public struct CLIResult: Equatable, Sendable {
 
 public protocol DetachCLIRunning: Sendable {
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult
+    func run(
+        arguments: [String],
+        timeout: TimeInterval,
+        currentDirectoryURL: URL?
+    ) async throws -> CLIResult
+}
+
+public extension DetachCLIRunning {
+    func run(
+        arguments: [String],
+        timeout: TimeInterval,
+        currentDirectoryURL _: URL?
+    ) async throws -> CLIResult {
+        try await run(arguments: arguments, timeout: timeout)
+    }
 }
 
 public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
@@ -182,13 +197,24 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
     }
 
     public func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        try await run(
+            arguments: arguments,
+            timeout: timeout,
+            currentDirectoryURL: URL(
+                fileURLWithPath: FileManager.default.currentDirectoryPath,
+                isDirectory: true))
+    }
+
+    public func run(
+        arguments: [String],
+        timeout: TimeInterval,
+        currentDirectoryURL: URL?
+    ) async throws -> CLIResult {
         let request = BoundedProcessRequest(
             executableURL: executable,
             arguments: arguments,
             environment: environment,
-            currentDirectoryURL: URL(
-                fileURLWithPath: FileManager.default.currentDirectoryPath,
-                isDirectory: true),
+            currentDirectoryURL: currentDirectoryURL,
             timeout: timeout,
             terminationGrace: terminationGrace,
             outputDrainGrace: outputDrainGrace)

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -13,6 +13,16 @@ public struct SessionDeletionFailure: Equatable, Sendable {
     }
 }
 
+public struct SessionStartResult: Equatable, Sendable {
+    public var sessionID: String?
+    public var message: String?
+
+    public init(sessionID: String? = nil, message: String? = nil) {
+        self.sessionID = sessionID
+        self.message = message
+    }
+}
+
 @Observable @MainActor
 public final class SessionStore {
     private enum Mutation {
@@ -138,6 +148,59 @@ public final class SessionStore {
         return result.message
     }
 
+    /// Starts a fresh managed run without an outer terminal. A successful
+    /// start refreshes typed state and returns the one unambiguous new session
+    /// for the selected provider and project.
+    public func startDetached(
+        provider: Provider,
+        projectDirectory: URL,
+        name: String?,
+        prompt: String?
+    ) async -> SessionStartResult {
+        let existingIDs = Set(sessions.map(\.id))
+        var arguments = [provider.rawValue]
+        if let name, !name.isEmpty {
+            arguments += ["--name", name]
+        }
+        arguments.append("--detach")
+        if let prompt, !prompt.isEmpty {
+            arguments += ["--", prompt]
+        }
+
+        do {
+            let result = try await cli.run(
+                arguments: arguments,
+                timeout: 120,
+                currentDirectoryURL: projectDirectory)
+            guard !result.timedOut else {
+                await refresh()
+                return SessionStartResult(
+                    message: L10n.string("detach start timed out"))
+            }
+            guard result.exitCode == 0 else {
+                let stderr = result.stderr.trimmingCharacters(
+                    in: .whitespacesAndNewlines)
+                return SessionStartResult(message: stderr.isEmpty
+                    ? L10n.format("detach exited with status %d", result.exitCode)
+                    : stderr)
+            }
+
+            await refresh()
+            let projectPath = Self.canonicalProjectPath(projectDirectory.path)
+            let candidates = sessions.filter {
+                !existingIDs.contains($0.id)
+                    && $0.provider == provider
+                    && $0.projectDir.map(Self.canonicalProjectPath) == projectPath
+            }
+            return SessionStartResult(
+                sessionID: candidates.count == 1 ? candidates[0].id : nil)
+        } catch {
+            return SessionStartResult(message: L10n.format(
+                "Could not run detach: %@",
+                error.localizedDescription))
+        }
+    }
+
     /// Starts Resume or Recover without an outer terminal. The provider starts
     /// detached; the app creates a separate attach-only PTY after this returns.
     public func prepareInteractive(
@@ -186,6 +249,12 @@ public final class SessionStore {
                 "Could not run detach: %@",
                 error.localizedDescription)
         }
+    }
+
+    private static func canonicalProjectPath(_ path: String) -> String {
+        URL(fileURLWithPath: path, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL.path
     }
 
     /// Deletes every selected finished session and reports failures without

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -102,6 +102,55 @@ final class NewSessionSheetTests: XCTestCase {
         _ = NewSessionLaunch.label(isLaunching: true)
     }
 
+    func testLaunchStartsInAppAndSelectsTheTypedSession() async {
+        let cli = NewSessionRecordingCLI()
+        cli.responses["list --json"] = .success(CLIResult(
+            exitCode: 0,
+            stdout: #"{"schema":1,"provider":"claude","session_name":"detach-claude-p-1","name":"p-1","effective_status":"running","meta_status":"running","agent_session_id":"u1","project_dir":"/tmp/proj","created_at":"2026-08-29T00:00:00Z","last_checkpoint_at":null,"exit_status":null,"finished_at":null}"#,
+            stderr: "",
+            timedOut: false))
+        var selectedID: String?
+        let sheet = NewSessionSheet(
+            store: SessionStore(cli: cli),
+            selectedID: Binding(
+                get: { selectedID },
+                set: { selectedID = $0 }),
+            initialProjectDir: URL(
+                fileURLWithPath: "/tmp/proj",
+                isDirectory: true))
+
+        let result = await sheet.launch()
+
+        XCTAssertEqual(result?.sessionID, "detach-claude-p-1")
+        XCTAssertEqual(selectedID, "detach-claude-p-1")
+        XCTAssertEqual(cli.calls, [["claude", "--detach"], ["list", "--json"]])
+    }
+
+    func testLaunchReturnsTheStartFailureWithoutSelectingASession() async {
+        let cli = NewSessionRecordingCLI()
+        cli.responses["claude --detach"] = .success(CLIResult(
+            exitCode: 17,
+            stdout: "",
+            stderr: "start refused",
+            timedOut: false))
+        var selectedID: String?
+        let sheet = NewSessionSheet(
+            store: SessionStore(cli: cli),
+            selectedID: Binding(
+                get: { selectedID },
+                set: { selectedID = $0 }),
+            initialProjectDir: URL(
+                fileURLWithPath: "/tmp/proj",
+                isDirectory: true))
+
+        let result = await sheet.launch()
+
+        XCTAssertEqual(result?.message, "start refused")
+        XCTAssertNil(selectedID)
+        XCTAssertEqual(cli.calls, [["claude", "--detach"]])
+        _ = sheet.body
+    }
+
     func testLaunchTitleAndDisplayNameUseTheSelectedTerminal() {
         XCTAssertEqual(
             TerminalLaunchPresentation.title(terminalDisplayName: "iTerm"),
@@ -122,6 +171,21 @@ final class NewSessionSheetTests: XCTestCase {
         XCTAssertFalse(rules.canChooseDirectories)
         XCTAssertFalse(rules.allowsMultipleSelection)
         XCTAssertFalse(rules.canCreateDirectories)
+    }
+
+    func testOpenPanelsApplyTheirTypedRules() {
+        let terminal = TerminalApplicationChooser.makeOpenPanel()
+        XCTAssertTrue(terminal.canChooseFiles)
+        XCTAssertFalse(terminal.canChooseDirectories)
+        XCTAssertEqual(terminal.allowedContentTypes, [.applicationBundle])
+        XCTAssertEqual(terminal.directoryURL?.path, "/Applications")
+
+        let project = ProjectDirectoryChooser.makeOpenPanel(
+            startingAt: URL(fileURLWithPath: "/tmp", isDirectory: true))
+        XCTAssertFalse(project.canChooseFiles)
+        XCTAssertTrue(project.canChooseDirectories)
+        XCTAssertEqual(project.allowedContentTypes, [])
+        XCTAssertEqual(project.directoryURL?.path, "/tmp")
     }
 
     func testProjectChooserStartsInTheSelectedProjectParent() {
@@ -205,6 +269,35 @@ final class NewSessionSheetTests: XCTestCase {
         pin.layout()
     }
 
+    func testPinViewKeepsAnAttachedWindowTopFixed() async {
+        let window = NSWindow(
+            contentRect: NSRect(x: 100, y: 200, width: 520, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: true)
+        let pin = PinWindowTopEdgeView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+        window.contentView = pin
+        pin.removeResizeObserver()
+        pin.startPinning()
+
+        let scheduled = expectation(description: "pin scheduled")
+        DispatchQueue.main.async { scheduled.fulfill() }
+        await fulfillment(of: [scheduled], timeout: 1)
+        let pinnedMaxY = window.frame.maxY
+
+        window.setFrame(
+            NSRect(x: 100, y: 150, width: 520, height: 400),
+            display: false)
+        pin.applyPinnedTop()
+
+        XCTAssertEqual(window.frame.maxY, pinnedMaxY, accuracy: 0.01)
+        NotificationCenter.default.post(
+            name: NSWindow.didResizeNotification,
+            object: window)
+        pin.removeResizeObserver()
+    }
+
     private static func terminalApplicationURL() -> URL? {
         [
             "/System/Applications/Utilities/Terminal.app",
@@ -221,6 +314,20 @@ private struct NewSessionNoopCLI: DetachCLIRunning {
         timeout: TimeInterval
     ) async throws -> CLIResult {
         CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
+    }
+}
+
+private final class NewSessionRecordingCLI: DetachCLIRunning, @unchecked Sendable {
+    var responses: [String: Result<CLIResult, Error>] = [:]
+    private(set) var calls: [[String]] = []
+
+    func run(
+        arguments: [String],
+        timeout: TimeInterval
+    ) async throws -> CLIResult {
+        calls.append(arguments)
+        return try responses[arguments.joined(separator: " ")]?.get()
+            ?? CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
     }
 }
 

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -7,45 +7,42 @@ import XCTest
 
 @MainActor
 final class NewSessionSheetTests: XCTestCase {
+    private func store() -> SessionStore {
+        SessionStore(cli: NewSessionNoopCLI())
+    }
+
     func testBuildsFormWithOptionalEmptyName() {
-        _ = NewSessionSheet(detachPath: "/tmp/detach").body
+        _ = NewSessionSheet(store: store()).body
     }
 
     func testBuildsFormWithHumanReadableName() {
         _ = NewSessionSheet(
-            detachPath: "/tmp/detach",
+            store: store(),
             initialName: "Rev (ai)").body
     }
 
     func testBuildsInlineValidationForOversizedName() {
         _ = NewSessionSheet(
-            detachPath: "/tmp/detach",
+            store: store(),
             initialName: String(repeating: "a", count: 101)).body
     }
 
     func testBuildsExpandedAdvancedSection() {
         _ = NewSessionSheet(
-            detachPath: "/tmp/detach",
+            store: store(),
             showsAdvanced: true).body
     }
 
     func testBuildsFormWithASelectedProject() {
         _ = NewSessionSheet(
-            detachPath: "/tmp/detach",
+            store: store(),
             initialProjectDir: URL(fileURLWithPath: "/tmp/proj", isDirectory: true)).body
     }
 
-    func testBuildsBothLaunchFailureBannerShapes() {
+    func testBuildsLaunchFailureBanner() {
         _ = NewSessionSheet(
-            detachPath: "/tmp/detach",
-            initialLaunchFailure: TerminalLaunchFailure(
-                message: "missing terminal",
-                reason: .terminalUnavailable)).body
-        _ = NewSessionSheet(
-            detachPath: "/tmp/detach",
-            initialLaunchFailure: TerminalLaunchFailure(
-                message: "open failed",
-                reason: .openFailed)).body
+            store: store(),
+            initialLaunchFailure: "start refused").body
     }
 
     func testPickerRefreshLoadsInstalledAndMissingSelections() {
@@ -98,27 +95,11 @@ final class NewSessionSheetTests: XCTestCase {
     func testLaunchPlanOmitsABlankPromptAndKeepsText() {
         XCTAssertNil(NewSessionLaunch.trimmedPrompt("  \n"))
         XCTAssertEqual(NewSessionLaunch.trimmedPrompt("  go\n"), "go")
-        let command = NewSessionLaunch.command(
-            detachPath: "/tmp/detach",
-            provider: .codex,
-            projectDir: "/tmp/proj",
-            name: "Rev",
-            prompt: "  review this  ")
-        XCTAssertTrue(command.contains("cd '/tmp/proj'"), command)
-        XCTAssertTrue(command.contains("--name 'Rev'"), command)
-        XCTAssertTrue(command.contains("-- 'review this'"), command)
-        let blank = NewSessionLaunch.command(
-            detachPath: "/tmp/detach",
-            provider: .claude,
-            projectDir: "/tmp/p",
-            name: nil,
-            prompt: "   ")
-        XCTAssertFalse(blank.contains(" -- "), blank)
     }
 
     func testLaunchLabelCoversBothIdleAndBusyStates() {
-        _ = NewSessionLaunch.label(isLaunching: false, terminalDisplayName: "iTerm")
-        _ = NewSessionLaunch.label(isLaunching: true, terminalDisplayName: "Terminal")
+        _ = NewSessionLaunch.label(isLaunching: false)
+        _ = NewSessionLaunch.label(isLaunching: true)
     }
 
     func testLaunchTitleAndDisplayNameUseTheSelectedTerminal() {
@@ -231,6 +212,15 @@ final class NewSessionSheetTests: XCTestCase {
         ]
         .map { URL(fileURLWithPath: $0, isDirectory: true) }
         .first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+}
+
+private struct NewSessionNoopCLI: DetachCLIRunning {
+    func run(
+        arguments: [String],
+        timeout: TimeInterval
+    ) async throws -> CLIResult {
+        CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
     }
 }
 

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -39,7 +39,7 @@ final class NewSessionSheetTests: XCTestCase {
             initialProjectDir: URL(fileURLWithPath: "/tmp/proj", isDirectory: true)).body
     }
 
-    func testBuildsLaunchFailureBanner() {
+    func testBuildsBothLaunchFailureBannerShapes() {
         _ = NewSessionSheet(
             store: store(),
             initialLaunchFailure: "start refused").body

--- a/app/Tests/DetachAppTests/SidebarViewTests.swift
+++ b/app/Tests/DetachAppTests/SidebarViewTests.swift
@@ -17,7 +17,6 @@ final class SidebarViewTests: XCTestCase {
     func testBuildsWithFreshFinishedSelectionState() {
         let view = SidebarView(
             store: SessionStore(cli: SidebarNoopCLI()),
-            detachPath: "/tmp/detach",
             selectedID: .constant(nil),
             navigation: MainNavigation())
 

--- a/app/Tests/DetachKitTests/DetachCLITests.swift
+++ b/app/Tests/DetachKitTests/DetachCLITests.swift
@@ -23,6 +23,29 @@ final class DetachCLITests: XCTestCase {
         XCTAssertFalse(result.timedOut)
     }
 
+    func testUsesAnExplicitWorkingDirectory() async throws {
+        let directory = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+            .appendingPathComponent("detach-cli-cwd-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cli = ProcessDetachCLI(executable: try fixture("pwd -P"))
+
+        let result = try await cli.run(
+            arguments: [],
+            timeout: 5,
+            currentDirectoryURL: directory)
+
+        XCTAssertEqual(result.exitCode, 0)
+        let reportedDirectory = result.stdout.trimmingCharacters(
+            in: .whitespacesAndNewlines)
+        XCTAssertEqual(
+            URL(fileURLWithPath: reportedDirectory).lastPathComponent,
+            directory.lastPathComponent)
+        XCTAssertNotEqual(reportedDirectory, FileManager.default.currentDirectoryPath)
+    }
+
     func testLargeOutputDoesNotDeadlock() async throws {
         let cli = ProcessDetachCLI(executable: try fixture("dd if=/dev/zero bs=1024 count=512 2>/dev/null | tr '\\0' 'x'"))
         let result = try await cli.run(arguments: [], timeout: 10)

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -13,6 +13,10 @@ final class PowerHelperPlatformTests: XCTestCase {
         }
     }
 
+    func testBootSessionReaderCanBeConstructed() {
+        _ = SysctlBootSessionReader()
+    }
+
     func testRootCommandRunnerTerminatesHungProcess() {
         let runner = RootProcessCommandRunner(
             // Give the child time to install its ignored-TERM handler before

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -4,6 +4,7 @@ import XCTest
 final class FakeCLI: DetachCLIRunning, @unchecked Sendable {
     var responses: [String: Result<CLIResult, Error>] = [:]
     private(set) var calls: [[String]] = []
+    private(set) var currentDirectories: [URL?] = []
 
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
         calls.append(arguments)
@@ -12,6 +13,15 @@ final class FakeCLI: DetachCLIRunning, @unchecked Sendable {
             return CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
         }
         return try response.get()
+    }
+
+    func run(
+        arguments: [String],
+        timeout: TimeInterval,
+        currentDirectoryURL: URL?
+    ) async throws -> CLIResult {
+        currentDirectories.append(currentDirectoryURL)
+        return try await run(arguments: arguments, timeout: timeout)
     }
 }
 
@@ -199,6 +209,60 @@ final class SessionStoreTests: XCTestCase {
         await store.refresh()
         _ = await store.perform(.delete, on: store.sessions[0])
         XCTAssertTrue(cli.calls.contains(["codex", "delete", "--force", "detach-codex-p-1"]))
+    }
+
+    func testStartDetachedUsesProjectAndSelectsTheNewTypedSession() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line)
+        let store = SessionStore(cli: cli)
+        let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
+
+        let result = await store.startDetached(
+            provider: .codex,
+            projectDirectory: project,
+            name: "Rev (ai)",
+            prompt: "review this")
+
+        XCTAssertEqual(
+            cli.calls,
+            [
+                ["codex", "--name", "Rev (ai)", "--detach", "--", "review this"],
+                ["list", "--json"],
+            ])
+        XCTAssertEqual(cli.currentDirectories, [project])
+        XCTAssertEqual(result, SessionStartResult(sessionID: "detach-codex-p-1"))
+    }
+
+    func testStartDetachedKeepsFailuresAndTimeoutsInTheCaller() async {
+        let failureCLI = FakeCLI()
+        failureCLI.responses["claude --detach"] = .success(CLIResult(
+            exitCode: 17,
+            stdout: "",
+            stderr: "start refused\n",
+            timedOut: false))
+        let failureStore = SessionStore(cli: failureCLI)
+        let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
+        let failure = await failureStore.startDetached(
+            provider: .claude,
+            projectDirectory: project,
+            name: nil,
+            prompt: nil)
+        XCTAssertEqual(failure.message, "start refused")
+
+        let timeoutCLI = FakeCLI()
+        timeoutCLI.responses["codex --detach"] = .success(CLIResult(
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            timedOut: true))
+        let timeoutStore = SessionStore(cli: timeoutCLI)
+        let timeout = await timeoutStore.startDetached(
+            provider: .codex,
+            projectDirectory: project,
+            name: nil,
+            prompt: nil)
+        XCTAssertEqual(timeout.message, L10n.string("detach start timed out"))
+        XCTAssertEqual(timeoutCLI.calls.last, ["list", "--json"])
     }
 
     func testPrepareResumeStartsDetachedThenRefreshes() async throws {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -130,7 +130,7 @@ final class SessionStoreTests: XCTestCase {
             .replacingOccurrences(
                 of: "2026-07-10T10:00:00Z",
                 with: "2026-07-11T10:00:00Z")
-        cli.responses["list --json"] = ok(olderWithoutDate + "\n" + line + "\n" + newest)
+        cli.responses["list --json"] = ok(line + "\n" + olderWithoutDate + "\n" + newest)
         let store = SessionStore(cli: cli)
 
         await store.refresh()
@@ -263,6 +263,63 @@ final class SessionStoreTests: XCTestCase {
             prompt: nil)
         XCTAssertEqual(timeout.message, L10n.string("detach start timed out"))
         XCTAssertEqual(timeoutCLI.calls.last, ["list", "--json"])
+    }
+
+    func testStartDetachedReportsEmptyFailureAndLaunchError() async {
+        let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
+        let emptyFailureCLI = FakeCLI()
+        emptyFailureCLI.responses["claude --detach"] = .success(CLIResult(
+            exitCode: 17,
+            stdout: "",
+            stderr: "",
+            timedOut: false))
+
+        let emptyFailure = await SessionStore(cli: emptyFailureCLI).startDetached(
+            provider: .claude,
+            projectDirectory: project,
+            name: nil,
+            prompt: nil)
+
+        XCTAssertEqual(
+            emptyFailure.message,
+            L10n.format("detach exited with status %d", 17))
+
+        let launchFailureCLI = FakeCLI()
+        launchFailureCLI.responses["codex --detach"] = .failure(FakeError())
+
+        let launchFailure = await SessionStore(cli: launchFailureCLI).startDetached(
+            provider: .codex,
+            projectDirectory: project,
+            name: nil,
+            prompt: nil)
+
+        XCTAssertTrue(launchFailure.message?.hasPrefix("Could not run detach: ") == true)
+    }
+
+    func testStartDetachedRejectsAnAmbiguousTypedRefresh() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line)
+        let store = SessionStore(cli: cli)
+        let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
+        await store.refresh()
+
+        let second = line
+            .replacingOccurrences(of: "detach-codex-p-1", with: "detach-codex-p-2")
+            .replacingOccurrences(of: #"\"name\":\"p-1\""#, with: #"\"name\":\"p-2\""#)
+        let third = line
+            .replacingOccurrences(of: "detach-codex-p-1", with: "detach-codex-p-3")
+            .replacingOccurrences(of: #"\"name\":\"p-1\""#, with: #"\"name\":\"p-3\""#)
+        cli.responses["list --json"] = ok(line + "\n" + second + "\n" + third)
+
+        let result = await store.startDetached(
+            provider: .codex,
+            projectDirectory: project,
+            name: "",
+            prompt: "")
+
+        XCTAssertEqual(cli.calls.suffix(2), [["codex", "--detach"], ["list", "--json"]])
+        XCTAssertNil(result.sessionID)
+        XCTAssertNil(result.message)
     }
 
     func testPrepareResumeStartsDetachedThenRefreshes() async throws {

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -162,18 +162,18 @@ user-specific path. Native power protection requires no Apple Events or
 Automation entitlement.
 
 Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
-In-app Resume and Recover call `--detach`, then attach through an
-ephemeral PTY on `detach <provider> attach <session>`. Closing the view or app
-ends that client. `Ctrl-V` reaches provider image paste; Detach stores no
-image. Live views move typed Mac Power to metadata and omit the duplicate strip.
-An exited client offers Reconnect without an agent restart. The selected
-terminal remains an `NSWorkspace` `.command` fallback. Without one, a private
-`.zshenv` is the outer
-`ZDOTDIR` until payload removal restores the original.
+App Start runs the provider with `--detach` in its project, keeps an error in
+the sheet, refreshes state, and selects one unambiguous new
+session. Start, Resume, and Recover attach through an ephemeral PTY on
+`detach <provider> attach <session>`. Closing the view or app ends that client.
+`Ctrl-V` reaches provider image paste; Detach stores no image. Live views move
+typed Mac Power to metadata and omit the duplicate strip. An exited client
+offers Reconnect without an agent restart. The selected terminal remains an
+`NSWorkspace` `.command` fallback.
 The new-session sheet accepts an optional UTF-8 name up to 100 bytes. It rejects
 control characters, blocks launch, and passes one `--name`. The launch button
-names the selected terminal. Advanced holds terminal choice and the prompt and
-grows down, top fixed. The app uses `display_name` as the title, with
+starts inside Detach. Advanced holds the prompt and grows down, top fixed. The
+app uses `display_name` as the title, with
 the project/internal name fallback for old records.
 Notifications are opt-in. One poller deduplicates baseline and transitions.
 

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -310,7 +310,7 @@ run_app_scenario() {
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
       new-session-advanced-keeps-top-edge|\
-      new-session-hosts-terminal-picker) ;;
+      new-session-starts-without-outer-terminal) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -349,7 +349,7 @@ run_app_scenario main sessions 32 \
   safe-action-reaches-fake-cli \
   finished-selection-clears-scrollbar \
   bulk-delete-reaches-fake-cli \
-  new-session-hosts-terminal-picker \
+  new-session-starts-without-outer-terminal \
   new-session-advanced-keeps-top-edge \
   new-session-sheet-semantics \
   empty-dashboard-state \


### PR DESCRIPTION
Closes #68.

## Product value

Starting a session from Detach no longer opens a second terminal application. The app starts the provider in the selected project with `--detach`, refreshes typed session state, selects the one unambiguous new session, and opens its embedded terminal.

## Contract delta

- **Before:** the new-session sheet built a shell command and delegated startup to the selected external terminal.
- **After:** the sheet calls the bounded Detach CLI directly with the selected project as its working directory. Start errors and timeouts remain in the sheet.
- **Fallback:** the terminal preference still owns external Attach, Resume, and Recover fallback actions. It is no longer part of new-session Advanced options.
- README, the app specification, English and Russian strings, and the UI E2E journey now describe the same behavior.

## Evidence

- focused Swift suites: 69 tests passed after implementation fixes
- Swift quality stage: 865 tests passed; stage passed in 18 seconds
- exact coverage contracts: changed executable Swift lines 100%; business coverage 95.21%
- static stage: PASS
- packaged app stage: PASS
- documentation/context contracts and `git diff --check`: PASS
- local UI E2E harness contract: PASS; the full local UI journey was blocked twice before the changed screen because macOS did not grant the isolated test copy frontmost/key-window focus. Hosted `quality-gates` remains readiness authority.

No signing, notarization, publication, or real power test ran.
