### PR TITLE
Fix terminal input and release impact analysis

### DIFF
--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -82,6 +82,7 @@
 "Check for updates…" = "Check for updates…";
 "Check the %@ path in Settings." = "Check the %@ path in Settings.";
 "Checking the system permission…" = "Checking the system permission…";
+"Checking…" = "Checking…";
 "Choose Another App…" = "Choose Another App…";
 "Choose another terminal" = "Choose another terminal";
 "Choose a project to launch." = "Choose a project to launch.";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -82,6 +82,7 @@
 "Check for updates…" = "Проверить наличие обновлений…";
 "Check the %@ path in Settings." = "Проверьте путь %@ в настройках.";
 "Checking the system permission…" = "Проверяем системное разрешение…";
+"Checking…" = "Проверяем…";
 "Choose Another App…" = "Выбрать другое приложение…";
 "Choose another terminal" = "Выбрать другой терминал";
 "Choose a project to launch." = "Выберите проект, чтобы запустить сессию.";

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -5,6 +5,18 @@ import SwiftTerm
 import DetachKit
 
 final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
+    var onDroppedPaths: ((String) -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes([.fileURL])
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard window != nil else { return }
@@ -13,11 +25,44 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
             window.makeFirstResponder(self)
         }
     }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        SessionAttachDroppedPaths.insertionText(from: sender.draggingPasteboard) == nil
+            ? [] : .copy
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard let text = SessionAttachDroppedPaths.insertionText(
+            from: sender.draggingPasteboard) else {
+            return false
+        }
+        window?.makeFirstResponder(self)
+        onDroppedPaths?(text)
+        return true
+    }
 }
 
 /// Preserves provider shortcuts that must reach the child as conventional
 /// control bytes, even after the child negotiates an enhanced keyboard mode.
 enum SessionAttachKeyboard {
+    enum AppAction: Equatable {
+        case copy
+        case paste
+        case find
+    }
+
+    static func appAction(for event: NSEvent) -> AppAction? {
+        let flags = event.modifierFlags.intersection(
+            [.command, .control, .option, .shift, .function])
+        guard flags == .command else { return nil }
+        switch event.keyCode {
+        case 8: return .copy
+        case 9: return .paste
+        case 3: return .find
+        default: return nil
+        }
+    }
+
     static func providerInput(for event: NSEvent) -> [UInt8]? {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         guard flags.contains(.control),
@@ -37,6 +82,55 @@ enum SessionAttachKeyboard {
         guard let bytes = providerInput(for: event) else { return false }
         send(bytes)
         return true
+    }
+}
+
+enum SessionAttachDroppedPaths {
+    static func insertionText(from pasteboard: NSPasteboard) -> String? {
+        let objects = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]) ?? []
+        let paths = objects.compactMap { object -> String? in
+            guard let url = object as? URL, url.isFileURL else { return nil }
+            let path = url.standardizedFileURL.path
+            return path.hasPrefix("/") ? shellEscaped(path) : nil
+        }
+        guard !paths.isEmpty else { return nil }
+        return paths.joined(separator: " ") + " "
+    }
+
+    static func shellEscaped(_ path: String) -> String {
+        if path.unicodeScalars.contains(where: {
+            CharacterSet.controlCharacters.contains($0)
+        }) {
+            let escaped = path.unicodeScalars.map { scalar -> String in
+                switch scalar.value {
+                case 0x27: return "\\'"
+                case 0x5c: return "\\\\"
+                case 0x0a: return "\\n"
+                case 0x0d: return "\\r"
+                case 0x09: return "\\t"
+                default:
+                    guard CharacterSet.controlCharacters.contains(scalar) else {
+                        return String(scalar)
+                    }
+                    if scalar.value <= 0xff {
+                        return String(format: "\\x%02X", scalar.value)
+                    }
+                    if scalar.value <= 0xffff {
+                        return String(format: "\\u%04X", scalar.value)
+                    }
+                    return String(format: "\\U%08X", scalar.value)
+                }
+            }.joined()
+            return "$'\(escaped)'"
+        }
+        let safe = path.unicodeScalars.allSatisfy { scalar in
+            CharacterSet.alphanumerics.contains(scalar)
+                || "/._-+=,:@%".unicodeScalars.contains(scalar)
+        }
+        guard !safe else { return path }
+        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 }
 
@@ -193,6 +287,9 @@ struct SessionAttachTerminalView: NSViewRepresentable {
 // quality-coverage:begin swiftterm-host
     func makeNSView(context: Context) -> LocalProcessTerminalView {
         let view = SessionAttachLocalProcessTerminalView(frame: .zero)
+        view.onDroppedPaths = { [weak controller = context.coordinator.controller] text in
+            controller?.send(text)
+        }
         context.coordinator.controller.onTerminated = context.coordinator.onTerminated
         context.coordinator.controller.configure(view, fontPointSize: fontPointSize)
         context.coordinator.installKeyboardMonitor(for: view)
@@ -211,6 +308,7 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         coordinator: Coordinator
     ) {
         coordinator.removeKeyboardMonitor()
+        (view as? SessionAttachLocalProcessTerminalView)?.onDroppedPaths = nil
         coordinator.controller.terminateClient()
     }
 // quality-coverage:end swiftterm-host
@@ -244,16 +342,20 @@ struct SessionAttachTerminalView: NSViewRepresentable {
             window: NSWindow?,
             firstResponder: NSResponder?,
             in view: LocalProcessTerminalView,
-            send: ([UInt8]) -> Void
+            send: ([UInt8]) -> Void,
+            performAppAction: ((SessionAttachKeyboard.AppAction) -> Void)? = nil
         ) -> NSEvent? {
             guard window === view.window,
-                  Self.isFocused(view, firstResponder: firstResponder),
-                  SessionAttachKeyboard.routeProviderShortcut(
-                      from: event,
-                      send: send) else {
+                  Self.isFocused(view, firstResponder: firstResponder) else {
                 return event
             }
-            return nil
+            if let action = SessionAttachKeyboard.appAction(for: event) {
+                (performAppAction ?? { Self.perform($0, in: view) })(action)
+                return nil
+            }
+            return SessionAttachKeyboard.routeProviderShortcut(
+                from: event,
+                send: send) ? nil : event
         }
 
         func removeKeyboardMonitor() {
@@ -269,6 +371,22 @@ struct SessionAttachTerminalView: NSViewRepresentable {
             guard let responder = firstResponder else { return false }
             if responder === view { return true }
             return (responder as? NSView)?.isDescendant(of: view) == true
+        }
+
+        private static func perform(
+            _ action: SessionAttachKeyboard.AppAction,
+            in view: LocalProcessTerminalView
+        ) {
+            switch action {
+            case .copy:
+                view.copy(view)
+            case .paste:
+                view.paste(view)
+            case .find:
+                let menuItem = NSMenuItem()
+                menuItem.tag = Int(NSFindPanelAction.showFindPanel.rawValue)
+                view.performFindPanelAction(menuItem)
+            }
         }
 
         deinit {

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -27,13 +27,20 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     }
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
-        SessionAttachDroppedPaths.insertionText(from: sender.draggingPasteboard) == nil
-            ? [] : .copy
+        acceptedDragOperation(from: sender.draggingPasteboard)
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        acceptDroppedPaths(from: sender.draggingPasteboard)
+    }
+
+    func acceptedDragOperation(from pasteboard: NSPasteboard) -> NSDragOperation {
+        SessionAttachDroppedPaths.insertionText(from: pasteboard) == nil ? [] : .copy
+    }
+
+    func acceptDroppedPaths(from pasteboard: NSPasteboard) -> Bool {
         guard let text = SessionAttachDroppedPaths.insertionText(
-            from: sender.draggingPasteboard) else {
+            from: pasteboard) else {
             return false
         }
         window?.makeFirstResponder(self)
@@ -373,7 +380,7 @@ struct SessionAttachTerminalView: NSViewRepresentable {
             return (responder as? NSView)?.isDescendant(of: view) == true
         }
 
-        private static func perform(
+        static func perform(
             _ action: SessionAttachKeyboard.AppAction,
             in view: LocalProcessTerminalView
         ) {

--- a/app/Sources/DetachApp/SettingsIllustrations.swift
+++ b/app/Sources/DetachApp/SettingsIllustrations.swift
@@ -45,16 +45,30 @@ enum SettingsTabIcon {
     }
 }
 
-/// Dot-plus-word component status, teal when healthy, orange otherwise.
+/// Dot-plus-word component status for a completed or in-flight check.
 struct StatusIndicator: View {
-    let healthy: Bool
+    let status: DiagnosticCheck.Status
 
-    private var color: Color { healthy ? Brand.teal : .orange }
+    private var color: Color {
+        switch status {
+        case .ok: Brand.teal
+        case .unknown: .secondary
+        case .warning, .error: .orange
+        }
+    }
+
+    private var label: String {
+        switch status {
+        case .ok: L10n.string("Ready")
+        case .unknown: L10n.string("Checking…")
+        case .warning, .error: L10n.string("Needs attention")
+        }
+    }
 
     var body: some View {
         HStack(spacing: 5) {
             Circle().fill(color).frame(width: 7, height: 7)
-            Text(healthy ? L10n.string("Ready") : L10n.string("Needs attention"))
+            Text(label)
                 .appFont(.caption, weight: .semibold)
                 .foregroundStyle(color)
         }

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -146,10 +146,18 @@ struct PowerHelperSettingsPresentation: Equatable {
 
     init(
         registrationStatus: PowerHelperRegistrationStatus,
-        readinessConfirmed: Bool
+        readinessConfirmed: Bool,
+        isChecking: Bool = false
     ) {
         if registrationStatus == .enabled, readinessConfirmed {
             status = .ok
+            detailLocalizationKey = nil
+            return
+        }
+
+        if isChecking,
+           registrationStatus == .enabled || registrationStatus == .unavailable {
+            status = .unknown
             detailLocalizationKey = nil
             return
         }
@@ -1259,7 +1267,8 @@ struct SettingsView: View {
     {
         PowerHelperSettingsPresentation(
             registrationStatus: installation.powerHelperStatus,
-            readinessConfirmed: installation.powerHelperReadinessConfirmed)
+            readinessConfirmed: installation.powerHelperReadinessConfirmed,
+            isChecking: installation.phase == .idle || installation.isBusy)
     }
 
     private func requiredComponentStatus(
@@ -1270,7 +1279,7 @@ struct SettingsView: View {
             Text(label)
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 12)
-            StatusIndicator(healthy: status == .ok)
+            StatusIndicator(status: status)
         }
     }
 

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -28,6 +28,26 @@ final class MacPowerSettingsPresentationTests: XCTestCase {
             "The native power helper is not registered yet.")
     }
 
+    func testPowerHelperHealthDoesNotReportFailureWhileChecking() {
+        for registrationStatus in [
+            PowerHelperRegistrationStatus.unavailable,
+            .enabled,
+        ] {
+            let presentation = PowerHelperSettingsPresentation(
+                registrationStatus: registrationStatus,
+                readinessConfirmed: false,
+                isChecking: true)
+            XCTAssertEqual(presentation.status, .unknown)
+            XCTAssertNil(presentation.detailLocalizationKey)
+        }
+
+        let approval = PowerHelperSettingsPresentation(
+            registrationStatus: .requiresApproval,
+            readinessConfirmed: false,
+            isChecking: true)
+        XCTAssertEqual(approval.status, .error)
+    }
+
     func testPowerHelperHealthExplainsRegistrationFailures() {
         let expected: [(PowerHelperRegistrationStatus, String)] = [
             (

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -233,6 +233,32 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), "selected text")
     }
 
+    func testDroppedFileURLsBecomeShellSafeAbsolutePaths() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        defer { pasteboard.releaseGlobally() }
+        let first = URL(fileURLWithPath: "/tmp/photo.png")
+        let second = URL(fileURLWithPath: "/tmp/Project File/a'b.txt")
+        XCTAssertTrue(pasteboard.writeObjects([first as NSURL, second as NSURL]))
+
+        XCTAssertEqual(
+            SessionAttachDroppedPaths.insertionText(from: pasteboard),
+            "/tmp/photo.png '/tmp/Project File/a'\\''b.txt' ")
+    }
+
+    func testDroppedPathsIgnoreNonFileURLs() throws {
+        let pasteboard = NSPasteboard.withUniqueName()
+        defer { pasteboard.releaseGlobally() }
+        let url = try XCTUnwrap(URL(string: "https://example.com/file.png"))
+        XCTAssertTrue(pasteboard.writeObjects([url as NSURL]))
+        XCTAssertNil(SessionAttachDroppedPaths.insertionText(from: pasteboard))
+    }
+
+    func testDroppedPathNeverInsertsAControlCharacter() {
+        XCTAssertEqual(
+            SessionAttachDroppedPaths.shellEscaped("/tmp/line\nbreak.txt"),
+            "$'/tmp/line\\nbreak.txt'")
+    }
+
     @MainActor
     func testControlVReachesTheProviderAsTheRawClipboardImageShortcut() throws {
         let root = FileManager.default.temporaryDirectory
@@ -311,6 +337,41 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertNil(SessionAttachKeyboard.providerInput(for: commandV))
     }
 
+    func testNativeTerminalCommandsUsePhysicalCommandKeys() throws {
+        let expected: [(UInt16, String, SessionAttachKeyboard.AppAction)] = [
+            (8, "с", .copy),
+            (9, "м", .paste),
+            (3, "а", .find),
+        ]
+        for (keyCode, characters, action) in expected {
+            let event = try XCTUnwrap(NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.command, .capsLock],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: characters,
+                charactersIgnoringModifiers: characters,
+                isARepeat: false,
+                keyCode: keyCode))
+            XCTAssertEqual(SessionAttachKeyboard.appAction(for: event), action)
+        }
+
+        let shiftedPaste = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "V",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9))
+        XCTAssertNil(SessionAttachKeyboard.appAction(for: shiftedPaste))
+    }
+
     @MainActor
     func testScopedKeyboardRouting() throws {
         let terminal = LocalProcessTerminalView(frame: .zero)
@@ -338,6 +399,27 @@ final class SessionAttachTerminalTests: XCTestCase {
             in: terminal,
             send: { received = $0 }))
         XCTAssertEqual(received, [0x16])
+
+        let commandPaste = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "v",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9))
+        var action: SessionAttachKeyboard.AppAction?
+        XCTAssertNil(coordinator.routeKeyboardEvent(
+            commandPaste,
+            window: nil,
+            firstResponder: terminal,
+            in: terminal,
+            send: { _ in },
+            performAppAction: { action = $0 }))
+        XCTAssertEqual(action, .paste)
 
         XCTAssertTrue(coordinator.routeKeyboardEvent(
             controlV,

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -12,6 +12,28 @@ private final class SilentDetachCLI: DetachCLIRunning, @unchecked Sendable {
     }
 }
 
+private final class RecordingTerminalView: LocalProcessTerminalView {
+    enum Action: Equatable {
+        case copy
+        case paste
+        case find(Int)
+    }
+
+    private(set) var actions: [Action] = []
+
+    override func copy(_ sender: Any) {
+        actions.append(.copy)
+    }
+
+    override func paste(_ sender: Any) {
+        actions.append(.paste)
+    }
+
+    override func performFindPanelAction(_ sender: Any?) {
+        actions.append(.find((sender as? NSMenuItem)?.tag ?? -1))
+    }
+}
+
 final class SessionAttachTerminalTests: XCTestCase {
     func testPublicAttachRoundTripResizeCopyAndTermination() throws {
         let root = FileManager.default.temporaryDirectory
@@ -253,10 +275,47 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertNil(SessionAttachDroppedPaths.insertionText(from: pasteboard))
     }
 
+    @MainActor
+    func testTerminalViewAcceptsFileDropsAndTakesFocus() {
+        let filePasteboard = NSPasteboard.withUniqueName()
+        let emptyPasteboard = NSPasteboard.withUniqueName()
+        defer {
+            filePasteboard.releaseGlobally()
+            emptyPasteboard.releaseGlobally()
+        }
+        XCTAssertTrue(filePasteboard.writeObjects([
+            URL(fileURLWithPath: "/tmp/Project File/image.png") as NSURL,
+        ]))
+
+        let terminal = SessionAttachLocalProcessTerminalView(frame: .zero)
+        XCTAssertTrue(terminal.registeredDraggedTypes.contains(.fileURL))
+        XCTAssertEqual(terminal.acceptedDragOperation(from: filePasteboard), .copy)
+        XCTAssertEqual(terminal.acceptedDragOperation(from: emptyPasteboard), [])
+
+        var insertedText: String?
+        terminal.onDroppedPaths = { insertedText = $0 }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [],
+            backing: .buffered,
+            defer: false)
+        window.contentView = terminal
+
+        XCTAssertFalse(terminal.acceptDroppedPaths(from: emptyPasteboard))
+        XCTAssertTrue(terminal.acceptDroppedPaths(from: filePasteboard))
+        XCTAssertEqual(insertedText, "'/tmp/Project File/image.png' ")
+        XCTAssertTrue(window.firstResponder === terminal)
+    }
+
     func testDroppedPathNeverInsertsAControlCharacter() {
         XCTAssertEqual(
             SessionAttachDroppedPaths.shellEscaped("/tmp/line\nbreak.txt"),
             "$'/tmp/line\\nbreak.txt'")
+        XCTAssertEqual(
+            SessionAttachDroppedPaths.shellEscaped(
+                "/tmp/a'\\\r\t\u{01}\u{200E}\u{E0001}b"),
+            "$'/tmp/a" + "\\'" + "\\\\" + "\\r" + "\\t"
+                + "\\x01\\u200E\\U000E0001b'")
     }
 
     @MainActor
@@ -358,6 +417,19 @@ final class SessionAttachTerminalTests: XCTestCase {
             XCTAssertEqual(SessionAttachKeyboard.appAction(for: event), action)
         }
 
+        let unrelatedCommand = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            isARepeat: false,
+            keyCode: 0))
+        XCTAssertNil(SessionAttachKeyboard.appAction(for: unrelatedCommand))
+
         let shiftedPaste = try XCTUnwrap(NSEvent.keyEvent(
             with: .keyDown,
             location: .zero,
@@ -370,6 +442,20 @@ final class SessionAttachTerminalTests: XCTestCase {
             isARepeat: false,
             keyCode: 9))
         XCTAssertNil(SessionAttachKeyboard.appAction(for: shiftedPaste))
+    }
+
+    @MainActor
+    func testNativeTerminalActionsCallSwiftTermCommands() {
+        let terminal = RecordingTerminalView(frame: .zero)
+        SessionAttachTerminalView.Coordinator.perform(.copy, in: terminal)
+        SessionAttachTerminalView.Coordinator.perform(.paste, in: terminal)
+        SessionAttachTerminalView.Coordinator.perform(.find, in: terminal)
+
+        XCTAssertEqual(terminal.actions, [
+            .copy,
+            .paste,
+            .find(Int(NSFindPanelAction.showFindPanel.rawValue)),
+        ])
     }
 
     @MainActor

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -131,14 +131,12 @@ recorded and the journal cleared. Approval and retry failures remain pending for
 the next launch. An ordinary helper SIGTERM/SIGINT uses only the process-local
 termination gate and must not create persistent update state.
 
-Settings → System owns one **Mac Power** block. It shows the sleep state,
-component health, the 10% battery rule, and the correct action. Helper Ready
-requires a doctor-confirmed live XPC connection. Registration alone is Needs
-attention. Power state comes from a healthy watchdog heartbeat no older than
-three minutes. A missing, stale, or malformed snapshot means `unknown`. Refresh
-the installation context when Settings appears or the app becomes active.
-While this tab is visible, publish a heartbeat snapshot every ten seconds so
-the state does not stay stale when SwiftUI does not re-render.
+Settings → System owns the only **Mac Power** status and approval block. Helper
+Ready requires a doctor live XPC check. Registration alone is Needs attention.
+During doctor or reconciliation, show Checking, not failure. Power
+requires a healthy watchdog heartbeat no older than three minutes; otherwise it
+is `unknown`. Refresh on Settings open, app activation, and every ten seconds
+while visible.
 
 The watchdog heartbeat carries the effective power state and typed raw
 thermal state/latch. With notifications enabled, the app emits one
@@ -159,10 +157,13 @@ App Start runs the provider with `--detach` in its project, keeps an error in
 the sheet, refreshes state, and selects one unambiguous new
 session. Start, Resume, and Recover attach through an ephemeral PTY on
 `detach <provider> attach <session>`. Closing the view or app ends that client.
-`Ctrl-V` reaches provider image paste; Detach stores no image. Live views move
-typed Mac Power to metadata and omit the duplicate strip. An exited client
-offers Reconnect without an agent restart. The selected terminal remains an
-`NSWorkspace` `.command` fallback.
+In a focused terminal, `Command-C/V/F` stay native copy, text paste, and find in
+extended keyboard mode. `Ctrl-V` reaches provider image paste. A Finder file
+drop sends shell-safe absolute paths without reading files. Detach
+stores no images or dropped files. Live views move typed Mac Power to metadata
+and omit the duplicate strip. An exited client offers Reconnect without an
+agent restart. The selected terminal remains an `NSWorkspace` `.command`
+fallback.
 The new-session sheet accepts an optional UTF-8 name up to 100 bytes. It rejects
 control characters, blocks launch, and passes one `--name`. The launch button
 starts inside Detach. Advanced holds the prompt and grows down, top fixed. The

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -74,7 +74,8 @@ change real power state, upload assets, or claim publication.
   confirm the exact `owner/repository@tag`; this omits only wall and per-stage
   timing enforcement. Every functional, artifact, signing, power, lid, and
   publication gate remains mandatory, and the waiver is recorded in private
-  gate and workflow evidence.
+  gate and workflow evidence. The interactive prompt and environment forms
+  pass the same exact confirmation to the nested release quality gate.
 - The pre-release quality gate classifies the complete diff from the last
   published tag to synchronized `main`. It runs that dependency-closed plan on
   the release Mac and applies the reference-machine budgets. An empty or

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -1463,6 +1463,13 @@
       "test_domain": "session-ui-source"
     },
     {
+      "pattern": "app/Sources/DetachApp/QuickChat.swift",
+      "priority": 870,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "session-ui-source"
+    },
+    {
       "pattern": "app/Sources/DetachApp/TerminalPreferencePicker.swift",
       "priority": 870,
       "release_domain": "safe",
@@ -2813,6 +2820,7 @@
         "app/Sources/DetachApp/MenuBar*.swift",
         "app/Sources/DetachApp/NewSessionSheet.swift",
         "app/Sources/DetachApp/Onboarding*.swift",
+        "app/Sources/DetachApp/QuickChat.swift",
         "app/Sources/DetachApp/RootView.swift",
         "app/Sources/DetachApp/Session*.swift",
         "app/Sources/DetachApp/Settings*.swift",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -179,6 +179,7 @@ It lists current specification ownership and verification links.
 - `app/Sources/DetachApp/MenuBar*.swift`
 - `app/Sources/DetachApp/NewSessionSheet.swift`
 - `app/Sources/DetachApp/Onboarding*.swift`
+- `app/Sources/DetachApp/QuickChat.swift`
 - `app/Sources/DetachApp/RootView.swift`
 - `app/Sources/DetachApp/Session*.swift`
 - `app/Sources/DetachApp/Settings*.swift`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -162,6 +162,7 @@ route	870	app/Sources/DetachApp/EmptySessionsView.swift	swift-source	safe	docs/s
 route	870	app/Sources/DetachApp/LogTextView.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/MenuBar*.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/NewSessionSheet.swift	session-ui-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/QuickChat.swift	session-ui-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/TerminalPreferencePicker.swift	session-ui-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/Session*.swift	session-ui-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/SidebarView.swift	session-ui-source	safe	docs/specs/app.md

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -516,7 +516,8 @@ run_full_tests() {
     exact_confirmation DETACH_CONFIRM_RELEASE \
       'Ignoring reference-machine timing budgets for this release'
     note 'owner waived reference-machine timing budgets for this release only'
-    DETACH_RELEASE_TIMING_OVERRIDE="$REPOSITORY@$TAG" \
+    DETACH_CONFIRM_RELEASE="$REPOSITORY@$TAG" \
+      DETACH_RELEASE_TIMING_OVERRIDE="$REPOSITORY@$TAG" \
       "$ROOT/scripts/quality-gate" --mode release --base "$impact_base" \
         --without-release-budget --resume auto
   else

--- a/tests/quality_scenarios_contract.py
+++ b/tests/quality_scenarios_contract.py
@@ -22,6 +22,8 @@ from quality_scenarios import (  # noqa: E402
     ScenarioError,
     assemble,
     finalize_stage,
+    main as scenario_main,
+    next_event_time_ns,
     read_jsonl,
     record_event,
     rerun,
@@ -93,6 +95,31 @@ class QualityScenarioContract(unittest.TestCase):
             with patch.dict("os.environ", environment, clear=False):
                 with self.assertRaisesRegex(ScenarioError, "passed without one begin"):
                     record_event("pass", "SC-UPDATE-CHECK")
+
+    def test_event_time_stays_ordered_across_process_clock_origins(self) -> None:
+        prior = [{"time_ns": 200}]
+        with patch("quality_scenarios.time.time_ns", return_value=100):
+            self.assertEqual(next_event_time_ns(prior), 201)
+
+    def test_event_command_records_multiple_scenarios_in_one_process(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            events = Path(directory) / "events.jsonl"
+            environment = {
+                "DETACH_QUALITY_SCENARIO_EVENTS": str(events),
+                "DETACH_QUALITY_SCENARIO_STAGE": "ui-e2e",
+            }
+            with patch.dict("os.environ", environment, clear=False):
+                self.assertEqual(scenario_main([
+                    "event",
+                    "begin",
+                    "SC-UI-DASHBOARD",
+                    "SC-UI-SESSION-DETAIL",
+                ]), 0)
+            records = read_jsonl(events, "events")
+        self.assertEqual(
+            [record["id"] for record in records],
+            ["SC-UI-DASHBOARD", "SC-UI-SESSION-DETAIL"],
+        )
 
     def test_missing_marker_is_a_contract_failure(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -56,8 +56,14 @@ assert_value "$TMP_ROOT/safe.tsv" lid_test_required false
 assert_value "$TMP_ROOT/safe.tsv" unknown_impact false
 ! grep -F 'install_matrix' "$TMP_ROOT/safe.tsv" >/dev/null
 
+QUICK_CHAT_HEAD="$(commit_path app/Sources/DetachApp/QuickChat.swift quick-chat)"
+"$REPO/scripts/release-impact" "$SAFE_HEAD" "$QUICK_CHAT_HEAD" \
+  >"$TMP_ROOT/quick-chat.tsv"
+assert_value "$TMP_ROOT/quick-chat.tsv" lid_test_required false
+assert_value "$TMP_ROOT/quick-chat.tsv" unknown_impact false
+
 MATRIX_HEAD="$(commit_path app/Sources/DetachApp/OnboardingView.swift onboarding)"
-"$REPO/scripts/release-impact" "$SAFE_HEAD" "$MATRIX_HEAD" >"$TMP_ROOT/matrix.tsv"
+"$REPO/scripts/release-impact" "$QUICK_CHAT_HEAD" "$MATRIX_HEAD" >"$TMP_ROOT/matrix.tsv"
 assert_value "$TMP_ROOT/matrix.tsv" lid_test_required false
 assert_value "$TMP_ROOT/matrix.tsv" unknown_impact false
 

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -40,6 +40,12 @@ setup_fixture() {
   RELEASE_EXISTS="$FIXTURE/release-exists"
   ACTION_LOG="$FIXTURE/actions.log"
   PUBLISHED_MANIFEST="$FIXTURE/published-manifest.json"
+  if [ -n "${FIXTURE_TEMPLATE:-}" ]; then
+    cp -cR "$FIXTURE_TEMPLATE" "$FIXTURE"
+    git -C "$REPO" remote set-url origin "$ORIGIN"
+    git -C "$REPO" config core.hooksPath "$FIXTURE/hooks"
+    return
+  fi
   mkdir -p "$REPO/scripts" "$REPO/tests/quality-gate-fixtures" "$REPO/app/scripts" \
     "$REPO/app/.build/artifacts/sparkle/Sparkle/bin" "$REPO/quality" "$REPO/tools" \
     "$BIN" "$APPS" "$FIXTURE/hooks" \
@@ -606,18 +612,24 @@ run_invalid_resume_artifact_credentials_case() {
   [ ! -f "$RELEASE_EXISTS" ]
 }
 
-run_timing_override_cases() {
+run_timing_override_confirmation_case() {
   setup_fixture timing-override-confirmation
+  grep -F 'DETACH_CONFIRM_RELEASE="$REPOSITORY@$TAG" \' \
+    "$REPO/scripts/release-version" >/dev/null
   expect_failure timing-override-confirmation \
     "confirmation must exactly equal example/detach@$TARGET_TAG" \
     run_workflow '' "example/detach@$TARGET_TAG" wrong-confirmation 1
   [ ! -s "$ACTION_LOG" ]
+}
 
+run_timing_override_invalid_case() {
   setup_fixture timing-override-invalid
   expect_failure timing-override-invalid 'DETACH_RELEASE_IGNORE_TIMING must be 0 or 1' \
     run_workflow '' "example/detach@$TARGET_TAG" "example/detach@$TARGET_TAG" invalid
   [ ! -s "$ACTION_LOG" ]
+}
 
+run_timing_override_case() {
   setup_fixture timing-override
   expect_failure timing-override 'injected safe failure after preflight' \
     run_workflow preflight "example/detach@$TARGET_TAG" "example/detach@$TARGET_TAG" 1
@@ -632,29 +644,37 @@ run_timing_override_cases() {
   [ -f "$REPO/app/build/release-workflow/$TARGET_VERSION/stage-verified" ]
 }
 
-run_preflight_rejection_cases() {
+run_dirty_preflight_rejection_case() {
   setup_fixture dirty
   printf '%s\n' dirty >"$REPO/untracked-note.txt"
   expect_failure dirty 'release workflow requires a clean worktree' run_workflow
   [ ! -s "$ACTION_LOG" ]
+}
 
+run_stale_build_preflight_rejection_case() {
   setup_fixture stale-build
   printf '%s\n' 12 >"$REPO/BUILD"
   git -C "$REPO" add BUILD
   git -C "$REPO" commit -qm 'stale tracked build'
   git -C "$REPO" push -q origin main
   expect_failure stale-build 'tracked BUILD 12 does not match published build 13' run_workflow
+}
 
+run_diverged_preflight_rejection_case() {
   setup_fixture diverged
   printf '%s\n' local >>"$REPO/README.md"
   git -C "$REPO" add README.md
   git -C "$REPO" commit -qm 'local divergence'
   expect_failure diverged 'main must be synchronized with origin/main' run_workflow
+}
 
+run_duplicate_tag_preflight_rejection_case() {
   setup_fixture duplicate-tag
   git -C "$REPO" tag -a "$TARGET_TAG" -m duplicate
   expect_failure duplicate-tag "local tag already exists: $TARGET_TAG" run_workflow
+}
 
+run_duplicate_release_preflight_rejection_case() {
   setup_fixture duplicate-release
   : >"$RELEASE_EXISTS"
   expect_failure duplicate-release "GitHub release already exists: $TARGET_TAG" run_workflow
@@ -711,8 +731,8 @@ run_unexpected_remote_asset_case() {
 
 run_post_push_main_rejection_case() {
   setup_fixture post-push-main
-  expect_failure post-push-artifacts 'injected safe failure after artifacts' \
-    run_workflow artifacts
+  expect_failure post-push-source 'injected safe failure after pushed' \
+    run_workflow pushed
   mkdir -p "$REPO/app/Sources/DetachKit"
   printf '%s\n' 'product change' >"$REPO/app/Sources/DetachKit/TerminalLauncher.swift"
   git -C "$REPO" add app/Sources/DetachKit/TerminalLauncher.swift
@@ -725,20 +745,30 @@ run_post_push_main_rejection_case() {
 
 # Each lane owns a separate repository below TMP_ROOT. Admit a bounded set of
 # lanes so independent Git and fake-publication work do not saturate the disk.
+# Clone one immutable APFS fixture instead of rebuilding the same Git history
+# and fake tools in every lane.
+setup_fixture fixture-template
+FIXTURE_TEMPLATE="$FIXTURE"
 release_case_limit=5
 release_case_pids=()
 release_case_names=()
 release_case_status=0
 release_cases=(
   run_resume_case
-  run_timing_override_cases
+  run_timing_override_case
   run_unexpected_remote_asset_case
   run_remote_hash_case
   run_hardware_rejection_case
   run_invalid_resume_artifact_credentials_case
   run_post_push_main_rejection_case
   run_test_mode_rejects_unproven_fixture_case
-  run_preflight_rejection_cases
+  run_timing_override_confirmation_case
+  run_timing_override_invalid_case
+  run_dirty_preflight_rejection_case
+  run_stale_build_preflight_rejection_case
+  run_diverged_preflight_rejection_case
+  run_duplicate_tag_preflight_rejection_case
+  run_duplicate_release_preflight_rejection_case
 )
 
 wait_for_release_case_slot() {

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -191,7 +191,7 @@ printf '#!/bin/bash\nprintf breach >%q\nexit 91\n' "$BREACH" \
   >"$TEST_HOME/.local/bin/detach"
 chmod 0755 "$TEST_HOME/.local/bin/detach"
 
-for scenario in \
+"$ROOT/scripts/quality-scenarios" event begin \
   SC-UI-DASHBOARD \
   SC-UI-SESSION-DETAIL \
   SC-UI-SESSION-DELETE \
@@ -203,13 +203,12 @@ for scenario in \
   SC-UI-ONBOARD-FIRST-RUN \
   SC-UI-ONBOARD-PROVIDER \
   SC-UI-ONBOARD-APPROVAL \
-  SC-UI-SETTINGS; do
-  "$ROOT/scripts/quality-scenarios" event begin "$scenario"
-done
+  SC-UI-SETTINGS
 
 run_app_scenario() {
   local scenario="$1" fixture="$2" scenario_budget="$3"
-  local app_status check_index=0 actual check scenario_deadline driver_budget
+  local app_status check_index=0 actual check scenario_deadline driver_budget pass
+  local passed_scenarios=()
   local scenario_started="$SECONDS"
   shift 3
   scenario_deadline=$((SECONDS + scenario_budget))
@@ -338,11 +337,14 @@ run_app_scenario() {
       *) printf 'UI e2e: unowned check: %s\n' "$check" >&2; exit 1 ;;
     esac
     if [ -n "${pass:-}" ]; then
-      "$ROOT/scripts/quality-scenarios" event pass "$pass"
+      passed_scenarios+=("$pass")
       pass=""
     fi
     check_index=$((check_index + 1))
   done
+  if [ "${#passed_scenarios[@]}" -gt 0 ]; then
+    "$ROOT/scripts/quality-scenarios" event pass "${passed_scenarios[@]}"
+  fi
   printf 'UI e2e: %s passed in %ss\n' "$scenario" "$((SECONDS - scenario_started))"
 }
 

--- a/tools/quality_scenarios.py
+++ b/tools/quality_scenarios.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 from pathlib import Path
@@ -93,7 +94,7 @@ def read_jsonl(path: Path, label: str) -> list[dict[str, Any]]:
 
 def append_event(path: Path, record: dict[str, Any]) -> None:
     safe_output(path, "scenario event file")
-    flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+    flags = os.O_RDWR | os.O_APPEND | os.O_CREAT
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     try:
@@ -101,10 +102,36 @@ def append_event(path: Path, record: dict[str, Any]) -> None:
     except OSError as error:
         raise ScenarioError(f"cannot open scenario event file: {error}") from error
     try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        prior = read_jsonl(path, "scenario events")
+        scenario_id = record["id"]
+        kind = record["kind"]
+        kinds = [
+            event.get("kind") for event in prior
+            if event.get("id") == scenario_id
+        ]
+        if kind == "begin" and kinds:
+            raise ScenarioError(f"scenario {scenario_id} began more than once")
+        if kind == "pass" and kinds != ["begin"]:
+            raise ScenarioError(
+                f"scenario {scenario_id} passed without one begin event")
+        record["time_ns"] = next_event_time_ns(prior)
         os.write(descriptor, (canonical(record) + "\n").encode("utf-8"))
+        os.fchmod(descriptor, 0o600)
     finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
         os.close(descriptor)
-    path.chmod(0o600)
+
+
+def next_event_time_ns(prior: list[dict[str, Any]]) -> int:
+    """Return a cross-process timestamp that stays ordered in the event file."""
+    now = time.time_ns()
+    if not prior:
+        return now
+    previous = prior[-1].get("time_ns")
+    if isinstance(previous, int) and previous > 0:
+        return max(now, previous + 1)
+    return now
 
 
 def scenario_context(policy: Policy) -> dict[str, dict[str, list[str]]]:
@@ -147,12 +174,6 @@ def record_event(kind: str, scenario_id: str) -> None:
     if policy_status != "instrumented":
         raise ScenarioError(f"scenario {scenario_id} is not instrumented in policy")
     path = Path(raw_path)
-    prior = read_jsonl(path, "scenario events")
-    kinds = [event.get("kind") for event in prior if event.get("id") == scenario_id]
-    if kind == "begin" and kinds:
-        raise ScenarioError(f"scenario {scenario_id} began more than once")
-    if kind == "pass" and kinds != ["begin"]:
-        raise ScenarioError(f"scenario {scenario_id} passed without one begin event")
     append_event(
         path,
         {
@@ -160,7 +181,6 @@ def record_event(kind: str, scenario_id: str) -> None:
             "id": scenario_id,
             "stage": stage,
             "kind": kind,
-            "time_ns": time.monotonic_ns(),
         },
     )
 
@@ -557,7 +577,7 @@ def parser() -> argparse.ArgumentParser:
     subparsers = result.add_subparsers(dest="command", required=True)
     event = subparsers.add_parser("event")
     event.add_argument("kind", choices=sorted(EVENT_KINDS))
-    event.add_argument("scenario_id")
+    event.add_argument("scenario_ids", nargs="+")
     rerun_parser = subparsers.add_parser("rerun")
     rerun_parser.add_argument("scenario_id")
     return result
@@ -566,7 +586,8 @@ def parser() -> argparse.ArgumentParser:
 def main(arguments: list[str]) -> int:
     options = parser().parse_args(arguments)
     if options.command == "event":
-        record_event(options.kind, options.scenario_id)
+        for scenario_id in options.scenario_ids:
+            record_event(options.kind, scenario_id)
         return 0
     if options.command == "rerun":
         return rerun(options.scenario_id)


### PR DESCRIPTION
## Summary

- Keep Command-C, Command-V, and Command-F as native embedded-terminal actions, while Control-V still reaches the provider. Finder drops now insert shell-safe absolute file paths without reading or storing file contents.
- Show Power Helper checks as in progress instead of reporting a transient failure. Helper Ready still requires the doctor-confirmed live XPC connection.
- Classify QuickChat.swift as known session UI, fix interactive timing-waiver propagation, and make scenario timestamps ordered across macOS Python processes.
- Preserve every release-workflow case while reducing repeated fixture I/O so the stage stays within its timing budget.

## Contract delta

The app spec now defines native terminal copy, paste, find, and file-drop behavior, plus the transient Power Helper presentation. The release spec now defines identical nested-gate confirmation for interactive and environment timing waivers. Quick Chat-only app changes no longer select the closed-lid gate as unknown impact.

## Evidence

- Focused Swift terminal and Power presentation tests passed.
- Quality scenario contracts, release-impact contracts, and the complete hermetic release workflow passed.
- Packaged UI scenarios passed in 13–14 seconds in an active local user session. A later full local diagnostic passed every non-UI functional stage and release-workflow at 69/70 seconds; its UI activation was blocked because macOS reported loginwindow as foreground. Hosted quality-gates remains the readiness authority.
- scripts/release-impact v0.4.1 HEAD: lid_test_required=false, unknown_impact=false.
- git diff --check passed.