### PR TITLE
Keep release regression tests within timing budget

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -244,7 +244,6 @@ enum UIE2ETestDriver {
                 throw Failure(message: "cannot enable test app activation")
             }
             try await activate(mainWindow)
-            try await Task.sleep(nanoseconds: 200_000_000)
             trace("test app activated")
 
             let dashboard = try await element(role: .splitGroup)
@@ -527,7 +526,6 @@ enum UIE2ETestDriver {
                 NSApp.windows.allSatisfy(\.sheets.isEmpty)
             }
             try await activate(mainWindow)
-            try await Task.sleep(nanoseconds: 200_000_000)
 
             let newSession = try await element(identifier: "new-session-button")
             try requireSemanticControl(newSession, name: "new session action")
@@ -581,7 +579,6 @@ enum UIE2ETestDriver {
             try await clickMeasuredControl(
                 identifier: "new-session-launch",
                 name: "disabled new session launch")
-            try await Task.sleep(nanoseconds: 200_000_000)
             guard NSApp.windows.contains(where: { !$0.sheets.isEmpty }) else {
                 throw Failure(message: "new-session launch is active without a project")
             }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1504,11 +1504,20 @@ PATH="$shadow_bin:$PATH" run_codex stop "$shadow_name"
 run_codex delete --force "$shadow_name"
 
 # A start holds the install lock through its readiness wait (up to 35
-# seconds). A concurrent config write must wait for that holder instead of
-# failing spuriously on a shorter acquisition timeout.
+# seconds). Scale lockf deadlines by 10 for this check so the regression stays
+# discriminating without adding 35 seconds to every Codex test run.
 install_lock_ready="$TMP_ROOT/install-lock-ready"
+scaled_install_lockf="$TMP_ROOT/scaled-install-lockf"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'set -eu' \
+  '[ "$1" = -k ] && [ "$2" = -t ]' \
+  'timeout=$((($3 + 9) / 10))' \
+  'shift 3' \
+  'exec /usr/bin/lockf -k -t "$timeout" "$@"' >"$scaled_install_lockf"
+chmod 0755 "$scaled_install_lockf"
 /usr/bin/lockf -k "$TEST_INSTALL_STATE_ROOT/install.lock" /bin/sh -c \
-  'touch "$1"; sleep 35' sh "$install_lock_ready" &
+  'touch "$1"; sleep 3.5' sh "$install_lock_ready" &
 install_holder=$!
 attempts=0
 while [ ! -f "$install_lock_ready" ]; do
@@ -1519,7 +1528,7 @@ while [ ! -f "$install_lock_ready" ]; do
   }
   sleep 0.05
 done
-"$SCRIPT" config tmux-mouse off
+DETACH_LOCKF_BIN="$scaled_install_lockf" "$SCRIPT" config tmux-mouse off
 wait "$install_holder"
 [ "$("$SCRIPT" config tmux-mouse)" = "off" ]
 "$SCRIPT" config tmux-mouse on


### PR DESCRIPTION
Summary
- scale only the test-injected install-lock deadline so the old 30-second regression still fails while the production 90-second contract passes in 3.5 seconds
- remove three redundant fixed UI E2E sleeps after condition-based activation, dismissal, and click checks
- keep production behavior, release policy, CI topology, coverage, and timing ceilings unchanged

Contract delta
- No user or production contract change.
- Test evidence is unchanged; only test waiting time changes.

Local diagnostics
- Codex delete part: PASS in 39.68s (previous release preflight: 74s)
- codex stage: PASS in 57s (previous release preflight: 106s)
- app stage: PASS in 31s
- ui-e2e stage: PASS in 15s (previous: 16-17s)
- impact gate: all functional stages PASS, wall 108s; its one local timing failure was a 25s Swift stage caused by the one-time rebuild of the changed test-driver source against a 20s reference ceiling
- git diff --check: PASS

Hosted pull-request quality-gates remains readiness authority.