### PR TITLE
Speed up quality and release diagnostics

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -135,11 +135,13 @@ jobs:
         run: |
           app/scripts/verify-app.sh
           printf 'DETACH_QUALITY_EXACT_APP=1\n' >>"$GITHUB_ENV"
-      - name: Prepare packaged provider runtime
+      - name: Build and bind exact packaged test app
         if: matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true'
         env:
           DETACH_QUALITY_APP_SCRATCH: 1
-        run: app/scripts/make-app.sh
+        run: |
+          app/scripts/make-app.sh
+          printf 'DETACH_QUALITY_EXACT_APP=1\n' >>"$GITHUB_ENV"
       - name: Run exact quality shard
         run: |
           BASE_SHA="$(git rev-parse HEAD^1)"

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -148,23 +148,27 @@ Swift tests, the normal app, and the instrumented app use isolated scratch and
 module-cache paths. CI materializes their shared dependency cache once before
 parallel builds. A host with at least three CPUs splits workers and builds all
 three at the same time. Smaller hosts run Swift and app work in sequence.
-The normal bundle is verified. Only the private UI copy gets the instrumented
-executable.
+The normal bundle is verified. On a hosted app-cache miss, the successful
+fresh build becomes the exact app for that job. The selected app stage verifies
+the same bundle and does not build it again. A failed build cannot create this
+binding. Only the private UI copy gets the instrumented executable.
 The short packaged UI lane runs after the verified app and before the
 CPU-intensive provider, runtime, and gate-contract lanes. This prevents
 WindowServer event delivery from competing with those workers. After the UI and metric phases,
 the scheduler starts ready process-heavy stages in descending policy timing
 order. It admits at most two process-heavy top-level lanes. One separate lane
 runs short runtime and release preflights during gate-contract. Distribution
-uses that lane only after gate-contract ends. A free slot starts the next ready
-stage without a fixed wave barrier.
+uses that lane only after gate-contract ends. Gate-contract excludes every
+heavy peer. Release-workflow can overlap one provider lane, but distribution
+waits until release-workflow ends. A free slot starts the next ready stage
+without a fixed wave barrier.
 
 Quality analysis runs after the UI lane. It merges the completed Swift profile
 with all passed packaged-app profiles. It reads the existing Swift log and does
 not run a test twice.
 
 The gate-contract stage keeps lightweight contracts concurrent. It admits
-three process-heavy orchestrator shards on a host with at least eight logical
+four process-heavy orchestrator shards on a host with at least eight logical
 CPUs, and two on a smaller host. This limit prevents process oversubscription
 without increasing the stage budget. At most four contract children run at one
 time, so lightweight contracts do not crowd adjacent preflights.
@@ -176,13 +180,15 @@ evidence. The packaged UI test uses a
 stripped process-private app, fake CLI, and private state. Provider tests use
 private state and socket roots plus the newly bundled `tmux` and
 `detach-state`. Each provider part has private state, socket, log, and failure
-artifact roots. Parts run concurrently. Smaller hosts use three Codex parts and
-two Claude parts; larger hosts use finer parts. Compact layouts reuse
+artifact roots. Parts run concurrently. The bounded large-host Codex lane
+starts the longest measured independent parts first, and still runs every
+part. Smaller hosts use three Codex parts and two Claude parts; larger hosts
+use finer parts. Compact layouts reuse
 checkpoints across recovery and restart, resume and identity, or Claude
 lifecycle and recovery. The parent writes scenario events in one order and
 fails the stage when any part fails. Tests do not use installed product state
 or ambient helpers. Distribution runs its runtime and shell-profile contracts
-as separate parts in private temporary homes.
+concurrently in separate private temporary homes.
 
 There are no quarantined tests. A future quarantine needs an owner, reason, and
 expiry. It cannot remove release evidence.

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -60,28 +60,28 @@ Hosted CI is the merge-readiness authority.
   defects, policy mutations, and scope violations. Its graders compare stages,
   specs, capabilities, journeys, release gates, and ignored paths. Change an
   expectation only when the intended outcome changes.
-- Instrumented user scenarios emit addressable begin and pass events. Gate
-  evidence records their requirement and journey links, duration, result, and
-  bounded rerun command. A passed stage with missing scenario events fails.
-- A local timing-budget failure creates performance work. Warm-cache or
-  variance reruns cannot turn it into readiness; an unchanged rerun is allowed
-  only for an evidenced unrelated external transient whose cause is recorded.
+- Instrumented scenarios emit begin and pass events. Evidence records their
+  requirement and journey links, duration, result, and bounded rerun. A missing
+  event fails a passed stage.
+- A local timing-budget failure creates performance work. Warm-cache and
+  variance reruns cannot prove readiness. Repeat an unchanged run only for a
+  recorded unrelated external transient.
 - CI binds checks to the tested merge and first parent. Linux runs level 0
-  planning and static work. Level 1 is unit and contract work. Level 2 is
-  packaged and runtime work on macOS. All selected levels are required.
+  planning and static work. Level 1 covers units and contracts. Level 2 covers
+  packaged and runtime work on macOS. Every selected level is required.
 - Shards revalidate merge identity but have no merge authority. The final Linux
   job recomputes the plan and accepts only exact digest-bound shard evidence.
-  Evidence roots are absolute; ambiguity fails closed and a failed shard cancels peers.
+  Evidence roots are absolute. Ambiguity fails closed. A failed shard cancels peers.
 - CI keeps a ten-minute timing ratchet with no reference-Mac limit.
-- Gate contracts admit three heavy shards on eight CPUs and two on smaller
+- Gate contracts admit four heavy shards on eight CPUs and two on smaller
   hosts; light contracts stay concurrent and budgets expose overload.
 - Swift and release builds use separate caches and split at three CPUs;
   smaller hosts run in order. UI waits for app; metrics require both.
-  Gate-contract and release-workflow exclude heavy peers. Gate-contract permits
-  preflight and gates distribution. Other work uses two heavy and one
-  integration lane.
-- Exact keys bind code, resources, scripts, version, and toolchain. `main` warms
-  only missing products; CI verifies hits and rebuilds misses. Warming is not
+  Gate-contract excludes heavy peers and gates distribution. Release-workflow
+  may overlap one provider and gates distribution. Other work uses two
+  heavy and one integration lane.
+- Exact keys bind inputs and toolchain. `main` warms missing products. CI
+  verifies hits and misses, then reuses a fresh app. Warming emits no
   evidence.
 - CI uses the newest green `main` artifact with metrics; a later run without
   them does not replace it. Test identities and aggregate or critical-source

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -54,6 +54,9 @@ change real power state, upload assets, or claim publication.
   for hermetic tests. It can simulate push and publication only after it proves
   the exact fixture repository, local origin, empty hooks, placeholder name,
   and fake external tools. This boundary never authorizes an external release.
+- End-to-end release fixtures use separate repositories and external-state
+  roots. They run with bounded admission, report each case duration, and always
+  run the complete case set. A scheduler change cannot omit a release case.
 - The release entry point supplies the low-level publication confirmation after
   all selected gates pass. After upload, verification lists every remote asset
   name. A name outside the expected set fails closed. Every expected remote

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -150,7 +150,9 @@
 - `tests/release-workflow.sh` — hermetic end-to-end orchestration, including
   resume after every durable stage, dirty/diverged source rejection, duplicate
   tag/release rejection, hardware-gate failure, remote hash mismatch,
-  hermetic publication-boundary rejection, and unexpected remote assets.
+  hermetic publication-boundary rejection, and unexpected remote assets. It
+  admits at most five independent fixture repositories and reports each case
+  duration. Every case remains required.
 - `cd app && swift test --enable-code-coverage --disable-sandbox`, followed by
   `tests/quality-contracts.sh` — unit tests plus measured UI and business test
   identities, aggregate coverage, and coverage for the 13 critical sources.

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -26,6 +26,8 @@ grep -F 'name: Validate and partition exact pull-request impact' \
 quality_plan_job="$(sed -n '/^  quality-plan:/,/^  quality-shards:/p' \
   "$ROOT/.github/workflows/quality-gates.yml")"
 printf '%s\n' "$quality_plan_job" | grep -F 'runs-on: ubuntu-latest' >/dev/null
+quality_shards_job="$(sed -n '/^  quality-shards:/,/^  quality-gates:/p' \
+  "$ROOT/.github/workflows/quality-gates.yml")"
 quality_gate_job="$(sed -n '/^  quality-gates:/,/^  quality-dashboard:/p' \
   "$ROOT/.github/workflows/quality-gates.yml")"
 printf '%s\n' "$quality_gate_job" | \
@@ -69,10 +71,34 @@ grep -F "'app/scripts/verify-app.sh'" \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'name: Verify and bind exact packaged test app' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
-grep -F 'DETACH_QUALITY_EXACT_APP=1' \
-  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F "steps.app-cache.outputs.cache-hit != 'true'" \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+app_cache_hit_step="$(printf '%s\n' "$quality_shards_job" | sed -n \
+  '/name: Verify and bind exact packaged test app/,/name: Build and bind exact packaged test app/p')"
+printf '%s\n' "$app_cache_hit_step" | \
+  grep -F "steps.app-cache.outputs.cache-hit == 'true'" >/dev/null
+printf '%s\n' "$app_cache_hit_step" | \
+  grep -F 'app/scripts/verify-app.sh' >/dev/null
+printf '%s\n' "$app_cache_hit_step" | \
+  grep -F 'DETACH_QUALITY_EXACT_APP=1' >/dev/null
+app_cache_miss_step="$(printf '%s\n' "$quality_shards_job" | sed -n \
+  '/name: Build and bind exact packaged test app/,/name: Run exact quality shard/p')"
+printf '%s\n' "$app_cache_miss_step" | \
+  grep -F "steps.app-cache.outputs.cache-hit != 'true'" >/dev/null
+printf '%s\n' "$app_cache_miss_step" | \
+  grep -F 'DETACH_QUALITY_APP_SCRATCH: 1' >/dev/null
+printf '%s\n' "$app_cache_miss_step" | \
+  grep -F 'app/scripts/make-app.sh' >/dev/null
+printf '%s\n' "$app_cache_miss_step" | \
+  grep -F 'DETACH_QUALITY_EXACT_APP=1' >/dev/null
+app_build_line="$(printf '%s\n' "$app_cache_miss_step" | \
+  grep -nF 'app/scripts/make-app.sh' | cut -d: -f1)"
+app_bind_line="$(printf '%s\n' "$app_cache_miss_step" | \
+  grep -nF 'DETACH_QUALITY_EXACT_APP=1' | cut -d: -f1)"
+if [ "$app_bind_line" -le "$app_build_line" ]; then
+  printf 'quality workflow bound a fresh app before its build completed\n' >&2
+  exit 1
+fi
 grep -F 'key: detach-quality-products-v1-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'app/.build/quality-products-v1.json' \
@@ -201,7 +227,7 @@ prepare_template() {
   printf '%s\n' actions.log results aggregate tampered-aggregate '*.out' /presentations/ \
     >"$TEMPLATE_REPO/.gitignore"
   for stage in static gate-contract swift quality-contracts app ui-e2e codex claude distribution tmux-runtime release-preflight publish-preflight release-workflow; do
-    printf '#!/bin/bash\nset -eu\nexpected_cache="${GATE_EXPECTED_MODULE_CACHE:?}/%s"\n[ -z "${DETACH_RELEASE_TIMING_OVERRIDE:-}" ] || { printf "release timing override leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_CONFIRM_RELEASE:-}" ] || { printf "release confirmation leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_QUALITY_GATE_RESULT_ROOT:-}" ] || { printf "quality result root leaked into stage\\n" >&2; exit 1; }\n[ "${CLANG_MODULE_CACHE_PATH:-}" = "$expected_cache" ] || { printf "unexpected Clang module cache: %%s\\n" "${CLANG_MODULE_CACHE_PATH:-missing}" >&2; exit 1; }\n[ "${SWIFTPM_MODULECACHE_OVERRIDE:-}" = "$expected_cache" ] || { printf "unexpected SwiftPM module cache: %%s\\n" "${SWIFTPM_MODULECACHE_OVERRIDE:-missing}" >&2; exit 1; }\nprintf "%%s\\n" "%s" >>"${GATE_ACTION_LOG:?}"\nsleep "${STAGE_SLEEP:-0}"\ncase " ${FAIL_STAGES:-} " in *" %s "*) exit 23 ;; esac\n' "$stage" "$stage" "$stage" \
+    printf '#!/bin/bash\nset -eu\nexpected_cache="${GATE_EXPECTED_MODULE_CACHE:?}/%s"\n[ -z "${DETACH_RELEASE_TIMING_OVERRIDE:-}" ] || { printf "release timing override leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_CONFIRM_RELEASE:-}" ] || { printf "release confirmation leaked into stage\\n" >&2; exit 1; }\n[ -z "${DETACH_QUALITY_GATE_RESULT_ROOT:-}" ] || { printf "quality result root leaked into stage\\n" >&2; exit 1; }\n[ "${CLANG_MODULE_CACHE_PATH:-}" = "$expected_cache" ] || { printf "unexpected Clang module cache: %%s\\n" "${CLANG_MODULE_CACHE_PATH:-missing}" >&2; exit 1; }\n[ "${SWIFTPM_MODULECACHE_OVERRIDE:-}" = "$expected_cache" ] || { printf "unexpected SwiftPM module cache: %%s\\n" "${SWIFTPM_MODULECACHE_OVERRIDE:-missing}" >&2; exit 1; }\nprintf "%%s\\n" "%s" >>"${GATE_ACTION_LOG:?}"\n[ "${STAGE_SLEEP:-0}" = 0 ] || sleep "$STAGE_SLEEP"\ncase " ${FAIL_STAGES:-} " in *" %s "*) exit 23 ;; esac\n' "$stage" "$stage" "$stage" \
       >"$TEMPLATE_REPO/tests/quality-gate-fixtures/$stage"
     chmod 0755 "$TEMPLATE_REPO/tests/quality-gate-fixtures/$stage"
   done
@@ -930,7 +956,12 @@ while [ ! -f "$GATE_ORDER_ROOT/app-started" ] && [ "$attempt" -lt 50 ]; do
   sleep 0.1
 done
 [ -f "$GATE_ORDER_ROOT/app-started" ]
-sleep 1
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/app" ] && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/app" ]
 : >"$GATE_ORDER_ROOT/swift"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/app" <<'SH'
@@ -951,7 +982,6 @@ cat >"$REPO/tests/quality-gate-fixtures/quality-contracts" <<'SH'
 set -eu
 [ -f "${GATE_ORDER_ROOT:?}/swift" ]
 [ -f "${GATE_ORDER_ROOT:?}/ui-e2e" ]
-sleep 1
 printf '{}\n' >"${DETACH_QUALITY_METRICS_OUTPUT:?}"
 : >"$GATE_ORDER_ROOT/quality-contracts"
 SH
@@ -970,12 +1000,12 @@ set -eu
 [ -f "$GATE_ORDER_ROOT/gate-contract" ]
 : >"$GATE_ORDER_ROOT/codex-started"
 attempt=0
-while [ ! -f "$GATE_ORDER_ROOT/integration-after-contract" ] && \
+while [ ! -f "$GATE_ORDER_ROOT/release-workflow-started" ] && \
     [ "$attempt" -lt 50 ]; do
   attempt=$((attempt + 1))
   sleep 0.1
 done
-[ -f "$GATE_ORDER_ROOT/integration-after-contract" ]
+[ -f "$GATE_ORDER_ROOT/release-workflow-started" ]
 : >"$GATE_ORDER_ROOT/codex"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/gate-contract" <<'SH'
@@ -984,7 +1014,13 @@ set -eu
 [ -f "${GATE_ORDER_ROOT:?}/ui-e2e" ]
 [ -f "$GATE_ORDER_ROOT/quality-contracts" ]
 : >"$GATE_ORDER_ROOT/gate-contract-started"
-sleep 1
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/short-preflight-during-contract" ] && \
+    [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/short-preflight-during-contract" ]
 : >"$GATE_ORDER_ROOT/gate-contract"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/distribution" <<'SH'
@@ -992,13 +1028,14 @@ cat >"$REPO/tests/quality-gate-fixtures/distribution" <<'SH'
 set -eu
 [ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
 attempt=0
-while [ ! -f "$GATE_ORDER_ROOT/codex-started" ] && [ "$attempt" -lt 50 ]; do
+while [ ! -f "$GATE_ORDER_ROOT/release-workflow" ] && [ "$attempt" -lt 50 ]; do
   attempt=$((attempt + 1))
   sleep 0.1
 done
-[ -f "$GATE_ORDER_ROOT/codex-started" ]
-[ ! -f "$GATE_ORDER_ROOT/codex" ]
-: >"$GATE_ORDER_ROOT/integration-after-contract"
+[ -f "$GATE_ORDER_ROOT/release-workflow" ]
+[ -f "$GATE_ORDER_ROOT/claude-started" ]
+[ ! -f "$GATE_ORDER_ROOT/claude" ]
+: >"$GATE_ORDER_ROOT/integration-after-release"
 SH
 cat >"$REPO/tests/quality-gate-fixtures/publish-preflight" <<'SH'
 #!/bin/bash
@@ -1018,25 +1055,37 @@ cat >"$REPO/tests/quality-gate-fixtures/release-workflow" <<'SH'
 #!/bin/bash
 set -eu
 [ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
-[ -f "$GATE_ORDER_ROOT/codex" ]
-[ -f "$GATE_ORDER_ROOT/claude" ]
-: >"$GATE_ORDER_ROOT/release-workflow-started"
-sleep 1
-: >"$GATE_ORDER_ROOT/release-workflow"
-SH
-cat >"$REPO/tests/quality-gate-fixtures/claude" <<'SH'
-#!/bin/bash
-set -eu
-[ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
-[ ! -f "$GATE_ORDER_ROOT/release-workflow-started" ]
-: >"$GATE_ORDER_ROOT/claude-started"
 attempt=0
 while [ ! -f "$GATE_ORDER_ROOT/codex-started" ] && [ "$attempt" -lt 50 ]; do
   attempt=$((attempt + 1))
   sleep 0.1
 done
 [ -f "$GATE_ORDER_ROOT/codex-started" ]
-sleep 1
+[ ! -f "$GATE_ORDER_ROOT/codex" ]
+: >"$GATE_ORDER_ROOT/release-workflow-started"
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/claude-started" ] && [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/claude-started" ]
+[ ! -f "$GATE_ORDER_ROOT/claude" ]
+: >"$GATE_ORDER_ROOT/release-workflow"
+SH
+cat >"$REPO/tests/quality-gate-fixtures/claude" <<'SH'
+#!/bin/bash
+set -eu
+[ -f "${GATE_ORDER_ROOT:?}/gate-contract" ]
+[ -f "$GATE_ORDER_ROOT/release-workflow-started" ]
+[ ! -f "$GATE_ORDER_ROOT/release-workflow" ]
+: >"$GATE_ORDER_ROOT/claude-started"
+attempt=0
+while [ ! -f "$GATE_ORDER_ROOT/integration-after-release" ] && \
+    [ "$attempt" -lt 50 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+[ -f "$GATE_ORDER_ROOT/integration-after-release" ]
 : >"$GATE_ORDER_ROOT/claude"
 SH
 for ordered_stage in tmux-runtime release-preflight; do
@@ -1064,8 +1113,8 @@ chmod 0755 \
   "$REPO/tests/quality-gate-fixtures/release-workflow"
 GATE_ORDER_ROOT="$ORDER_ROOT" gate --mode repository >"$REPO/resource-order.out"
 grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/resource-order.out" >/dev/null
-[ -f "$ORDER_ROOT/integration-after-contract" ] || {
-  printf 'bounded scheduler did not open integration after gate-contract\n' >&2
+[ -f "$ORDER_ROOT/integration-after-release" ] || {
+  printf 'bounded scheduler did not defer distribution until after release workflow\n' >&2
   exit 1
 }
 [ -f "$ORDER_ROOT/short-preflight-during-contract" ] || {
@@ -1073,7 +1122,7 @@ grep -F 'quality-gate: DIAGNOSTIC PASS' "$REPO/resource-order.out" >/dev/null
   exit 1
 }
 [ -f "$ORDER_ROOT/release-workflow" ] || {
-  printf 'bounded scheduler overlapped the nested release workflow with a heavy peer\n' >&2
+  printf 'bounded scheduler did not complete the provider-overlapped release workflow\n' >&2
   exit 1
 }
 

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -108,8 +108,8 @@ class QualityGateContract(unittest.TestCase):
         self.assertTrue(include_gate_orchestrators("change", "gate-contract"))
 
     def test_gate_orchestrator_capacity_tracks_available_processors(self) -> None:
-        self.assertEqual(gate_orchestrator_limit(10), 3)
-        self.assertEqual(gate_orchestrator_limit(8), 3)
+        self.assertEqual(gate_orchestrator_limit(10), 4)
+        self.assertEqual(gate_orchestrator_limit(8), 4)
         self.assertEqual(gate_orchestrator_limit(4), 2)
         self.assertEqual(gate_contract_process_limit(10), 4)
         self.assertEqual(gate_contract_process_limit(4), 4)
@@ -283,13 +283,13 @@ class QualityGateContract(unittest.TestCase):
                 self.assertEqual(
                     provider_test_parts("codex"),
                     (
-                        "preflight",
-                        "lifecycle",
-                        "recovery",
-                        "resume",
-                        "identity",
                         "delete",
+                        "resume",
                         "crash",
+                        "lifecycle",
+                        "preflight",
+                        "recovery",
+                        "identity",
                     ),
                 )
 
@@ -389,18 +389,32 @@ class QualityGateContract(unittest.TestCase):
                 "#!/bin/bash\n"
                 "set -eu\n"
                 "[ \"$DETACH_QUALITY_PARTITIONED_DISTRIBUTION\" = 1 ]\n"
+                "root=\"${GATE_DISTRIBUTION_PARALLEL_ROOT:?}\"\n"
+                "part=\"$DETACH_DISTRIBUTION_TEST_PART\"\n"
+                "peer=runtime\n"
+                "[ \"$part\" = runtime ] && peer=shells\n"
+                ": >\"$root/$part\"\n"
+                "attempt=0\n"
+                "while [ ! -f \"$root/$peer\" ] && [ \"$attempt\" -lt 40 ]; do\n"
+                "  attempt=$((attempt + 1))\n"
+                "  sleep 0.05\n"
+                "done\n"
+                "[ -f \"$root/$peer\" ]\n"
                 "printf '%s\\n' \"$DETACH_DISTRIBUTION_TEST_PART\"\n",
                 encoding="utf-8",
             )
             suite.chmod(0o755)
             run_dir = root / "evidence"
             run_dir.mkdir()
+            barrier = root / "barrier"
+            barrier.mkdir()
             events = run_dir / "distribution-events.jsonl"
             with patch.dict(
                 "os.environ",
                 {
                     "DETACH_QUALITY_SCENARIO_STAGE": "distribution",
                     "DETACH_QUALITY_SCENARIO_EVENTS": str(events),
+                    "GATE_DISTRIBUTION_PARALLEL_ROOT": str(barrier),
                 },
             ):
                 self.assertEqual(run_distribution_parts(root, run_dir), 0)

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -14,7 +14,10 @@ cleanup() {
   if [ "${DETACH_RELEASE_WORKFLOW_TEST_KEEP:-0}" = 1 ]; then
     printf 'Kept release workflow test state: %s\n' "$TMP_ROOT" >&2
   else
+    cleanup_started="$SECONDS"
     rm -rf "$TMP_ROOT"
+    printf 'release-workflow: cleanup completed in %ss\n' \
+      "$((SECONDS - cleanup_started))"
   fi
 }
 trap cleanup EXIT
@@ -720,34 +723,69 @@ run_post_push_main_rejection_case() {
   [ ! -f "$RELEASE_EXISTS" ]
 }
 
-# Each lane owns a separate repository below TMP_ROOT. Run the lanes together.
-# This keeps independent Git and fake-publication work out of the critical path.
+# Each lane owns a separate repository below TMP_ROOT. Admit a bounded set of
+# lanes so independent Git and fake-publication work do not saturate the disk.
+release_case_limit=5
 release_case_pids=()
 release_case_names=()
-for release_case in \
-  run_resume_case \
-  run_timing_override_cases \
-  run_preflight_rejection_cases \
-  run_hardware_rejection_case \
-  run_remote_hash_case \
-  run_test_mode_rejects_unproven_fixture_case \
-  run_unexpected_remote_asset_case \
-  run_post_push_main_rejection_case \
-  run_invalid_resume_artifact_credentials_case; do
-  "$release_case" &
+release_case_status=0
+release_cases=(
+  run_resume_case
+  run_timing_override_cases
+  run_unexpected_remote_asset_case
+  run_remote_hash_case
+  run_hardware_rejection_case
+  run_invalid_resume_artifact_credentials_case
+  run_post_push_main_rejection_case
+  run_test_mode_rejects_unproven_fixture_case
+  run_preflight_rejection_cases
+)
+
+wait_for_release_case_slot() {
+  local index pid
+  while :; do
+    for index in "${!release_case_pids[@]}"; do
+      pid="${release_case_pids[$index]}"
+      if kill -0 "$pid" 2>/dev/null; then
+        continue
+      fi
+      if ! wait "$pid"; then
+        printf 'release workflow lane failed: %s\n' \
+          "${release_case_names[$index]}" >&2
+        release_case_status=1
+      fi
+      unset 'release_case_pids[index]' 'release_case_names[index]'
+      if [ "${#release_case_pids[@]}" -gt 0 ]; then
+        release_case_pids=("${release_case_pids[@]}")
+        release_case_names=("${release_case_names[@]}")
+      fi
+      return
+    done
+    sleep 0.05
+  done
+}
+
+for release_case in "${release_cases[@]}"; do
+  while [ "${#release_case_pids[@]}" -ge "$release_case_limit" ]; do
+    wait_for_release_case_slot
+  done
+  (
+    release_case_started="$SECONDS"
+    trap 'release_case_status=$?; printf "%s\n" "$((SECONDS - release_case_started))" >"$TMP_ROOT/$release_case.seconds"; exit "$release_case_status"' EXIT
+    "$release_case"
+  ) &
   release_case_pids+=("$!")
   release_case_names+=("$release_case")
 done
 
-release_case_status=0
-for release_case_index in "${!release_case_pids[@]}"; do
-  if ! wait "${release_case_pids[$release_case_index]}"; then
-    printf 'release workflow lane failed: %s\n' \
-      "${release_case_names[$release_case_index]}" >&2
-    release_case_status=1
-  fi
+while [ "${#release_case_pids[@]}" -gt 0 ]; do
+  wait_for_release_case_slot
 done
 [ "$release_case_status" -eq 0 ] || exit 1
+for release_case in "${release_cases[@]}"; do
+  printf 'release-workflow: %s completed in %ss\n' \
+    "$release_case" "$(<"$TMP_ROOT/$release_case.seconds")"
+done
 
 "$ROOT/scripts/quality-scenarios" event pass SC-RELEASE-WORKFLOW
 printf 'Detach release workflow tests passed\n'

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -69,13 +69,15 @@ POST_UI_STAGES = (
 )
 PROCESS_HEAVY_LIMIT = 2
 INTEGRATION_LANE_LIMIT = 1
+PROCESS_POLL_SECONDS = 0.01
 PROCESS_HEAVY_STAGES = {"gate-contract", "codex", "claude", "release-workflow"}
-EXCLUSIVE_PROCESS_HEAVY_STAGES = {"gate-contract", "release-workflow"}
+EXCLUSIVE_PROCESS_HEAVY_STAGES = {"gate-contract"}
 GATE_COMPATIBLE_INTEGRATION_STAGES = {
     "tmux-runtime",
     "release-preflight",
     "publish-preflight",
 }
+RELEASE_COMPETING_INTEGRATION_STAGES = {"distribution"}
 UI_COVERAGE_SCRATCH = "quality-ui-release"
 SWIFT_TEST_SCRATCH = "quality-swift-tests"
 QUALITY_TEST_BUNDLE = Path(
@@ -89,14 +91,16 @@ QUALITY_UI_BINARY = Path(
     "app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp"
 )
 PROVIDER_TEST_PARTS = {
+    # The Codex lane admits three parts at a time. Start the longest measured
+    # independent parts first so a short part cannot delay the critical path.
     "codex": (
-        "preflight",
-        "lifecycle",
-        "recovery",
-        "resume",
-        "identity",
         "delete",
+        "resume",
         "crash",
+        "lifecycle",
+        "preflight",
+        "recovery",
+        "identity",
     ),
     "claude": (
         "lifecycle-guardrails",
@@ -1421,7 +1425,7 @@ class QualityGate:
         while any(stage not in self.results for stage in wanted):
             self.poll_active()
             if any(stage not in self.results for stage in wanted):
-                time.sleep(0.05)
+                time.sleep(PROCESS_POLL_SECONDS)
         for stage in stages:
             if stage in self.results:
                 self.report(stage)
@@ -1469,6 +1473,13 @@ class QualityGate:
                             if stage in PROCESS_HEAVY_STAGES
                             else (
                                 active_integration < INTEGRATION_LANE_LIMIT
+                                and not (
+                                    stage in RELEASE_COMPETING_INTEGRATION_STAGES
+                                    and (
+                                        "release-workflow" in self.active
+                                        or "release-workflow" in pending
+                                    )
+                                )
                                 and (
                                     "gate-contract" not in self.active
                                     or stage in GATE_COMPATIBLE_INTEGRATION_STAGES
@@ -1490,7 +1501,7 @@ class QualityGate:
                 if stage in self.results:
                     self.report(stage)
             if pending or any(stage in self.active for stage in POST_UI_STAGES):
-                time.sleep(0.05)
+                time.sleep(PROCESS_POLL_SECONDS)
 
     def budget_values(self) -> dict[str, str | None]:
         if not self.release_budget.is_file() or self.release_budget.is_symlink():
@@ -2050,7 +2061,7 @@ def run_provider_parts(
                         record_scenario_event("pass", scenario_id)
                 pending.remove(index)
             if pending:
-                time.sleep(0.05)
+                time.sleep(PROCESS_POLL_SECONDS)
         for index, (part, log, _, _, _) in enumerate(processes):
             status = statuses[index]
             sys.stdout.write(log.read_text(encoding="utf-8", errors="replace"))
@@ -2109,12 +2120,19 @@ def run_distribution_parts(root: Path, run_dir: Path) -> int:
                 stderr=subprocess.STDOUT,
             )
             processes.append((part, log, process, output, time.monotonic()))
-            index = len(processes) - 1
-            statuses[index] = process.wait()
-            durations[index] = max(
-                0, round(time.monotonic() - processes[index][4])
-            )
-            output.close()
+        pending = set(range(len(processes)))
+        while pending:
+            for index in list(pending):
+                _, _, process, output, started = processes[index]
+                part_status = process.poll()
+                if part_status is None:
+                    continue
+                output.close()
+                statuses[index] = part_status
+                durations[index] = max(0, round(time.monotonic() - started))
+                pending.remove(index)
+            if pending:
+                time.sleep(PROCESS_POLL_SECONDS)
         status = next(
             (statuses[index] for index in range(len(processes)) if statuses[index]),
             0,
@@ -2182,7 +2200,7 @@ def run_static_contracts(root: Path, run_dir: Path) -> int:
                 durations[index] = max(0, round(time.monotonic() - started))
                 pending.remove(index)
             if pending:
-                time.sleep(0.05)
+                time.sleep(PROCESS_POLL_SECONDS)
         for index, (name, log, _, _, _) in enumerate(processes):
             sys.stdout.write(log.read_text(encoding="utf-8", errors="replace"))
             print(
@@ -2426,7 +2444,7 @@ def gate_contract_definitions(
 
 def gate_orchestrator_limit(logical_cpus: int | None = None) -> int:
     available = logical_cpus if logical_cpus is not None else os.cpu_count()
-    return 3 if (available or 0) >= 8 else 2
+    return 4 if (available or 0) >= 8 else 2
 
 
 def gate_contract_process_limit(logical_cpus: int | None = None) -> int:
@@ -2488,7 +2506,7 @@ def run_gate_contract_stage(root: Path, *, include_orchestrators: bool) -> int:
                 if path.name.startswith("orchestrator-"):
                     running_orchestrators -= 1
             if running:
-                time.sleep(0.05)
+                time.sleep(PROCESS_POLL_SECONDS)
         for path, _, _, expected, _ in sorted(processes, key=lambda item: item[0].name):
             content = path.read_text(encoding="utf-8", errors="replace")
             sys.stdout.write(content)


### PR DESCRIPTION
## Contract delta

- Bind a successful hosted app-cache miss as the exact packaged app, so the selected app stage verifies it instead of rebuilding it.
- Start every existing Codex, distribution, and release-workflow partition with bounded admission; no scenario or release case is removed.
- Allow release-workflow to overlap one provider lane, but keep gate-contract exclusive and defer distribution until release-workflow completes.
- Replace scheduler timing sleeps with explicit handshakes and admit four gate orchestrator shards on the 10-CPU reference Mac.
- Keep all timing ceilings, coverage floors, merge authority, signing, notarization, power, artifact, and publication gates unchanged.

## Measured decisions

- Codex: 55s to 47s after longest-first admission.
- Distribution: 32s to 25s after its two independent parts start together.
- Release workflow: 70-74s unbounded; 63s with five bounded lanes. Four lanes under provider load took 74s and was rejected.
- Gate contracts: final workload 73s with three workers, 66s with four, 65s with five. Four keeps headroom for light contracts.
- Unsafe gate/release overlap exceeded both unchanged budgets (117s and 102s) and was rejected.
- The prior hosted cold build repeated about 83s of packaged-app work; this PR removes that second normal build.

## Evidence

- `bash -n tests/quality-gate.sh tests/release-workflow.sh`
- `git diff --check`
- `python3 tests/quality_gate_contract.py` (16 tests)
- `DETACH_QUALITY_GATE_CONTRACT_SHARD=evidence-runtime-a tests/quality-gate.sh`
- `tests/docs-contract.sh`
- One full local repository diagnostic ran. All independent runnable stages passed. The unchanged interactive desktop activation failure blocked UI-dependent evidence; hosted `quality-gates` is readiness authority.

No release-only signing, notarization, real power, or closed-lid gate was run.