### PR TITLE
Fix Quick Chat UI fixture JSON

### DIFF
--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -41,7 +41,7 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   quick=''
   if [ -f "$ROOT/fake/quick-chat-started" ]; then
     quick_cwd="$(<"$ROOT/fake/quick-chat-cwd")"
-    quick="$(printf '{\"schema\":1,\"provider\":\"codex\",\"session_name\":\"detach-codex-ui-quick\",\"name\":\"UI Quick\",\"effective_status\":\"running\",\"created_at\":\"2026-08-29T10:01:00Z\",\"project_dir\":\"%s\",\"session_color\":\"#36C5F0\",\"power_protection_state\":\"protected\",\"health_actions\":[\"attach\",\"stop\"]}' "$quick_cwd")"
+    quick="$(printf '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-quick","name":"UI Quick","effective_status":"running","created_at":"2026-08-29T10:01:00Z","project_dir":"%s","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}' "$quick_cwd")"
   fi
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}' \

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -6,6 +6,7 @@ ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 APP="$ROOT/app/build/Detach.app"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/detach-ui-e2e-contract.XXXXXX")"
 FAKE_ROOT=""
+FAKE_QUICK_ROOT=""
 
 cleanup() {
   case "$TMP_ROOT" in
@@ -13,6 +14,9 @@ cleanup() {
   esac
   case "$FAKE_ROOT" in
     /private/tmp/detach-ui-e2e.contract.*) rm -rf "$FAKE_ROOT" ;;
+  esac
+  case "$FAKE_QUICK_ROOT" in
+    /private/tmp/detach-chat-contract.*) rm -rf "$FAKE_QUICK_ROOT" ;;
   esac
 }
 trap cleanup EXIT
@@ -95,6 +99,19 @@ if run_fake config tmux-style detach >/dev/null 2>&1; then
   printf 'Fake UI CLI accepted a Settings mutation\n' >&2
   exit 1
 fi
+
+FAKE_QUICK_ROOT="$(mktemp -d /private/tmp/detach-chat-contract.XXXXXX)"
+chmod 0700 "$FAKE_QUICK_ROOT"
+(
+  cd "$FAKE_QUICK_ROOT"
+  run_fake codex --detach
+)
+printf 'sessions\n' >"$FAKE_STATE"
+quick_json="$(run_fake list --json | tail -n 1)"
+[ "$(printf '%s\n' "$quick_json" \
+  | plutil -extract session_name raw -o - -)" = detach-codex-ui-quick ]
+[ "$(printf '%s\n' "$quick_json" \
+  | plutil -extract project_dir raw -o - -)" = "$FAKE_QUICK_ROOT" ]
 
 mkdir -p "$TMP_ROOT/mismatch.app/Contents/MacOS" \
   "$TMP_ROOT/mismatch.app/Contents/Resources"


### PR DESCRIPTION
## Contract delta

- Emit the Quick Chat fake session as valid JSONL after an isolated temporary project starts.
- Keep the product behavior unchanged. This removes a false packaged-UI release failure.

## Durable regression

- The UI E2E contract now starts the fake Quick Chat in a private /private/tmp/detach-chat-* directory.
- It parses the emitted session and verifies its session name and exact project directory.

## Evidence

- tests/ui-e2e-contract.sh
- tests/ui-e2e.sh: packaged main and onboarding journeys pass
- scripts/quality-gate: local diagnostic PASS (static, app, ui-e2e, release-budget)
- git diff --check