### PR TITLE
Add stable session shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The embedded terminal keeps the shortcuts that matter:
 |---|---|
 | Open the standard New session sheet | `Cmd-N` |
 | Start a Quick chat immediately | `Cmd-T` |
+| Switch to a numbered Working or Answer ready session | `Cmd-1` … `Cmd-9` |
 | Paste text | `Cmd-V` |
 | Give Codex or Claude Code an image from the clipboard | `Ctrl-V` |
 | Find terminal output | `Cmd-F` |
@@ -129,6 +130,11 @@ default folder is `/tmp`. The same settings page selects the default folder
 where the standard project chooser opens. Quick chat uses the normal managed
 session lifecycle; it does not automatically delete project files, Detach
 state, or provider transcripts.
+
+Detach shows each assigned session shortcut beside its name. The number stays
+with the session while it is in Working or Answer ready. Detach reuses the
+number after the session leaves both sections. If more than nine sessions are
+eligible, each extra session waits for the first free number.
 
 Start, Resume, and Recover run inside Detach and do not require an outer
 terminal. The selected external terminal remains available as a fallback for

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -420,6 +420,10 @@
 
 /* Session shortcuts and defaults */
 "Quick chat" = "Quick chat";
+"Sessions" = "Sessions";
+"Session %d" = "Session %d";
+"%@, Command-%d" = "%@, Command-%d";
+"Switch to %@ with Command-%d" = "Switch to %@ with Command-%d";
 "Settings" = "Settings";
 "Find output" = "Find output";
 "Keyboard shortcuts" = "Keyboard shortcuts";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -420,6 +420,10 @@
 
 /* Session shortcuts and defaults */
 "Quick chat" = "Быстрый чат";
+"Sessions" = "Сессии";
+"Session %d" = "Сессия %d";
+"%@, Command-%d" = "%@, Command-%d";
+"Switch to %@ with Command-%d" = "Переключиться на «%@»: Command-%d";
 "Settings" = "Настройки";
 "Find output" = "Поиск в выводе";
 "Keyboard shortcuts" = "Сочетания клавиш";

--- a/app/Sources/DetachApp/DetachApp.swift
+++ b/app/Sources/DetachApp/DetachApp.swift
@@ -188,11 +188,17 @@ final class MainNavigation: ObservableObject {
     func requestQuickChat() {
         quickChatRequestID = UUID()
     }
+
+    func requestSession(_ sessionID: String) {
+        requestedSessionID = sessionID
+    }
 }
 
 struct SessionCommands: Commands {
     @Environment(\.openWindow) private var openWindow
     @ObservedObject var navigation: MainNavigation
+    let store: SessionStore
+    let shortcuts: SessionShortcutRegistry
 
     var body: some Commands {
         CommandGroup(replacing: .newItem) {
@@ -207,6 +213,21 @@ struct SessionCommands: Commands {
                 showMainWindow()
             }
             .keyboardShortcut("t", modifiers: .command)
+        }
+
+        CommandMenu(L10n.string("Sessions")) {
+            ForEach(Array(SessionShortcutRegistry.slots), id: \.self) { slot in
+                Button(L10n.format("Session %d", slot)) {
+                    shortcuts.reconcile(store.sessions)
+                    guard let sessionID = shortcuts.sessionID(
+                        for: slot) else { return }
+                    navigation.requestSession(sessionID)
+                    showMainWindow()
+                }
+                .keyboardShortcut(
+                    KeyEquivalent(Character(String(slot))),
+                    modifiers: .command)
+            }
         }
     }
 
@@ -252,6 +273,7 @@ struct DetachApp: App {
     @StateObject private var tips = TipSession(defaults: AppSettings.defaults)
     @StateObject private var settingsNavigation = SettingsNavigation()
     @StateObject private var mainNavigation = MainNavigation()
+    @StateObject private var sessionShortcuts = SessionShortcutRegistry()
 
     var body: some Scene {
         Window("Detach", id: "main") {
@@ -260,12 +282,16 @@ struct DetachApp: App {
             RootView(detachPath: activeDetachPath, pollInterval: pollInterval,
                      installation: installation, store: sessionStore,
                      navigation: mainNavigation,
+                     shortcuts: sessionShortcuts,
                      notifications: notifications,
                      tips: tips, settingsNavigation: settingsNavigation)
                 .id(activeDetachPath) // reattach tasks when the CLI path changes
         }
         .commands {
-            SessionCommands(navigation: mainNavigation)
+            SessionCommands(
+                navigation: mainNavigation,
+                store: sessionStore,
+                shortcuts: sessionShortcuts)
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesCommand(updater: updater)
             }

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -18,11 +18,13 @@ struct RootView: View {
     /// stops it, so notifications and the menu bar stay fed after close.
     let store: SessionStore
     @ObservedObject var navigation: MainNavigation
+    @ObservedObject var shortcuts: SessionShortcutRegistry
     @ObservedObject var notifications: SessionNotificationService
     @ObservedObject var tips: TipSession
     @ObservedObject var settingsNavigation: SettingsNavigation
 
     @State private var selectedID: String?
+    @State private var shortcutAssignments: [SessionShortcutAssignment] = []
 
     private var selectedSession: Session? {
         store.sessions.first { $0.id == selectedID }
@@ -47,7 +49,8 @@ struct RootView: View {
                         SidebarView(
                             store: store,
                             selectedID: $selectedID,
-                            navigation: navigation)
+                            navigation: navigation,
+                            shortcutAssignments: shortcutAssignments)
                     } detail: {
                         if store.sessions.isEmpty && store.state == .ok {
                             EmptySessionsView()
@@ -93,7 +96,8 @@ struct RootView: View {
             // keep notifications fed from the same single poller. The
             // transition detector baselines on its first successful snapshot,
             // so historical sessions never fire as fresh notifications.
-            store.onSnapshot = { [weak notifications] sessions in
+            store.onSnapshot = { [weak notifications, weak shortcuts] sessions in
+                shortcuts?.reconcile(sessions)
                 await notifications?.observe(sessions)
             }
             await store.configure(cli: ProcessDetachCLI(
@@ -105,7 +109,12 @@ struct RootView: View {
             await notifications.configure(enabled: notificationsEnabled)
         }
 // quality-coverage:begin ui-e2e-instrumentation
-        .task { await UIE2ETestDriver.runIfRequested(installation: installation, store: store) }
+        .task {
+            await UIE2ETestDriver.runIfRequested(
+                installation: installation,
+                store: store,
+                shortcuts: shortcuts)
+        }
 // quality-coverage:end ui-e2e-instrumentation
         .onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }
@@ -122,6 +131,12 @@ struct RootView: View {
             guard let requested else { return }
             selectedID = requested
             navigation.requestedSessionID = nil
+        }
+        .onChange(of: store.sessions, initial: true) { _, sessions in
+            shortcuts.reconcile(sessions)
+        }
+        .onReceive(shortcuts.$assignments) { assignments in
+            shortcutAssignments = assignments
         }
         .onAppear { store.updateCadence(foreground: true) }
         .onDisappear { store.updateCadence(foreground: false) }

--- a/app/Sources/DetachApp/SessionShortcuts.swift
+++ b/app/Sources/DetachApp/SessionShortcuts.swift
@@ -1,0 +1,85 @@
+import Combine
+import DetachKit
+
+struct SessionShortcutAssignment: Equatable, Identifiable {
+    let sessionID: String
+    let displayTitle: String
+    let slot: Int
+
+    var id: Int { slot }
+}
+
+@MainActor
+final class SessionShortcutRegistry: ObservableObject {
+    static let slots = 1...9
+
+    @Published private(set) var assignments: [SessionShortcutAssignment] = []
+
+    private var slotsBySessionID: [String: Int] = [:]
+    private var admissionOrder: [String] = []
+
+    func reconcile(_ sessions: [Session]) {
+        let eligible = sessions.filter(Self.isEligible)
+        let eligibleIDs = Set(eligible.map(\.id))
+
+        slotsBySessionID = slotsBySessionID.filter {
+            eligibleIDs.contains($0.key)
+        }
+        admissionOrder.removeAll { !eligibleIDs.contains($0) }
+
+        let admittedIDs = Set(admissionOrder)
+        admissionOrder.append(contentsOf: eligible.lazy.map(\.id).filter {
+            !admittedIDs.contains($0)
+        })
+
+        var freeSlots = Self.slots.filter {
+            !slotsBySessionID.values.contains($0)
+        }
+        for sessionID in admissionOrder where slotsBySessionID[sessionID] == nil {
+            guard let slot = freeSlots.first else { break }
+            slotsBySessionID[sessionID] = slot
+            freeSlots.removeFirst()
+        }
+
+        let sessionsByID = Dictionary(uniqueKeysWithValues: eligible.map {
+            ($0.id, $0)
+        })
+        let updated = slotsBySessionID.compactMap { sessionID, slot in
+            sessionsByID[sessionID].map {
+                SessionShortcutAssignment(
+                    sessionID: sessionID,
+                    displayTitle: $0.displayTitle,
+                    slot: slot)
+            }
+        }.sorted { $0.slot < $1.slot }
+
+        // Published delivers its current value to a later subscriber, so an
+        // unchanged poll does not need to redraw the sidebar or command menu.
+        if assignments != updated {
+            assignments = updated
+        }
+    }
+
+    func slot(for sessionID: String) -> Int? {
+        assignments.first { $0.sessionID == sessionID }?.slot
+    }
+
+    func sessionID(for slot: Int) -> String? {
+        assignments.first { $0.slot == slot }?.sessionID
+    }
+
+    private static func isEligible(_ session: Session) -> Bool {
+        session.section == .answerReady || session.section == .active
+    }
+}
+
+enum SessionShortcutPresentation {
+    static func badge(slot: Int) -> String {
+        "⌘\(slot)"
+    }
+
+    static func accessibilityLabel(title: String, slot: Int?) -> String {
+        guard let slot else { return title }
+        return L10n.format("%@, Command-%d", title, slot)
+    }
+}

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -35,6 +35,7 @@ struct SidebarView: View {
     let store: SessionStore
     @Binding var selectedID: String?
     @ObservedObject var navigation: MainNavigation
+    let shortcutAssignments: [SessionShortcutAssignment]
     @AppStorage(AppSettings.defaultProjectsDirectoryKey, store: AppSettings.defaults)
     private var defaultProjectsDirectoryPath =
         AppSettings.defaultProjectsDirectoryPath
@@ -277,6 +278,9 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func sessionRow(_ session: Session) -> some View {
+        let shortcutSlot = shortcutAssignments.first {
+            $0.sessionID == session.id
+        }?.slot
         if isSelectingFinished && session.canDeleteFromFinishedList {
             HStack(spacing: 8) {
                 Button {
@@ -314,7 +318,7 @@ struct SidebarView: View {
                 }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
-                SessionRow(session: session)
+                SessionRow(session: session, shortcutSlot: shortcutSlot)
             }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
@@ -323,7 +327,9 @@ struct SidebarView: View {
 // quality-coverage:end ui-e2e-instrumentation
             .tag(session.id)
             .accessibilityElement(children: .contain)
-            .accessibilityLabel(session.displayTitle)
+            .accessibilityLabel(SessionShortcutPresentation.accessibilityLabel(
+                title: session.displayTitle,
+                slot: shortcutSlot))
             .accessibilityIdentifier("session-row-\(session.id)")
             .listRowBackground(
                 session.isWaitingForUser ? Color.orange.opacity(0.10) : nil)
@@ -331,7 +337,7 @@ struct SidebarView: View {
             Button {
                 selectedID = session.id
             } label: {
-                SessionRow(session: session)
+                SessionRow(session: session, shortcutSlot: shortcutSlot)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(Rectangle())
             }
@@ -343,7 +349,9 @@ struct SidebarView: View {
 // quality-coverage:end ui-e2e-instrumentation
             .tag(session.id)
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(session.displayTitle)
+            .accessibilityLabel(SessionShortcutPresentation.accessibilityLabel(
+                title: session.displayTitle,
+                slot: shortcutSlot))
             .accessibilityIdentifier("session-row-\(session.id)")
             .listRowBackground(
                 session.isWaitingForUser ? Color.orange.opacity(0.10) : nil)
@@ -472,6 +480,7 @@ struct SidebarView: View {
 
 struct SessionRow: View {
     let session: Session
+    let shortcutSlot: Int?
 
     private var dotColor: Color {
         SessionIdentity.statusColor(for: session)
@@ -516,6 +525,34 @@ struct SessionRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(session.displayTitle).appFont(.body, weight: .semibold).lineLimit(1)
+                    if let shortcutSlot {
+                        Text(SessionShortcutPresentation.badge(slot: shortcutSlot))
+                            .appFont(.caption2, weight: .semibold, design: .monospaced)
+                            .foregroundStyle(Brand.indigo)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(
+                                Brand.indigo.opacity(0.12),
+                                in: RoundedRectangle(cornerRadius: 4))
+                            .fixedSize()
+                            .help(L10n.format(
+                                "Switch to %@ with Command-%d",
+                                session.displayTitle,
+                                shortcutSlot))
+                            .accessibilityHidden(true)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                            .background {
+                                if AppSettings.uiE2E != nil {
+                                    UIE2EGeometryProbe(
+                                        identifier: "session-shortcut-\(session.id)",
+                                        semanticLabel: "Command-\(shortcutSlot)",
+                                        semanticRole: .staticText)
+                                }
+                            }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
+                    }
                     Text(session.provider.rawValue)
                         .appFont(.caption2)
                         .foregroundStyle(Brand.tint(for: session.provider))

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -159,7 +159,8 @@ enum UIE2ETestDriver {
 
     static func runIfRequested(
         installation: InstallationStore,
-        store: SessionStore
+        store: SessionStore,
+        shortcuts: SessionShortcutRegistry
     ) async {
         guard let configuration = AppSettings.uiE2E, !started else { return }
         started = true
@@ -173,7 +174,8 @@ enum UIE2ETestDriver {
             let report = await runScenario(
                 configuration: configuration,
                 installation: installation,
-                store: store)
+                store: store,
+                shortcuts: shortcuts)
             trace("\(configuration.scenario) driver finished: \(report.passed)")
             try? write(report, to: configuration.result)
             NSApp.terminate(nil)
@@ -189,7 +191,8 @@ enum UIE2ETestDriver {
     private static func runScenario(
         configuration: UIE2EConfiguration,
         installation: InstallationStore,
-        store: SessionStore
+        store: SessionStore,
+        shortcuts: SessionShortcutRegistry
     ) async -> Report {
         cursorRestorePoint = CGEvent(source: nil)?.location
         defer {
@@ -216,13 +219,15 @@ enum UIE2ETestDriver {
         default:
             return await runMainScenario(
                 configuration: configuration,
-                store: store)
+                store: store,
+                shortcuts: shortcuts)
         }
     }
 
     private static func runMainScenario(
         configuration: UIE2EConfiguration,
-        store: SessionStore
+        store: SessionStore,
+        shortcuts: SessionShortcutRegistry
     ) async -> Report {
         var checks: [String] = []
         let previousFrontmost = NSWorkspace.shared.frontmostApplication
@@ -375,10 +380,18 @@ enum UIE2ETestDriver {
             let runningRow = try await element(
                 identifier: "session-row-\(runningID)")
             try requireSemanticControl(runningRow, name: "running session row")
-            _ = try await clickUntilElement(
-                runningRow,
-                name: "running session row",
-                resultIdentifier: "session-detail-\(runningID)")
+            try await waitUntil("running session Command-1 assignment") {
+                shortcuts.slot(for: runningID) == 1
+            }
+            let shortcutBadge = try await element(
+                identifier: "session-shortcut-\(runningID)")
+            try requireGeometry(shortcutBadge, name: "running session shortcut")
+            guard label(shortcutBadge) == "Command-1" else {
+                throw Failure(message: "running session badge is not Command-1")
+            }
+            try await keyPress("1", keyCode: 18, modifiers: [.command])
+            _ = try await element(identifier: "session-detail-\(runningID)")
+            checks.append("session-shortcut-selects-assigned-session")
             try await waitUntil("live attach terminal", attempts: 80) {
                 find(identifier: "session-preview-terminal") != nil
             }

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -152,6 +152,10 @@ final class QuickChatTests: XCTestCase {
         XCTAssertFalse(navigation.requestsNewSession)
         navigation.requestNewSession()
         XCTAssertTrue(navigation.requestsNewSession)
+        navigation.requestSession("detach-codex-project-12345678")
+        XCTAssertEqual(
+            navigation.requestedSessionID,
+            "detach-codex-project-12345678")
     }
 
     func testSidebarGuideListsImplementedAndStandardShortcuts() {
@@ -172,7 +176,10 @@ final class QuickChatTests: XCTestCase {
     }
 
     func testSessionCommandsBuildWithTheSharedNavigation() {
-        let commands = SessionCommands(navigation: MainNavigation())
+        let commands = SessionCommands(
+            navigation: MainNavigation(),
+            store: SessionStore(cli: QuickChatRecordingCLI()),
+            shortcuts: SessionShortcutRegistry())
         _ = commands.body
     }
 }

--- a/app/Tests/DetachAppTests/SessionShortcutTests.swift
+++ b/app/Tests/DetachAppTests/SessionShortcutTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import DetachApp
+@testable import DetachKit
+
+@MainActor
+final class SessionShortcutTests: XCTestCase {
+    func testAssignsOnlyWorkingAndAnswerReadySessions() {
+        let registry = SessionShortcutRegistry()
+
+        registry.reconcile([
+            session(id: "starting", status: "starting"),
+            session(id: "waiting", status: "running", turnState: "waiting"),
+            session(id: "hung", status: "hung"),
+            session(id: "done", status: "completed"),
+        ])
+
+        XCTAssertEqual(registry.slot(for: "starting"), 1)
+        XCTAssertEqual(registry.slot(for: "waiting"), 2)
+        XCTAssertNil(registry.slot(for: "hung"))
+        XCTAssertNil(registry.slot(for: "done"))
+    }
+
+    func testKeepsSlotsAcrossOrderAndSectionChanges() {
+        let registry = SessionShortcutRegistry()
+        registry.reconcile([
+            session(id: "first", status: "running"),
+            session(id: "second", status: "running", turnState: "waiting"),
+        ])
+
+        registry.reconcile([
+            session(id: "second", status: "running"),
+            session(id: "first", status: "running", turnState: "waiting"),
+        ])
+
+        XCTAssertEqual(registry.slot(for: "first"), 1)
+        XCTAssertEqual(registry.slot(for: "second"), 2)
+        XCTAssertEqual(registry.sessionID(for: 1), "first")
+        XCTAssertEqual(registry.sessionID(for: 2), "second")
+    }
+
+    func testWaitingSessionReceivesTheFirstFreedSlot() {
+        let registry = SessionShortcutRegistry()
+        registry.reconcile((1...10).map {
+            session(id: "session-\($0)", status: "running")
+        })
+
+        XCTAssertEqual(registry.assignments.count, 9)
+        XCTAssertNil(registry.slot(for: "session-10"))
+
+        registry.reconcile((1...10).map {
+            session(
+                id: "session-\($0)",
+                status: $0 == 3 ? "stopped" : "running")
+        })
+
+        XCTAssertNil(registry.slot(for: "session-3"))
+        XCTAssertEqual(registry.slot(for: "session-10"), 3)
+        XCTAssertEqual(registry.sessionID(for: 3), "session-10")
+    }
+
+    func testRefreshesMenuTitleWithoutChangingTheSlot() {
+        let registry = SessionShortcutRegistry()
+        registry.reconcile([
+            session(id: "work", status: "running", displayName: "First title"),
+        ])
+
+        registry.reconcile([
+            session(id: "work", status: "running", displayName: "New title"),
+        ])
+
+        XCTAssertEqual(registry.assignments, [
+            SessionShortcutAssignment(
+                sessionID: "work",
+                displayTitle: "New title",
+                slot: 1),
+        ])
+    }
+
+    func testFormatsBadgeAndAccessibleRowLabel() {
+        XCTAssertEqual(SessionShortcutPresentation.badge(slot: 7), "⌘7")
+        XCTAssertEqual(
+            SessionShortcutPresentation.accessibilityLabel(
+                title: "Deploy",
+                slot: 7),
+            L10n.format("%@, Command-%d", "Deploy", 7))
+        XCTAssertEqual(
+            SessionShortcutPresentation.accessibilityLabel(
+                title: "Deploy",
+                slot: nil),
+            "Deploy")
+    }
+}
+
+private func session(
+    id: String,
+    status: String,
+    turnState: String? = nil,
+    displayName: String? = nil
+) -> Session {
+    let turnStateField = turnState.map {
+        #","agent_turn_state":"\#($0)""#
+    } ?? ""
+    let displayNameField = displayName.map {
+        #","display_name":"\#($0)""#
+    } ?? ""
+    let json = #"{"schema":1,"provider":"codex","session_name":"\#(id)","name":"\#(id)","effective_status":"\#(status)","meta_status":null,"agent_session_id":"agent","project_dir":"/tmp/\#(id)","created_at":"2026-09-01T10:00:00Z","last_checkpoint_at":null,"exit_status":null,"finished_at":null\#(turnStateField)\#(displayNameField)}"#
+    return SessionListParser.parse(json).sessions[0]
+}

--- a/app/Tests/DetachAppTests/SidebarViewTests.swift
+++ b/app/Tests/DetachAppTests/SidebarViewTests.swift
@@ -18,7 +18,8 @@ final class SidebarViewTests: XCTestCase {
         let view = SidebarView(
             store: SessionStore(cli: SidebarNoopCLI()),
             selectedID: .constant(nil),
-            navigation: MainNavigation())
+            navigation: MainNavigation(),
+            shortcutAssignments: [])
 
         _ = view.body
     }

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -7,12 +7,10 @@
 bundles signed arm64-only executables, the immutable CLI payload, pinned tmux
 sources/licenses/provenance, Sparkle, SwiftTerm, and their license notices.
 
-`ANSIParser` is the terminal-preview decoder. It strips non-SGR sequences and
-keeps terminal foreground/background colors, bold, dim,
-italic, underline, strikethrough, and reverse video. Reverse video swaps
-against `ANSIParser.terminalBackground`, also the `LogTextView` background;
-keep one canvas color. Font scaling changes only the font and keeps every ANSI
-attribute.
+`ANSIParser` strips non-SGR sequences and preserves colors, bold, dim, italic,
+underline, strikethrough, and reverse video. Reverse swaps colors against
+`ANSIParser.terminalBackground`, also the `LogTextView` background. Font
+scaling changes only the font.
 
 Onboarding uses the pure reducer in `SetupGuidance.step(for:)`; a setup failure
 outranks provider discovery. A bare
@@ -81,10 +79,10 @@ Mac Power status and approval controls. The Settings window follows the hosting
 screen; System scrolls. Temperature safety has its own warning shape and the
 text **Mac can sleep: temperature**.
 
-The dashboard shows identity, status, and Mac Power separately. Identity is a
-thin tmux-colored capsule. Status is a filled circle. Power has a neutral
-surface and semantic color. The UUID chip is one copy control. Any click copies
-the full UUID and shows **Copied**.
+The dashboard separates identity, status, and Mac Power. Identity is a thin
+tmux-colored capsule. Status is a filled circle. Power uses a neutral surface
+and semantic color. Clicking the single UUID chip copies the full UUID and
+shows **Copied**.
 
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
@@ -164,16 +162,18 @@ stores no images or dropped files. Live views move typed Mac Power to metadata
 and omit the duplicate strip. An exited client offers Reconnect without an
 agent restart. The selected terminal remains an `NSWorkspace` `.command`
 fallback.
-The new-session sheet accepts an optional UTF-8 name up to 100 bytes. It rejects
-control characters, blocks launch, and passes one `--name`. The launch button
-starts inside Detach. Advanced holds the prompt and grows down, top fixed. The
-app uses `display_name` as the title, with
-the project/internal name fallback for old records.
+New session accepts an optional printable UTF-8 name of at most 100 bytes
+and rejects invalid input. Launch runs in Detach. Advanced holds the prompt
+below a fixed top. Titles use `display_name`, then the project or internal name.
 Command-N opens New session in main. Its chooser starts at the configured project
-folder or the selection's parent. Command-T opens Quick Chat in main with the
-configured provider and folder (`/tmp` default). It selects the new typed
+folder or the selection's parent. Command-T opens Quick Chat with the
+configured provider and folder (`/tmp` default). It selects the
 `starting` session before runtime checks finish. Invalid folders block launch.
-The sidebar shows Command-N, Command-T, Command-comma, and terminal Command-F.
+Command-1 through Command-9 open main and select numbered Working or Answer
+ready sessions. Numbers appear in rows and stay stable across both sections.
+When a session leaves them, the earliest waiting session gets its number;
+extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
+Command-comma, and terminal Command-F.
 Notifications are opt-in. One poller deduplicates baseline and transitions.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -310,6 +310,7 @@ run_app_scenario() {
       live-terminal-routes-control-v|\
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
+      session-shortcut-selects-assigned-session|\
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
       new-session-advanced-keeps-top-edge|\
@@ -356,6 +357,7 @@ run_app_scenario main sessions 32 \
   sidebar-selects-completed-session \
   session-uuid-copies-from-text-side \
   resume-runs-in-app-with-terminal-fallback \
+  session-shortcut-selects-assigned-session \
   live-session-hosts-attach-client \
   live-terminal-routes-control-v \
   session-signals-stay-distinct \


### PR DESCRIPTION
## Contract delta

- Assign Command-1 through Command-9 to Working and Answer ready sessions.
- Keep an assignment stable across those states, then reuse its slot when the session leaves both.
- Show the assigned shortcut beside the session title and open the main window on shortcut use.
- Leave sessions above the nine-slot limit unnumbered until a slot is free.

## Evidence

- SessionShortcutTests: 5 passed.
- Full Swift diagnostic: 917 passed.
- Packaged app diagnostic: passed.
- Packaged UI diagnostic: visible Command-1 badge and real Command-1 selection passed.
- Static, quality-contracts, and tmux-runtime diagnostics passed.
- Impact selection excludes power and closed-lid gates.

The local release budget diagnostic reported Swift at 33 seconds against 20 seconds. Its build took 17.10 seconds and tests took 13.06 seconds while the app stage compiled in parallel. No functional stage failed. Hosted quality-gates is the readiness authority.