### PR TITLE
Compare coverage within matching profiles

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -86,7 +86,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          baseline_root="$(scripts/quality-baseline)"
+          baseline_root="$(scripts/quality-baseline --profile '${{ matrix.coverage_profile }}')"
           printf 'DETACH_QUALITY_BASELINE_ROOT=%s\n' "$baseline_root" >>"$GITHUB_ENV"
       - name: Restore exact packaged test app
         id: app-cache

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -200,6 +200,7 @@ unknown path selects every functional stage and every release impact.
 | Documentation | static |
 | Quality policy or CI | static and gate self-contracts |
 | Swift source | Swift, metrics, app, packaged UI, and required dependencies |
+| Swift tests | Swift and matching-profile metrics |
 | CLI or session lifecycle | app, both providers, distribution, runtime, and dependencies |
 | One provider test | static and that provider; its shard verifies the exact app prerequisite |
 | Install or distribution | app, distribution, runtime, and dependencies |
@@ -219,10 +220,14 @@ its impact does not select `quality-contracts`. An authoritative metric run
 accepts only a digest-bound `quality-metrics.json` from `ci-main`. It never
 reads a manual floor file.
 
-The metric artifact records exact UI and business test identities, aggregate
-line coverage, critical-source coverage, and changed executable Swift lines.
-Swift-test changes run the packaged-app journeys before metrics so the current
-and baseline coverage inputs are equivalent.
+The metric artifact records its `swift` or `combined` profile, exact UI and
+business test identities, aggregate line coverage, critical-source coverage,
+and changed executable Swift lines. The baseline restore selects the newest
+green-main artifact with the same profile. Schema-1 artifacts are combined
+profiles during migration. Each combined run also records a digest-bound Swift
+snapshot for later Swift-profile comparisons without a second ratchet. Thus,
+Swift-test-only changes do not run packaged app journeys only to make coverage
+inputs equivalent.
 CI rejects a removed test or a lower aggregate or critical-source ratio.
 Changed executable lines need at least 90 percent coverage. A new critical
 source needs 100 percent coverage for its first baseline. Missing, stale,

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -89,12 +89,11 @@ Hosted CI is the merge-readiness authority.
   person cannot raise floors. Policy exclusions need
   scenario evidence and cannot cover critical sources. Named test-only regions
   stay in aggregate coverage but not changed-line metrics.
-- Authoritative coverage combines Swift and packaged-app tests. Swift-test
-  changes run both, so metrics match the baseline. CI resolves one shared
-  cache, then three builds use isolated paths. The gate splits workers and
-  verifies the normal bundle. Only a stripped private
-  copy gets the instrumented executable. Metrics merge profiles without a
-  second test run.
+- Coverage artifacts name `swift` or `combined`. Ratchets use the newest
+  matching main profile; schema-1 means combined. Full runs record a Swift
+  snapshot; test-only changes skip app journeys. CI shares one cache
+  across isolated builds, splits workers, verifies the bundle, and instruments
+  only a private copy. Combined metrics merge profiles without another run.
 - `coverage-opportunities.json` is a separate digest-bound advisory artifact.
   It ranks uncovered UI sources from policy routes, release impact,
   requirements, and journeys. Its next milestone is the five-point boundary

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -34,10 +34,10 @@ change real power state, upload assets, or claim publication.
 - Developer ID signing, notarization, and the real signed power smoke are
   mandatory for every release. `scripts/release-impact` compares the last
   published tag with the release source. It selects supervised closed-lid
-  testing only for power, helper, watchdog, lease, assertion, lid-probe, or
-  `scripts/release-version` impact. An unknown product path selects the
-  closed-lid gate. Test-only, documentation-only, and known unrelated product
-  paths do not select it.
+  testing only for power, helper, watchdog, lease, assertion, or lid-probe
+  impact. An unknown product path selects the closed-lid gate. Test-only,
+  documentation-only, release-orchestrator, and known unrelated product paths
+  do not select it.
 - Notary credential preflight gives `notarytool` a private PTY and captures its
   output in private workflow evidence. This supports protected Keychain
   profiles without exposing submission history in the release log.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -714,7 +714,7 @@
     "mutation_timeout_seconds": 240,
     "pr_feedback_seconds": 600
   },
-  "policy": 53,
+  "policy": 54,
   "release_domains": [
     {
       "gates": "-",
@@ -1794,7 +1794,7 @@
     {
       "pattern": "scripts/release-version",
       "priority": 900,
-      "release_domain": "lid",
+      "release_domain": "safe",
       "spec": "docs/specs/release.md",
       "test_domain": "release-tool"
     },
@@ -3275,7 +3275,7 @@
     {
       "capabilities": "quality-system",
       "id": "swift-test",
-      "stages": "static,swift,quality-contracts,app,release-budget"
+      "stages": "static,swift,quality-contracts,release-budget"
     },
     {
       "capabilities": "installation,update",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	53
+policy	54
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
@@ -39,7 +39,7 @@ test-domain	update-source	static,swift,quality-contracts,app,release-budget	upda
 test-domain	diagnostics-source	static,swift,quality-contracts,app,release-budget	diagnostics
 test-domain	runtime-source	static,swift,quality-contracts,app,release-budget	session-lifecycle
 test-domain	session-ui-source	static,swift,quality-contracts,app,release-budget	session-lifecycle,app-experience
-test-domain	swift-test	static,swift,quality-contracts,app,release-budget	quality-system
+test-domain	swift-test	static,swift,quality-contracts,release-budget	quality-system
 test-domain	package	static,swift,quality-contracts,app,tmux-runtime,release-budget	installation,update
 test-domain	cli	static,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
 test-domain	install	static,app,distribution,tmux-runtime,release-budget	installation
@@ -209,7 +209,7 @@ route	900	app/scripts/bundle-modes.sh	app-script	unknown	docs/specs/release.md
 route	890	app/scripts/publish-release.sh	release-tool	safe	docs/specs/release.md
 route	890	app/scripts/verify-appcast.sh	release-tool	safe	docs/specs/release.md
 route	880	app/scripts/*	app-script	safe	docs/specs/release.md
-route	900	scripts/release-version	release-tool	lid	docs/specs/release.md
+route	900	scripts/release-version	release-tool	safe	docs/specs/release.md
 route	900	scripts/release-impact	release-tool	safe	docs/specs/release.md
 route	800	scripts/*	unknown	unknown	docs/specs/documentation.md
 route	900	tests/run.sh	codex-test	safe	docs/specs/runtime.md

--- a/tests/quality-contracts.sh
+++ b/tests/quality-contracts.sh
@@ -102,3 +102,15 @@ fi
   arguments+=(--baseline-root "$DETACH_QUALITY_BASELINE_ROOT")
 
 "$ROOT/scripts/quality-metrics" "${arguments[@]}"
+
+if [ -n "${DETACH_UI_COVERAGE_BINARY:-}" ]; then
+  swift_output="${DETACH_QUALITY_SWIFT_METRICS_OUTPUT:-$(dirname "$output")/quality-metrics-swift.json}"
+  "$ROOT/scripts/quality-metrics" evaluate \
+    --test-binary "$test_binary" \
+    --profile "$profdata" \
+    --tests "$tests" \
+    --output "$swift_output" \
+    --source-commit "$source_commit" \
+    --coverage-profile swift \
+    --authority local-diagnostic
+fi

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -344,7 +344,7 @@ mkdir -p "$REPO/app/Tests/DetachKitTests"
 printf '%s\n' 'final class ChangedTests {}' \
   >"$REPO/app/Tests/DetachKitTests/ChangedTests.swift"
 plan="$(gate --plan)"
-[[ "$plan" = *'stages=static,swift,quality-contracts,app,ui-e2e,release-budget' ]]
+[[ "$plan" = *'stages=static,swift,quality-contracts,release-budget' ]]
 
 setup_fixture typed-state-impact
 mkdir -p "$REPO/app/Sources/DetachKit"

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -78,7 +78,7 @@ expect_route app/Sources/DetachKit/TerminalLauncher.swift runtime-source safe fa
 expect_route app/Sources/DetachApp/OnboardingView.swift onboarding-source install false
 expect_route app/Sources/DetachApp/FutureFlow.swift swift-source unknown true
 expect_route scripts/release-lid-probe release-tool lid false
-expect_route scripts/release-version release-tool lid false
+expect_route scripts/release-version release-tool safe false
 expect_route scripts/quality-metrics policy safe false
 expect_route scripts/quality-mutation policy safe false
 

--- a/tests/quality_baseline_contract.py
+++ b/tests/quality_baseline_contract.py
@@ -19,6 +19,7 @@ def invoke(
     output_root: Path,
     *,
     mode: str = "success",
+    profile: str = "combined",
     expected: int = 0,
     test_mode: bool = True,
 ) -> subprocess.CompletedProcess[str]:
@@ -33,6 +34,7 @@ def invoke(
         [
             str(SCRIPT), "--repository", "owner/repository",
             "--output-root", str(output_root),
+            "--profile", profile,
         ],
         cwd=ROOT,
         env=environment,
@@ -68,6 +70,8 @@ if arguments[0] == "api" and "workflows/quality-gates.yml/runs" in arguments[1]:
     if mode == "malformed": print("{")
     elif mode == "no-runs": print(json.dumps({"workflow_runs": []}))
     elif mode == "partial-latest": print(json.dumps({"workflow_runs": [{"id": 124}, {"id": 123}]}))
+    elif mode == "profile-selection": print(json.dumps({"workflow_runs": [{"id": 125}, {"id": 124}]}))
+    elif mode == "dual-profile": print(json.dumps({"workflow_runs": [{"id": 126}]}))
     else: print(json.dumps({"workflow_runs": [{"id": 123}]}))
 elif arguments[0] == "api" and "/artifacts" in arguments[1]:
     run_id = arguments[1].split("/actions/runs/")[1].split("/")[0]
@@ -82,7 +86,17 @@ elif arguments[:2] == ["run", "download"]:
         (destination / "manifest.tsv").write_text("schema\\t4\\n")
         run_id = arguments[2]
         if mode != "no-metrics" and not (mode == "partial-latest" and run_id == "124"):
-            (destination / "quality-metrics.json").write_text("{}\\n")
+            if mode == "legacy":
+                metrics = {"schema": 1}
+            elif mode == "invalid-profile":
+                metrics = {"schema": 2, "coverage_profile": "other"}
+            else:
+                profile = "swift" if mode == "profile-selection" and run_id == "125" else "combined"
+                metrics = {"schema": 2, "coverage_profile": profile}
+            (destination / "quality-metrics.json").write_text(json.dumps(metrics) + "\\n")
+            if mode == "dual-profile":
+                (destination / "quality-metrics-swift.json").write_text(
+                    json.dumps({"schema": 2, "coverage_profile": "swift"}) + "\\n")
 else:
     raise SystemExit(3)
 """,
@@ -106,6 +120,30 @@ else:
         if not (partial_root / "124/run/manifest.tsv").is_file():
             raise AssertionError("partial main evidence was not inspected")
 
+        profile_root = root / "profile-selection"
+        combined = invoke(
+            fake_gh, profile_root, mode="profile-selection", profile="combined")
+        if Path(combined.stdout.strip()) != profile_root / "124":
+            raise AssertionError("baseline did not skip a newer mismatched profile")
+        swift = invoke(
+            fake_gh, profile_root, mode="profile-selection", profile="swift")
+        if Path(swift.stdout.strip()) != profile_root / "125":
+            raise AssertionError("baseline did not select the newest Swift profile")
+
+        dual_root = root / "dual-profile"
+        dual_swift = invoke(
+            fake_gh, dual_root, mode="dual-profile", profile="swift")
+        if Path(dual_swift.stdout.strip()) != dual_root / "126":
+            raise AssertionError("baseline did not select the auxiliary Swift profile")
+        dual_combined = invoke(
+            fake_gh, dual_root, mode="dual-profile", profile="combined")
+        if Path(dual_combined.stdout.strip()) != dual_root / "126":
+            raise AssertionError("baseline did not select the primary combined profile")
+
+        legacy = invoke(fake_gh, root / "legacy", mode="legacy")
+        if Path(legacy.stdout.strip()) != root / "legacy/123":
+            raise AssertionError("schema-1 metrics did not retain combined continuity")
+
         malformed = invoke(fake_gh, root / "malformed", mode="malformed", expected=2)
         require(malformed, "response is malformed")
         missing = invoke(fake_gh, root / "no-runs", mode="no-runs", expected=2)
@@ -117,7 +155,10 @@ else:
         require(no_manifest, "no unique quality manifest")
         no_metrics = invoke(
             fake_gh, root / "no-metrics", mode="no-metrics", expected=2)
-        require(no_metrics, "no successful main quality run has quality metrics")
+        require(no_metrics, "no successful main quality run has combined quality metrics")
+        invalid_profile = invoke(
+            fake_gh, root / "invalid-profile", mode="invalid-profile", expected=2)
+        require(invalid_profile, "coverage profile is invalid")
         override = invoke(
             fake_gh, root / "production-override", expected=2, test_mode=False)
         require(override, "baseline output must use")

--- a/tests/quality_metrics_contract.py
+++ b/tests/quality_metrics_contract.py
@@ -87,17 +87,24 @@ def create_baseline(
     authority: str = "ci-main",
     source_commit: str = BASE_COMMIT,
     promotion_main: Optional[str] = None,
+    swift_metrics: Optional[Path] = None,
 ) -> Path:
     run_dir = root / "run"
     run_dir.mkdir(parents=True)
     artifacts = run_dir / "artifacts.tsv"
     if include_metrics:
         shutil.copyfile(metrics, run_dir / "quality-metrics.json")
-        artifacts.write_text(
-            "schema\t1\n"
-            f"file\tquality-metrics.json\t{digest(run_dir / 'quality-metrics.json')}\n",
-            encoding="utf-8",
-        )
+        artifact_lines = [
+            "schema\t1",
+            f"file\tquality-metrics.json\t{digest(run_dir / 'quality-metrics.json')}",
+        ]
+        if swift_metrics is not None:
+            shutil.copyfile(swift_metrics, run_dir / "quality-metrics-swift.json")
+            artifact_lines.append(
+                "file\tquality-metrics-swift.json\t"
+                f"{digest(run_dir / 'quality-metrics-swift.json')}"
+            )
+        artifacts.write_text("\n".join(artifact_lines) + "\n", encoding="utf-8")
     else:
         artifacts.write_text("schema\t1\n", encoding="utf-8")
     (run_dir / "manifest.tsv").write_text(
@@ -167,6 +174,7 @@ def evaluate_arguments(
     authority: str = "local-diagnostic",
     source_commit: str = SOURCE_COMMIT,
     opportunities: Optional[Path] = None,
+    profile: str = "",
 ) -> list[str]:
     arguments = [
         "evaluate",
@@ -185,6 +193,8 @@ def evaluate_arguments(
     ]
     if baseline is not None:
         arguments.extend(("--baseline-root", str(baseline)))
+    if profile:
+        arguments.extend(("--coverage-profile", profile))
     if opportunities is not None:
         arguments.extend(("--opportunities-output", str(opportunities)))
     return arguments
@@ -258,7 +268,65 @@ def main() -> None:
             )
         )
         invoke(["validate", str(baseline_metrics)])
+        baseline_document = json.loads(baseline_metrics.read_text(encoding="utf-8"))
+        assert baseline_document["schema"] == 2
+        assert baseline_document["coverage_profile"] == "swift"
         run_dir = create_baseline(baseline_root, baseline_metrics)
+
+        combined_metrics = root / "combined-metrics.json"
+        combined_document = dict(baseline_document)
+        combined_document["coverage_profile"] = "combined"
+        write_json(combined_metrics, combined_document)
+        combined_root = root / "combined-baseline"
+        create_baseline(combined_root, combined_metrics)
+        profile_mismatch = invoke(
+            evaluate_arguments(
+                coverage,
+                tests,
+                root / "profile-mismatch.json",
+                changed,
+                baseline=combined_root,
+                authority="ci-merge",
+            ),
+            expected=2,
+        )
+        require_text(profile_mismatch, "has no swift quality metrics")
+
+        dual_root = root / "dual-profile-baseline"
+        create_baseline(
+            dual_root,
+            combined_metrics,
+            swift_metrics=baseline_metrics,
+        )
+        invoke(
+            evaluate_arguments(
+                coverage,
+                tests,
+                root / "dual-profile-current.json",
+                changed,
+                baseline=dual_root,
+                authority="ci-merge",
+            )
+        )
+
+        legacy_metrics = root / "legacy-metrics.json"
+        legacy_document = dict(combined_document)
+        legacy_document["schema"] = 1
+        legacy_document.pop("coverage_profile")
+        write_json(legacy_metrics, legacy_document)
+        legacy_root = root / "legacy-baseline"
+        create_baseline(legacy_root, legacy_metrics)
+        invoke(
+            evaluate_arguments(
+                coverage,
+                tests,
+                root / "legacy-current.json",
+                changed,
+                baseline=legacy_root,
+                authority="ci-merge",
+                profile="combined",
+            )
+        )
 
         write_json(changed, {"app/Sources/DetachApp/Synthetic.swift": list(range(1, 11))})
         current = root / "current.json"
@@ -636,7 +704,7 @@ def main() -> None:
             ),
             expected=2,
         )
-        require_text(no_metrics, "has no quality metrics")
+        require_text(no_metrics, "has no swift quality metrics")
 
         old_floor_root = root / "old-floor-only"
         create_baseline(
@@ -656,7 +724,7 @@ def main() -> None:
             ),
             expected=2,
         )
-        require_text(old_floor_only, "has no quality metrics")
+        require_text(old_floor_only, "has no swift quality metrics")
 
         removed_bootstrap_flag = invoke(
             [

--- a/tests/quality_shard_contract.py
+++ b/tests/quality_shard_contract.py
@@ -42,6 +42,7 @@ class QualityShardContract(unittest.TestCase):
                     "needs_app": False,
                     "needs_cache": False,
                     "needs_metrics": False,
+                    "coverage_profile": "",
                 }
             ],
         )
@@ -76,6 +77,7 @@ class QualityShardContract(unittest.TestCase):
         self.assertTrue(build["needs_app"])
         self.assertTrue(build["needs_cache"])
         self.assertTrue(build["needs_metrics"])
+        self.assertEqual(build["coverage_profile"], "combined")
         contracts = shard_for({"stages": stages}, "contracts-and-runtime")
         self.assertEqual(
             contracts["stages"], "gate-contract,tmux-runtime,release-preflight"
@@ -85,6 +87,14 @@ class QualityShardContract(unittest.TestCase):
         codex = shard_for({"stages": stages}, "codex")
         self.assertTrue(codex["needs_app"])
         self.assertFalse(codex["needs_cache"])
+
+    def test_swift_only_metrics_shard_selects_swift_profile(self) -> None:
+        build = shard_for(
+            {"stages": ["static", "swift", "quality-contracts"]},
+            "build-and-coverage",
+        )
+        self.assertTrue(build["needs_metrics"])
+        self.assertEqual(build["coverage_profile"], "swift")
 
     def test_unowned_or_malformed_plan_fails_closed(self) -> None:
         with self.assertRaisesRegex(ShardError, "no shard owns"):

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -154,12 +154,12 @@ assert_value "$TMP_ROOT/new-app.tsv" unknown_impact true
 grep -F $'unknown_reason\tapp/Sources/DetachApp/FutureFlow.swift' \
   "$TMP_ROOT/new-app.tsv" >/dev/null
 
-ORCHESTRATOR_HEAD="$(commit_path scripts/release-version lid-orchestrator)"
+ORCHESTRATOR_HEAD="$(commit_path scripts/release-version release-orchestrator)"
 "$REPO/scripts/release-impact" "$NEW_APP_HEAD" "$ORCHESTRATOR_HEAD" \
   >"$TMP_ROOT/orchestrator.tsv"
-assert_value "$TMP_ROOT/orchestrator.tsv" lid_test_required true
+assert_value "$TMP_ROOT/orchestrator.tsv" lid_test_required false
 assert_value "$TMP_ROOT/orchestrator.tsv" unknown_impact false
-grep -F $'lid_test_reason\tscripts/release-version' \
+! grep -F $'lid_test_reason\tscripts/release-version' \
   "$TMP_ROOT/orchestrator.tsv" >/dev/null
 
 git -C "$REPO" checkout -qb unrelated "$BASE"

--- a/tools/quality_baseline.py
+++ b/tools/quality_baseline.py
@@ -11,12 +11,13 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Optional
 
 
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OUTPUT = ROOT / "app/build/quality-baseline"
 REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+COVERAGE_PROFILES = ("swift", "combined")
 
 
 class BaselineError(Exception):
@@ -87,8 +88,43 @@ def evidence_artifact(value: dict[str, Any], run_id: int) -> str:
     return matches[0]
 
 
+def metrics_profile(path: Path) -> str:
+    if not path.is_file() or path.is_symlink():
+        raise BaselineError("quality metrics are missing or unsafe")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BaselineError(f"quality metrics are malformed: {error}") from error
+    if not isinstance(value, dict):
+        raise BaselineError("quality metrics are malformed")
+    if value.get("schema") == 1:
+        return "combined"
+    profile = value.get("coverage_profile")
+    if value.get("schema") != 2 or profile not in COVERAGE_PROFILES:
+        raise BaselineError("quality metrics coverage profile is invalid")
+    return profile
+
+
+def matching_metrics(run_dir: Path, coverage_profile: str) -> Optional[Path]:
+    matches = []
+    for name in ("quality-metrics.json", "quality-metrics-swift.json"):
+        candidate = run_dir / name
+        if candidate.exists() and metrics_profile(candidate) == coverage_profile:
+            matches.append(candidate)
+    if len(matches) > 1:
+        raise BaselineError(
+            f"quality evidence contains duplicate {coverage_profile} metrics"
+        )
+    return matches[0] if matches else None
+
+
 def restore(
-    repository: str, output_root: Path, executable: str, *, test_mode: bool
+    repository: str,
+    output_root: Path,
+    executable: str,
+    coverage_profile: str,
+    *,
+    test_mode: bool,
 ) -> Path:
     if not REPOSITORY.fullmatch(repository):
         raise BaselineError("repository must identify owner/repository")
@@ -140,11 +176,12 @@ def restore(
         if len(manifests) != 1:
             raise BaselineError("downloaded evidence has no unique quality manifest")
         run_dir = manifests[0].parent
-        metrics = run_dir / "quality-metrics.json"
-        if metrics.is_file() and not metrics.is_symlink():
+        if matching_metrics(run_dir, coverage_profile) is not None:
             print(destination)
             return destination
-    raise BaselineError("no successful main quality run has quality metrics")
+    raise BaselineError(
+        f"no successful main quality run has {coverage_profile} quality metrics"
+    )
 
 
 def parser() -> argparse.ArgumentParser:
@@ -157,6 +194,9 @@ def parser() -> argparse.ArgumentParser:
         "--output-root",
         type=Path,
         default=Path(os.environ.get("DETACH_QUALITY_BASELINE_OUTPUT", DEFAULT_OUTPUT)),
+    )
+    result.add_argument(
+        "--profile", choices=COVERAGE_PROFILES, default="combined"
     )
     return result
 
@@ -171,6 +211,7 @@ def main() -> int:
         arguments.repository,
         arguments.output_root,
         executable,
+        arguments.profile,
         test_mode=test_mode,
     )
     return 0

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -485,7 +485,7 @@ def build_data(
     metrics_origin = "current-run"
     if metrics is None and metrics_baseline is not None:
         try:
-            metrics, _, _ = load_baseline(metrics_baseline)
+            metrics, _, _ = load_baseline(metrics_baseline, "combined")
         except MetricsError as error:
             raise DashboardError(f"quality metrics baseline is invalid: {error}") from error
         metrics_origin = "green-main-artifact"

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -815,6 +815,7 @@ class QualityGate:
         files: list[Path] = []
         for name in (
             "quality-metrics.json",
+            "quality-metrics-swift.json",
             "coverage-opportunities.json",
             "shards.tsv",
         ):
@@ -1067,6 +1068,7 @@ class QualityGate:
                 raise GateError("resume artifact inventory path is unsafe")
             if not (
                 relative == "quality-metrics.json"
+                or relative == "quality-metrics-swift.json"
                 or relative == "coverage-opportunities.json"
                 or relative == "scenarios.jsonl"
                 or relative == "scenarios.junit.xml"
@@ -1303,6 +1305,16 @@ class QualityGate:
                     )
                 shutil.copyfile(metrics, self.run_dir / "quality-metrics.json")
                 (self.run_dir / "quality-metrics.json").chmod(0o600)
+                swift_metrics = self.resume_dir / "quality-metrics-swift.json"
+                if swift_metrics.exists():
+                    if not swift_metrics.is_file() or swift_metrics.is_symlink():
+                        raise GateError(
+                            "reused quality-contracts evidence has unsafe Swift metrics"
+                        )
+                    shutil.copyfile(
+                        swift_metrics, self.run_dir / "quality-metrics-swift.json"
+                    )
+                    (self.run_dir / "quality-metrics-swift.json").chmod(0o600)
                 opportunities = self.resume_dir / "coverage-opportunities.json"
                 if not opportunities.is_file() or opportunities.is_symlink():
                     raise GateError(

--- a/tools/quality_metrics.py
+++ b/tools/quality_metrics.py
@@ -27,6 +27,7 @@ SWIFT_LOG_TEST = re.compile(
 HUNK = re.compile(r"^@@ -[0-9]+(?:,[0-9]+)? \+([0-9]+)(?:,([0-9]+))? @@")
 UI_PREFIX = "app/Sources/DetachApp/"
 BUSINESS_PREFIX = "app/Sources/DetachKit/"
+COVERAGE_PROFILES = ("swift", "combined")
 
 
 class MetricsError(Exception):
@@ -535,6 +536,31 @@ def artifact_digest(run_dir: Path, relative: str) -> Optional[str]:
     return values[0] if values else None
 
 
+def baseline_metrics_file(run_dir: Path, coverage_profile: str) -> Path:
+    matches: list[Path] = []
+    for name in ("quality-metrics.json", "quality-metrics-swift.json"):
+        candidate = run_dir / name
+        digest = artifact_digest(run_dir, name)
+        if not candidate.exists() and digest is None:
+            continue
+        if digest is None or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise MetricsError(f"baseline metrics digest is missing or invalid: {name}")
+        if sha256(safe_file(candidate, "baseline metrics")) != digest:
+            raise MetricsError(f"baseline metrics digest does not match its inventory: {name}")
+        document = validate_metrics(read_json(candidate, "baseline metrics"))
+        if metrics_coverage_profile(document) == coverage_profile:
+            matches.append(candidate)
+    if not matches:
+        raise MetricsError(
+            f"last green main artifact has no {coverage_profile} quality metrics"
+        )
+    if len(matches) > 1:
+        raise MetricsError(
+            f"baseline contains duplicate {coverage_profile} metrics artifacts"
+        )
+    return matches[0]
+
+
 def validate_coverage(value: Any, label: str, *, allow_empty: bool = False) -> tuple[int, int]:
     if not isinstance(value, dict) or set(value) != {"covered", "percent", "total"}:
         raise MetricsError(f"{label} coverage is malformed")
@@ -545,17 +571,40 @@ def validate_coverage(value: Any, label: str, *, allow_empty: bool = False) -> t
     return covered, total
 
 
-def validate_metrics(document: Any, *, expected_policy: Optional[int] = None) -> dict[str, Any]:
+def metrics_coverage_profile(document: dict[str, Any]) -> str:
+    """Return the measured profile, including the schema-1 migration rule."""
+    if document.get("schema") == 1:
+        return "combined"
+    profile = document.get("coverage_profile")
+    if profile not in COVERAGE_PROFILES:
+        raise MetricsError("quality metrics coverage profile is invalid")
+    return profile
+
+
+def validate_metrics(
+    document: Any,
+    *,
+    expected_policy: Optional[int] = None,
+    expected_profile: Optional[str] = None,
+) -> dict[str, Any]:
     required_fields = {
         "schema", "policy", "source_commit", "suites", "critical_files",
         "changed_lines", "comparison",
     }
+    schema = document.get("schema") if isinstance(document, dict) else None
+    if schema == 2:
+        required_fields.add("coverage_profile")
     if (
         not isinstance(document, dict)
         or set(document) != required_fields
-        or document.get("schema") != 1
+        or schema not in (1, 2)
     ):
         raise MetricsError("quality metrics schema is unsupported")
+    coverage_profile = metrics_coverage_profile(document)
+    if expected_profile is not None and coverage_profile != expected_profile:
+        raise MetricsError(
+            "quality metrics coverage profile does not match the selected profile"
+        )
     if not isinstance(document.get("policy"), int) or document["policy"] <= 0:
         raise MetricsError("quality metrics policy is invalid")
     if expected_policy is not None and document["policy"] != expected_policy:
@@ -682,18 +731,18 @@ def validate_metrics(document: Any, *, expected_policy: Optional[int] = None) ->
     return document
 
 
-def load_baseline(root: Optional[Path]) -> tuple[Optional[dict[str, Any]], str, str]:
+def load_baseline(
+    root: Optional[Path], coverage_profile: str
+) -> tuple[Optional[dict[str, Any]], str, str]:
     if root is None:
         return None, "none", ""
     run_dir, manifest, effective_source = load_baseline_run(root)
-    metrics_path = run_dir / "quality-metrics.json"
-    digest = artifact_digest(run_dir, "quality-metrics.json")
-    if metrics_path.exists() or digest is not None:
-        if digest is None or not re.fullmatch(r"[0-9a-f]{64}", digest):
-            raise MetricsError("baseline metrics digest is missing or invalid")
-        if sha256(safe_file(metrics_path, "baseline metrics")) != digest:
-            raise MetricsError("baseline metrics digest does not match its inventory")
-        document = validate_metrics(read_json(metrics_path, "baseline metrics"))
+    metrics_path = baseline_metrics_file(run_dir, coverage_profile)
+    if metrics_path.exists():
+        document = validate_metrics(
+            read_json(metrics_path, "baseline metrics"),
+            expected_profile=coverage_profile,
+        )
         if document["source_commit"] != manifest["source_commit"]:
             raise MetricsError("baseline metrics source does not match its manifest")
         if document["policy"] != int(manifest["policy"]):
@@ -718,9 +767,12 @@ def build_metrics(
     baseline: Optional[dict[str, Any]],
     baseline_mode: str,
     *,
+    coverage_profile: str = "swift",
     changed_override: Optional[dict[str, set[int]]] = None,
     allow_incomplete_sources: bool = False,
 ) -> dict[str, Any]:
+    if coverage_profile not in COVERAGE_PROFILES:
+        raise MetricsError("coverage profile is invalid")
     if not HEX_COMMIT.fullmatch(source_commit):
         raise MetricsError("source commit is invalid")
     if not allow_incomplete_sources:
@@ -858,9 +910,10 @@ def build_metrics(
     baseline_source = baseline.get("source_commit", "") if baseline else ""
     baseline_policy = baseline.get("policy", 0) if baseline else 0
     return {
-        "schema": 1,
+        "schema": 2,
         "policy": policy.version,
         "source_commit": source_commit,
+        "coverage_profile": coverage_profile,
         "suites": suites,
         "critical_files": critical_files,
         "changed_lines": {
@@ -941,6 +994,7 @@ def evaluate(arguments: argparse.Namespace) -> int:
         if arguments.additional_object or arguments.additional_profile_directory:
             raise MetricsError("additional coverage inputs require a test binary")
         coverage_document = read_json(Path(arguments.coverage_json), "LLVM coverage")
+        inferred_profile = arguments.coverage_profile or "swift"
     else:
         if not arguments.test_binary or not arguments.profile:
             raise MetricsError("test binary and profile are required")
@@ -960,10 +1014,16 @@ def evaluate(arguments: argparse.Namespace) -> int:
             additional_objects,
             profile_directory,
         )
+        inferred_profile = "combined" if additional_objects else "swift"
+    coverage_profile = arguments.coverage_profile or inferred_profile
+    if not arguments.coverage_json and coverage_profile != inferred_profile:
+        raise MetricsError("coverage profile does not match the supplied coverage inputs")
     coverage = collect_coverage(coverage_document)
     tests = collect_tests(Path(arguments.tests))
     baseline_root = Path(arguments.baseline_root) if arguments.baseline_root else None
-    baseline, baseline_mode, baseline_commit = load_baseline(baseline_root)
+    baseline, baseline_mode, baseline_commit = load_baseline(
+        baseline_root, coverage_profile
+    )
     if arguments.authority != "local-diagnostic" and baseline is None:
         raise MetricsError("authoritative quality metrics require last green main evidence")
     base_commit = baseline_commit or arguments.base_commit
@@ -991,6 +1051,7 @@ def evaluate(arguments: argparse.Namespace) -> int:
         base_commit,
         baseline,
         baseline_mode,
+        coverage_profile=coverage_profile,
         changed_override=changed_override,
         allow_incomplete_sources=test_mode == "1",
     )
@@ -1006,6 +1067,7 @@ def evaluate(arguments: argparse.Namespace) -> int:
     changed = document["changed_lines"]
     print(
         "Quality metrics evaluated: "
+        f"profile={coverage_profile}; "
         f"UI tests={suites['ui']['test_count']} coverage={suites['ui']['line_coverage']['percent']:.2f}%; "
         f"business tests={suites['business']['test_count']} "
         f"coverage={suites['business']['line_coverage']['percent']:.2f}%; "
@@ -1030,6 +1092,9 @@ def parser() -> argparse.ArgumentParser:
     evaluate_parser.add_argument("--profile")
     evaluate_parser.add_argument("--additional-object", action="append", default=[])
     evaluate_parser.add_argument("--additional-profile-directory", default="")
+    evaluate_parser.add_argument(
+        "--coverage-profile", choices=COVERAGE_PROFILES, default=""
+    )
     evaluate_parser.add_argument("--tests", required=True)
     evaluate_parser.add_argument("--output", required=True)
     evaluate_parser.add_argument("--opportunities-output", default="")

--- a/tools/quality_shard.py
+++ b/tools/quality_shard.py
@@ -129,6 +129,7 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
         remaining.difference_update(stages)
         needs_app = bool({"app", "codex", "claude", "tmux-runtime"} & set(stages))
         needs_cache = bool({"swift", "app", "ui-e2e"} & set(stages))
+        needs_metrics = "quality-contracts" in stages
         shards.append(
             {
                 "id": identifier,
@@ -136,7 +137,12 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
                 "level": level,
                 "needs_app": needs_app,
                 "needs_cache": needs_cache,
-                "needs_metrics": "quality-contracts" in stages,
+                "needs_metrics": needs_metrics,
+                "coverage_profile": (
+                    "combined" if needs_metrics and "ui-e2e" in stages
+                    else "swift" if needs_metrics
+                    else ""
+                ),
             }
         )
     if remaining:


### PR DESCRIPTION
Follow-up to #136 and #121.

Contract delta:

- identify quality metrics as swift or combined and compare only with the newest green-main artifact for the same profile;
- record a digest-bound Swift snapshot during combined runs so the first narrow test-only run has a baseline;
- stop selecting packaged app and UI journeys for Swift-test-only changes;
- classify scripts/release-version as known safe release impact instead of requiring the closed-lid gate for every orchestrator edit;
- preserve the PowerHelperPlatform timeout repair, the Mac Power presentation changes, the test-mode publication boundary, and exact remote-asset verification.

Focused evidence:

- metrics, baseline, shard, promotion, dashboard, policy, planner, release-impact, documentation, suite, and shell-safety contracts passed;
- 892 Swift tests passed;
- the full local diagnostic passed every functional stage and emitted schema-2 combined and swift metrics;
- git diff --check passed.

The local reference-Mac postflight recorded 257/180 seconds. Swift was 30/20 and the unchanged release-workflow suite was 75/70; quality-contracts stayed at 2/5. The unchanged run was not retried. Hosted quality-gates runs without the local reference-Mac budget and remains readiness authority.

No product runtime code, release publication boundary, asset verification, signing, notarization, or real power behavior changed.