### PR TITLE
Add quick chat shortcuts and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,18 @@ The embedded terminal keeps the shortcuts that matter:
 
 | Action | Control |
 |---|---|
+| Open the standard New session sheet | `Cmd-N` |
+| Start a Quick chat immediately | `Cmd-T` |
 | Paste text | `Cmd-V` |
 | Give Codex or Claude Code an image from the clipboard | `Ctrl-V` |
 | Find terminal output | `Cmd-F` |
 | Replace an exited terminal client without restarting the agent | **Reconnect** |
+
+Settings → General selects the provider and working folder for Quick chat. The
+default folder is `/tmp`. The same settings page selects the default folder
+where the standard project chooser opens. Quick chat uses the normal managed
+session lifecycle; it does not automatically delete project files, Detach
+state, or provider transcripts.
 
 Start, Resume, and Recover run inside Detach and do not require an outer
 terminal. The selected external terminal remains available as a fallback for
@@ -154,6 +162,9 @@ Codex and Claude Code share one dashboard. Each managed session includes:
 - optional notifications for an answer, completion, failure, or recovery;
 - one stable identity color in the sidebar and the tmux status bar. Current
   Codex and Claude tasks avoid colors that are already in use.
+
+A compact guide below the session list keeps `Cmd-N`, `Cmd-T`, `Cmd-,`, and
+`Cmd-F` visible without opening a help screen.
 
 Sessions that wait for your reply move into **Answer ready**, before agents
 that are still working. Detach reads structured provider lifecycle records for

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -421,6 +421,7 @@
 "Quick chat" = "Quick chat";
 "Settings" = "Settings";
 "Find output" = "Find output";
+"Keyboard shortcuts" = "Keyboard shortcuts";
 "Session defaults" = "Session defaults";
 "Default project folder" = "Default project folder";
 "Quick chat provider" = "Quick chat provider";

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -417,6 +417,18 @@
 "The live runtime disappeared, but a valid checkpoint can be recovered." = "The live runtime disappeared, but a valid checkpoint can be recovered.";
 "The live runtime disappeared without a valid recovery checkpoint." = "The live runtime disappeared without a valid recovery checkpoint.";
 
+/* Session shortcuts and defaults */
+"Quick chat" = "Quick chat";
+"Settings" = "Settings";
+"Find output" = "Find output";
+"Session defaults" = "Session defaults";
+"Default project folder" = "Default project folder";
+"Quick chat provider" = "Quick chat provider";
+"Quick chat folder" = "Quick chat folder";
+"⌘N opens New session. ⌘T starts Quick chat immediately." = "⌘N opens New session. ⌘T starts Quick chat immediately.";
+"Could not start quick chat" = "Could not start quick chat";
+"Quick chat folder is unavailable: %@" = "Quick chat folder is unavailable: %@";
+
 /* Menu bar item */
 "Open Detach" = "Open Detach";
 "New Session…" = "New Session…";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -421,6 +421,7 @@
 "Quick chat" = "Быстрый чат";
 "Settings" = "Настройки";
 "Find output" = "Поиск в выводе";
+"Keyboard shortcuts" = "Сочетания клавиш";
 "Session defaults" = "Настройки сессий";
 "Default project folder" = "Папка проектов по умолчанию";
 "Quick chat provider" = "Провайдер быстрого чата";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -417,6 +417,18 @@
 "The live runtime disappeared, but a valid checkpoint can be recovered." = "Живой runtime исчез, но доступна корректная контрольная точка для восстановления.";
 "The live runtime disappeared without a valid recovery checkpoint." = "Живой runtime исчез без корректной контрольной точки для восстановления.";
 
+/* Session shortcuts and defaults */
+"Quick chat" = "Быстрый чат";
+"Settings" = "Настройки";
+"Find output" = "Поиск в выводе";
+"Session defaults" = "Настройки сессий";
+"Default project folder" = "Папка проектов по умолчанию";
+"Quick chat provider" = "Провайдер быстрого чата";
+"Quick chat folder" = "Папка быстрого чата";
+"⌘N opens New session. ⌘T starts Quick chat immediately." = "⌘N открывает новую сессию. ⌘T сразу запускает быстрый чат.";
+"Could not start quick chat" = "Не удалось запустить быстрый чат";
+"Quick chat folder is unavailable: %@" = "Папка быстрого чата недоступна: %@";
+
 /* Menu bar item */
 "Open Detach" = "Открыть Detach";
 "New Session…" = "Новая сессия…";

--- a/app/Sources/DetachApp/DetachApp.swift
+++ b/app/Sources/DetachApp/DetachApp.swift
@@ -136,6 +136,10 @@ private struct UIE2EConfigurationError: LocalizedError {
 
 enum AppSettings {
     static let defaultDetachPath = ("~/.local/bin/detach" as NSString).expandingTildeInPath
+    static let defaultProjectsDirectoryPath =
+        FileManager.default.homeDirectoryForCurrentUser.path
+    static let defaultQuickChatDirectoryPath = "/tmp"
+    static let defaultQuickChatProvider = Provider.claude.rawValue
     static let uiE2E = UIE2EConfiguration.fromEnvironment()
     static let initialDetachPath = uiE2E?.cli.path ?? defaultDetachPath
     static let defaults = makeDefaults(
@@ -165,6 +169,9 @@ enum AppSettings {
     static let lastShownTipIdentifierKey = "lastShownTipIdentifier"
     static let menuBarIconEnabledKey = "menuBarIconEnabled"
     static let menuBarShowsSessionCountKey = "menuBarShowsSessionCount"
+    static let defaultProjectsDirectoryKey = "defaultProjectsDirectory"
+    static let quickChatDirectoryKey = "quickChatDirectory"
+    static let quickChatProviderKey = "quickChatProvider"
 }
 
 /// App-level navigation requests from surfaces that live outside the main
@@ -172,6 +179,41 @@ enum AppSettings {
 final class MainNavigation: ObservableObject {
     @Published var requestedSessionID: String?
     @Published var requestsNewSession = false
+    @Published var quickChatRequestID: UUID?
+
+    func requestNewSession() {
+        requestsNewSession = true
+    }
+
+    func requestQuickChat() {
+        quickChatRequestID = UUID()
+    }
+}
+
+struct SessionCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+    @ObservedObject var navigation: MainNavigation
+
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) {
+            Button(L10n.string("New session")) {
+                navigation.requestNewSession()
+                showMainWindow()
+            }
+            .keyboardShortcut("n", modifiers: .command)
+
+            Button(L10n.string("Quick chat")) {
+                navigation.requestQuickChat()
+                showMainWindow()
+            }
+            .keyboardShortcut("t", modifiers: .command)
+        }
+    }
+
+    private func showMainWindow() {
+        openWindow(id: "main")
+        NSApp.activate(ignoringOtherApps: true)
+    }
 }
 
 /// Closing the last window must not terminate the app while the menu bar item
@@ -223,6 +265,7 @@ struct DetachApp: App {
                 .id(activeDetachPath) // reattach tasks when the CLI path changes
         }
         .commands {
+            SessionCommands(navigation: mainNavigation)
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
             }

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -7,6 +7,7 @@ struct NewSessionSheet: View {
 
     let store: SessionStore
     @Binding var selectedID: String?
+    let projectPickerRoot: URL
 
     @State private var projectDir: URL?
     @State private var provider: Provider = .claude
@@ -23,9 +24,11 @@ struct NewSessionSheet: View {
         initialName: String = "",
         showsAdvanced: Bool = false,
         initialProjectDir: URL? = nil,
-        initialLaunchFailure: String? = nil
+        initialLaunchFailure: String? = nil,
+        projectPickerRoot: URL = FileManager.default.homeDirectoryForCurrentUser
     ) {
         self.store = store
+        self.projectPickerRoot = projectPickerRoot
         _selectedID = selectedID
         _name = State(initialValue: initialName)
         _showAdvanced = State(initialValue: showsAdvanced)
@@ -306,7 +309,8 @@ struct NewSessionSheet: View {
     private func presentProjectChooser() {
         ProjectDirectoryChooser.present(
             from: PanelHostWindow.current(),
-            selectedProject: projectDir
+            selectedProject: projectDir,
+            defaultDirectory: projectPickerRoot
         ) { url in
             guard let url else { return }
             projectDir = url

--- a/app/Sources/DetachApp/QuickChat.swift
+++ b/app/Sources/DetachApp/QuickChat.swift
@@ -1,0 +1,79 @@
+import Foundation
+import DetachKit
+
+enum DirectoryPreference {
+    static func existingDirectoryURL(
+        path: String,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        guard path.hasPrefix("/") else { return nil }
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+            .standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(
+            atPath: url.path,
+            isDirectory: &isDirectory),
+              isDirectory.boolValue else { return nil }
+        return url.resolvingSymlinksInPath().standardizedFileURL
+    }
+
+    static func configuredOrFallback(
+        path: String,
+        fallback: URL,
+        fileManager: FileManager = .default
+    ) -> URL {
+        existingDirectoryURL(path: path, fileManager: fileManager)
+            ?? fallback
+    }
+}
+
+@MainActor
+enum QuickChatLaunch {
+    static func provider(rawValue: String) -> Provider {
+        Provider(rawValue: rawValue) ?? .claude
+    }
+
+    static func start(
+        store: SessionStore,
+        providerRawValue: String,
+        directoryPath: String,
+        fileManager: FileManager = .default
+    ) async -> SessionStartResult {
+        guard let directory = DirectoryPreference.existingDirectoryURL(
+            path: directoryPath,
+            fileManager: fileManager) else {
+            return SessionStartResult(message: L10n.format(
+                "Quick chat folder is unavailable: %@",
+                directoryPath))
+        }
+        return await store.startDetached(
+            provider: provider(rawValue: providerRawValue),
+            projectDirectory: directory,
+            name: nil,
+            prompt: nil)
+    }
+}
+
+struct SidebarShortcutHint: Equatable, Identifiable {
+    let shortcut: String
+    let title: String
+
+    var id: String { shortcut }
+}
+
+enum SidebarShortcutPresentation {
+    static var hints: [SidebarShortcutHint] { [
+        SidebarShortcutHint(
+            shortcut: "⌘N",
+            title: L10n.string("New session")),
+        SidebarShortcutHint(
+            shortcut: "⌘T",
+            title: L10n.string("Quick chat")),
+        SidebarShortcutHint(
+            shortcut: "⌘,",
+            title: L10n.string("Settings")),
+        SidebarShortcutHint(
+            shortcut: "⌘F",
+            title: L10n.string("Find output")),
+    ] }
+}

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -175,7 +175,7 @@ private extension SettingsDestination {
     /// the selected tab like classic AppKit preference panes.
     var baseHeight: CGFloat {
         switch self {
-        case .general: 450
+        case .general: 620
         case .terminal: 460
         case .notifications: 350
         case .system: 780
@@ -211,6 +211,13 @@ struct SettingsView: View {
     private var menuBarIconEnabled = true
     @AppStorage(AppSettings.menuBarShowsSessionCountKey, store: AppSettings.defaults)
     private var menuBarShowsSessionCount = true
+    @AppStorage(AppSettings.defaultProjectsDirectoryKey, store: AppSettings.defaults)
+    private var defaultProjectsDirectoryPath =
+        AppSettings.defaultProjectsDirectoryPath
+    @AppStorage(AppSettings.quickChatDirectoryKey, store: AppSettings.defaults)
+    private var quickChatDirectoryPath = AppSettings.defaultQuickChatDirectoryPath
+    @AppStorage(AppSettings.quickChatProviderKey, store: AppSettings.defaults)
+    private var quickChatProvider = AppSettings.defaultQuickChatProvider
 
     @State private var terminalApplications: [TerminalApplication] = []
     @State private var terminalIcons: [String: NSImage] = [:]
@@ -518,6 +525,30 @@ struct SettingsView: View {
 #endif
 // quality-coverage:end ui-e2e-instrumentation
             }
+            Section(L10n.string("Session defaults")) {
+                directoryPreferenceRow(
+                    title: L10n.string("Default project folder"),
+                    path: $defaultProjectsDirectoryPath,
+                    accessibilityIdentifier: "settings-default-project-folder")
+                Picker(
+                    L10n.string("Quick chat provider"),
+                    selection: $quickChatProvider
+                ) {
+                    ForEach(Provider.allCases, id: \.self) { provider in
+                        Text(verbatim: provider == .claude ? "Claude Code" : "Codex")
+                            .tag(provider.rawValue)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("settings-quick-chat-provider")
+                directoryPreferenceRow(
+                    title: L10n.string("Quick chat folder"),
+                    path: $quickChatDirectoryPath,
+                    accessibilityIdentifier: "settings-quick-chat-folder")
+                Text(L10n.string(
+                    "⌘N opens New session. ⌘T starts Quick chat immediately."))
+                    .settingsMessage()
+            }
             Section(L10n.string("Menu Bar")) {
                 Toggle(
                     L10n.string("Show Detach in the menu bar"),
@@ -554,6 +585,43 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private func directoryPreferenceRow(
+        title: String,
+        path: Binding<String>,
+        accessibilityIdentifier: String
+    ) -> some View {
+        HStack(spacing: 12) {
+            Text(title)
+            Spacer(minLength: 12)
+            Text(path.wrappedValue)
+                .appFont(.body, design: .monospaced)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(path.wrappedValue)
+            Button(L10n.string("Choose…")) {
+                presentDirectoryChooser(path: path)
+            }
+            .accessibilityIdentifier(accessibilityIdentifier)
+        }
+    }
+
+    @MainActor
+    private func presentDirectoryChooser(path: Binding<String>) {
+        let fallback = FileManager.default.homeDirectoryForCurrentUser
+        let start = DirectoryPreference.configuredOrFallback(
+            path: path.wrappedValue,
+            fallback: fallback)
+        ProjectDirectoryChooser.present(
+            from: PanelHostWindow.current(),
+            selectedProject: nil,
+            defaultDirectory: start
+        ) { url in
+            guard let url else { return }
+            path.wrappedValue = url.standardizedFileURL.path
+        }
     }
 
     private func applyFontPointSize() {

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -541,6 +541,18 @@ struct SettingsView: View {
                 }
                 .pickerStyle(.segmented)
                 .accessibilityIdentifier("settings-quick-chat-provider")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                .overlay {
+                    if AppSettings.uiE2E != nil {
+                        UIE2EGeometryProbe(
+                            identifier: "settings-quick-chat-provider",
+                            semanticLabel: L10n.string("Quick chat provider"),
+                            semanticRole: .radioGroup)
+                    }
+                }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                 directoryPreferenceRow(
                     title: L10n.string("Quick chat folder"),
                     path: $quickChatDirectoryPath,
@@ -605,6 +617,18 @@ struct SettingsView: View {
                 presentDirectoryChooser(path: path)
             }
             .accessibilityIdentifier(accessibilityIdentifier)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+            .overlay {
+                if AppSettings.uiE2E != nil {
+                    UIE2EGeometryProbe(
+                        identifier: accessibilityIdentifier,
+                        semanticLabel: title,
+                        semanticRole: .button)
+                }
+            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
         }
     }
 

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -14,7 +14,16 @@ struct SidebarView: View {
     let store: SessionStore
     @Binding var selectedID: String?
     @ObservedObject var navigation: MainNavigation
+    @AppStorage(AppSettings.defaultProjectsDirectoryKey, store: AppSettings.defaults)
+    private var defaultProjectsDirectoryPath =
+        AppSettings.defaultProjectsDirectoryPath
+    @AppStorage(AppSettings.quickChatDirectoryKey, store: AppSettings.defaults)
+    private var quickChatDirectoryPath = AppSettings.defaultQuickChatDirectoryPath
+    @AppStorage(AppSettings.quickChatProviderKey, store: AppSettings.defaults)
+    private var quickChatProvider = AppSettings.defaultQuickChatProvider
     @State private var showNewSession = false
+    @State private var isStartingQuickChat = false
+    @State private var quickChatFailure: String?
     @State private var isSelectingFinished = false
     @State private var selectedFinishedIDs: Set<String> = []
     @State private var confirmFinishedDelete = false
@@ -79,6 +88,10 @@ struct SidebarView: View {
                     }
                 }
             }
+            if store.state != .cliMissing {
+                Divider()
+                shortcutGuide
+            }
             if isSelectingFinished {
                 finishedSelectionBar
                 Divider()
@@ -109,7 +122,10 @@ struct SidebarView: View {
             NewSessionSheet(
                 store: store,
                 selectedID: $selectedID,
-                initialProjectDir: uiE2EInitialProjectDirectory
+                initialProjectDir: uiE2EInitialProjectDirectory,
+                projectPickerRoot: DirectoryPreference.configuredOrFallback(
+                    path: defaultProjectsDirectoryPath,
+                    fallback: FileManager.default.homeDirectoryForCurrentUser)
             )
         }
         .confirmationDialog(
@@ -136,12 +152,27 @@ struct SidebarView: View {
         } message: {
             Text(finishedDeleteError ?? "")
         }
+        .alert(
+            L10n.string("Could not start quick chat"),
+            isPresented: .init(
+                get: { quickChatFailure != nil },
+                set: { if !$0 { quickChatFailure = nil } })
+        ) {
+            Button(L10n.string("OK"), role: .cancel) {}
+        } message: {
+            Text(quickChatFailure ?? "")
+        }
         // The menu can request a sheet before reopening the main window, so
         // consume an already-pending request on the sidebar's first render.
         .onChange(of: navigation.requestsNewSession, initial: true) { _, requested in
             guard requested else { return }
             showNewSession = true
             navigation.requestsNewSession = false
+        }
+        .onChange(of: navigation.quickChatRequestID, initial: true) { _, requestID in
+            guard requestID != nil else { return }
+            navigation.quickChatRequestID = nil
+            startQuickChat()
         }
         .onChange(of: deletableFinishedSessions.map(\.id)) { _, currentIDs in
             selectedFinishedIDs.formIntersection(currentIDs)
@@ -152,6 +183,31 @@ struct SidebarView: View {
         .navigationSplitViewColumnWidth(
             min: max(230, fontPointSize * 18),
             ideal: max(260, fontPointSize * 20))
+    }
+
+    private var shortcutGuide: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible()), GridItem(.flexible())],
+            alignment: .leading,
+            spacing: 6
+        ) {
+            ForEach(SidebarShortcutPresentation.hints) { hint in
+                HStack(spacing: 6) {
+                    Text(hint.shortcut)
+                        .appFont(.caption, weight: .semibold, design: .monospaced)
+                        .foregroundStyle(Brand.indigo)
+                    Text(isStartingQuickChat && hint.shortcut == "⌘T"
+                         ? L10n.string("Starting…") : hint.title)
+                        .appFont(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .accessibilityElement(children: .combine)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .accessibilityIdentifier("sidebar-shortcut-guide")
     }
 
     @ViewBuilder
@@ -353,6 +409,24 @@ struct SidebarView: View {
             } else {
                 finishedDeleteError = FinishedDeletionPresentation.errorMessage(
                     for: failures)
+            }
+        }
+    }
+
+    private func startQuickChat() {
+        guard !isStartingQuickChat else { return }
+        isStartingQuickChat = true
+        quickChatFailure = nil
+        Task { @MainActor in
+            let result = await QuickChatLaunch.start(
+                store: store,
+                providerRawValue: quickChatProvider,
+                directoryPath: quickChatDirectoryPath)
+            isStartingQuickChat = false
+            if let message = result.message {
+                quickChatFailure = message
+            } else if let sessionID = result.sessionID {
+                selectedID = sessionID
             }
         }
     }

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -213,7 +213,21 @@ struct SidebarView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(L10n.string("Keyboard shortcuts"))
         .accessibilityIdentifier("sidebar-shortcut-guide")
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+        .background {
+            if AppSettings.uiE2E != nil {
+                UIE2EGeometryProbe(
+                    identifier: "sidebar-shortcut-guide",
+                    semanticLabel: L10n.string("Keyboard shortcuts"),
+                    semanticRole: .group)
+            }
+        }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
     }
 
     @ViewBuilder

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -9,6 +9,27 @@ enum FinishedDeletionPresentation {
     }
 }
 
+struct SidebarFailurePresentation: Equatable, Identifiable {
+    enum Kind: Hashable {
+        case finishedDeletion
+        case quickChat
+    }
+
+    let kind: Kind
+    let message: String
+
+    var id: Kind { kind }
+
+    var title: String {
+        switch kind {
+        case .finishedDeletion:
+            L10n.string("Could not delete some sessions")
+        case .quickChat:
+            L10n.string("Could not start quick chat")
+        }
+    }
+}
+
 struct SidebarView: View {
     @Environment(\.appFontPointSize) private var fontPointSize
     let store: SessionStore
@@ -23,12 +44,11 @@ struct SidebarView: View {
     private var quickChatProvider = AppSettings.defaultQuickChatProvider
     @State private var showNewSession = false
     @State private var isStartingQuickChat = false
-    @State private var quickChatFailure: String?
+    @State private var failurePresentation: SidebarFailurePresentation?
     @State private var isSelectingFinished = false
     @State private var selectedFinishedIDs: Set<String> = []
     @State private var confirmFinishedDelete = false
     @State private var isDeletingFinished = false
-    @State private var finishedDeleteError: String?
 
     private func sessions(in section: SessionSection) -> [Session] {
         store.sessions.filter { $0.section == section }
@@ -142,25 +162,11 @@ struct SidebarView: View {
             Text(L10n.string(
                 "The selected Detach state directories and checkpoints will be permanently deleted. Provider transcripts in ~/.claude and ~/.codex will not be affected."))
         }
-        .alert(
-            L10n.string("Could not delete some sessions"),
-            isPresented: .init(
-                get: { finishedDeleteError != nil },
-                set: { if !$0 { finishedDeleteError = nil } })
-        ) {
-            Button(L10n.string("OK"), role: .cancel) {}
-        } message: {
-            Text(finishedDeleteError ?? "")
-        }
-        .alert(
-            L10n.string("Could not start quick chat"),
-            isPresented: .init(
-                get: { quickChatFailure != nil },
-                set: { if !$0 { quickChatFailure = nil } })
-        ) {
-            Button(L10n.string("OK"), role: .cancel) {}
-        } message: {
-            Text(quickChatFailure ?? "")
+        .alert(item: $failurePresentation) { failure in
+            Alert(
+                title: Text(failure.title),
+                message: Text(failure.message),
+                dismissButton: .cancel(Text(L10n.string("OK"))))
         }
         // The menu can request a sheet before reopening the main window, so
         // consume an already-pending request on the sidebar's first render.
@@ -407,8 +413,10 @@ struct SidebarView: View {
             if failures.isEmpty {
                 isSelectingFinished = false
             } else {
-                finishedDeleteError = FinishedDeletionPresentation.errorMessage(
-                    for: failures)
+                failurePresentation = SidebarFailurePresentation(
+                    kind: .finishedDeletion,
+                    message: FinishedDeletionPresentation.errorMessage(
+                        for: failures))
             }
         }
     }
@@ -416,7 +424,7 @@ struct SidebarView: View {
     private func startQuickChat() {
         guard !isStartingQuickChat else { return }
         isStartingQuickChat = true
-        quickChatFailure = nil
+        failurePresentation = nil
         Task { @MainActor in
             let result = await QuickChatLaunch.start(
                 store: store,
@@ -424,7 +432,9 @@ struct SidebarView: View {
                 directoryPath: quickChatDirectoryPath)
             isStartingQuickChat = false
             if let message = result.message {
-                quickChatFailure = message
+                failurePresentation = SidebarFailurePresentation(
+                    kind: .quickChat,
+                    message: message)
             } else if let sessionID = result.sessionID {
                 selectedID = sessionID
             }

--- a/app/Sources/DetachApp/TerminalPreferencePicker.swift
+++ b/app/Sources/DetachApp/TerminalPreferencePicker.swift
@@ -323,9 +323,12 @@ enum ProjectDirectoryChooser {
             prompt: L10n.string("Choose…"))
     }
 
-    static func startingDirectory(selectedProject: URL?) -> URL {
+    static func startingDirectory(
+        selectedProject: URL?,
+        defaultDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
         selectedProject?.deletingLastPathComponent()
-            ?? FileManager.default.homeDirectoryForCurrentUser
+            ?? defaultDirectory
     }
 }
 
@@ -394,9 +397,12 @@ extension ProjectDirectoryChooser {
     static func present(
         from window: NSWindow?,
         selectedProject: URL?,
+        defaultDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         completion: @escaping (URL?) -> Void
     ) {
-        let panel = makeOpenPanel(startingAt: startingDirectory(selectedProject: selectedProject))
+        let panel = makeOpenPanel(startingAt: startingDirectory(
+            selectedProject: selectedProject,
+            defaultDirectory: defaultDirectory))
         let finish: (NSApplication.ModalResponse) -> Void = { response in
             let url = OpenPanelPresentation.selectedURL(response: response, url: panel.url)
             DispatchQueue.main.async {

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -250,6 +250,10 @@ enum UIE2ETestDriver {
             try requireGeometry(dashboard, name: "dashboard")
             checks.append("dashboard-accessible")
             trace("dashboard accessible")
+            let shortcutGuide = try await element(
+                identifier: "sidebar-shortcut-guide")
+            try requireGeometry(shortcutGuide, name: "sidebar shortcut guide")
+            checks.append("sidebar-shortcut-guide-visible")
 
             let recoverableID = "detach-codex-ui-recoverable"
             let recoverableRow = try await element(
@@ -593,9 +597,11 @@ enum UIE2ETestDriver {
 
             try Data().write(to: configuration.root.appendingPathComponent(
                 "fake/enable-new-session-project"), options: .atomic)
-            try await click(newSession, name: "new session action")
+            try await activate(mainWindow)
+            try await keyPress("n", keyCode: 45, modifiers: [.command])
             _ = try await measuredFrame(
                 identifier: "new-session-sheet", name: "new session sheet")
+            checks.append("new-session-command-opens-sheet")
             try await waitUntil("enabled new session launch") {
                 find(identifier: "new-session-launch").map(isEnabled) == true
             }
@@ -634,6 +640,19 @@ enum UIE2ETestDriver {
                 to: configuration.fixtureState, options: .atomic)
             checks.append(try await verifyFailurePresentation(in: mainWindow))
             checks.append(contentsOf: try await verifySettings(in: mainWindow))
+
+            try Data("sessions\n".utf8).write(
+                to: configuration.fixtureState, options: .atomic)
+            try await activate(mainWindow)
+            try await keyPress("t", keyCode: 17, modifiers: [.command])
+            try await waitUntil("quick chat reaches fake CLI") {
+                FileManager.default.fileExists(atPath: configuration.root
+                    .appendingPathComponent("fake/quick-chat-started").path)
+            }
+            try await waitUntil("quick chat selection") {
+                find(identifier: "session-detail-detach-codex-ui-quick") != nil
+            }
+            checks.append("quick-chat-command-starts-session")
 
             try await restoreFocus(
                 to: previousFrontmost, policy: previousActivationPolicy)
@@ -689,6 +708,44 @@ enum UIE2ETestDriver {
                     forKey: AppSettings.tipsEnabledKey) != priorTips
             }
         checks.append("settings-change-persists")
+        let defaultProjectFolder = try await element(
+            identifier: "settings-default-project-folder")
+        let quickChatProvider = try await element(
+            identifier: "settings-quick-chat-provider")
+        let quickChatFolder = try await element(
+            identifier: "settings-quick-chat-folder")
+        try requireSemanticControl(
+            defaultProjectFolder, name: "default project folder")
+        try requireSemanticControl(
+            quickChatProvider, name: "quick chat provider")
+        try requireSemanticControl(
+            quickChatFolder, name: "quick chat folder")
+        checks.append("settings-session-defaults-visible")
+        let codexProvider = try await buttonLabeled("Codex", attempts: 20)
+        try await clickUntil(
+            codexProvider,
+            name: "Codex quick chat provider",
+            outcome: "quick chat provider persists") {
+                AppSettings.defaults.string(
+                    forKey: AppSettings.quickChatProviderKey)
+                    == Provider.codex.rawValue
+            }
+        checks.append("settings-quick-chat-provider-persists")
+        _ = try await clickUntilElement(
+            quickChatFolder,
+            name: "quick chat folder",
+            resultIdentifier: "open-panel")
+        let openPanels = (NSApp.windows + NSApp.windows.flatMap(\.sheets))
+            .compactMap { $0 as? NSOpenPanel }
+        guard let openPanel = openPanels.first else {
+            throw Failure(message: "quick chat folder panel is not an open panel")
+        }
+        openPanel.cancel(nil)
+        try await waitUntil("quick chat folder panel closes") {
+            find(identifier: "open-panel") == nil
+                && NSApp.windows.allSatisfy(\.sheets.isEmpty)
+        }
+        checks.append("settings-quick-chat-folder-panel")
         guard let settingsWindow = UIE2EEventWindowResolver.owner(of: tipsToggle)
         else {
             throw Failure(message: "Settings window is missing")
@@ -986,6 +1043,8 @@ enum UIE2ETestDriver {
     private static func usesMeasuredGeometry(_ identifier: String) -> Bool {
         identifier == "new-session-button"
             || identifier == "settings-show-tips"
+            || identifier.hasPrefix("settings-default-project-")
+            || identifier.hasPrefix("settings-quick-chat-")
             || identifier.hasPrefix("new-session-")
             || identifier.hasPrefix("onboarding-")
             || identifier.hasPrefix("finished-")

--- a/app/Tests/DetachAppTests/NewSessionSheetTests.swift
+++ b/app/Tests/DetachAppTests/NewSessionSheetTests.swift
@@ -198,6 +198,17 @@ final class NewSessionSheetTests: XCTestCase {
             FileManager.default.homeDirectoryForCurrentUser)
     }
 
+    func testProjectChooserUsesTheConfiguredRootWhenNothingIsSelected() {
+        let configured = URL(
+            fileURLWithPath: "/tmp/Projects",
+            isDirectory: true)
+        XCTAssertEqual(
+            ProjectDirectoryChooser.startingDirectory(
+                selectedProject: nil,
+                defaultDirectory: configured),
+            configured)
+    }
+
     func testOpenPanelPresentationKeepsOnlyAnOKSelection() {
         let url = URL(fileURLWithPath: "/Applications/Terminal.app")
         XCTAssertEqual(

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import XCTest
+@testable import DetachKit
+@testable import DetachApp
+
+@MainActor
+final class QuickChatTests: XCTestCase {
+    func testDefaultsMatchTheExistingSessionProviderAndTemporaryFolder() {
+        XCTAssertEqual(AppSettings.defaultQuickChatProvider, Provider.claude.rawValue)
+        XCTAssertEqual(AppSettings.defaultQuickChatDirectoryPath, "/tmp")
+        XCTAssertEqual(
+            AppSettings.defaultProjectsDirectoryPath,
+            FileManager.default.homeDirectoryForCurrentUser.path)
+    }
+
+    func testDirectoryPreferenceAcceptsOnlyExistingAbsoluteDirectories() {
+        XCTAssertNotNil(DirectoryPreference.existingDirectoryURL(path: "/tmp"))
+        XCTAssertNil(DirectoryPreference.existingDirectoryURL(path: "relative"))
+        XCTAssertNil(DirectoryPreference.existingDirectoryURL(
+            path: "/tmp/detach-missing-\(UUID().uuidString)"))
+        XCTAssertNil(DirectoryPreference.existingDirectoryURL(path: "/etc/hosts"))
+    }
+
+    func testDirectoryPreferenceFallsBackWhenTheSettingIsStale() {
+        let fallback = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        XCTAssertEqual(
+            DirectoryPreference.configuredOrFallback(
+                path: "/tmp/detach-missing-\(UUID().uuidString)",
+                fallback: fallback),
+            fallback)
+    }
+
+    func testQuickChatUsesConfiguredProviderAndWorkingDirectory() async {
+        let directory = try! XCTUnwrap(
+            DirectoryPreference.existingDirectoryURL(path: "/tmp"))
+        let cli = QuickChatRecordingCLI()
+        cli.responses["list --json"] = CLIResult(
+            exitCode: 0,
+            stdout: #"{"schema":1,"provider":"codex","session_name":"detach-codex-tmp-1","name":"tmp-1","effective_status":"running","meta_status":"running","agent_session_id":"u1","project_dir":"\#(directory.path)","created_at":"2026-08-31T00:00:00Z","last_checkpoint_at":null,"finished_at":null}"#,
+            stderr: "",
+            timedOut: false)
+        let store = SessionStore(cli: cli)
+
+        let result = await QuickChatLaunch.start(
+            store: store,
+            providerRawValue: Provider.codex.rawValue,
+            directoryPath: "/tmp")
+
+        XCTAssertEqual(result.sessionID, "detach-codex-tmp-1")
+        XCTAssertNil(result.message)
+        XCTAssertEqual(cli.calls.map(\.arguments), [
+            ["codex", "--detach"],
+            ["list", "--json"],
+        ])
+        XCTAssertEqual(cli.calls.first?.currentDirectory?.path, directory.path)
+    }
+
+    func testQuickChatRejectsAnUnavailableFolderWithoutCallingTheCLI() async {
+        let cli = QuickChatRecordingCLI()
+        let missing = "/tmp/detach-missing-\(UUID().uuidString)"
+
+        let result = await QuickChatLaunch.start(
+            store: SessionStore(cli: cli),
+            providerRawValue: Provider.claude.rawValue,
+            directoryPath: missing)
+
+        XCTAssertEqual(
+            result.message,
+            L10n.format("Quick chat folder is unavailable: %@", missing))
+        XCTAssertTrue(cli.calls.isEmpty)
+    }
+
+    func testUnknownStoredProviderFallsBackToClaude() {
+        XCTAssertEqual(
+            QuickChatLaunch.provider(rawValue: "removed-provider"),
+            .claude)
+    }
+
+    func testNavigationCreatesDistinctQuickChatRequests() {
+        let navigation = MainNavigation()
+        XCTAssertNil(navigation.quickChatRequestID)
+
+        navigation.requestQuickChat()
+        let first = navigation.quickChatRequestID
+        navigation.requestQuickChat()
+
+        XCTAssertNotNil(first)
+        XCTAssertNotEqual(navigation.quickChatRequestID, first)
+        XCTAssertFalse(navigation.requestsNewSession)
+        navigation.requestNewSession()
+        XCTAssertTrue(navigation.requestsNewSession)
+    }
+
+    func testSidebarGuideListsImplementedAndStandardShortcuts() {
+        XCTAssertEqual(
+            SidebarShortcutPresentation.hints.map(\.shortcut),
+            ["⌘N", "⌘T", "⌘,", "⌘F"])
+        XCTAssertEqual(
+            SidebarShortcutPresentation.hints.map(\.title),
+            [
+                L10n.string("New session"),
+                L10n.string("Quick chat"),
+                L10n.string("Settings"),
+                L10n.string("Find output"),
+            ])
+    }
+}
+
+private final class QuickChatRecordingCLI: DetachCLIRunning, @unchecked Sendable {
+    struct Call: Equatable {
+        let arguments: [String]
+        let currentDirectory: URL?
+    }
+
+    var responses: [String: CLIResult] = [:]
+    private(set) var calls: [Call] = []
+
+    func run(
+        arguments: [String],
+        timeout: TimeInterval
+    ) async throws -> CLIResult {
+        calls.append(Call(arguments: arguments, currentDirectory: nil))
+        return response(for: arguments)
+    }
+
+    func run(
+        arguments: [String],
+        timeout: TimeInterval,
+        currentDirectoryURL: URL?
+    ) async throws -> CLIResult {
+        calls.append(Call(
+            arguments: arguments,
+            currentDirectory: currentDirectoryURL))
+        return response(for: arguments)
+    }
+
+    private func response(for arguments: [String]) -> CLIResult {
+        responses[arguments.joined(separator: " ")]
+            ?? CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
+    }
+}

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -103,6 +103,14 @@ final class QuickChatTests: XCTestCase {
                 L10n.string("Settings"),
                 L10n.string("Find output"),
             ])
+        XCTAssertEqual(
+            SidebarShortcutPresentation.hints.map(\.id),
+            ["⌘N", "⌘T", "⌘,", "⌘F"])
+    }
+
+    func testSessionCommandsBuildWithTheSharedNavigation() {
+        let commands = SessionCommands(navigation: MainNavigation())
+        _ = commands.body
     }
 }
 

--- a/app/Tests/DetachAppTests/SidebarViewTests.swift
+++ b/app/Tests/DetachAppTests/SidebarViewTests.swift
@@ -39,4 +39,23 @@ final class SidebarViewTests: XCTestCase {
             FinishedDeletionPresentation.errorMessage(for: failures),
             "First task: still busy\nSecond task: permission denied")
     }
+
+    func testUsesOneTypedPresentationForSidebarFailures() {
+        let deletion = SidebarFailurePresentation(
+            kind: .finishedDeletion,
+            message: "delete failed")
+        let quickChat = SidebarFailurePresentation(
+            kind: .quickChat,
+            message: "start failed")
+
+        XCTAssertEqual(
+            deletion.title,
+            L10n.string("Could not delete some sessions"))
+        XCTAssertEqual(
+            quickChat.title,
+            L10n.string("Could not start quick chat"))
+        XCTAssertNotEqual(deletion.id, quickChat.id)
+        XCTAssertEqual(deletion.message, "delete failed")
+        XCTAssertEqual(quickChat.message, "start failed")
+    }
 }

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -41,26 +41,19 @@ transient SMAppService Code=1 race. Do not replace a helper with active leases:
 defer the update. Report a normal reconciliation outcome and retry on the next
 activation.
 
-Each readiness build stores one `detach-app-build:<UUID>` in its executable and
-signed marker. UI smoke uses a stripped private copy at
-`/private/tmp/detach-ui-e2e.*`. It excludes production CLI, watchdog, helper,
-power, state, and tmux. Injections stay below its root. An escape,
+Each readiness build puts one `detach-app-build:<UUID>` in its executable and
+signed marker. UI smoke uses a stripped private copy below
+`/private/tmp/detach-ui-e2e.*` without production payloads. An escaped path,
 unsafe identity, build mismatch, or payload fails closed.
 
-Smoke restores focus and the pointer, then sends ordered AppKit down/up pairs to
-measured SwiftUI controls; semantic locators have no actions. Row clicks select
-sessions even after preview text takes focus.
-Each launch and stage meets its deadline. Journeys cover main surfaces,
+Smoke restores focus and the pointer and sends ordered AppKit events to measured
+visible controls; semantic probes have no actions. It covers main surfaces,
 Settings, onboarding, focus, Codex Recover, Claude Resume, reconnect, and App
-Start through typed-session selection and embedded PTY attach. It disconnects
-Stop before real control invocation.
-Only visible controls complete onboarding.
-
-Coverage builds the normal bundle, instrumented binary, and Swift tests in
-isolated paths. UI waits for the bundle; metrics wait for UI and Swift tests.
-Only the copy gets it. The binary and profiles stay out of public artifacts.
-If an overlay scroller ignores a page event, the driver reveals the measured
-semantic control, then posts the action to it.
+Start through typed selection and PTY attach. Stop disconnects before control
+invocation. Each stage has a deadline. Coverage isolates the normal bundle,
+instrumented copy, Swift tests, binary, and profiles. UI precedes metrics; only
+the private copy is instrumented. The driver reveals clipped controls before
+posting an action.
 
 The per-user watchdog adds a launch-readiness rule: macOS can report an approved
 agent as enabled while no launchd job loaded after approval. During first
@@ -175,6 +168,11 @@ control characters, blocks launch, and passes one `--name`. The launch button
 starts inside Detach. Advanced holds the prompt and grows down, top fixed. The
 app uses `display_name` as the title, with
 the project/internal name fallback for old records.
+Command-N opens main with New session. Its chooser starts in the General project
+folder or the selection's parent. Command-T opens main and calls
+`SessionStore.startDetached` without a sheet, with the General provider and
+folder (`/tmp` default). An invalid folder blocks launch; it deletes nothing.
+The sidebar shows Command-N, Command-T, Command-comma, and terminal Command-F.
 Notifications are opt-in. One poller deduplicates baseline and transitions.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -38,12 +38,17 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   if [ -f "$ROOT/fake/new-session-started" ]; then
     started="$(printf '{"schema":1,"provider":"claude","session_name":"detach-claude-ui-new","name":"UI New","effective_status":"running","created_at":"2026-08-29T10:00:00Z","project_dir":"%s/project","session_color":"#A855F7","power_protection_state":"protected","health_actions":["attach","stop"]}' "$ROOT")"
   fi
+  quick=''
+  if [ -f "$ROOT/fake/quick-chat-started" ]; then
+    quick='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-quick","name":"UI Quick","effective_status":"running","created_at":"2026-08-29T10:01:00Z","project_dir":"/private/tmp","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}'
+  fi
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}' \
     "$recoverable" \
     "$completed" \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-stopped","name":"UI Stopped","effective_status":"stopped","created_at":"2026-07-22T06:00:00Z","finished_at":"2026-07-22T06:30:00Z","exit_status":143,"session_color":"#1D4ED8","power_protection_state":"allowed","health_actions":["delete"]}'
   [ -z "$started" ] || printf '%s\n' "$started"
+  [ -z "$quick" ] || printf '%s\n' "$quick"
   exit 0
 fi
 
@@ -116,6 +121,22 @@ if [ "$#" -eq 2 ] && [ "$1" = claude ] && [ "$2" = --detach ]; then
   : >"$ROOT/fake/new-session-started"
   printf '%s\n' "$*" >>"$ACTIONS"
   exit 0
+fi
+
+if [ "$#" -eq 2 ] && [ "$1" = codex ] && [ "$2" = --detach ]; then
+  [ "$(pwd -P)" = /private/tmp ] || {
+    printf 'quick chat started outside /tmp\n' >&2
+    exit 65
+  }
+  : >"$ROOT/fake/quick-chat-started"
+  printf '%s\n' "$*" >>"$ACTIONS"
+  exit 0
+fi
+
+if [ "$#" -eq 3 ] && [ "$1" = codex ] && [ "$2" = attach ] \
+    && [ "$3" = detach-codex-ui-quick ]; then
+  printf 'UI fixture attach for %s\n' "$3"
+  exec /bin/cat
 fi
 
 if [ "$#" -eq 3 ] && [ "$1" = claude ] && [ "$2" = attach ] \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -23,6 +23,8 @@ approved_invocation() {
     'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9'|\
     'claude attach detach-claude-ui-completed'|\
     'claude --detach'|\
+    'codex --detach'|\
+    'codex attach detach-codex-ui-quick'|\
     'claude attach detach-claude-ui-new'|\
     'codex stop detach-codex-ui-running'|\
     'codex delete --force detach-codex-ui-stopped'|\
@@ -315,11 +317,13 @@ run_app_scenario() {
       new-session-starts-without-outer-terminal|\
       new-session-start-opens-embedded-terminal) ;;
       dashboard-accessible) pass=SC-UI-DASHBOARD ;;
+      sidebar-shortcut-guide-visible) ;;
       sidebar-selects-completed-session) ;;
       bulk-delete-reaches-fake-cli) pass=SC-UI-SESSION-DELETE ;;
       session-signals-stay-distinct) pass=SC-UI-SESSION-DETAIL ;;
       safe-action-reaches-fake-cli) pass=SC-UI-SESSION-STOP ;;
       new-session-sheet-semantics) pass=SC-UI-NEW-SESSION ;;
+      new-session-command-opens-sheet) ;;
       empty-dashboard-state) pass=SC-UI-EMPTY ;;
       installed-app-focus-restored) pass=SC-UI-FOCUS ;;
       actionable-failure-presentation) pass=SC-UI-FAILURE ;;
@@ -327,6 +331,10 @@ run_app_scenario() {
       onboarding-detects-provider) pass=SC-UI-ONBOARD-PROVIDER ;;
       onboarding-explains-approval) pass=SC-UI-ONBOARD-APPROVAL ;;
       settings-change-persists) pass=SC-UI-SETTINGS ;;
+      settings-session-defaults-visible) ;;
+      settings-quick-chat-provider-persists) ;;
+      settings-quick-chat-folder-panel) ;;
+      quick-chat-command-starts-session) ;;
       *) printf 'UI e2e: unowned check: %s\n' "$check" >&2; exit 1 ;;
     esac
     if [ -n "${pass:-}" ]; then
@@ -341,6 +349,7 @@ run_app_scenario() {
 run_app_scenario main sessions 32 \
   background-app-starts-without-focus \
   dashboard-accessible \
+  sidebar-shortcut-guide-visible \
   recover-and-reconnect-run-in-app-with-terminal-fallback \
   sidebar-selects-completed-session \
   session-uuid-copies-from-text-side \
@@ -355,12 +364,17 @@ run_app_scenario main sessions 32 \
   new-session-starts-without-outer-terminal \
   new-session-advanced-keeps-top-edge \
   new-session-sheet-semantics \
+  new-session-command-opens-sheet \
   new-session-start-opens-embedded-terminal \
   empty-dashboard-state \
   actionable-failure-presentation \
   settings-change-persists \
+  settings-session-defaults-visible \
+  settings-quick-chat-provider-persists \
+  settings-quick-chat-folder-panel \
   settings-window-stays-on-screen \
   settings-system-reveals-storage-and-installation \
+  quick-chat-command-starts-session \
   installed-app-focus-restored
 run_app_scenario onboarding-first-run empty 8 onboarding-first-run-completes
 run_app_scenario onboarding-provider empty 8 onboarding-detects-provider
@@ -380,6 +394,9 @@ done <"$FAKE_DIR/invocations.log"
 [ "$(grep -Fxc 'codex attach detach-codex-ui-recoverable' \
   "$FAKE_DIR/invocations.log")" -ge 2 ]
 [ "$(grep -Fxc 'claude --detach' "$FAKE_DIR/invocations.log")" -eq 1 ]
+[ "$(grep -Fxc 'codex --detach' "$FAKE_DIR/invocations.log")" -eq 1 ]
+[ "$(grep -Fxc 'codex attach detach-codex-ui-quick' \
+  "$FAKE_DIR/invocations.log")" -ge 1 ]
 [ "$(grep -Fxc 'claude attach detach-claude-ui-new' \
   "$FAKE_DIR/invocations.log")" -ge 1 ]
 


### PR DESCRIPTION
## Summary

- add Command-N for the existing New session sheet
- add Command-T for an immediate managed Quick chat
- add General settings for the default project folder, Quick chat folder, and Quick chat provider
- add a compact shortcut guide below the sidebar session list
- document the user contract in the README and app specification

## Contract delta

- Quick chat uses the normal typed in-app start path. Its default folder is `/tmp` and its default provider is Claude Code.
- An unavailable Quick chat folder blocks launch and shows a localized error.
- The default project folder changes only the initial folder in the project chooser.
- Quick chat does not delete working files, Detach state, or provider transcripts.
- Runtime ownership, project locking, power protection, and recovery behavior do not change.

## Evidence

- `swift test --filter QuickChat`: 9 passed
- `swift test --filter DetachAppTests`: 366 passed
- `tests/docs-contract.sh`: passed
- `tests/ui-e2e-contract.sh`: passed
- packaged app UI E2E: main and all onboarding scenarios passed; the main
  journey covers the shortcut guide, Command-N, new settings, and Command-T
- impact-aware local gate: static, app, UI E2E, and tmux-runtime passed
- the local aggregate has one unrelated environment-sensitive failure: an existing NVM-path test finds an installed Homebrew Codex before its fixture; the other 900 Swift tests passed
- `git diff --check`: passed

The first hosted build exposed competing sidebar alert presentation modifiers:
the New session sheet did not dismiss in Release UI E2E. The follow-up commit
uses one typed alert for deletion and Quick chat failures. Focused tests and the
full packaged UI E2E pass with that presentation contract.

The next hosted build passed UI E2E and exposed a changed-line coverage gap.
The current branch adds the missing packaged user journey instead of a
coverage exclusion.

Hosted `quality-gates` remains readiness authority.
