### PR TITLE
Test App Start through the embedded terminal

### DIFF
--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -33,6 +33,22 @@ struct SidebarView: View {
         deletableFinishedSessions.filter { selectedFinishedIDs.contains($0.id) }
     }
 
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+    private var uiE2EInitialProjectDirectory: URL? {
+        guard let configuration = AppSettings.uiE2E,
+              FileManager.default.fileExists(atPath: configuration.root
+                .appendingPathComponent(
+                    "fake/enable-new-session-project").path)
+        else { return nil }
+        return configuration.root.appendingPathComponent(
+            "project", isDirectory: true)
+    }
+#else
+    private var uiE2EInitialProjectDirectory: URL? { nil }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+
     var body: some View {
         VStack(spacing: 0) {
             List(selection: $selectedID) {
@@ -90,7 +106,11 @@ struct SidebarView: View {
             }
         }
         .sheet(isPresented: $showNewSession) {
-            NewSessionSheet(store: store, selectedID: $selectedID)
+            NewSessionSheet(
+                store: store,
+                selectedID: $selectedID,
+                initialProjectDir: uiE2EInitialProjectDirectory
+            )
         }
         .confirmationDialog(
             L10n.format(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -594,6 +594,38 @@ enum UIE2ETestDriver {
             checks.append("new-session-sheet-semantics")
             trace("new-session sheet closed")
 
+            try Data().write(to: configuration.root.appendingPathComponent(
+                "fake/enable-new-session-project"), options: .atomic)
+            try await click(newSession, name: "new session action")
+            _ = try await measuredFrame(
+                identifier: "new-session-sheet", name: "new session sheet")
+            try await waitUntil("enabled new session launch") {
+                find(identifier: "new-session-launch").map(isEnabled) == true
+            }
+            let enabledLaunch = try await element(
+                identifier: "new-session-launch")
+            try requireSemanticControl(
+                enabledLaunch, name: "enabled new session launch")
+            try await clickUntil(
+                enabledLaunch,
+                name: "enabled new session launch",
+                outcome: "new session start reaches fake CLI") {
+                FileManager.default.fileExists(atPath: configuration.root
+                    .appendingPathComponent("fake/new-session-started").path)
+            }
+            let startedID = "detach-claude-ui-new"
+            try await waitUntil("new session selection") {
+                find(identifier: "session-detail-\(startedID)") != nil
+            }
+            try await waitUntil("new session embedded terminal", attempts: 40) {
+                find(identifier: "session-preview-terminal") != nil
+                    && FileManager.default.fileExists(atPath: configuration.root
+                        .appendingPathComponent(
+                            "fake/new-session-attach-ready").path)
+            }
+            checks.append("new-session-start-opens-embedded-terminal")
+            trace("new session selected and attached inside Detach")
+
             try Data("empty\n".utf8).write(
                 to: configuration.fixtureState, options: .atomic)
             let emptyGuide = try await element(identifier: "empty-sessions-guide")

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -50,9 +50,10 @@ unsafe identity, build mismatch, or payload fails closed.
 Smoke restores focus and the pointer, then sends ordered AppKit down/up pairs to
 measured SwiftUI controls; semantic locators have no actions. Row clicks select
 sessions even after preview text takes focus.
-Each launch and stage stays within its deadline. Journeys cover main surfaces,
-Settings, onboarding, focus, Codex Recover, Claude Resume, and reconnect after
-an attach client exits. It disconnects Stop before the real control invokes it.
+Each launch and stage meets its deadline. Journeys cover main surfaces,
+Settings, onboarding, focus, Codex Recover, Claude Resume, reconnect, and App
+Start through typed-session selection and embedded PTY attach. It disconnects
+Stop before real control invocation.
 Only visible controls complete onboarding.
 
 Coverage builds the normal bundle, instrumented binary, and Swift tests in

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -34,11 +34,16 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   if [ -f "$ROOT/fake/recovered" ]; then
     recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","effective_status":"running","created_at":"2026-07-22T07:40:00Z","session_color":"#F97316","power_protection_state":"protected","health_actions":["attach","stop"]}'
   fi
+  started=''
+  if [ -f "$ROOT/fake/new-session-started" ]; then
+    started="$(printf '{"schema":1,"provider":"claude","session_name":"detach-claude-ui-new","name":"UI New","effective_status":"running","created_at":"2026-08-29T10:00:00Z","project_dir":"%s/project","session_color":"#A855F7","power_protection_state":"protected","health_actions":["attach","stop"]}' "$ROOT")"
+  fi
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}' \
     "$recoverable" \
     "$completed" \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-stopped","name":"UI Stopped","effective_status":"stopped","created_at":"2026-07-22T06:00:00Z","finished_at":"2026-07-22T06:30:00Z","exit_status":143,"session_color":"#1D4ED8","power_protection_state":"allowed","health_actions":["delete"]}'
+  [ -z "$started" ] || printf '%s\n' "$started"
   exit 0
 fi
 
@@ -100,6 +105,23 @@ fi
 if [ "$#" -eq 3 ] && [ "$1" = claude ] && [ "$2" = attach ] \
     && [ "$3" = detach-claude-ui-completed ]; then
   printf 'UI fixture attach for %s\n' "$3"
+  exec /bin/cat
+fi
+
+if [ "$#" -eq 2 ] && [ "$1" = claude ] && [ "$2" = --detach ]; then
+  [ "$(pwd -P)" = "$ROOT/project" ] || {
+    printf 'new session started outside its selected project\n' >&2
+    exit 65
+  }
+  : >"$ROOT/fake/new-session-started"
+  printf '%s\n' "$*" >>"$ACTIONS"
+  exit 0
+fi
+
+if [ "$#" -eq 3 ] && [ "$1" = claude ] && [ "$2" = attach ] \
+    && [ "$3" = detach-claude-ui-new ]; then
+  printf 'UI fixture attach for %s\n' "$3"
+  : >"$ROOT/fake/new-session-attach-ready"
   exec /bin/cat
 fi
 

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -51,6 +51,8 @@ for invocation in \
   'claude logs --ansi detach-claude-ui-completed' \
   'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9' \
   'claude attach detach-claude-ui-completed' \
+  'claude --detach' \
+  'claude attach detach-claude-ui-new' \
   'codex stop detach-codex-ui-running' \
   'storage --json' \
   'config tmux-style' \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -22,6 +22,8 @@ approved_invocation() {
     'claude logs --ansi detach-claude-ui-completed'|\
     'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9'|\
     'claude attach detach-claude-ui-completed'|\
+    'claude --detach'|\
+    'claude attach detach-claude-ui-new'|\
     'codex stop detach-codex-ui-running'|\
     'codex delete --force detach-codex-ui-stopped'|\
     'storage --json'|\
@@ -143,7 +145,7 @@ IDENTIFIER="dev.tsarev.detach.ui-e2e.$$"
 UI_E2E_DEADLINE=$((SECONDS + 50))
 
 mkdir -p "$TEST_HOME/.local/bin" "$TEST_HOME/Library/Preferences" \
-  "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
+  "$TEST_ROOT/state" "$TEST_ROOT/power" "$TEST_ROOT/project" "$FAKE_DIR"
 cp -cR "$SOURCE_APP" "$TEST_APP"
 
 if [ -n "$COVERAGE_BINARY" ]; then
@@ -310,7 +312,8 @@ run_app_scenario() {
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
       new-session-advanced-keeps-top-edge|\
-      new-session-starts-without-outer-terminal) ;;
+      new-session-starts-without-outer-terminal|\
+      new-session-start-opens-embedded-terminal) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
@@ -352,6 +355,7 @@ run_app_scenario main sessions 32 \
   new-session-starts-without-outer-terminal \
   new-session-advanced-keeps-top-edge \
   new-session-sheet-semantics \
+  new-session-start-opens-embedded-terminal \
   empty-dashboard-state \
   actionable-failure-presentation \
   settings-change-persists \
@@ -375,5 +379,8 @@ done <"$FAKE_DIR/invocations.log"
   "$FAKE_DIR/invocations.log")" -ge 1 ]
 [ "$(grep -Fxc 'codex attach detach-codex-ui-recoverable' \
   "$FAKE_DIR/invocations.log")" -ge 2 ]
+[ "$(grep -Fxc 'claude --detach' "$FAKE_DIR/invocations.log")" -eq 1 ]
+[ "$(grep -Fxc 'claude attach detach-claude-ui-new' \
+  "$FAKE_DIR/invocations.log")" -ge 1 ]
 
 printf 'Packaged Detach.app UI e2e smoke passed\n'


### PR DESCRIPTION
## Contract delta

No product behavior changes. The isolated packaged-app smoke now proves the complete App Start path introduced by #153:

- Start invokes the provider with `--detach` in the selected project.
- The typed session refresh selects the one new session.
- The selected session starts its existing in-app PTY attach client.

The test-only project injection remains inside the validated stripped UI-E2E copy. It cannot activate in the production app. The normal project picker keeps its unit coverage.

## Evidence

- `cd app && swift test --filter NewSessionSheetTests`
- `cd app && swift test --filter SidebarViewTests`
- `tests/ui-e2e-contract.sh`
- `tests/ui-e2e.sh`
- `tests/docs-contract.sh`
- `git diff --check`
- `scripts/quality-gate --plan --explain`

Hosted `quality-gates` remains merge authority.