### PR TITLE
Speed up Quick Chat selection

### DIFF
--- a/app/Sources/DetachApp/QuickChat.swift
+++ b/app/Sources/DetachApp/QuickChat.swift
@@ -37,7 +37,11 @@ enum QuickChatLaunch {
         store: SessionStore,
         providerRawValue: String,
         directoryPath: String,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        onSessionAvailable: (@MainActor (String) -> Void)? = nil,
+        discoverySleep: @escaping @Sendable (UInt64) async throws -> Void = {
+            try await Task.sleep(nanoseconds: $0)
+        }
     ) async -> SessionStartResult {
         guard let directory = DirectoryPreference.existingDirectoryURL(
             path: directoryPath,
@@ -46,11 +50,75 @@ enum QuickChatLaunch {
                 "Quick chat folder is unavailable: %@",
                 directoryPath))
         }
-        return await store.startDetached(
-            provider: provider(rawValue: providerRawValue),
-            projectDirectory: directory,
-            name: nil,
-            prompt: nil)
+        let provider = provider(rawValue: providerRawValue)
+        guard let onSessionAvailable else {
+            return await store.startDetached(
+                provider: provider,
+                projectDirectory: directory,
+                name: nil,
+                prompt: nil)
+        }
+
+        let existingIDs = Set(store.sessions.map(\.id))
+        var launchFinished = false
+        let launchTask = Task { @MainActor in
+            defer { launchFinished = true }
+            return await store.startDetached(
+                provider: provider,
+                projectDirectory: directory,
+                name: nil,
+                prompt: nil)
+        }
+        defer { launchTask.cancel() }
+
+        // The typed `starting` row exists before the CLI finishes its runtime
+        // readiness checks. Select it as soon as it is unambiguous.
+        var selectedEarly = false
+        for delay in [75_000_000, 175_000_000] where !launchFinished {
+            do {
+                try await discoverySleep(UInt64(delay))
+            } catch {
+                break
+            }
+            guard !launchFinished else { break }
+            await store.refresh()
+            if let sessionID = newSessionID(
+                in: store.sessions,
+                excluding: existingIDs,
+                provider: provider,
+                projectDirectory: directory) {
+                selectedEarly = true
+                onSessionAvailable(sessionID)
+                break
+            }
+        }
+
+        let result = await launchTask.value
+        if selectedEarly && result.message != nil {
+            await store.refresh()
+        }
+        return result
+    }
+
+    private static func newSessionID(
+        in sessions: [Session],
+        excluding existingIDs: Set<String>,
+        provider: Provider,
+        projectDirectory: URL
+    ) -> String? {
+        let projectPath = canonicalProjectPath(projectDirectory.path)
+        let candidates = sessions.filter {
+            !existingIDs.contains($0.id)
+                && $0.provider == provider
+                && $0.projectDir.map(canonicalProjectPath) == projectPath
+        }
+        return candidates.count == 1 ? candidates[0].id : nil
+    }
+
+    private static func canonicalProjectPath(_ path: String) -> String {
+        URL(fileURLWithPath: path, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL.path
     }
 }
 

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -443,7 +443,10 @@ struct SidebarView: View {
             let result = await QuickChatLaunch.start(
                 store: store,
                 providerRawValue: quickChatProvider,
-                directoryPath: quickChatDirectoryPath)
+                directoryPath: quickChatDirectoryPath,
+                onSessionAvailable: { sessionID in
+                    selectedID = sessionID
+                })
             isStartingQuickChat = false
             if let message = result.message {
                 failurePresentation = SidebarFailurePresentation(

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -90,6 +90,34 @@ final class QuickChatTests: XCTestCase {
         XCTAssertEqual(listCallCount, 2)
     }
 
+    func testQuickChatReconcilesAnEarlySelectionAfterLaunchFailure() async {
+        let directory = try! XCTUnwrap(
+            DirectoryPreference.existingDirectoryURL(path: "/tmp"))
+        let line = #"{"schema":1,"provider":"codex","session_name":"detach-codex-tmp-1","name":"tmp-1","effective_status":"starting","meta_status":"starting","agent_session_id":null,"project_dir":"\#(directory.path)","created_at":"2026-08-31T00:00:00Z","last_checkpoint_at":null,"finished_at":null}"#
+        let cli = SlowQuickChatCLI(listOutput: line)
+        let store = SessionStore(cli: cli)
+        let selected = expectation(description: "starting session selected")
+
+        let launch = Task { @MainActor in
+            await QuickChatLaunch.start(
+                store: store,
+                providerRawValue: Provider.codex.rawValue,
+                directoryPath: "/tmp",
+                onSessionAvailable: { _ in selected.fulfill() },
+                discoverySleep: { _ in
+                    await cli.waitUntilStartBegan()
+                })
+        }
+
+        await fulfillment(of: [selected], timeout: 1)
+        await cli.finishStart(exitCode: 17, stderr: "start refused\n")
+        let result = await launch.value
+        let listCallCount = await cli.listCallCount
+
+        XCTAssertEqual(result.message, "start refused")
+        XCTAssertEqual(listCallCount, 2)
+    }
+
     func testQuickChatRejectsAnUnavailableFolderWithoutCallingTheCLI() async {
         let cli = QuickChatRecordingCLI()
         let missing = "/tmp/detach-missing-\(UUID().uuidString)"
@@ -186,11 +214,12 @@ private actor SlowQuickChatCLI: DetachCLIRunning {
         await withCheckedContinuation { startWaiters.append($0) }
     }
 
-    func finishStart() {
+    func finishStart(exitCode: Int32 = 0, stderr: String = "") {
         startContinuation?.resume(returning: CLIResult(
-            exitCode: 0,
-            stdout: "Started detach-codex-tmp-1 in /tmp\n",
-            stderr: "",
+            exitCode: exitCode,
+            stdout: exitCode == 0
+                ? "Started detach-codex-tmp-1 in /tmp\n" : "",
+            stderr: stderr,
             timedOut: false))
         startContinuation = nil
     }

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -55,6 +55,41 @@ final class QuickChatTests: XCTestCase {
         XCTAssertEqual(cli.calls.first?.currentDirectory?.path, directory.path)
     }
 
+    func testQuickChatSelectsTheTypedStartingSessionBeforeLaunchFinishes() async {
+        let directory = try! XCTUnwrap(
+            DirectoryPreference.existingDirectoryURL(path: "/tmp"))
+        let line = #"{"schema":1,"provider":"codex","session_name":"detach-codex-tmp-1","name":"tmp-1","effective_status":"starting","meta_status":"starting","agent_session_id":null,"project_dir":"\#(directory.path)","created_at":"2026-08-31T00:00:00Z","last_checkpoint_at":null,"finished_at":null}"#
+        let cli = SlowQuickChatCLI(listOutput: line)
+        let store = SessionStore(cli: cli)
+        let selected = expectation(description: "starting session selected")
+        var selectedID: String?
+
+        let launch = Task { @MainActor in
+            await QuickChatLaunch.start(
+                store: store,
+                providerRawValue: Provider.codex.rawValue,
+                directoryPath: "/tmp",
+                onSessionAvailable: { sessionID in
+                    selectedID = sessionID
+                    selected.fulfill()
+                },
+                discoverySleep: { _ in
+                    await cli.waitUntilStartBegan()
+                })
+        }
+
+        await fulfillment(of: [selected], timeout: 1)
+        XCTAssertEqual(selectedID, "detach-codex-tmp-1")
+        XCTAssertEqual(store.sessions.first?.effectiveStatus, .starting)
+
+        await cli.finishStart()
+        let result = await launch.value
+        let listCallCount = await cli.listCallCount
+
+        XCTAssertEqual(result.sessionID, "detach-codex-tmp-1")
+        XCTAssertEqual(listCallCount, 2)
+    }
+
     func testQuickChatRejectsAnUnavailableFolderWithoutCallingTheCLI() async {
         let cli = QuickChatRecordingCLI()
         let missing = "/tmp/detach-missing-\(UUID().uuidString)"
@@ -111,6 +146,53 @@ final class QuickChatTests: XCTestCase {
     func testSessionCommandsBuildWithTheSharedNavigation() {
         let commands = SessionCommands(navigation: MainNavigation())
         _ = commands.body
+    }
+}
+
+private actor SlowQuickChatCLI: DetachCLIRunning {
+    private let listOutput: String
+    private var startContinuation: CheckedContinuation<CLIResult, Never>?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var startBegan = false
+    private(set) var listCallCount = 0
+
+    init(listOutput: String) {
+        self.listOutput = listOutput
+    }
+
+    func run(
+        arguments: [String], timeout: TimeInterval
+    ) async throws -> CLIResult {
+        if arguments == ["list", "--json"] {
+            listCallCount += 1
+            return CLIResult(
+                exitCode: 0,
+                stdout: listOutput,
+                stderr: "",
+                timedOut: false)
+        }
+
+        startBegan = true
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        return await withCheckedContinuation { continuation in
+            startContinuation = continuation
+        }
+    }
+
+    func waitUntilStartBegan() async {
+        if startBegan { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func finishStart() {
+        startContinuation?.resume(returning: CLIResult(
+            exitCode: 0,
+            stdout: "Started detach-codex-tmp-1 in /tmp\n",
+            stderr: "",
+            timedOut: false))
+        startContinuation = nil
     }
 }
 

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -168,10 +168,10 @@ control characters, blocks launch, and passes one `--name`. The launch button
 starts inside Detach. Advanced holds the prompt and grows down, top fixed. The
 app uses `display_name` as the title, with
 the project/internal name fallback for old records.
-Command-N opens main with New session. Its chooser starts in the General project
-folder or the selection's parent. Command-T opens main and calls
-`SessionStore.startDetached` without a sheet, with the General provider and
-folder (`/tmp` default). An invalid folder blocks launch; it deletes nothing.
+Command-N opens New session in main. Its chooser starts at the configured project
+folder or the selection's parent. Command-T opens Quick Chat in main with the
+configured provider and folder (`/tmp` default). It selects the new typed
+`starting` session before runtime checks finish. Invalid folders block launch.
 The sidebar shows Command-N, Command-T, Command-comma, and terminal Command-F.
 Notifications are opt-in. One poller deduplicates baseline and transitions.
 


### PR DESCRIPTION
## Summary

- Select the typed starting session while detach still verifies runtime readiness.
- Match only one new session for the configured provider and project.
- Reconcile state if a launch fails after early selection.
- Add regression coverage and update the app contract.

## Contract delta

Before, Command-T waited for the launch command and its final list refresh before changing selection. Now Quick Chat checks typed state during the readiness wait and switches as soon as one new session is unambiguous. The launch command still completes all power and process checks, and its errors remain visible.

## Evidence

- swift test --filter QuickChatTests: PASS (10 tests)
- tests/docs-contract.sh: PASS
- git diff --check: PASS
- Local change gate: static and app stages passed
- Local full Swift and UI e2e GUI stages were blocked by macOS AppKit registration failure before affected code ran: NSXPCSharedListener Connection invalid and _RegisterApplication SIGABRT. Hosted quality-gates remains readiness authority.