### PR TITLE
Rewrite README as a modern product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Close the window. Keep the agent running.</strong><br>
-  A native macOS workspace for persistent, interactive Codex and Claude Code sessions.
+  The native macOS control center for persistent Codex and Claude Code sessions.
 </p>
 
 <p align="center">
@@ -17,76 +17,103 @@
   <img src="https://img.shields.io/badge/Claude_Code-B43B24?style=flat-square" alt="Claude Code supported">
 </p>
 
-## Install Detach
-
-> [!IMPORTANT]
-> Detach is a Mac app. Install it from the DMG in Finder—do not give this
-> repository link to Codex or Claude Code and ask the agent to install it.
-
-1. [**Download Detach.dmg**](https://github.com/iltsarev/detach/releases/latest/download/Detach.dmg).
-2. Open the DMG and drag **Detach.app** to **Applications**.
-3. Open **Detach** and follow the guided setup.
-
-That is the entire Detach installation. The setup assistant installs the
-bundled `detach` CLI, checks every component, and walks you through the one-time
-macOS approvals for its background monitor and sleep-protection helper.
-After the bundled runtime is verified, pending approval is shown as its own
-actionable step rather than as an installation failure. Setup completes only
-after the signed helper is reachable and the background monitor reports.
-
-Detach manages Codex CLI and Claude Code; it does not replace them. You need at
-least one provider installed and authenticated before starting a session. The
-assistant detects both providers and explains what is missing without mixing
-their installation with the Detach installation above.
+<p align="center">
+  <a href="https://github.com/iltsarev/detach/releases/latest/download/Detach.dmg"><strong>Download Detach.dmg →</strong></a>
+  &nbsp;·&nbsp;
+  <a href="#why-detach">Why Detach</a>
+  &nbsp;·&nbsp;
+  <a href="#command-line-reference">CLI reference</a>
+</p>
 
 <p align="center">
-  <img src="docs/assets/detach-app.png" width="920" alt="Detach.app showing Codex and Claude Code sessions with a live interactive terminal">
+  <img src="docs/assets/detach-app.png" width="920" alt="Detach showing Codex and Claude Code sessions with a live interactive terminal">
 </p>
+
+Detach gives long-running coding agents a durable place to work. Start a run,
+use the built-in terminal, close the app, and return when the agent needs you.
+Detach keeps the process, health state, checkpoints, logs, and Mac power policy
+together.
 
 ## Why Detach
 
-AI agents are good at work that takes longer than a terminal window should have
-to stay open: refactors, migrations, test-and-fix loops, repository audits, and
-large code generation. Detach gives those runs a durable home.
+Codex and Claude Code can work for minutes or hours. A terminal window should
+not be the weak link.
 
-- **Leave without killing the run.** Close Terminal, close the Detach window,
-  or detach from tmux. The managed agent keeps running independently.
-- **Work in one app.** Type in the embedded Codex or Claude Code terminal,
-  paste text or images, search output, and reconnect the terminal client without
-  restarting the agent.
-- **See every agent in one place.** Codex and Claude Code share one native
-  dashboard with interactive sessions, retained logs, model, context usage,
-  checkpoint time, and clear next actions.
-- **Come back the right way.** Attach to the process that is still alive,
-  resume an existing provider conversation, or recover an interrupted managed
-  run from a validated local checkpoint.
-- **Let the Mac keep working.** Native sleep protection can keep a run active
-  with the lid closed, reports its real state, and releases protection at low
-  battery.
-- **Know when something actually broke.** Detach verifies tmux ownership,
-  worker and provider identity, run tokens, heartbeats, metadata, and
-  checkpoints. A long provider turn is not mislabeled as hung just because it
-  is quiet.
+- **Leave without ending the run.** Close Terminal, close the Detach window, or
+  detach from tmux. The managed agent continues in the background.
+- **Run everything in one native app.** Start Codex or Claude Code, type in the
+  interactive terminal, paste text or images, search output, and reconnect a
+  terminal client without restarting the agent.
+- **See what needs you now.** Sessions that wait for a reply move into
+  **Answer ready**. Notifications and the menu bar show when a turn finishes,
+  fails, or becomes recoverable.
+- **Return the correct way.** Attach to a live process, Resume a provider
+  conversation, or Recover an interrupted Detach run from a validated local
+  checkpoint.
+- **Let the Mac keep working safely.** Two-layer sleep protection can keep an
+  active run working with the lid closed. It releases protection while all
+  agents wait, and it fails safe for low battery or high temperature.
 - **Keep control of local data.** Checkpoints and retained logs stay on your
-  Mac. Storage usage is visible, and cleanup is limited to state Detach can
-  prove is safe to remove.
+  Mac. Detach shows their size and removes only state that it proves is safe to
+  delete.
 
-Detach does not replace Codex or Claude Code. It adds an interactive terminal,
-process ownership, recovery, power protection, and operations around them.
+Detach does not replace Codex or Claude Code. It adds process ownership,
+interactive access, recovery, power protection, and operations around them.
 
-## The everyday workflow
+## Download and install
 
-1. Click **＋** in Detach. Choose a project, provider, and optional session name.
-2. Expand **Advanced** only when you want to add an initial prompt. Click
-   **Start**. Detach starts the run in the background and selects it.
-3. Work in the embedded terminal. An external terminal remains available as a
-   fallback.
-4. Close Detach.app whenever you want. The managed agent
-   keeps running.
-5. Reopen Detach to answer the agent, inspect progress, stop the run, Resume a
-   conversation, or Recover an interrupted managed run.
+1. [**Download Detach.dmg**](https://github.com/iltsarev/detach/releases/latest/download/Detach.dmg).
+2. Open the DMG and drag **Detach.app** to **Applications**.
+3. Open **Detach** and complete the guided setup.
 
-The embedded terminal keeps the provider shortcuts that matter:
+That is the complete Detach installation. You do not need Homebrew, a separate
+tmux or JSON tool, `caffeinate`, or another keep-awake app.
+
+Detach manages provider CLIs; it does not install or replace them. Install and
+authenticate at least one supported provider first:
+
+- [Codex CLI](https://github.com/openai/codex)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)
+
+> [!IMPORTANT]
+> Detach is a Mac app. Install it from the DMG in Finder. Do not give this
+> repository link to an agent and ask the agent to install it.
+
+<details>
+<summary><strong>What guided setup does</strong></summary>
+
+The setup assistant installs the bundled `detach` CLI, checks every component,
+and explains the one-time macOS approvals for the background monitor and the
+sleep-protection helper. A pending approval is an actionable setup step, not an
+installation failure. Setup completes after the signed helper is reachable and
+the background monitor reports.
+
+The assistant detects Codex CLI and Claude Code separately. It explains which
+provider is missing or not authenticated without mixing provider setup with the
+Detach installation.
+
+</details>
+
+## From prompt to finished work
+
+1. Click **＋**. Choose a project, provider, and optional session name.
+2. Expand **Advanced** if you want to add an initial prompt. Click **Start**.
+3. Work in the embedded terminal or leave Detach while the agent works.
+4. Return to answer the agent, inspect progress, stop the run, Resume a
+   conversation, or Recover an interrupted run.
+
+The app and CLI control the same sessions. Start in one and continue in the
+other.
+
+```bash
+cd ~/my/repo
+detach codex -- "implement the queued task"
+
+# Use Claude Code and return immediately to the shell.
+detach claude --detach -- "run the test suite and fix failures"
+```
+
+The embedded terminal keeps the shortcuts that matter:
 
 | Action | Control |
 |---|---|
@@ -95,72 +122,85 @@ The embedded terminal keeps the provider shortcuts that matter:
 | Find terminal output | `Cmd-F` |
 | Replace an exited terminal client without restarting the agent | **Reconnect** |
 
-Prefer the shell? Guided setup adds `detach` to your login and interactive
-shell. Open a new terminal window and run:
+Start, Resume, and Recover run inside Detach and do not require an outer
+terminal. The selected external terminal remains available as a fallback for
+Attach, Resume, and Recover.
 
-```bash
-cd ~/my/repo
-detach codex -- "implement the queued task"
+<details>
+<summary><strong>How a new in-app session starts</strong></summary>
 
-# Or use Claude Code and return immediately to your shell:
-detach claude --detach -- "run the test suite and fix failures"
-```
+Detach runs the CLI with `--detach` in the selected project and refreshes the
+session list. When it finds one new matching session, it selects the session
+and opens the embedded terminal. A start error stays in the sheet so that you
+can correct it. Terminal, iTerm2, Warp, or another configured shell runner
+remains available from the named fallback button.
 
-The app and CLI operate on the same sessions. Start in one and continue in the
-other.
+</details>
 
-New sessions start inside Detach. The app runs the CLI with `--detach` in the
-selected project and refreshes the session list. When Detach identifies one
-new match, it selects the session and opens the embedded terminal. A start
-error stays in the sheet. The selected external terminal remains a fallback
-for Attach, Resume, and Recover.
+## One control center for every run
 
-## The terminal and control center in one window
-
-Detach.app owns the session lifecycle. Start, Resume, and Recover run inside
-the app and do not require an outer terminal. The selected Terminal, iTerm2,
-Warp, or other shell-script runner remains available from the named fallback
-button.
-
-The dashboard gives every managed session:
+Codex and Claude Code share one dashboard. Each managed session includes:
 
 - live working, waiting, completed, failed, hung, recoverable, orphaned, and
   stopped state;
 - an explicit health reason when the runtime needs attention;
 - provider, project, model, context use, checkpoint time, and exit status;
-- an interactive terminal for live sessions and ANSI-aware retained logs for
+- an interactive terminal for a live session and ANSI-aware retained logs for
   session history;
-- safe actions chosen from **Attach**, **Stop**, **Resume**, **Recover**, and
-  **Delete** according to the proven state;
-- checkboxes in **Finished** for one-confirmation deletion of selected eligible
-  sessions; one failed deletion does not stop the remaining deletions;
-- optional notifications when a turn is ready for an answer, a session
-  finishes or fails, or recovery becomes available;
-- a stable identity color shared by the sidebar and that session's tmux status
-  bar. Current tasks avoid occupied hues across Codex and Claude. Finished
-  history does not keep a palette slot occupied.
+- safe **Attach**, **Stop**, **Resume**, **Recover**, and **Delete** actions
+  selected from the proven session state;
+- checkboxes in **Finished** for one-confirmation deletion of eligible
+  sessions; a failed deletion does not stop the remaining deletions;
+- optional notifications for an answer, completion, failure, or recovery;
+- one stable identity color in the sidebar and the tmux status bar. Current
+  Codex and Claude tasks avoid colors that are already in use.
 
-Sessions waiting for your reply move into **Answer ready**, ahead of agents
-that are still working. That signal comes from structured provider lifecycle
-records, not guesses based on terminal text. Mid-turn permission prompts are
-not currently part of that signal.
+Sessions that wait for your reply move into **Answer ready**, before agents
+that are still working. Detach reads structured provider lifecycle records for
+this signal. It does not guess from terminal text. Mid-turn permission prompts
+are not currently part of the signal.
 
-The optional menu bar companion shows whether the Mac can sleep, how fresh the
-background health report is, how many sessions hold protection, and which
-sessions are waiting for an answer. While sessions are active, the dot in the
-menu bar glyph turns green; it turns orange when at least one session is
-waiting for your reply. Closing the main window keeps the menu bar and
-background checks available; quitting Detach.app does not kill managed
-sessions.
+The optional menu bar companion shows:
 
-## Built to survive the ordinary interruptions
+- whether the Mac can sleep;
+- whether the background health report is fresh;
+- how many sessions hold power protection;
+- which sessions wait for an answer.
+
+The menu bar dot is green while an agent works and orange while at least one
+session waits for you. Closing the main window keeps the menu bar and background
+checks available. Quitting Detach.app does not kill managed sessions.
+
+## Attach, Resume, and Recover
+
+These actions solve different problems:
+
+| Situation | Action | What Detach does |
+|---|---|---|
+| The managed worker is still alive | **Attach** | Open a client for the existing tmux session. Do not start another agent. |
+| The provider conversation exists | **Resume** | Continue the conversation by UUID in its saved project. |
+| A Detach-managed run was interrupted | **Recover** | Validate saved context and a checkpoint, then restart the exact conversation under Detach. |
+
+**Attach = live process. Resume = provider conversation. Recover = interrupted
+managed run.**
+
+Recovery validates identity, paths, and provider data before it writes. It
+never rolls repository files back. A shared project lock also prevents two
+Detach-managed agents, including agents from different providers, from writing
+the same worktree at the same time.
+
+## Reliability that distinguishes slow from broken
+
+Detach owns a private Apple Silicon tmux runtime. Each agent runs on a private,
+absolute socket. Closing a client does not kill the worker. Unmounting one
+project does not affect sessions for other projects.
 
 ```mermaid
 flowchart LR
     U["You"] --> D["Detach.app or CLI"]
     D --> T["Private managed tmux"]
     T --> P["Codex or Claude Code"]
-    T --> L["Retained logs + live health"]
+    T --> L["Retained logs + typed health"]
     T --> A["Native sleep protection"]
     P -. "validated local snapshots" .-> C["Recovery checkpoint"]
     C -. "conservative restore" .-> P
@@ -175,101 +215,58 @@ flowchart LR
     class L,A,C state;
 ```
 
-Every agent runs under a Detach-owned Apple Silicon tmux runtime on a private,
-absolute socket. Closing a client does not kill the worker. The tmux server is
-anchored in persistent Detach state rather than in the first project directory,
-so unmounting one project does not poison unrelated sessions.
-
-Once provider identity is known, Detach attempts an initial conversation
-checkpoint, repeats every five minutes by default, and attempts a final
-checkpoint when the worker exits. It also retains terminal output and records
-canonical repository context without invoking Git or Apple's Command Line
-Tools shim. When a Codex session starts a fresh conversation inside the same
-run (for example with `/clear`), Detach follows the provider to that new
-conversation, so status and later checkpoints track the conversation you are
-actually in.
-
-The app window is not the runtime. A session and its checkpoint loop continue
-independently. Its power protection follows whether the agent is working or
-waiting; the dashboard catches up when it is opened again.
-
-## Health that distinguishes slow from broken
-
-Detach evaluates health from several independent facts instead of one timeout:
+Detach evaluates health from independent facts:
 
 - the expected tmux server, managed session, and retained pane;
-- the Detach ownership marker and matching per-run token;
-- the exact worker PID and provider PID, their user ownership, and their
-  process relationship;
-- valid session metadata and provider conversation identity;
+- the Detach ownership marker and per-run token;
+- the exact worker PID and provider PID, user ownership, and process relation;
+- valid metadata and provider conversation identity;
 - worker heartbeat and checkpoint freshness;
-- whether the latest checkpoint is valid enough for conservative recovery.
-
-This produces useful states rather than a generic red light:
+- a checkpoint that is valid enough for conservative recovery.
 
 | State | Meaning | Safe actions |
 |---|---|---|
-| **Running** | The managed pane, worker, provider, and run token agree. | Attach, Stop |
-| **Hung** | A required runtime identity is missing or inconsistent, or a recorded process survived tmux. | Attach/Stop only when tmux ownership is still proven; otherwise no mutation |
+| **Running** | The pane, worker, provider, and run token agree. | Attach, Stop |
+| **Hung** | A required runtime identity is missing or inconsistent, or a recorded process survived tmux. | Attach or Stop only when tmux ownership is proven. Otherwise, no mutation. |
 | **Recoverable** | The live runtime is gone and a matching validated checkpoint exists. | Recover, Delete |
 | **Orphaned** | The live runtime is gone and no safe recovery checkpoint exists. | Delete |
-| **Finished / stopped** | The worker reached a terminal state. | Resume or Delete, depending on provider identity |
-| **Collision / corrupt** | tmux ownership or metadata cannot be trusted. | Conservative, state-specific actions only |
+| **Finished / stopped** | The worker reached a terminal state. | Resume or Delete, according to provider identity. |
+| **Collision / corrupt** | tmux ownership or metadata cannot be trusted. | Conservative, state-specific actions only. |
 
-A stale heartbeat or old checkpoint is diagnostic information, not proof that
-the provider is hung. If the owned worker and provider are alive, Detach keeps
-the session running even through an arbitrarily long provider turn.
+A stale heartbeat or old checkpoint is diagnostic information. It does not
+prove that an agent is hung. If the owned worker and provider are alive, Detach
+keeps the session running through a long provider turn.
 
-If tmux disappears while a recorded process is still alive, Detach does not
-guess which signal is safe. It blocks Stop, Recover, Delete, and bulk cleanup
-until that exact runtime is gone. Foreign processes and unmanaged tmux sessions
-are never signaled or removed. Concurrent Stop, Recover, and Delete requests
-are serialized per session and recheck ownership immediately before mutation.
-
-For automation and diagnosis:
-
-```bash
-detach list --json
-detach reconcile --dry-run --json
-detach cleanup --dry-run --json
-```
-
-The reconcile preview reports only declarative repairs supported by current
-evidence, such as removing a dead managed pane and marking a session
-recoverable or orphaned. The cleanup preview includes only stopped or orphaned
-sessions whose typed health result explicitly authorizes cleanup and that pass
-the storage and ownership checks.
-
-## Attach, Resume, and Recover are different on purpose
-
-| Situation | Action | What Detach does |
-|---|---|---|
-| The managed worker is still alive | **Attach** | Opens an embedded client for the existing tmux session without starting another agent. |
-| The provider conversation exists | **Resume** | Continues the conversation by UUID after detecting its provider and saved project. |
-| A Detach-managed run was interrupted | **Recover** | Validates the saved context and checkpoint, then restarts the exact conversation under management. |
-
-In short: **Attach = live process**, **Resume = provider conversation**,
-**Recover = interrupted managed run**.
-
-Recovery validates identity, paths, and provider data before it writes. It
-never rolls repository files back. A shared project lock also prevents two
-Detach-managed agents—even from different providers—from writing the same
-worktree at once.
+If tmux disappears while a recorded process is still alive, Detach blocks
+Stop, Recover, Delete, and bulk cleanup until that exact runtime is gone. It
+never signals or removes foreign processes and unmanaged tmux sessions.
+Concurrent Stop, Recover, and Delete requests are serialized per session and
+recheck ownership immediately before mutation.
 
 <details>
-<summary><strong>Provider-specific checkpoint and recovery rules</strong></summary>
+<summary><strong>Checkpoint and recovery rules</strong></summary>
 
-- **Codex:** Detach saves the session UUID and rollout JSONL. It preserves a
-  valid live rollout when that file is at least as large as the checkpoint and
-  restores only when the matching live rollout is missing, invalid, or
-  smaller. A separately validated SQLite backup is an emergency artifact and
-  is never restored over Codex's shared database automatically.
+After Detach knows the provider identity, it attempts an initial conversation
+checkpoint. By default, it repeats the checkpoint every five minutes and makes
+a final attempt when the worker exits. Detach also retains terminal output and
+records canonical repository context without invoking Git or the Apple Command
+Line Tools shim.
+
+When Codex starts a fresh conversation in the same run, for example with
+`/clear`, Detach follows the new conversation. Status and later checkpoints
+then refer to the conversation that is in use.
+
+- **Codex:** Detach saves the session UUID and rollout JSONL. It keeps a valid
+  live rollout when that file is at least as large as the checkpoint. It
+  restores only when the matching live rollout is missing, invalid, or smaller.
+  A separately validated SQLite backup is an emergency artifact. Detach never
+  restores it over the shared Codex database automatically.
 - **Claude Code:** Detach saves the preassigned session UUID, transcript,
   project companion data, file history, session environment, tasks, and
-  matching team data in an atomic archive. Explicit recovery restores a valid,
+  matching team data in one atomic archive. Explicit recovery restores a valid,
   matching checkpoint and its companion artifacts before resume.
-- **Both:** unsafe paths, ambiguous or mismatched UUIDs, malformed JSONL, and
-  invalid checkpoint contents are rejected.
+- **Both:** Detach rejects unsafe paths, ambiguous or mismatched UUIDs,
+  malformed JSONL, and invalid checkpoint contents.
 
 Checkpoint state lives here:
 
@@ -278,35 +275,109 @@ Checkpoint state lives here:
 ~/.local/state/detach/claude/sessions/
 ```
 
-Change the default interval for a special run:
+Change the default checkpoint interval for a special run:
 
 ```bash
 DETACH_CODEX_CHECKPOINT_INTERVAL=600 detach codex
 DETACH_CLAUDE_CHECKPOINT_INTERVAL=600 detach claude
 ```
 
+The Detach app is not the runtime. A session, its checkpoint loop, and its
+power protection continue independently. The dashboard reads the latest state
+when you open it again.
+
 </details>
 
-## See exactly what Detach stores
+## Closed-lid work with fail-safe limits
 
-Settings → System shows total Detach disk use, checkpoint/log breakdowns, and
-the largest sessions. You can select safe sessions, preview the exact allocated
-size and contents, delete every safely removable session, or open the state
-directory in Finder.
+Keep-awake protection starts automatically with a managed session. An
+unprivileged wrapper holds the normal IOKit idle-sleep assertion. A narrowly
+scoped signed helper manages closed-lid protection. Detach starts the provider
+only after it confirms both layers.
+
+When an agent finishes a turn and waits for your reply, that session releases
+both Detach protection layers. The provider, tmux session, and checkpoints stay
+available. A new turn acquires both layers again. The Mac can sleep only when
+every live session waits. Missing or invalid lifecycle state keeps protection
+active.
+
+The app, menu bar, CLI, and tmux status bar use the same state:
+
+- **Mac stays awake**
+- **Mac can sleep**
+- **Mac can sleep: low battery**
+- **Mac can sleep: temperature**
+- an honest unknown state when the helper or health report cannot be trusted
+
+At 10% battery or lower while on battery power, Detach releases its sleep
+assertions. At a public macOS thermal state of `serious` or `critical`, it
+immediately releases both layers that it owns and refuses new protected runs.
+The provider can continue only while macOS keeps the machine awake. Protection
+can return after the state is `nominal` or `fair` for 30 seconds. Detach sends
+one warning for each hot interval when session notifications are enabled.
+
+When the lid closes during a protected run, Detach asks macOS to turn off the
+display through the normal Lock Screen path. Reopening the lid returns to your
+existing Touch ID, Apple Watch, or password policy. Detach does not weaken the
+lock policy.
+
+> [!CAUTION]
+> Long closed-lid work can hide excess heat. Keep the Mac on a hard, flat, and
+> well-ventilated surface. Never put it in a sleeve, bag, or on bedding. Thermal
+> safety permits sleep, but it cannot cool a blocked Mac or disable another
+> tool's sleep setting. See [Apple's temperature guidance](https://support.apple.com/en-us/102336).
+
+<details>
+<summary><strong>Power safety boundary</strong></summary>
+
+Each working session has a renewable root-helper lease. The wrapper renews it
+every 30 seconds. A lease expires after 120 seconds without a heartbeat. A
+waiting session releases its lease immediately. The last working lease restores
+normal closed-lid sleep. An orderly stop also releases the lease immediately.
+The TTL limits stale protection after a crash or `SIGKILL`.
+
+Detach records ownership before power changes. If closed-lid protection is
+already active, Detach borrows it and never disables it. If Detach enabled the
+setting, it restores it after the last lease, a stale lease, or an orderly
+helper shutdown. Detach discards leases from an earlier macOS boot session.
+
+The helper accepts requests only from signed Detach power clients with the same
+Team ID and from the current non-root console user. It provides only status and
+lease operations. It cannot run providers or arbitrary root commands.
+
+Closed-lid protection uses `/usr/bin/pmset -a disablesleep`, an undocumented
+macOS interface. Each production release therefore requires a signed real-power
+smoke test and a supervised physical lid test on Apple Silicon.
+
+</details>
+
+## Local data, visible and controlled
+
+Checkpoints, metadata, and retained logs stay local with private file
+permissions. Detach has no account and no hosted session backend. Codex and
+Claude Code continue to use their normal services and local provider storage.
+Detach checks tmux ownership and run tokens before Attach, Stop, Recover, or
+Delete. It leaves foreign sessions unchanged.
+
+Settings → System shows total Detach disk use, checkpoint and log sizes, and
+the largest sessions. You can select safe sessions, preview their exact
+allocated size and contents, delete all safely removable sessions, or open the
+state directory in Finder.
 
 Cleanup is deliberately narrow:
 
 - only fully measured `stopped` or `orphaned` sessions are eligible;
-- a missing cleanup authorization is never inferred from the displayed status;
-- live, recoverable, corrupt, foreign, or ownership-ambiguous state is not;
+- a missing cleanup authorization is never inferred from displayed status;
+- live, recoverable, corrupt, foreign, or ownership-ambiguous state is not
+  eligible;
 - provider storage under `~/.codex` and `~/.claude` is excluded;
-- symlinks are measured as links and never followed;
+- symlinks are measured as links and are never followed;
 - sparse files, hard links, unreadable entries, and partial deletion are
   handled conservatively;
-- the exact preview is rechecked under the session/checkpoint locks before a
-  destructive action.
+- the preview is rechecked under the session and checkpoint locks before
+  deletion.
 
-The same data is available to scripts:
+Deleting Detach state does not delete provider transcripts or conversations.
 
 ```bash
 detach storage --json
@@ -314,87 +385,24 @@ detach storage cleanup --dry-run --json
 detach storage cleanup --dry-run --json --session detach-codex-my-project
 ```
 
-Deleting Detach state does not delete provider transcripts or conversations.
+## Command-line reference
 
-## Close the lid without abandoning the run
-
-Keep-awake protection starts automatically when a managed session starts. An
-unprivileged wrapper holds the normal IOKit idle-sleep assertion while a
-narrowly scoped signed helper manages closed-lid protection. The provider is
-started only after both protections are confirmed.
-
-When an agent finishes a turn and waits for your reply, that session releases
-both Detach protection layers. Its provider, tmux session, and checkpoints stay
-available. A new turn reacquires both layers. The Mac can sleep only when every
-live session is waiting. If at least one agent is working, that session keeps
-the Mac awake. Missing or invalid lifecycle state keeps protection active.
-
-The app, menu bar, CLI, and tmux status bar expose the same text-first state:
-**Mac stays awake**, **Mac can sleep**, **Low battery**, **Mac can sleep:
-temperature**, or an honest unknown state when the helper or health report
-cannot be trusted.
-
-When the lid closes during a protected run, Detach asks macOS to turn the
-display off through the normal Lock Screen path. Reopening the lid returns to
-Touch ID, Apple Watch, or password authentication according to your existing
-macOS settings; Detach does not weaken the lock policy.
-
-At 10% battery or below on battery power, Detach releases its sleep assertions
-and reports **Mac can sleep: low battery**. It will not trade the machine's last
-battery reserve for a hidden promise that the run is protected.
-
-At a public macOS thermal state of `serious` or `critical`, Detach immediately
-releases both sleep-protection layers it owns and reports **Mac can sleep:
-temperature**. The provider may continue only while macOS keeps the machine
-awake. New protected runs are refused, and protection is eligible to return
-only after `nominal` or `fair` has remained stable for 30 seconds. The app sends
-one warning per hot interval when session notifications are enabled.
-
-> [!CAUTION]
-> Sustained closed-lid work can hide excess heat. Keep the Mac on a hard, flat,
-> well-ventilated surface—never in a sleeve, bag, or on bedding. Thermal safety
-> permits sleep but cannot cool a blocked Mac or disable another tool's sleep
-> setting. See [Apple's temperature guidance](https://support.apple.com/en-us/102336).
-
-<details>
-<summary><strong>How the power safety boundary works</strong></summary>
-
-Each working session has a renewable root-helper lease. The wrapper renews it
-every 30 seconds; a lease expires after 120 seconds without a heartbeat. A
-waiting session releases its lease immediately. The last working lease restores
-normal closed-lid sleep. An orderly stop also releases the lease immediately,
-while the TTL bounds stale protection after an uncatchable crash or `SIGKILL`.
-
-Ownership is persisted before power changes. If closed-lid protection was
-already active, Detach borrows it and never disables it. If Detach enabled the
-setting, it restores it after the last lease, a stale lease, or orderly helper
-shutdown. Previous-boot leases are discarded using the macOS boot-session UUID.
-
-The helper accepts only signed Detach power-client requests from the same Team
-ID and the current non-root console user. It exposes status and lease
-operations only; it cannot execute providers or arbitrary root commands.
-
-Closed-lid protection uses `/usr/bin/pmset -a disablesleep`, an undocumented
-macOS interface. Every production release therefore requires a signed
-real-power smoke test and a supervised physical lid test on Apple Silicon.
-
-</details>
-
-## A first-class CLI
+Guided setup adds `detach` to login and interactive shells. Open a new terminal
+window after setup.
 
 ```bash
-# Start
+# Start.
 detach codex
 detach codex --detach -- "run the migration"
 detach claude --name "Rev (ai)" -- "review the repository"
 
-# Monitor and return
+# Monitor and return.
 detach list
 detach list --json
 detach claude attach review
 detach resume SESSION_UUID
 
-# Diagnose and maintain
+# Diagnose and maintain.
 detach doctor
 detach storage --json
 detach reconcile --dry-run --json
@@ -404,96 +412,96 @@ detach reconcile --dry-run --json
 |---|---|
 | `detach <provider> [start]` | Start a fresh conversation for the current project. |
 | `detach <provider> attach [name]` | Attach to a live managed session. |
-| `detach list [--json]` | List Codex and Claude sessions together; JSON mode emits JSONL. |
-| `detach resume <uuid>` | Detect provider and project, then continue the conversation. An owned Claude session without a transcript restarts with the same UUID. |
+| `detach list [--json]` | List Codex and Claude sessions together. JSON mode emits JSONL. |
+| `detach resume <uuid>` | Detect the provider and project, then continue the conversation. An owned Claude session without a transcript restarts with the same UUID. |
 | `detach <provider> status [name]` | Show runtime, checkpoint, and power state. |
 | `detach <provider> logs [--ansi] [name]` | Read retained output without attaching. |
 | `detach <provider> stop [name]` | Stop a live session only when its managed runtime is proven. |
 | `detach <provider> recover [name]` | Restart an interrupted run from validated saved context. |
-| `detach <provider> delete [--force] [name]` | Delete eligible Detach state; leave provider storage untouched. |
+| `detach <provider> delete [--force] [name]` | Delete eligible Detach state. Leave provider storage unchanged. |
 | `detach storage --json` | Report logical and allocated storage by session and data type. |
 | `detach storage cleanup --dry-run --json [--session name]` | Preview an exact safe cleanup selection. |
 | `detach reconcile --dry-run --json` | Preview safe stale-state and dead-runtime reconciliation. |
-| `detach cleanup --dry-run --json` | Preview bulk cleanup of stopped/orphaned sessions. |
+| `detach cleanup --dry-run --json` | Preview bulk cleanup of stopped or orphaned sessions. |
 | `detach power status --json` | Read combined idle-sleep and closed-lid protection. |
-| `detach config tmux-style [detach\|inherit]` | Use Detach's session identity bar or your tmux theme. |
-| `detach config tmux-mouse [on\|off]` | Toggle managed scrolling, clipboard selection, and copy-mode type-through behavior. |
+| `detach config tmux-style [detach\|inherit]` | Use the Detach identity bar or your tmux theme. |
+| `detach config tmux-mouse [on\|off]` | Toggle managed scrolling, selection, and copy-mode type-through. |
 | `detach config tmux-extended-keys [on\|off]` | Toggle Shift+Return multiline input in managed sessions. |
 | `detach doctor [--json]` | Verify the app-installed runtime, provider CLIs, helper, and monitor. |
 | `detach repair` | Reinstall the pristine immutable CLI payload from Detach.app. |
 | `detach uninstall [--keep-state\|--purge-state]` | Remove Detach components and choose whether checkpoints stay. |
 
-Name a session when the project-derived default is not memorable. In the app,
-press **+** and fill the optional **Name** field. In the CLI, pass
-`--name "Rev (ai)"`; spaces, parentheses, Cyrillic, emoji, and other printable
-text are accepted up to 100 UTF-8 bytes. Detach stores that label separately
-and derives a safe internal tmux/state identifier. The `SESSION` column and
-`session_name` JSON field expose that identifier; `NAME` and `display_name`
-carry the human label. Existing safe names such as `review` keep their previous
-`detach-<provider>-review` identifiers. Press `Ctrl-b d` to detach a terminal
-client without closing its window.
+For automation and diagnosis:
 
-Project-derived sessions keep a separate history for every fresh run. The first
-uses the familiar project-derived identifier; later runs receive a short,
-monotonically allocated suffix. Starting again while a run is live refuses a
-second writer: attach to it, or stop it before starting another conversation.
-After a run finishes, stops, or becomes safely orphaned, a default start creates
-a new history without replacing the older metadata, logs, or checkpoints.
-Commands without a name target the live or newest history. Use the internal
-`session_name` shown by `detach list` to Resume, Recover, inspect, or Delete an
-older one. Ordinary typed storage cleanup may also remove eligible histories.
+```bash
+detach list --json
+detach reconcile --dry-run --json
+detach cleanup --dry-run --json
+```
 
-## Terminal details that make parallel work readable
+The reconcile preview includes only declarative repairs that current evidence
+supports. The cleanup preview includes only stopped or orphaned sessions whose
+typed health result permits cleanup and whose storage and ownership checks pass.
 
-Every managed session receives a deterministic color based on provider and
-project. The app uses it in the sidebar; the tmux bar uses the same tint with
-provider, project, state, and power labels. Completed sessions fade and failed
-sessions turn red. A new or resumed task walks the shared palette when its
-preferred color is in use by another current task. Finished history keeps its
-displayed color but releases that palette slot. All styling is session-local:
-Detach never edits the user's global tmux config.
+<details>
+<summary><strong>Session names and retained history</strong></summary>
 
-Shells opened in user-created split panes close normally on `Ctrl-D` or exit.
-Only the managed Codex or Claude pane is retained after completion so Detach
-can preserve its output and exit status.
+In the app, set the optional **Name** field. In the CLI, pass
+`--name "Rev (ai)"`. Names can contain spaces, parentheses, Cyrillic, emoji,
+and other printable text, up to 100 UTF-8 bytes. Detach stores the label
+separately and derives a safe internal tmux and state identifier.
 
-Inside managed tmux, the mouse wheel scrolls one line at a time and mouse
-selection copies to the macOS clipboard while keeping the highlight and your
-scroll position. While managed mouse input is on, typing an ASCII or Cyrillic
-printable key, Space, Enter, or Backspace in copy-mode returns to the live
-prompt and delivers that key to the session. This intentionally gives those
-keys to the live prompt instead of tmux's printable copy-mode commands; arrows,
-page navigation, Escape, and control chords retain their copy-mode behavior.
-Use `detach config tmux-mouse off` to restore the original copy-mode key tables
-and return mouse handling to the terminal emulator. In Terminal.app,
-Option-drag also bypasses tmux selection.
+The `SESSION` column and `session_name` JSON field contain the internal
+identifier. `NAME` and `display_name` contain the human label. Existing safe
+names such as `review` keep their `detach-<provider>-review` identifier. Press
+`Ctrl-b d` to detach a terminal client without closing its window.
 
-Shift+Return inserts a newline in managed sessions by default. Detach recognizes
-the modified key at its private tmux boundary and sends the same stable
-multiline input as Option+Return. Toggle it in Settings → Terminal or with
-`detach config tmux-extended-keys off`; Option+Return always inserts a newline.
-OSC 8 links from agent output remain clickable in outer terminals that support
-them and are independent of this keyboard toggle.
+Project-derived sessions keep separate history for each fresh run. The first
+run uses the project-derived identifier. Later runs receive a short increasing
+suffix. A new start is refused while a run is live. Attach to the run or stop
+it before you start another conversation.
+
+After a run finishes, stops, or becomes safely orphaned, the next default start
+creates a new history. It does not replace old metadata, logs, or checkpoints.
+Commands without a name select the live or newest history. Use the
+`session_name` from `detach list` to select an older history. Typed storage
+cleanup can remove eligible histories.
+
+</details>
+
+<details>
+<summary><strong>Terminal behavior and appearance</strong></summary>
+
+Each session receives a deterministic provider-and-project color. The app uses
+it in the sidebar, and the tmux bar uses the same tint with provider, project,
+state, and power labels. Completed sessions fade, and failed sessions turn red.
+A new or resumed current task selects another palette color when its preferred
+color is in use. Finished history keeps its displayed color but releases that
+palette slot. Detach never edits the global tmux configuration.
+
+Shells in user-created split panes close normally on `Ctrl-D` or exit. Only the
+managed Codex or Claude pane is retained after completion so that Detach can
+preserve output and exit status.
+
+Inside managed tmux, the mouse wheel scrolls one line at a time. Mouse selection
+copies to the macOS clipboard and keeps the highlight and scroll position. When
+managed mouse input is on, an ASCII or Cyrillic printable key, Space, Enter, or
+Backspace leaves copy mode and sends that key to the live prompt. Arrows, page
+navigation, Escape, and control chords keep their copy-mode behavior. Use
+`detach config tmux-mouse off` to restore the original copy-mode key tables and
+return mouse handling to the terminal emulator. In Terminal.app, Option-drag
+also bypasses tmux selection.
+
+Shift+Return inserts a newline in managed sessions by default. It sends the
+same stable multiline input as Option+Return. Toggle this behavior in Settings
+→ Terminal or with `detach config tmux-extended-keys off`. Option+Return always
+inserts a newline. OSC 8 links from agent output remain clickable in outer
+terminals that support them.
 
 Choose **My tmux theme** in Settings → Terminal, or run
-`detach config tmux-style inherit`, to remove Detach's bar overrides.
+`detach config tmux-style inherit`, to remove the Detach bar overrides.
 
-## Privacy and security defaults
-
-- Checkpoints, metadata, and retained logs stay local with private file
-  permissions. Detach has no account or hosted session backend.
-- Codex and Claude Code continue to use their normal services and local
-  provider storage.
-- Immutable CLI payloads are activated atomically, so an update does not
-  rewrite bytes used by sessions that are already running.
-- A managed project lock prevents accidental concurrent writers in one
-  worktree.
-- tmux ownership and run tokens are checked before Attach, Stop, Recover, or
-  Delete; foreign sessions are left untouched.
-- Provider credentials are passed to tmux in memory and are never written as
-  session startup scratch files.
-- Cleanup never follows symlinks into another tree and never treats provider
-  storage as Detach-owned state.
+</details>
 
 <details>
 <summary><strong>Default provider flags</strong></summary>
@@ -508,69 +516,67 @@ On an unmanaged Mac, Detach defaults to:
 
 Explicit approval and sandbox arguments override these defaults. If managed
 requirements disallow `never`, Detach inherits the managed approval policy and
-reviewer. Detach owns `-C/--cd`; start it from the target project.
+reviewer. Detach owns `-C/--cd`. Start it from the target project.
 
 ### Claude Code
 
-Detach defaults to `--permission-mode auto` unless an explicit mode is passed.
+Detach defaults to `--permission-mode auto` unless you pass an explicit mode.
 It never adds `--dangerously-skip-permissions`. Detach owns provider session
-and background flags so checkpoint identity and tmux lifetime remain
-deterministic. Provider flags that collide with Detach flags belong after `--`.
+and background flags so that checkpoint identity and tmux lifetime stay
+deterministic. Put provider flags that collide with Detach flags after `--`.
 
-Both providers run without the alternate screen so retained output remains
+Both providers run without the alternate screen so that retained output stays
 readable.
 
 </details>
 
-## Self-contained Mac product
-
-Detach includes:
+## A self-contained Mac product
 
 | Component | Included behavior |
 |---|---|
 | Native app | Interactive terminal, dashboard, settings, notifications, menu bar companion, setup, repair, and uninstall. |
-| Private tmux | Bundled Apple Silicon runtime; no separate tmux install or global config changes. |
-| Typed state runtime | Reads and updates Detach JSON/JSONL without a `jq` dependency. |
+| Private tmux | Bundled Apple Silicon runtime with no separate tmux install or global configuration changes. |
+| Typed state runtime | Reads and updates Detach JSON and JSONL without a `jq` dependency. |
 | Native power components | Idle-sleep assertion, signed closed-lid helper, and background health monitor. |
-| Updates | Signed Sparkle updater embedded in Detach.app. |
+| Updates | Signed Sparkle updater in Detach.app. |
 | CLI | App-installed `detach` command that controls the same sessions as the dashboard. |
 
-You do not need Homebrew, a separate tmux or JSON tool, Amphetamine, Power
-Protect, `caffeinate`, or another keep-awake package.
+Immutable CLI payloads activate atomically. An update does not rewrite bytes
+that running sessions use. Provider credentials pass to tmux in memory and are
+never written to session startup scratch files.
 
-## Requirements and honest boundaries
+## Requirements and honest limits
 
 | Component | Requirement |
 |---|---|
-| Mac | macOS 26 or newer on Apple Silicon (`arm64`); Intel Macs are not supported. |
-| Provider | At least one authenticated [Codex CLI](https://github.com/openai/codex) or [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview). |
-| macOS approval | An administrator password is required once to register the signed power helper; Login Items approval may also be required. |
+| Mac | macOS 26 or newer on Apple Silicon (`arm64`). Intel Macs are not supported. |
+| Provider | At least one authenticated Codex CLI or Claude Code installation. |
+| macOS approval | An administrator password is required once to register the signed power helper. Login Items approval can also be required. |
 
-Detach keeps a live process running while the current macOS user session and
-Mac are running. Live sessions do not survive logout or reboot. Intentionally
-killing the provider, worker, or private tmux server ends the live run; the
-last valid checkpoint may still offer Resume or Recover.
+Detach keeps a live process running while the macOS user session is active and
+the Mac is on. Live sessions do not survive logout or reboot. If you kill the
+provider, worker, or private tmux server, the live run ends. The last valid
+checkpoint can still offer Resume or Recover.
 
 Checkpoints protect provider conversation state, not repository files. Detach
-does not roll source code back and does not replace version control or backups.
+does not roll source code back. It does not replace version control or backups.
 
-## Repair, update, or uninstall
+## Repair, update, and uninstall
 
-Updates are handled in Detach.app. Settings also exposes installation health,
-CLI repair, helper status, and removal of Detach-owned components.
+Detach.app handles updates. Settings shows installation health, CLI repair,
+helper status, and removal of Detach-owned components.
 
-Detach changes the active CLI only after it validates a complete payload. If
-an update fails, the active CLI does not change. Move Detach to `/Applications`
-before you try an update. For a download failure, check the network connection
-and try again. For an archive, signature, or installation failure, download
-the latest DMG. If the CLI does not match the app, open Detach settings, select
-System, and run Repair. A normal app update does not interrupt live sessions.
-If working sessions hold power leases, Detach keeps the current helper and the
-session dashboard. It retries the helper update after the leases are released
-and the app becomes active again. Repairing a damaged active payload can still
-require you to end the sessions that use it.
+Detach changes the active CLI only after it validates a complete payload. If an
+update fails, the active CLI does not change. A normal app update does not
+interrupt live sessions. If a working session holds a power lease, Detach keeps
+the current helper and session dashboard. It retries the helper update after
+the leases are released and the app becomes active again. Repairing a damaged
+active payload can require you to end sessions that use it.
 
-From a terminal:
+Move Detach to `/Applications` before you update it. For a download failure,
+check the network and try again. For an archive, signature, or installation
+failure, download the latest DMG. If the CLI does not match the app, open
+Settings → System and run Repair.
 
 ```bash
 detach doctor
@@ -580,9 +586,9 @@ detach uninstall --purge-state
 ```
 
 `--keep-state` preserves recovery checkpoints for a future reinstall.
-`--purge-state` removes Detach state but still leaves `~/.codex` and
-`~/.claude` alone. Uninstall refuses to proceed while a managed session is
-alive; Detach.app itself remains until it is moved to Trash.
+`--purge-state` removes Detach state but leaves `~/.codex` and `~/.claude`
+unchanged. Uninstall refuses to continue while a managed session is alive.
+Detach.app remains until you move it to Trash.
 
 ## Give the next long run a durable home
 


### PR DESCRIPTION
## Summary

- Reframe the README around one clear product promise and a direct DMG download.
- Put the real app screenshot, primary benefits, and four-step workflow before technical reference.
- Surface Answer ready, in-app session control, recovery, retained history, safe cleanup, and adaptive power protection.
- Keep detailed runtime, power, privacy, CLI, and lifecycle contracts in focused sections and disclosure blocks.

## Contract delta

This changes documentation presentation only. Product behavior, supported platforms, safety boundaries, provider requirements, and command contracts do not change.

## Durable decisions

- Keep the README as the complete user-facing contract.
- Use the existing product screenshot as visual proof.
- Apply progressive disclosure to low-frequency technical detail.
- Keep installation and honest platform limits explicit.

## Evidence

- tests/docs-contract.sh: PASS
- scripts/quality-gate --plan --explain: static documentation stage selected
- scripts/quality-gate: local DIAGNOSTIC PASS, policy 54
- git diff --check: PASS

Hosted quality-gates remains the readiness authority.