### PR TITLE
Keep the Resume checkpoint until the new run is ready

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -3863,7 +3863,7 @@ resume_agent_session() {
       restore_matching_claude_checkpoint "$session" "$id" "$rollout" || \
         die "could not restore the matching Claude checkpoint"
       start_under_project_lock "$session" "$cwd" "$display_name" \
-        "$id" "$rollout" 0 resume "$id" "$@" || \
+        "$id" "$rollout" 1 resume "$id" "$@" || \
         die "could not start Claude resume session"
     elif claude_matching_checkpoint_exists "$session" "$id"; then
       [ -n "$rollout" ] && safe_claude_transcript_path "$rollout" "$id" || \
@@ -3873,7 +3873,7 @@ resume_agent_session() {
       valid_claude_transcript "$rollout" "$id" || \
         die "Claude transcript for '$id' is missing or invalid"
       start_under_project_lock "$session" "$cwd" "$display_name" \
-        "$id" "$rollout" 0 resume "$id" "$@" || \
+        "$id" "$rollout" 1 resume "$id" "$@" || \
         die "could not start Claude resume session"
     elif [ "$saved_id" = "$id" ]; then
       # Detach owns this UUID. Claude never wrote a transcript, and no
@@ -3901,7 +3901,7 @@ resume_agent_session() {
   valid_jsonl "$rollout" "$id" || die "Codex rollout for '$id' is missing or invalid"
 
   start_under_project_lock "$session" "$cwd" "$display_name" \
-    "$id" "$rollout" 0 resume "$id" "$@" || \
+    "$id" "$rollout" 1 resume "$id" "$@" || \
     die "could not start Codex resume session"
   [ "$detach" -eq 1 ] || attach_session "$session"
 }

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -155,8 +155,9 @@ without a state directory and never reports success over leftover state.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
-session. They do not promise survival across logout or reboot; an explicit
-kill of tmux/provider ends the live run. Recovery checkpoints remain available.
+session. They do not promise survival across logout or reboot. A kill of
+tmux or provider ends the live run. Resume keeps the last
+checkpoint until the new run is ready.
 Provider test parts need private state, socket, and artifact roots; their
 parent orders events and requires every part. Small hosts reuse lifecycle
 checkpoints in three Codex and two Claude parts; larger hosts use finer parts.

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -679,6 +679,20 @@ grep -Fx "release --session $session --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
 claude_scenario_event pass SC-SESSION-STOP-CLAUDE
 
+[ -s "$checkpoint/transcript.jsonl" ]
+resume_checkpoint_before="$(cksum "$checkpoint/transcript.jsonl")"
+if FAKE_POWER_FAIL_RUN=1 \
+  "$SCRIPT" resume --detach "$session_id"; then
+  printf 'resume unexpectedly passed a failed worker readiness handshake\n' >&2
+  exit 1
+fi
+[ -s "$checkpoint/transcript.jsonl" ] || {
+  printf 'failed resume deleted the last Claude checkpoint transcript\n' >&2
+  exit 1
+}
+[ "$(cksum "$checkpoint/transcript.jsonl")" = "$resume_checkpoint_before" ]
+! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+
 if [ "$CLAUDE_TEST_PART" = lifecycle ]; then
   "$SCRIPT" claude delete --force "$human_label"
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1130,12 +1130,28 @@ if [ "$CODEX_TEST_PART" = resume ] || [ "$CODEX_TEST_PART" = resume-identity ]; 
   bootstrap_codex_checkpoint
 fi
 
-# Explicit resume follows Codex semantics and accepts the exact thread UUID.
+# A failed power handshake must not delete the last Resume checkpoint.
 export FAKE_CODEX_INIT_DELAY=0
 export FAKE_CODEX_SLEEP=1
 expected_rollout="$("$STATE_HELPER" meta get "$meta" transcript_path)"
 [ -n "$expected_rollout" ]
 [ -f "$expected_rollout" ]
+[ -s "$checkpoint/rollout.jsonl" ] || cp -p "$expected_rollout" "$checkpoint/rollout.jsonl"
+[ -s "$checkpoint/rollout.jsonl" ]
+resume_checkpoint_before="$(cksum "$checkpoint/rollout.jsonl")"
+if FAKE_POWER_FAIL_RUN=1 \
+  "$DETACH" resume --name integration --detach "$expected_id"; then
+  printf 'resume unexpectedly passed a failed worker readiness handshake\n' >&2
+  exit 1
+fi
+[ -s "$checkpoint/rollout.jsonl" ] || {
+  printf 'failed resume deleted the last checkpoint rollout\n' >&2
+  exit 1
+}
+[ "$(cksum "$checkpoint/rollout.jsonl")" = "$resume_checkpoint_before" ]
+! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
+
+# Explicit resume follows Codex semantics and accepts the exact thread UUID.
 cp -p "$expected_rollout" "$checkpoint/rollout.jsonl"
 printf '{damaged rollout\n' >"$expected_rollout"
 uppercase_id="$(printf '%s' "$expected_id" | tr '[:lower:]' '[:upper:]')"


### PR DESCRIPTION
Fixes #178.

## Contract delta

- MODIFIED (`docs/specs/runtime.md`): Resume keeps the last Detach checkpoint until the new run is ready. A failed power handshake must not delete it.
- Start of a new thread still clears the previous run's checkpoint.
- Recover is unchanged (`preserve_checkpoint=1`).

## Durable decisions

- Resume now passes `preserve_checkpoint=1` into `write_initial_meta`, same as Recover. The live `meta.json` still starts with a null checkpoint timestamp, so health does not inherit the old run's epoch.
- A Claude Resume that has no transcript and no matching checkpoint stays a fresh start (`preserve_checkpoint=0`).

## Acceptance evidence

- Codex: `tests/run.sh` resume part plants `checkpoint/rollout.jsonl`, fails Resume with `FAKE_POWER_FAIL_RUN=1`, and requires the file checksum to stay.
- Claude: `tests/run-claude.sh` lifecycle does the same for `checkpoint/transcript.jsonl` after Stop.
- `tests/docs-contract.sh` passed. `runtime.md` is 12285 / 12288 bytes.
- `bash -n` passed on `bin/detach-core`, `tests/run.sh`, and `tests/run-claude.sh`.
- Hosted `quality-gates` is readiness authority. This host is macOS 15.7 and cannot run the macOS 26 `detach-state` binary, so the Codex/Claude integration parts were not executed here.

## Test plan

- [ ] Hosted `quality-gates` selects the runtime / Codex / Claude lanes
- [ ] Codex resume part keeps the checkpoint on a failed handshake
- [ ] Claude lifecycle part keeps the checkpoint on a failed handshake
- [ ] Fresh Start with the same name still clears the previous checkpoint
- [ ] Closed-lid and signing gates are not claimed

Made with [Cursor](https://cursor.com)