### PR TITLE
Isolate Quick Chat projects and add on-demand terminal rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ The embedded terminal keeps the shortcuts that matter:
 | Find terminal output | `Cmd-F` |
 | Replace an exited terminal client without restarting the agent | **Reconnect** |
 
-Settings → General selects the provider and working folder for Quick chat. The
-default folder is `/tmp`. The same settings page selects the default folder
-where the standard project chooser opens. Quick chat uses the normal managed
-session lifecycle; it does not automatically delete project files, Detach
-state, or provider transcripts.
+Settings → General selects the provider and parent folder for Quick chat. The
+default is `/tmp`. Each `Cmd-T` creates a private
+`detach-chat-<uuid>` project inside that folder, so another Quick chat can
+start while earlier chats are still running. The same settings page selects
+the default folder for the standard project chooser. Quick chat uses the
+normal managed session lifecycle. Detach does not automatically delete its
+project files, state, or provider transcripts.
 
 Detach shows each assigned session shortcut beside its name. The number stays
 with the session while it is in Working or Answer ready. Detach reuses the
@@ -139,6 +141,10 @@ eligible, each extra session waits for the first free number.
 Start, Resume, and Recover run inside Detach and do not require an outer
 terminal. The selected external terminal remains available as a fallback for
 Attach, Resume, and Recover.
+
+The live terminal processes PTY input and output as events. Its on-demand GPU
+renderer repaints only when content changes. A steady cursor avoids an idle
+redraw timer. If Metal is unavailable, Detach keeps the CoreGraphics renderer.
 
 <details>
 <summary><strong>How a new in-app session starts</strong></summary>

--- a/app/Sources/DetachApp/QuickChat.swift
+++ b/app/Sources/DetachApp/QuickChat.swift
@@ -27,6 +27,22 @@ enum DirectoryPreference {
     }
 }
 
+enum QuickChatProjectDirectory {
+    static func create(
+        inside parent: URL,
+        fileManager: FileManager = .default,
+        id: UUID = UUID()
+    ) throws -> URL {
+        let name = "detach-chat-\(id.uuidString.lowercased())"
+        let directory = parent.appendingPathComponent(name, isDirectory: true)
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700])
+        return directory.resolvingSymlinksInPath().standardizedFileURL
+    }
+}
+
 @MainActor
 enum QuickChatLaunch {
     static func provider(rawValue: String) -> Provider {
@@ -39,6 +55,9 @@ enum QuickChatLaunch {
         directoryPath: String,
         fileManager: FileManager = .default,
         onSessionAvailable: (@MainActor (String) -> Void)? = nil,
+        createProjectDirectory: (URL, FileManager) throws -> URL = {
+            try QuickChatProjectDirectory.create(inside: $0, fileManager: $1)
+        },
         discoverySleep: @escaping @Sendable (UInt64) async throws -> Void = {
             try await Task.sleep(nanoseconds: $0)
         }
@@ -50,11 +69,19 @@ enum QuickChatLaunch {
                 "Quick chat folder is unavailable: %@",
                 directoryPath))
         }
+        let projectDirectory: URL
+        do {
+            projectDirectory = try createProjectDirectory(directory, fileManager)
+        } catch {
+            return SessionStartResult(message: L10n.format(
+                "Quick chat folder is unavailable: %@",
+                directoryPath))
+        }
         let provider = provider(rawValue: providerRawValue)
         guard let onSessionAvailable else {
             return await store.startDetached(
                 provider: provider,
-                projectDirectory: directory,
+                projectDirectory: projectDirectory,
                 name: nil,
                 prompt: nil)
         }
@@ -65,7 +92,7 @@ enum QuickChatLaunch {
             defer { launchFinished = true }
             return await store.startDetached(
                 provider: provider,
-                projectDirectory: directory,
+                projectDirectory: projectDirectory,
                 name: nil,
                 prompt: nil)
         }
@@ -86,7 +113,7 @@ enum QuickChatLaunch {
                 in: store.sessions,
                 excluding: existingIDs,
                 provider: provider,
-                projectDirectory: directory) {
+                projectDirectory: projectDirectory) {
                 selectedEarly = true
                 onSessionAvailable(sessionID)
                 break

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -1,11 +1,13 @@
 import AppKit
 import Darwin
+import MetalKit
 import SwiftUI
 import SwiftTerm
 import DetachKit
 
 final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     var onDroppedPaths: ((String) -> Void)?
+    private var didConfigureRealtimeRenderer = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -20,10 +22,39 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard window != nil else { return }
+        configureRealtimeRendererIfNeeded()
         DispatchQueue.main.async { [weak self] in
             guard let self, let window = self.window else { return }
             window.makeFirstResponder(self)
         }
+    }
+
+    func configureRealtimeRendererIfNeeded() {
+        guard !didConfigureRealtimeRenderer else { return }
+        didConfigureRealtimeRenderer = true
+        let enabled = SessionAttachRendering.enableOnDemandMetal {
+            try setUseMetal(true)
+        }
+        if enabled {
+            terminal.setCursorStyle(SessionAttachRendering.steadyCursorStyle(
+                for: terminal.options.cursorStyle))
+        }
+    }
+
+    override func cursorStyleChanged(
+        source: Terminal,
+        newStyle: CursorStyle
+    ) {
+        guard isUsingMetalRenderer else {
+            super.cursorStyleChanged(source: source, newStyle: newStyle)
+            return
+        }
+        let steadyStyle = SessionAttachRendering.steadyCursorStyle(for: newStyle)
+        if steadyStyle.tagName != newStyle.tagName {
+            source.setCursorStyle(steadyStyle)
+            return
+        }
+        super.cursorStyleChanged(source: source, newStyle: steadyStyle)
     }
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
@@ -46,6 +77,53 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         window?.makeFirstResponder(self)
         onDroppedPaths?(text)
         return true
+    }
+}
+
+enum SessionAttachRendering {
+    /// SwiftTerm's Metal view is paused and redraws only on terminal events.
+    /// A renderer failure keeps the default CoreGraphics terminal active.
+    @discardableResult
+    static func enableOnDemandMetal(
+        _ activate: () throws -> Void
+    ) -> Bool {
+        do {
+            try activate()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func steadyCursorStyle(for style: CursorStyle) -> CursorStyle {
+        switch style {
+        case .blinkBlock, .steadyBlock:
+            return .steadyBlock
+        case .blinkUnderline, .steadyUnderline:
+            return .steadyUnderline
+        case .blinkBar, .steadyBar:
+            return .steadyBar
+        }
+    }
+
+    static func isPausedOnDemand(_ view: MTKView) -> Bool {
+        view.isPaused
+            && view.enableSetNeedsDisplay
+            && !view.autoResizeDrawable
+    }
+
+    static func hasEnergyEfficientMetalRenderer(
+        in terminalView: LocalProcessTerminalView
+    ) -> Bool {
+        guard terminalView.isUsingMetalRenderer,
+              let metalView = terminalView.subviews.compactMap({
+                  $0 as? MTKView
+              }).first,
+              isPausedOnDemand(metalView) else {
+            return false
+        }
+        let style = terminalView.terminal.options.cursorStyle
+        return steadyCursorStyle(for: style).tagName == style.tagName
     }
 }
 
@@ -170,7 +248,7 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
 
     func send(_ text: String) {
         let bytes = Array(text.utf8)
-        terminalView?.process.send(data: bytes[...])
+        terminalView?.send(data: bytes[...])
     }
 
     func copySelection(to pasteboard: NSPasteboard = .general) -> String {

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -29,6 +29,7 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         }
     }
 
+// quality-coverage:begin swiftterm-metal
     func configureRealtimeRendererIfNeeded() {
         guard !didConfigureRealtimeRenderer else { return }
         didConfigureRealtimeRenderer = true
@@ -56,6 +57,7 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         }
         super.cursorStyleChanged(source: source, newStyle: steadyStyle)
     }
+// quality-coverage:end swiftterm-metal
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
         acceptedDragOperation(from: sender.draggingPasteboard)
@@ -112,6 +114,7 @@ enum SessionAttachRendering {
             && !view.autoResizeDrawable
     }
 
+// quality-coverage:begin swiftterm-metal
     static func hasEnergyEfficientMetalRenderer(
         in terminalView: LocalProcessTerminalView
     ) -> Bool {
@@ -125,6 +128,7 @@ enum SessionAttachRendering {
         let style = terminalView.terminal.options.cursorStyle
         return steadyCursorStyle(for: style).tagName == style.tagName
     }
+// quality-coverage:end swiftterm-metal
 }
 
 /// Preserves provider shortcuts that must reach the child as conventional

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -2,6 +2,7 @@ import AppKit
 import Darwin
 import DetachKit
 import Foundation
+import SwiftTerm
 
 @MainActor
 enum UIE2EControlFault {
@@ -396,6 +397,16 @@ enum UIE2ETestDriver {
                 find(identifier: "session-preview-terminal") != nil
             }
             checks.append("live-session-hosts-attach-client")
+            try await waitUntil("event-driven terminal renderer", attempts: 80) {
+                guard let terminal = find(
+                    identifier: "session-preview-terminal")
+                    as? LocalProcessTerminalView else {
+                    return false
+                }
+                return SessionAttachRendering
+                    .hasEnergyEfficientMetalRenderer(in: terminal)
+            }
+            checks.append("live-terminal-renders-on-demand")
             try await waitUntil("live terminal input readiness", attempts: 80) {
                 FileManager.default.fileExists(atPath: configuration.root
                     .appendingPathComponent("fake/control-v-ready").path)

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -406,6 +406,18 @@ enum UIE2ETestDriver {
                 return SessionAttachRendering
                     .hasEnergyEfficientMetalRenderer(in: terminal)
             }
+            guard let liveTerminal = find(
+                identifier: "session-preview-terminal")
+                as? LocalProcessTerminalView else {
+                throw Failure(message: "live terminal is not a SwiftTerm view")
+            }
+            liveTerminal.terminal.setCursorStyle(.blinkUnderline)
+            guard liveTerminal.terminal.options.cursorStyle.tagName
+                    == CursorStyle.steadyUnderline.tagName,
+                  SessionAttachRendering.hasEnergyEfficientMetalRenderer(
+                    in: liveTerminal) else {
+                throw Failure(message: "live terminal retained a blinking cursor timer")
+            }
             checks.append("live-terminal-renders-on-demand")
             try await waitUntil("live terminal input readiness", attempts: 80) {
                 FileManager.default.fileExists(atPath: configuration.root

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -103,35 +103,44 @@ public final class SessionStore {
         foreground ? baseInterval : max(baseInterval * 5, 10)
     }
 
-    public func refresh() async {
+    /// Returns this request's valid typed snapshot even when a newer refresh
+    /// owns publication to the shared store.
+    @discardableResult
+    public func refresh() async -> [Session]? {
         refreshGeneration &+= 1
         let generation = refreshGeneration
         let cli = self.cli
         do {
             let result = try await cli.run(arguments: ["list", "--json"], timeout: 5)
-            // Polling, explicit refreshes, and CLI reconfiguration may overlap
-            // while their subprocesses are suspended. Only the latest request
-            // may publish state or notify transition consumers.
-            guard generation == refreshGeneration else { return }
             guard result.exitCode == 0, !result.timedOut else {
-                state = .error(result.timedOut ? L10n.string("detach list timed out")
-                               : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
-                return
+                if generation == refreshGeneration {
+                    state = .error(result.timedOut ? L10n.string("detach list timed out")
+                                   : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+                }
+                return nil
             }
             let parsed = SessionListParser.parse(result.stdout)
             if parsed.hadInvalidLines {
-                state = .incompatible // spec: never update the list from bad data
-                return
+                if generation == refreshGeneration {
+                    state = .incompatible // spec: never update the list from bad data
+                }
+                return nil
             }
-            sessions = parsed.sessions.sorted {
+            let snapshot = parsed.sessions.sorted {
                 ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
             }
+            // Polling, explicit refreshes, and CLI reconfiguration may overlap
+            // while their subprocesses are suspended. Only the latest request
+            // may publish state or notify transition consumers.
+            guard generation == refreshGeneration else { return snapshot }
+            sessions = snapshot
             lastUpdated = Date()
             state = .ok
             if let onSnapshot { await onSnapshot(sessions) }
+            return snapshot
         } catch {
-            guard generation == refreshGeneration else { return }
-            state = .cliMissing
+            if generation == refreshGeneration { state = .cliMissing }
+            return nil
         }
     }
 
@@ -185,9 +194,9 @@ public final class SessionStore {
                     : stderr)
             }
 
-            await refresh()
+            let refreshedSessions = await refresh() ?? sessions
             let projectPath = Self.canonicalProjectPath(projectDirectory.path)
-            let candidates = sessions.filter {
+            let candidates = refreshedSessions.filter {
                 !existingIDs.contains($0.id)
                     && $0.provider == provider
                     && $0.projectDir.map(Self.canonicalProjectPath) == projectPath

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -106,7 +106,7 @@ public final class SessionStore {
     /// Returns this request's valid typed snapshot even when a newer refresh
     /// owns publication to the shared store.
     @discardableResult
-    public func refresh() async -> [Session]? {
+    public func refresh() async -> [Session] {
         refreshGeneration &+= 1
         let generation = refreshGeneration
         let cli = self.cli
@@ -117,14 +117,14 @@ public final class SessionStore {
                     state = .error(result.timedOut ? L10n.string("detach list timed out")
                                    : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
                 }
-                return nil
+                return []
             }
             let parsed = SessionListParser.parse(result.stdout)
             if parsed.hadInvalidLines {
                 if generation == refreshGeneration {
                     state = .incompatible // spec: never update the list from bad data
                 }
-                return nil
+                return []
             }
             let snapshot = parsed.sessions.sorted {
                 ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
@@ -140,7 +140,7 @@ public final class SessionStore {
             return snapshot
         } catch {
             if generation == refreshGeneration { state = .cliMissing }
-            return nil
+            return []
         }
     }
 
@@ -194,7 +194,7 @@ public final class SessionStore {
                     : stderr)
             }
 
-            let refreshedSessions = await refresh() ?? sessions
+            let refreshedSessions = await refresh()
             let projectPath = Self.canonicalProjectPath(projectDirectory.path)
             let candidates = refreshedSessions.filter {
                 !existingIDs.contains($0.id)

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -30,6 +30,26 @@ final class QuickChatTests: XCTestCase {
             fallback)
     }
 
+    func testQuickChatCreatesDistinctPrivateProjectDirectories() throws {
+        let parent = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-quick-chat-test-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: parent) }
+
+        let first = try QuickChatProjectDirectory.create(inside: parent)
+        let second = try QuickChatProjectDirectory.create(inside: parent)
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertEqual(first.deletingLastPathComponent(), parent.standardizedFileURL)
+        XCTAssertTrue(first.lastPathComponent.hasPrefix("detach-chat-"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.path))
+        let attributes = try FileManager.default.attributesOfItem(atPath: first.path)
+        XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, NSNumber(value: 0o700))
+    }
+
     func testQuickChatUsesConfiguredProviderAndWorkingDirectory() async {
         let directory = try! XCTUnwrap(
             DirectoryPreference.existingDirectoryURL(path: "/tmp"))
@@ -44,7 +64,8 @@ final class QuickChatTests: XCTestCase {
         let result = await QuickChatLaunch.start(
             store: store,
             providerRawValue: Provider.codex.rawValue,
-            directoryPath: "/tmp")
+            directoryPath: "/tmp",
+            createProjectDirectory: { directory, _ in directory })
 
         XCTAssertEqual(result.sessionID, "detach-codex-tmp-1")
         XCTAssertNil(result.message)
@@ -53,6 +74,52 @@ final class QuickChatTests: XCTestCase {
             ["list", "--json"],
         ])
         XCTAssertEqual(cli.calls.first?.currentDirectory?.path, directory.path)
+    }
+
+    func testRepeatedQuickChatsUseDistinctProjectDirectories() async throws {
+        let parent = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-repeated-chat-test-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let firstProject = try QuickChatProjectDirectory.create(inside: parent)
+        let secondProject = try QuickChatProjectDirectory.create(inside: parent)
+        let cli = QuickChatRecordingCLI()
+        let store = SessionStore(cli: cli)
+
+        func line(id: String, project: URL) -> String {
+            #"{"schema":1,"provider":"codex","session_name":"\#(id)","name":"Quick","effective_status":"running","project_dir":"\#(project.path)"}"#
+        }
+        cli.responses["list --json"] = CLIResult(
+            exitCode: 0,
+            stdout: line(id: "detach-codex-quick-1", project: firstProject),
+            stderr: "",
+            timedOut: false)
+        let first = await QuickChatLaunch.start(
+            store: store,
+            providerRawValue: Provider.codex.rawValue,
+            directoryPath: parent.path,
+            createProjectDirectory: { _, _ in firstProject })
+
+        cli.responses["list --json"] = CLIResult(
+            exitCode: 0,
+            stdout: line(id: "detach-codex-quick-2", project: secondProject),
+            stderr: "",
+            timedOut: false)
+        let second = await QuickChatLaunch.start(
+            store: store,
+            providerRawValue: Provider.codex.rawValue,
+            directoryPath: parent.path,
+            createProjectDirectory: { _, _ in secondProject })
+
+        XCTAssertEqual(first.sessionID, "detach-codex-quick-1")
+        XCTAssertEqual(second.sessionID, "detach-codex-quick-2")
+        XCTAssertEqual(
+            cli.calls.filter { $0.arguments == ["codex", "--detach"] }
+                .compactMap(\.currentDirectory),
+            [firstProject, secondProject])
     }
 
     func testQuickChatSelectsTheTypedStartingSessionBeforeLaunchFinishes() async {
@@ -73,6 +140,7 @@ final class QuickChatTests: XCTestCase {
                     selectedID = sessionID
                     selected.fulfill()
                 },
+                createProjectDirectory: { directory, _ in directory },
                 discoverySleep: { _ in
                     await cli.waitUntilStartBegan()
                 })
@@ -104,6 +172,7 @@ final class QuickChatTests: XCTestCase {
                 providerRawValue: Provider.codex.rawValue,
                 directoryPath: "/tmp",
                 onSessionAvailable: { _ in selected.fulfill() },
+                createProjectDirectory: { directory, _ in directory },
                 discoverySleep: { _ in
                     await cli.waitUntilStartBegan()
                 })
@@ -130,6 +199,20 @@ final class QuickChatTests: XCTestCase {
         XCTAssertEqual(
             result.message,
             L10n.format("Quick chat folder is unavailable: %@", missing))
+        XCTAssertTrue(cli.calls.isEmpty)
+    }
+
+    func testQuickChatReportsProjectDirectoryCreationFailure() async {
+        enum Failure: Error { case denied }
+        let cli = QuickChatRecordingCLI()
+
+        let result = await QuickChatLaunch.start(
+            store: SessionStore(cli: cli),
+            providerRawValue: Provider.codex.rawValue,
+            directoryPath: "/tmp",
+            createProjectDirectory: { _, _ in throw Failure.denied })
+
+        XCTAssertNotNil(result.message)
         XCTAssertTrue(cli.calls.isEmpty)
     }
 

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Darwin
+import MetalKit
 import SwiftUI
 import XCTest
 import SwiftTerm
@@ -305,6 +306,41 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertTrue(terminal.acceptDroppedPaths(from: filePasteboard))
         XCTAssertEqual(insertedText, "'/tmp/Project File/image.png' ")
         XCTAssertTrue(window.firstResponder === terminal)
+    }
+
+    func testRealtimeRendererRequiresPausedOnDemandMetal() {
+        let view = MTKView(frame: .zero)
+        view.isPaused = true
+        view.enableSetNeedsDisplay = true
+        view.autoResizeDrawable = false
+        XCTAssertTrue(SessionAttachRendering.isPausedOnDemand(view))
+
+        view.isPaused = false
+        XCTAssertFalse(SessionAttachRendering.isPausedOnDemand(view))
+    }
+
+    func testRealtimeRendererUsesSteadyCursorVariants() {
+        let mappings: [(CursorStyle, String)] = [
+            (.blinkBlock, CursorStyle.steadyBlock.tagName),
+            (.steadyBlock, CursorStyle.steadyBlock.tagName),
+            (.blinkUnderline, CursorStyle.steadyUnderline.tagName),
+            (.steadyUnderline, CursorStyle.steadyUnderline.tagName),
+            (.blinkBar, CursorStyle.steadyBar.tagName),
+            (.steadyBar, CursorStyle.steadyBar.tagName),
+        ]
+        for (input, expected) in mappings {
+            XCTAssertEqual(
+                SessionAttachRendering.steadyCursorStyle(for: input).tagName,
+                expected)
+        }
+    }
+
+    func testRealtimeRendererFailureKeepsTheFallbackAvailable() {
+        enum Failure: Error { case unavailable }
+        XCTAssertFalse(SessionAttachRendering.enableOnDemandMetal {
+            throw Failure.unavailable
+        })
+        XCTAssertTrue(SessionAttachRendering.enableOnDemandMetal {})
     }
 
     func testDroppedPathNeverInsertsAControlCharacter() {

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -343,6 +343,18 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertTrue(SessionAttachRendering.enableOnDemandMetal {})
     }
 
+    @MainActor
+    func testRealtimeRendererKeepsTheCoreGraphicsTerminalInteractive() {
+        let terminal = SessionAttachLocalProcessTerminalView(frame: .zero)
+
+        XCTAssertFalse(
+            SessionAttachRendering.hasEnergyEfficientMetalRenderer(in: terminal))
+        terminal.cursorStyleChanged(
+            source: terminal.terminal,
+            newStyle: .steadyBlock)
+        XCTAssertFalse(terminal.isUsingMetalRenderer)
+    }
+
     func testDroppedPathNeverInsertsAControlCharacter() {
         XCTAssertEqual(
             SessionAttachDroppedPaths.shellEscaped("/tmp/line\nbreak.txt"),

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -57,6 +57,46 @@ private actor DelayedCLI: DetachCLIRunning {
     }
 }
 
+private actor OverlappingStartCLI: DetachCLIRunning {
+    private let listOutput: String
+    private var listCallCount = 0
+    private var listContinuations: [Int: CheckedContinuation<CLIResult, Never>] = [:]
+    private var listWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(listOutput: String) {
+        self.listOutput = listOutput
+    }
+
+    func run(
+        arguments: [String], timeout: TimeInterval
+    ) async throws -> CLIResult {
+        guard arguments == ["list", "--json"] else {
+            return CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
+        }
+        listCallCount += 1
+        let call = listCallCount
+        let ready = listWaiters.filter { $0.0 <= call }
+        listWaiters.removeAll { $0.0 <= call }
+        ready.forEach { $0.1.resume() }
+        return await withCheckedContinuation { continuation in
+            listContinuations[call] = continuation
+        }
+    }
+
+    func waitForListCall(_ call: Int) async {
+        if listCallCount >= call { return }
+        await withCheckedContinuation { listWaiters.append((call, $0)) }
+    }
+
+    func finishListCall(_ call: Int) {
+        listContinuations.removeValue(forKey: call)?.resume(returning: CLIResult(
+            exitCode: 0,
+            stdout: listOutput,
+            stderr: "",
+            timedOut: false))
+    }
+}
+
 private actor PollSleepProbe {
     private(set) var intervals: [UInt64] = []
     private var startedWaiters: [CheckedContinuation<Void, Never>] = []
@@ -231,6 +271,31 @@ final class SessionStoreTests: XCTestCase {
             ])
         XCTAssertEqual(cli.currentDirectories, [project])
         XCTAssertEqual(result, SessionStartResult(sessionID: "detach-codex-p-1"))
+    }
+
+    func testStartDetachedKeepsItsSelectionWhenABackgroundPollSupersedesPublication() async {
+        let cli = OverlappingStartCLI(listOutput: line)
+        let store = SessionStore(cli: cli)
+        let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
+
+        let launch = Task { @MainActor in
+            await store.startDetached(
+                provider: .codex,
+                projectDirectory: project,
+                name: nil,
+                prompt: nil)
+        }
+        await cli.waitForListCall(1)
+        let backgroundPoll = Task { @MainActor in await store.refresh() }
+        await cli.waitForListCall(2)
+
+        await cli.finishListCall(1)
+        let result = await launch.value
+        await cli.finishListCall(2)
+        _ = await backgroundPoll.value
+
+        XCTAssertEqual(result.sessionID, "detach-codex-p-1")
+        XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
     }
 
     func testStartDetachedKeepsFailuresAndTimeoutsInTheCaller() async {
@@ -670,7 +735,7 @@ final class SessionStoreTests: XCTestCase {
         await store.configure(cli: second)
         await first.finish(with: CLIResult(
             exitCode: 0, stdout: line, stderr: "", timedOut: false))
-        await staleRefresh.value
+        _ = await staleRefresh.value
 
         XCTAssertEqual(store.sessions, [])
         XCTAssertEqual(store.state, .ok)

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -164,11 +164,11 @@ Reconnect. The external terminal stays a `.command` fallback.
 New session accepts an optional printable UTF-8 name of at most 100 bytes
 and rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.
-Command-N opens New session in main. Its chooser starts at the configured project
-folder or the selection's parent. Command-T uses the configured provider and
-creates a private 0700 `detach-chat-<UUID>` project under the configured folder
-(`/tmp` default). It selects the `starting` session before runtime checks
-finish. Invalid folders block launch.
+Command-N opens New session. Its chooser starts at the default project or the
+selection's parent. Command-T starts the chosen provider in a private 0700
+`detach-chat-<UUID>` directory in the quick-chat folder (`/tmp` default). It
+selects the typed `starting` session despite an overlapping poll, before runtime
+readiness. Invalid folders block launch.
 Command-1 through Command-9 open main and select numbered Working or Answer
 ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -151,24 +151,24 @@ user-specific path. Native power protection requires no Apple Events or
 Automation entitlement.
 
 Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
-App Start runs the provider with `--detach` in its project, keeps an error in
-the sheet, refreshes state, and selects one unambiguous new
-session. Start, Resume, and Recover attach through an ephemeral PTY on
-`detach <provider> attach <session>`. Closing the view or app ends that client.
-In a focused terminal, `Command-C/V/F` stay native copy, text paste, and find in
-extended keyboard mode. `Ctrl-V` reaches provider image paste. A Finder file
-drop sends shell-safe absolute paths without reading files. Detach
-stores no images or dropped files. Live views move typed Mac Power to metadata
-and omit the duplicate strip. An exited client offers Reconnect without an
-agent restart. The selected terminal remains an `NSWorkspace` `.command`
-fallback.
+App Start uses `--detach`, keeps sheet errors, and selects one new session.
+Start, Resume, and Recover use an ephemeral PTY on
+`detach <provider> attach <session>`. Closing its view ends the client.
+Terminal I/O is event-driven. Paused Metal redraws changes with a steady
+cursor and no timer. Failure keeps CoreGraphics. No poller or continuous frame
+loop runs. In a focused terminal, `Command-C/V/F`
+stay native copy, paste, and find. `Ctrl-V` reaches provider image paste. A
+Finder drop sends shell-safe paths without reading or storing files. Live views
+move typed Mac Power to metadata and omit its strip. An exited client offers
+Reconnect. The external terminal stays a `.command` fallback.
 New session accepts an optional printable UTF-8 name of at most 100 bytes
 and rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.
 Command-N opens New session in main. Its chooser starts at the configured project
-folder or the selection's parent. Command-T opens Quick Chat with the
-configured provider and folder (`/tmp` default). It selects the
-`starting` session before runtime checks finish. Invalid folders block launch.
+folder or the selection's parent. Command-T uses the configured provider and
+creates a private 0700 `detach-chat-<UUID>` project under the configured folder
+(`/tmp` default). It selects the `starting` session before runtime checks
+finish. Invalid folders block launch.
 Command-1 through Command-9 open main and select numbered Working or Answer
 ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -40,7 +40,8 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   fi
   quick=''
   if [ -f "$ROOT/fake/quick-chat-started" ]; then
-    quick='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-quick","name":"UI Quick","effective_status":"running","created_at":"2026-08-29T10:01:00Z","project_dir":"/private/tmp","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}'
+    quick_cwd="$(<"$ROOT/fake/quick-chat-cwd")"
+    quick="$(printf '{\"schema\":1,\"provider\":\"codex\",\"session_name\":\"detach-codex-ui-quick\",\"name\":\"UI Quick\",\"effective_status\":\"running\",\"created_at\":\"2026-08-29T10:01:00Z\",\"project_dir\":\"%s\",\"session_color\":\"#36C5F0\",\"power_protection_state\":\"protected\",\"health_actions\":[\"attach\",\"stop\"]}' "$quick_cwd")"
   fi
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}' \
@@ -124,10 +125,16 @@ if [ "$#" -eq 2 ] && [ "$1" = claude ] && [ "$2" = --detach ]; then
 fi
 
 if [ "$#" -eq 2 ] && [ "$1" = codex ] && [ "$2" = --detach ]; then
-  [ "$(pwd -P)" = /private/tmp ] || {
-    printf 'quick chat started outside /tmp\n' >&2
+  quick_cwd="$(pwd -P)"
+  case "$quick_cwd" in
+    /private/tmp/detach-chat-*) ;;
+    *) printf 'quick chat did not use an isolated /tmp project\n' >&2; exit 65 ;;
+  esac
+  [ "$(stat -f '%Lp' "$quick_cwd")" = 700 ] || {
+    printf 'quick chat project is not private\n' >&2
     exit 65
   }
+  printf '%s\n' "$quick_cwd" >"$ROOT/fake/quick-chat-cwd"
   : >"$ROOT/fake/quick-chat-started"
   printf '%s\n' "$*" >>"$ACTIONS"
   exit 0

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -307,6 +307,7 @@ run_app_scenario() {
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
       finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
       live-session-hosts-attach-client|\
+      live-terminal-renders-on-demand|\
       live-terminal-routes-control-v|\
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
@@ -359,6 +360,7 @@ run_app_scenario main sessions 32 \
   resume-runs-in-app-with-terminal-fallback \
   session-shortcut-selects-assigned-session \
   live-session-hosts-attach-client \
+  live-terminal-renders-on-demand \
   live-terminal-routes-control-v \
   session-signals-stay-distinct \
   disconnected-stop-blocks-action \


### PR DESCRIPTION
## Contract delta

- Each Quick Chat creates a private 0700 detach-chat UUID project under its configured parent folder. Repeated chats no longer collide on the runtime single-live-project gate.
- Live terminals use paused, on-demand Metal rendering with a steady cursor, so idle sessions have no renderer loop. Metal initialization failure keeps CoreGraphics.
- Programmatic path insertion now uses the same SwiftTerm input path as typing, which preserves immediate echo handling.
- README and the app contract describe the new behavior.

## Evidence

- QuickChatTests: 14 passed across focused runs, including distinct repeated project directories and creation failure.
- SessionAttachTerminalTests: 21 passed, including PTY round trip, drop, keyboard, resize, teardown, renderer policy, and fallback.
- Impact diagnostic functional stages passed: static, Swift (923 tests), packaged app, UI E2E, quality contracts, and tmux runtime.
- Packaged UI E2E proves paused on-demand Metal, steady cursor, PTY input, and the private Quick Chat directory contract.
- git diff --check and documentation contracts passed.

The local reference-machine release budget reported Swift at 26 seconds over its 20-second limit. Tests took 13.3 seconds and incremental build/link took 10.9 seconds. The unrelated Settings source invalidation was removed. The run was not repeated unchanged for a warm-cache pass. Hosted PR quality-gates omit this local timing budget and remain readiness authority.

Real power, signing, notarization, and publication gates were not run.