### PR TITLE
Harden event-driven session reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ not be the weak link.
 - **See what needs you now.** Sessions that wait for a reply move into
   **Answer ready**. Notifications and the menu bar show when a turn finishes,
   fails, or becomes recoverable.
+- **Get changes without a refresh delay.** Native filesystem events wake the
+  dashboard when lifecycle or provider turn data changes. Detach does not run
+  a repeating session-list timer while nothing changes.
 - **Return the correct way.** Attach to a live process, Resume a provider
   conversation, or Recover an interrupted Detach run from a validated local
   checkpoint.
@@ -146,14 +149,21 @@ The live terminal processes PTY input and output as events. Its on-demand GPU
 renderer repaints only when content changes. A steady cursor avoids an idle
 redraw timer. If Metal is unavailable, Detach keeps the CoreGraphics renderer.
 
+The dashboard also updates from events. Detach coalesces a provider transcript
+burst into one update at the start and one after output becomes quiet. Each
+event reads a complete typed session list. A dropped event or app activation
+causes a full resync. There is no Refresh interval setting and no periodic
+session-list process while state is idle.
+
 <details>
 <summary><strong>How a new in-app session starts</strong></summary>
 
-Detach runs the CLI with `--detach` in the selected project and refreshes the
-session list. When it finds one new matching session, it selects the session
-and opens the embedded terminal. A start error stays in the sheet so that you
-can correct it. Terminal, iTerm2, Warp, or another configured shell runner
-remains available from the named fallback button.
+Detach runs the CLI with `--detach` in the selected project. It waits for the
+event-driven typed session source. When one new matching `starting` session
+appears, Detach selects it and opens the embedded terminal before the full
+readiness check ends. A start error stays in the sheet so that you can correct
+it. Terminal, iTerm2, Warp, or another configured shell runner remains
+available from the named fallback button.
 
 </details>
 
@@ -422,6 +432,7 @@ detach claude --name "Rev (ai)" -- "review the repository"
 # Monitor and return.
 detach list
 detach list --json
+detach watch --json
 detach claude attach review
 detach resume SESSION_UUID
 
@@ -436,6 +447,7 @@ detach reconcile --dry-run --json
 | `detach <provider> [start]` | Start a fresh conversation for the current project. |
 | `detach <provider> attach [name]` | Attach to a live managed session. |
 | `detach list [--json]` | List Codex and Claude sessions together. JSON mode emits JSONL. |
+| `detach watch --json` | Stream typed `ready`, `changed`, and `resync` hints for session consumers. Read `list --json` after each hint. |
 | `detach resume <uuid>` | Detect the provider and project, then continue the conversation. An owned Claude session without a transcript restarts with the same UUID. |
 | `detach <provider> status [name]` | Show runtime, checkpoint, and power state. |
 | `detach <provider> logs [--ansi] [name]` | Read retained output without attaching. |
@@ -458,6 +470,7 @@ For automation and diagnosis:
 
 ```bash
 detach list --json
+detach watch --json
 detach reconcile --dry-run --json
 detach cleanup --dry-run --json
 ```

--- a/README.md
+++ b/README.md
@@ -145,15 +145,33 @@ Start, Resume, and Recover run inside Detach and do not require an outer
 terminal. The selected external terminal remains available as a fallback for
 Attach, Resume, and Recover.
 
-The live terminal processes PTY input and output as events. Its on-demand GPU
-renderer repaints only when content changes. A steady cursor avoids an idle
-redraw timer. If Metal is unavailable, Detach keeps the CoreGraphics renderer.
+The live terminal processes PTY input and output as events. Its stable
+CoreGraphics renderer repaints only when content changes. A steady cursor
+avoids an idle redraw timer. Switching between live sessions keeps the same
+terminal and PTY. tmux synchronized output replaces the complete frame at once.
+
+Detach preloads the last text screen for up to nine live sessions in a small
+bounded burst. A cold attachment can show that text until its first frame. It
+does not keep hidden PTYs alive or use raster snapshots during live switching.
+
+Detach preloads recent non-live session logs in a bounded startup burst. This
+includes finished and recoverable sessions. Switching to a cached result shows
+its content immediately. Reopening unchanged content starts no new process.
+
+The dashboard also keeps a small private copy of the last valid session list.
+It can paint that list on the first app frame while Detach reads current state.
+Cached rows cannot Stop, Resume, Recover, or Delete a session. Those controls
+return only after the current typed state proves that they are safe.
 
 The dashboard also updates from events. Detach coalesces a provider transcript
 burst into one update at the start and one after output becomes quiet. Each
 event reads a complete typed session list. A dropped event or app activation
 causes a full resync. There is no Refresh interval setting and no periodic
 session-list process while state is idle.
+
+Power status is event-driven too. An atomic watchdog report wakes the app
+immediately. One deadline marks a silent report stale. The menu bar, Settings,
+and notifications do not poll the same file on repeating timers.
 
 <details>
 <summary><strong>How a new in-app session starts</strong></summary>

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ not be the weak link.
 - **See what needs you now.** Sessions that wait for a reply move into
   **Answer ready**. Notifications and the menu bar show when a turn finishes,
   fails, or becomes recoverable.
-- **Get changes without a refresh delay.** Native filesystem events wake the
-  dashboard when lifecycle or provider turn data changes. Detach does not run
-  a repeating session-list timer while nothing changes.
+- **Update only when state changes.** Native filesystem events trigger a
+  dashboard refresh for lifecycle and provider turn changes. Detach does not
+  run a repeating session-list timer while nothing changes.
 - **Return the correct way.** Attach to a live process, Resume a provider
   conversation, or Recover an interrupted Detach run from a validated local
   checkpoint.
@@ -167,10 +167,12 @@ The dashboard also updates from events. Detach coalesces a provider transcript
 burst into one update at the start and one after output becomes quiet. Each
 event reads a complete typed session list. A dropped event or app activation
 causes a full resync. There is no Refresh interval setting and no periodic
-session-list process while state is idle.
+session-list process while state is idle. Unchanged transcript summaries use a
+private file-identity cache, so consecutive event refreshes do not reread every
+retained transcript tail.
 
-Power status is event-driven too. An atomic watchdog report wakes the app
-immediately. One deadline marks a silent report stale. The menu bar, Settings,
+Power status is event-driven too. An atomic watchdog report wakes the app when
+it changes. One deadline marks a silent report stale. The menu bar, Settings,
 and notifications do not poll the same file on repeating timers.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -295,6 +295,9 @@ Stop, Recover, Delete, and bulk cleanup until that exact runtime is gone. It
 never signals or removes foreign processes and unmanaged tmux sessions.
 Concurrent Stop, Recover, and Delete requests are serialized per session and
 recheck ownership immediately before mutation.
+Stop gives a live provider its full termination grace. After that provider
+exits, Detach gives its worker a short final-checkpoint grace, then ends the
+exact run. Resume and Delete stay unavailable until the worker is gone.
 
 <details>
 <summary><strong>Checkpoint and recovery rules</strong></summary>

--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ detach reconcile --dry-run --json
 | `detach <provider> attach [name]` | Attach to a live managed session. |
 | `detach list [--json]` | List Codex and Claude sessions together. JSON mode emits JSONL. |
 | `detach watch --json` | Stream typed `ready`, `changed`, and `resync` hints for session consumers. Read `list --json` after each hint. |
+| `detach client switch --pid PID --from SESSION --to SESSION --provider PROVIDER` | Retarget one attached tmux client that you own to another live managed session. The app uses it for in-place switching. |
 | `detach resume <uuid>` | Detect the provider and project, then continue the conversation. An owned Claude session without a transcript restarts with the same UUID. |
 | `detach <provider> status [name]` | Show runtime, checkpoint, and power state. |
 | `detach <provider> logs [--ansi] [name]` | Read retained output without attaching. |

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -153,7 +153,6 @@
 "Recover" = "Recover";
 "Reconnect" = "Reconnect";
 "Recover in %@" = "Recover in %@";
-"Refresh interval" = "Refresh interval";
 "Refresh terminal list" = "Refresh terminal list";
 "Reinstall command-line tools" = "Reinstall command-line tools";
 "Remove everything, including checkpoints…" = "Remove everything, including checkpoints…";
@@ -278,7 +277,6 @@
 "Text size preview" = "Text size preview";
 "Apply" = "Apply";
 "%d pt" = "%d pt";
-"%d sec" = "%d sec";
 "Command line" = "Command line";
 "Answer ready · 2 min ago" = "Answer ready · 2 min ago";
 "tmux status line" = "tmux status line";

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 
 /* DetachKit errors */
 "detach list timed out" = "detach list timed out";
+"detach returned incomplete output" = "detach returned incomplete output";
 "Internal error: %@ must run in Terminal" = "Internal error: %@ must run in Terminal";
 "Internal error: %@ is not an in-app start action" = "Internal error: %@ is not an in-app start action";
 "The session has no provider UUID to resume." = "The session has no provider UUID to resume.";

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -432,6 +432,8 @@
 "⌘N opens New session. ⌘T starts Quick chat immediately." = "⌘N opens New session. ⌘T starts Quick chat immediately.";
 "Could not start quick chat" = "Could not start quick chat";
 "Quick chat folder is unavailable: %@" = "Quick chat folder is unavailable: %@";
+"Could not identify the active terminal client" = "Could not identify the active terminal client";
+"Could not switch the terminal session" = "Could not switch the terminal session";
 
 /* Menu bar item */
 "Open Detach" = "Open Detach";
@@ -446,3 +448,5 @@
 "Show Detach in the menu bar" = "Show Detach in the menu bar";
 "Show active session count next to the icon" = "Show active session count next to the icon";
 "You can close the window — the icon keeps showing sleep state. ⌘Q quits Detach; sessions and sleep protection continue on their own." = "You can close the window — the icon keeps showing sleep state. ⌘Q quits Detach; sessions and sleep protection continue on their own.";
+"Only a signed Detach release can update the background monitor." = "Only a signed Detach release can update the background monitor.";
+"Only a signed Detach release can update the power helper." = "Only a signed Detach release can update the power helper.";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -432,6 +432,8 @@
 "⌘N opens New session. ⌘T starts Quick chat immediately." = "⌘N открывает новую сессию. ⌘T сразу запускает быстрый чат.";
 "Could not start quick chat" = "Не удалось запустить быстрый чат";
 "Quick chat folder is unavailable: %@" = "Папка быстрого чата недоступна: %@";
+"Could not identify the active terminal client" = "Не удалось определить активный клиент терминала";
+"Could not switch the terminal session" = "Не удалось переключить сессию терминала";
 
 /* Menu bar item */
 "Open Detach" = "Открыть Detach";
@@ -446,3 +448,5 @@
 "Show Detach in the menu bar" = "Показывать Detach в строке меню";
 "Show active session count next to the icon" = "Число активных сессий рядом со значком";
 "You can close the window — the icon keeps showing sleep state. ⌘Q quits Detach; sessions and sleep protection continue on their own." = "Окно можно закрывать — значок продолжит показывать состояние сна. ⌘Q завершает Detach; сессии и защита от сна продолжаются сами.";
+"Only a signed Detach release can update the background monitor." = "Только подписанный релиз Detach может обновить фоновый монитор.";
+"Only a signed Detach release can update the power helper." = "Только подписанный релиз Detach может обновить помощник питания.";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -153,7 +153,6 @@
 "Recover" = "Восстановить";
 "Reconnect" = "Переподключиться";
 "Recover in %@" = "Восстановить в %@";
-"Refresh interval" = "Интервал обновления";
 "Refresh terminal list" = "Обновить список терминалов";
 "Reinstall command-line tools" = "Переустановить командные инструменты";
 "Remove everything, including checkpoints…" = "Удалить всё, включая чекпойнты…";
@@ -278,7 +277,6 @@
 "Text size preview" = "Предпросмотр размера текста";
 "Apply" = "Применить";
 "%d pt" = "%d пт";
-"%d sec" = "%d с";
 "Command line" = "Командная строка";
 "Answer ready · 2 min ago" = "Ответ готов · 2 мин назад";
 "tmux status line" = "Строка статуса tmux";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 
 /* DetachKit errors */
 "detach list timed out" = "Истекло время ожидания detach list";
+"detach returned incomplete output" = "detach вернул неполный вывод";
 "Internal error: %@ must run in Terminal" = "Внутренняя ошибка: команда %@ должна выполняться в Terminal";
 "Internal error: %@ is not an in-app start action" = "Внутренняя ошибка: %@ не запускается внутри приложения";
 "The session has no provider UUID to resume." = "У сессии нет UUID провайдера для продолжения.";

--- a/app/Sources/DetachApp/DetachApp.swift
+++ b/app/Sources/DetachApp/DetachApp.swift
@@ -157,7 +157,6 @@ enum AppSettings {
             return .standard
         }
         defaults.set(uiE2E.cli.path, forKey: "detachPath")
-        defaults.set(0.5, forKey: "pollInterval")
         defaults.set(false, forKey: notificationsEnabledKey)
         defaults.set(false, forKey: tipsEnabledKey)
         defaults.set(false, forKey: menuBarIconEnabledKey)
@@ -253,7 +252,6 @@ struct DetachApp: App {
     private var appDelegate
     @AppStorage("detachPath", store: AppSettings.defaults)
     private var detachPath = AppSettings.initialDetachPath
-    @AppStorage("pollInterval", store: AppSettings.defaults) private var pollInterval = 2.0
     @AppStorage(AppSettings.menuBarIconEnabledKey, store: AppSettings.defaults)
     private var menuBarIconEnabled = true
     @AppStorage(AppSettings.menuBarShowsSessionCountKey, store: AppSettings.defaults)
@@ -279,7 +277,7 @@ struct DetachApp: App {
         Window("Detach", id: "main") {
             let activeDetachPath = installation.hasDistributionPayload
                 ? AppSettings.defaultDetachPath : detachPath
-            RootView(detachPath: activeDetachPath, pollInterval: pollInterval,
+            RootView(detachPath: activeDetachPath,
                      installation: installation, store: sessionStore,
                      navigation: mainNavigation,
                      shortcuts: sessionShortcuts,

--- a/app/Sources/DetachApp/DetachApp.swift
+++ b/app/Sources/DetachApp/DetachApp.swift
@@ -262,7 +262,14 @@ struct DetachApp: App {
         defaults: AppSettings.defaults)
     @State private var sessionStore = SessionStore(
         cli: ProcessDetachCLI(executable: URL(
-            fileURLWithPath: AppSettings.initialDetachPath)))
+            fileURLWithPath: AppSettings.initialDetachPath)),
+        snapshotCache: UserDefaultsSessionSnapshotCache(
+            defaults: AppSettings.defaults))
+    @State private var sessionLogSnapshots = SessionLogSnapshotCache(
+        cli: ProcessDetachCLI(executable: URL(
+            fileURLWithPath: AppSettings.initialDetachPath)),
+        configurationID: AppSettings.initialDetachPath)
+    @State private var terminalScreens = SessionTerminalScreenCache()
     @State private var storageStore = StorageStore(
         cli: ProcessDetachCLI(executable: URL(
             fileURLWithPath: AppSettings.initialDetachPath)))
@@ -279,6 +286,8 @@ struct DetachApp: App {
                 ? AppSettings.defaultDetachPath : detachPath
             RootView(detachPath: activeDetachPath,
                      installation: installation, store: sessionStore,
+                     sessionLogSnapshots: sessionLogSnapshots,
+                     terminalScreens: terminalScreens,
                      navigation: mainNavigation,
                      shortcuts: sessionShortcuts,
                      notifications: notifications,

--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 import DetachKit
 
 enum InstallationContextOperation: Equatable, Sendable {
@@ -106,6 +107,9 @@ final class InstallationStore {
     @ObservationIgnored private var contextOperationWaiters:
         [CheckedContinuation<Void, Never>] = []
     @ObservationIgnored private var heartbeatMonitor: PowerHeartbeatMonitor?
+    @ObservationIgnored private var lastPowerSnapshotSequence: UInt64 = 0
+    @ObservationIgnored private let powerSnapshotSequence =
+        OSAllocatedUnfairLock<UInt64>(initialState: 0)
     @ObservationIgnored var onPowerSnapshot:
         (@MainActor (PowerHeartbeatSnapshot) async -> Void)?
 
@@ -193,15 +197,34 @@ final class InstallationStore {
     var isBusy: Bool { phase == .syncing || contextOperationRunning }
 
     func refreshPowerProtectionState() {
-        publishPowerSnapshot(heartbeatReader.read())
+        // Reserve the number before reading. A monitor delivery numbered
+        // later then read the document no earlier than this read did, so the
+        // higher number is never the older document.
+        let sequence = nextPowerSnapshotSequence()
+        publishPowerSnapshot(heartbeatReader.read(), sequence: sequence)
+    }
+
+    private func nextPowerSnapshotSequence() -> UInt64 {
+        powerSnapshotSequence.withLock { state -> UInt64 in
+            state += 1
+            return state
+        }
     }
 
     func startPowerObservation() {
         guard heartbeatMonitor == nil else { return }
+        // The monitor delivers on a serial queue, but each hop to the main
+        // actor is an unordered task. Number the snapshots so a stale one can
+        // never land after a newer one.
+        let sequence = powerSnapshotSequence
         let monitor = PowerHeartbeatMonitor(reader: heartbeatReader) {
             [weak self] snapshot in
+            let number = sequence.withLock { state -> UInt64 in
+                state += 1
+                return state
+            }
             Task { @MainActor [weak self] in
-                self?.publishPowerSnapshot(snapshot)
+                self?.publishPowerSnapshot(snapshot, sequence: number)
             }
         }
         heartbeatMonitor = monitor
@@ -214,18 +237,23 @@ final class InstallationStore {
         }
     }
 
-    private func publishPowerSnapshot(_ snapshot: PowerHeartbeatSnapshot) {
+    private func publishPowerSnapshot(
+        _ snapshot: PowerHeartbeatSnapshot,
+        sequence: UInt64? = nil
+    ) {
+        if let sequence {
+            guard sequence > lastPowerSnapshotSequence else { return }
+            lastPowerSnapshotSequence = sequence
+        }
         let previous = watchdogHeartbeatStorage
         let presentedStateChanged = !snapshot.hasSamePresentedState(as: previous)
-        if presentedStateChanged {
+        if snapshot != previous {
+            // Views present `checked_at` as an age, so a timestamp-only write
+            // must redraw them too. Only the semantic change below fans out
+            // to notifications.
             withMutation(keyPath: \.watchdogHeartbeat) {
                 watchdogHeartbeatStorage = snapshot
             }
-        } else {
-            // Keep checked_at current without waking every view that reads the
-            // heartbeat. The vnode monitor still reschedules its stale
-            // deadline from every document.
-            watchdogHeartbeatStorage = snapshot
         }
         if snapshot.effectivePowerState != powerProtectionState {
             powerProtectionState = snapshot.effectivePowerState

--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -59,7 +59,15 @@ final class InstallationStore {
     private(set) var report: DoctorReport?
     private(set) var watchdogStatus: WatchdogStatus = .unavailable
     private(set) var watchdogError: String?
-    private(set) var watchdogHeartbeat: PowerHeartbeatSnapshot
+    /// Timestamp-only watchdog writes update the backing snapshot without
+    /// invalidating SwiftUI. A semantic power or freshness change uses the
+    /// observation registrar and redraws all dependent surfaces at once.
+    @ObservationIgnored private var watchdogHeartbeatStorage:
+        PowerHeartbeatSnapshot
+    var watchdogHeartbeat: PowerHeartbeatSnapshot {
+        access(keyPath: \.watchdogHeartbeat)
+        return watchdogHeartbeatStorage
+    }
     private(set) var powerHelperStatus: PowerHelperRegistrationStatus = .unavailable
     private(set) var powerHelperError: String?
     private(set) var lastInstallMessage: String?
@@ -97,6 +105,9 @@ final class InstallationStore {
     @ObservationIgnored private var pendingContextRepair = false
     @ObservationIgnored private var contextOperationWaiters:
         [CheckedContinuation<Void, Never>] = []
+    @ObservationIgnored private var heartbeatMonitor: PowerHeartbeatMonitor?
+    @ObservationIgnored var onPowerSnapshot:
+        (@MainActor (PowerHeartbeatSnapshot) async -> Void)?
 
     init(
         detachPath: String,
@@ -123,7 +134,7 @@ final class InstallationStore {
             statusURL: self.powerStateRoot
                 .appendingPathComponent("watchdog-status.json"))
         self.heartbeatReader = heartbeatReader
-        watchdogHeartbeat = heartbeatReader.read()
+        watchdogHeartbeatStorage = heartbeatReader.read()
         self.defaults = defaults
         onboardingEverCompleted = defaults.bool(
             forKey: Self.onboardingCompletedKey)
@@ -182,9 +193,47 @@ final class InstallationStore {
     var isBusy: Bool { phase == .syncing || contextOperationRunning }
 
     func refreshPowerProtectionState() {
-        let snapshot = heartbeatReader.read()
-        watchdogHeartbeat = snapshot
-        powerProtectionState = snapshot.effectivePowerState
+        publishPowerSnapshot(heartbeatReader.read())
+    }
+
+    func startPowerObservation() {
+        guard heartbeatMonitor == nil else { return }
+        let monitor = PowerHeartbeatMonitor(reader: heartbeatReader) {
+            [weak self] snapshot in
+            Task { @MainActor [weak self] in
+                self?.publishPowerSnapshot(snapshot)
+            }
+        }
+        heartbeatMonitor = monitor
+        monitor.start()
+        if let onPowerSnapshot {
+            let snapshot = watchdogHeartbeat
+            Task { @MainActor in
+                await onPowerSnapshot(snapshot)
+            }
+        }
+    }
+
+    private func publishPowerSnapshot(_ snapshot: PowerHeartbeatSnapshot) {
+        let previous = watchdogHeartbeatStorage
+        let presentedStateChanged = !snapshot.hasSamePresentedState(as: previous)
+        if presentedStateChanged {
+            withMutation(keyPath: \.watchdogHeartbeat) {
+                watchdogHeartbeatStorage = snapshot
+            }
+        } else {
+            // Keep checked_at current without waking every view that reads the
+            // heartbeat. The vnode monitor still reschedules its stale
+            // deadline from every document.
+            watchdogHeartbeatStorage = snapshot
+        }
+        if snapshot.effectivePowerState != powerProtectionState {
+            powerProtectionState = snapshot.effectivePowerState
+        }
+        guard presentedStateChanged, let onPowerSnapshot else { return }
+        Task { @MainActor in
+            await onPowerSnapshot(snapshot)
+        }
     }
 
     /// Pure registration-status read for live onboarding polling: no
@@ -240,19 +289,25 @@ final class InstallationStore {
         onboardingEverCompleted: Bool,
         input: OnboardingStepInput
     ) -> OnboardingStep {
-        // A returning user must never see a transient setup card while the
-        // app bootstraps, refreshes, or waits for active power leases to end.
-        // Keep the dashboard mounted until a completed check publishes a real
-        // actionable state.
+        let step = SetupGuidance.step(for: input)
+        // A returning user keeps access to existing sessions when power
+        // readiness regresses. The dashboard and Settings surface the error;
+        // the runtime still fails closed before starting a new provider.
         if onboardingEverCompleted {
             switch phase {
             case .idle, .syncing, .updateDeferred, .ready:
                 return .mainApp
             case .actionRequired, .failed:
-                break
+                if !input.isStableApplicationLocation {
+                    return .moveToApplications
+                }
+                if !input.distributionMatchesBundle {
+                    return step
+                }
+                return .mainApp
             }
         }
-        return SetupGuidance.step(for: input)
+        return step
     }
 
     func bootstrap() async {

--- a/app/Sources/DetachApp/InstallationStore.swift
+++ b/app/Sources/DetachApp/InstallationStore.swift
@@ -108,6 +108,7 @@ final class InstallationStore {
         [CheckedContinuation<Void, Never>] = []
     @ObservationIgnored private var heartbeatMonitor: PowerHeartbeatMonitor?
     @ObservationIgnored private var lastPowerSnapshotSequence: UInt64 = 0
+    @ObservationIgnored private var powerObservationNeedsInitialDelivery = true
     @ObservationIgnored private let powerSnapshotSequence =
         OSAllocatedUnfairLock<UInt64>(initialState: 0)
     @ObservationIgnored var onPowerSnapshot:
@@ -224,26 +225,29 @@ final class InstallationStore {
                 return state
             }
             Task { @MainActor [weak self] in
-                self?.publishPowerSnapshot(snapshot, sequence: number)
+                self?.publishPowerSnapshot(
+                    snapshot,
+                    sequence: number,
+                    isObservationDelivery: true)
             }
         }
         heartbeatMonitor = monitor
         monitor.start()
-        if let onPowerSnapshot {
-            let snapshot = watchdogHeartbeat
-            Task { @MainActor in
-                await onPowerSnapshot(snapshot)
-            }
-        }
     }
 
     private func publishPowerSnapshot(
         _ snapshot: PowerHeartbeatSnapshot,
-        sequence: UInt64? = nil
+        sequence: UInt64? = nil,
+        isObservationDelivery: Bool = false
     ) {
         if let sequence {
             guard sequence > lastPowerSnapshotSequence else { return }
             lastPowerSnapshotSequence = sequence
+        }
+        let isInitialObservation = isObservationDelivery
+            && powerObservationNeedsInitialDelivery
+        if isInitialObservation {
+            powerObservationNeedsInitialDelivery = false
         }
         let previous = watchdogHeartbeatStorage
         let presentedStateChanged = !snapshot.hasSamePresentedState(as: previous)
@@ -258,7 +262,8 @@ final class InstallationStore {
         if snapshot.effectivePowerState != powerProtectionState {
             powerProtectionState = snapshot.effectivePowerState
         }
-        guard presentedStateChanged, let onPowerSnapshot else { return }
+        guard presentedStateChanged || isInitialObservation,
+              let onPowerSnapshot else { return }
         Task { @MainActor in
             await onPowerSnapshot(snapshot)
         }

--- a/app/Sources/DetachApp/LogTextView.swift
+++ b/app/Sources/DetachApp/LogTextView.swift
@@ -9,7 +9,18 @@ struct LogTextView: NSViewRepresentable {
     let text: NSAttributedString
 
     func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = Self.makeScrollView()
+        Self.apply(
+            text: text,
+            pointSize: fontPointSize,
+            to: scrollView,
+            coordinator: context.coordinator)
+        return scrollView
+    }
+
+    static func makeScrollView() -> NSScrollView {
         let scrollView = NSTextView.scrollableTextView()
+        scrollView.setAccessibilityIdentifier("session-preview-log")
         let textView = scrollView.documentView as! NSTextView
         textView.isEditable = false
         textView.isSelectable = true
@@ -37,15 +48,28 @@ struct LogTextView: NSViewRepresentable {
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        Self.apply(
+            text: text,
+            pointSize: fontPointSize,
+            to: scrollView,
+            coordinator: context.coordinator)
+    }
+
+    static func apply(
+        text: NSAttributedString,
+        pointSize: CGFloat,
+        to scrollView: NSScrollView,
+        coordinator: Coordinator
+    ) {
         guard let textView = scrollView.documentView as? NSTextView,
               let storage = textView.textStorage,
               let layoutManager = textView.layoutManager,
               let container = textView.textContainer else { return }
         // Identity check keeps resize frames free of O(n) text work.
-        guard context.coordinator.lastText !== text
-                || context.coordinator.lastFontPointSize != fontPointSize else { return }
-        context.coordinator.lastText = text
-        context.coordinator.lastFontPointSize = fontPointSize
+        guard coordinator.lastText !== text
+                || coordinator.lastFontPointSize != pointSize else { return }
+        coordinator.lastText = text
+        coordinator.lastFontPointSize = pointSize
 
         // Terminal semantics: pinned to the bottom → follow the tail;
         // scrolled up → keep the current offset (both axes).
@@ -54,7 +78,7 @@ struct LogTextView: NSViewRepresentable {
         let oldHeight = textView.frame.height
         let wasAtBottom = oldHeight <= visible.height + 1 || visible.maxY >= oldHeight - 5
 
-        storage.setAttributedString(Self.resizedText(text, to: fontPointSize))
+        storage.setAttributedString(Self.resizedText(text, to: pointSize))
         // Force layout so the new document height is real before we scroll.
         layoutManager.ensureLayout(for: container)
         textView.sizeToFit()

--- a/app/Sources/DetachApp/MenuBarView.swift
+++ b/app/Sources/DetachApp/MenuBarView.swift
@@ -12,9 +12,11 @@ struct MenuBarLabel: View {
     let showsSessionCount: Bool
 
     var body: some View {
+        // Cached rows paint the sidebar on cold start, but a power or activity
+        // claim needs typed fresh state.
         let presentation = MenuBarPresentation(
             heartbeat: installation.watchdogHeartbeat,
-            sessions: sessionStore.sessions,
+            sessions: sessionStore.hasFreshSnapshot ? sessionStore.sessions : [],
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,
@@ -74,7 +76,7 @@ struct MenuBarMenu: View {
     private var presentation: MenuBarPresentation {
         MenuBarPresentation(
             heartbeat: installation.watchdogHeartbeat,
-            sessions: sessionStore.sessions,
+            sessions: sessionStore.hasFreshSnapshot ? sessionStore.sessions : [],
             helperStatus: installation.powerHelperStatus,
             watchdogStatus: installation.watchdogStatus,
             distributionMatchesBundle: installation.distributionMatchesBundle,

--- a/app/Sources/DetachApp/MenuBarView.swift
+++ b/app/Sources/DetachApp/MenuBarView.swift
@@ -28,20 +28,6 @@ struct MenuBarLabel: View {
         }
         .accessibilityLabel(accessibilityText(
             for: presentation.icon, dot: presentation.sessionDot))
-        // The watchdog writes its heartbeat independently of the app. Keep
-        // the observable snapshot moving even when the session list and every
-        // window are idle, otherwise MenuBarExtra can preserve an obsolete
-        // protected/allowed glyph indefinitely.
-        .task {
-            while !Task.isCancelled {
-                installation.refreshPowerProtectionState()
-                do {
-                    try await Task.sleep(nanoseconds: 5_000_000_000)
-                } catch {
-                    return
-                }
-            }
-        }
     }
 
     private func countBadge(for icon: MenuBarPresentation.Icon) -> String? {

--- a/app/Sources/DetachApp/PowerHelperService.swift
+++ b/app/Sources/DetachApp/PowerHelperService.swift
@@ -345,7 +345,7 @@ final class PowerHelperService {
     {
         var transaction = try loadOrMigrateTransaction(desired: desired)
         if transaction == nil {
-            transaction = try bootstrapTransaction(for: desired)
+            transaction = try await bootstrapTransaction(for: desired)
             if transaction == nil { return .complete }
         }
 
@@ -517,9 +517,14 @@ final class PowerHelperService {
         throw PowerHelperServiceError.registrationDidNotComplete
     }
 
+    /// An enabled helper record without a lifetime holder can be a helper
+    /// that launchd has not finished spawning at login. Re-read once after
+    /// this grace before treating a matching definition as a stale job.
+    static let staleRegistrationGraceNanoseconds: UInt64 = 3_000_000_000
+
     private func bootstrapTransaction(
         for desired: DesiredGoal
-    ) throws -> PowerHelperHandoffTransaction? {
+    ) async throws -> PowerHelperHandoffTransaction? {
         let bootSession = try currentBootSession()
         switch desired {
         case let .install(digest):
@@ -528,7 +533,11 @@ final class PowerHelperService {
                 || defaults.bool(forKey: pendingDigestKey)
             switch status {
             case .enabled:
-                let lifetimeStatus = try lifetimeBarrierStatus()
+                var lifetimeStatus = try lifetimeBarrierStatus()
+                if !definitionNeedsReconcile, lifetimeStatus != .busy {
+                    try await sleep(Self.staleRegistrationGraceNanoseconds)
+                    lifetimeStatus = try lifetimeBarrierStatus()
+                }
                 if !definitionNeedsReconcile, lifetimeStatus == .busy {
                     return nil
                 }

--- a/app/Sources/DetachApp/PowerHelperService.swift
+++ b/app/Sources/DetachApp/PowerHelperService.swift
@@ -130,6 +130,7 @@ private final class SystemPowerHelperRegistrationBackend:
 
 enum PowerHelperServiceError: LocalizedError {
     case bundledDefinitionMissing
+    case releaseSignatureRequired
     case registrationDidNotComplete
     case unregistrationBarrierDidNotComplete
     case activeLeasesPreventUnregistration
@@ -140,6 +141,9 @@ enum PowerHelperServiceError: LocalizedError {
         switch self {
         case .bundledDefinitionMissing:
             L10n.string("The bundled power helper definition is missing or incomplete.")
+        case .releaseSignatureRequired:
+            L10n.string(
+                "Only a signed Detach release can update the power helper.")
         case .registrationDidNotComplete:
             L10n.string("macOS did not finish registering the power helper.")
         case .unregistrationBarrierDidNotComplete:
@@ -194,6 +198,7 @@ final class PowerHelperService {
     private let systemHandoffLockProvider: () throws
         -> (any PowerHelperHandoffLocking)?
     private let currentProcessIsActiveConsoleUser: () -> Bool
+    private let serviceMutationAllowed: () -> Bool
     private let sleep: (UInt64) async throws -> Void
 
     private let digestKey = "powerHelperDefinitionDigest"
@@ -231,6 +236,9 @@ final class PowerHelperService {
             PowerHelperConsoleUserAdmission()
                 .currentProcessIsActiveConsoleUser()
         }
+        serviceMutationAllowed = {
+            ServiceManagementMutationAdmission.currentBundleIsReleaseSigned
+        }
         sleep = { try await Task.sleep(nanoseconds: $0) }
     }
 
@@ -250,6 +258,7 @@ final class PowerHelperService {
                 UncontendedPowerHelperSystemHandoffLock()
             },
         currentProcessIsActiveConsoleUser: @escaping () -> Bool = { true },
+        serviceMutationAllowed: @escaping () -> Bool = { true },
         sleep: @escaping (UInt64) async throws -> Void = {
             try await Task.sleep(nanoseconds: $0)
         }
@@ -264,6 +273,7 @@ final class PowerHelperService {
         self.systemHandoffLockProvider = systemHandoffLockProvider
         self.currentProcessIsActiveConsoleUser =
             currentProcessIsActiveConsoleUser
+        self.serviceMutationAllowed = serviceMutationAllowed
         self.sleep = sleep
     }
 
@@ -273,6 +283,7 @@ final class PowerHelperService {
     func reconcileAfterAppUpdate() async throws
         -> PowerHelperReconciliationOutcome
     {
+        try requireReleaseSignature()
         guard let digest = digestProvider() else {
             throw PowerHelperServiceError.bundledDefinitionMissing
         }
@@ -288,6 +299,7 @@ final class PowerHelperService {
     }
 
     func disable() async throws {
+        try requireReleaseSignature()
         try await performExclusiveOperation {
             _ = try await drive(to: .remove)
         }
@@ -347,9 +359,13 @@ final class PowerHelperService {
             case .preparing:
                 switch status {
                 case .enabled:
-                    if try lifetimeBarrierStatus() == .missing {
-                        // launchd/BTM can keep an enabled job that never
-                        // spawned. There is no live helper to prepare.
+                    let lifetimeStatus = try lifetimeBarrierStatus()
+                    if lifetimeStatus == .missing
+                        || lifetimeStatus == .released {
+                        // launchd/BTM can keep an enabled job after its helper
+                        // failed to spawn or exited. A missing or unlocked
+                        // lifetime barrier proves there is no live helper to
+                        // prepare over XPC, so replay unregister directly.
                         transaction.phase = .unregisterSubmitted
                         transaction.bootSessionIdentifier =
                             try currentBootSession()
@@ -511,9 +527,17 @@ final class PowerHelperService {
                 defaults.string(forKey: digestKey) != digest
                 || defaults.bool(forKey: pendingDigestKey)
             switch status {
-            case .enabled where !definitionNeedsReconcile:
-                return nil
             case .enabled:
+                let lifetimeStatus = try lifetimeBarrierStatus()
+                if !definitionNeedsReconcile, lifetimeStatus == .busy {
+                    return nil
+                }
+                // SMAppService can retain an enabled BTM record whose parent
+                // bundle UUID no longer resolves after an in-place app
+                // replacement. A matching definition digest does not prove
+                // that launchd can spawn it. The helper takes this lock before
+                // exposing XPC, so an absent holder is direct stale-job
+                // evidence and must force the normal durable handoff.
                 defaults.set(true, forKey: pendingDigestKey)
                 let transaction = makeTransaction(
                     phase: .preparing, desired: desired,
@@ -743,6 +767,12 @@ final class PowerHelperService {
     private func requireActiveConsoleUser() throws {
         guard currentProcessIsActiveConsoleUser() else {
             throw PowerHelperServiceError.notActiveConsoleUser
+        }
+    }
+
+    private func requireReleaseSignature() throws {
+        guard serviceMutationAllowed() else {
+            throw PowerHelperServiceError.releaseSignatureRequired
         }
     }
 

--- a/app/Sources/DetachApp/QuickChat.swift
+++ b/app/Sources/DetachApp/QuickChat.swift
@@ -45,6 +45,11 @@ enum QuickChatProjectDirectory {
 
 @MainActor
 enum QuickChatLaunch {
+    private enum Outcome: Sendable {
+        case session(String?)
+        case launch(SessionStartResult)
+    }
+
     static func provider(rawValue: String) -> Provider {
         Provider(rawValue: rawValue) ?? .claude
     }
@@ -57,9 +62,6 @@ enum QuickChatLaunch {
         onSessionAvailable: (@MainActor (String) -> Void)? = nil,
         createProjectDirectory: (URL, FileManager) throws -> URL = {
             try QuickChatProjectDirectory.create(inside: $0, fileManager: $1)
-        },
-        discoverySleep: @escaping @Sendable (UInt64) async throws -> Void = {
-            try await Task.sleep(nanoseconds: $0)
         }
     ) async -> SessionStartResult {
         guard let directory = DirectoryPreference.existingDirectoryURL(
@@ -87,65 +89,42 @@ enum QuickChatLaunch {
         }
 
         let existingIDs = Set(store.sessions.map(\.id))
-        var launchFinished = false
-        let launchTask = Task { @MainActor in
-            defer { launchFinished = true }
-            return await store.startDetached(
-                provider: provider,
-                projectDirectory: projectDirectory,
-                name: nil,
-                prompt: nil)
-        }
-        defer { launchTask.cancel() }
-
-        // The typed `starting` row exists before the CLI finishes its runtime
-        // readiness checks. Select it as soon as it is unambiguous.
-        var selectedEarly = false
-        for delay in [75_000_000, 175_000_000] where !launchFinished {
-            do {
-                try await discoverySleep(UInt64(delay))
-            } catch {
-                break
+        return await withTaskGroup(of: Outcome.self) { group in
+            group.addTask {
+                .launch(await store.startDetached(
+                    provider: provider,
+                    projectDirectory: projectDirectory,
+                    name: nil,
+                    prompt: nil))
             }
-            guard !launchFinished else { break }
-            await store.refresh()
-            if let sessionID = newSessionID(
-                in: store.sessions,
-                excluding: existingIDs,
-                provider: provider,
-                projectDirectory: projectDirectory) {
-                selectedEarly = true
-                onSessionAvailable(sessionID)
-                break
+            group.addTask {
+                .session(await store.waitForSession(
+                    provider: provider,
+                    projectDirectory: projectDirectory,
+                    excluding: existingIDs))
             }
-        }
 
-        let result = await launchTask.value
-        if selectedEarly && result.message != nil {
-            await store.refresh()
+            var selectedEarly = false
+            while let outcome = await group.next() {
+                switch outcome {
+                case .session(let sessionID):
+                    guard let sessionID else { continue }
+                    selectedEarly = true
+                    onSessionAvailable(sessionID)
+                case .launch(let result):
+                    if !selectedEarly, let sessionID = result.sessionID {
+                        onSessionAvailable(sessionID)
+                    }
+                    if selectedEarly, result.message != nil {
+                        await store.refresh()
+                    }
+                    group.cancelAll()
+                    return result
+                }
+            }
+            return SessionStartResult(message: L10n.string(
+                "Could not start quick chat"))
         }
-        return result
-    }
-
-    private static func newSessionID(
-        in sessions: [Session],
-        excluding existingIDs: Set<String>,
-        provider: Provider,
-        projectDirectory: URL
-    ) -> String? {
-        let projectPath = canonicalProjectPath(projectDirectory.path)
-        let candidates = sessions.filter {
-            !existingIDs.contains($0.id)
-                && $0.provider == provider
-                && $0.projectDir.map(canonicalProjectPath) == projectPath
-        }
-        return candidates.count == 1 ? candidates[0].id : nil
-    }
-
-    private static func canonicalProjectPath(_ path: String) -> String {
-        URL(fileURLWithPath: path, isDirectory: true)
-            .resolvingSymlinksInPath()
-            .standardizedFileURL.path
     }
 }
 

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import DetachKit
 
 @MainActor
@@ -16,6 +17,8 @@ struct RootView: View {
     /// App-level shared store: its event stream outlives this window, so
     /// notifications and the menu bar stay current after close.
     let store: SessionStore
+    let sessionLogSnapshots: SessionLogSnapshotCache
+    let terminalScreens: SessionTerminalScreenCache
     @ObservedObject var navigation: MainNavigation
     @ObservedObject var shortcuts: SessionShortcutRegistry
     @ObservedObject var notifications: SessionNotificationService
@@ -24,6 +27,7 @@ struct RootView: View {
 
     @State private var selectedID: String?
     @State private var shortcutAssignments: [SessionShortcutAssignment] = []
+    @State private var initialSetupComplete = false
 
     private var selectedSession: Session? {
         store.sessions.first { $0.id == selectedID }
@@ -54,8 +58,12 @@ struct RootView: View {
                         if store.sessions.isEmpty && store.state == .ok {
                             EmptySessionsView()
                         } else if let session = selectedSession {
-                            SessionDetailView(session: session, store: store, detachPath: detachPath)
-                                .id(session.id)
+                            SessionDetailSwitcher(
+                                session: session,
+                                store: store,
+                                detachPath: detachPath,
+                                sessionLogSnapshots: sessionLogSnapshots,
+                                terminalScreens: terminalScreens)
                         } else {
                             ContentUnavailableView {
                                 Label {
@@ -90,17 +98,35 @@ struct RootView: View {
             minWidth: AppFontSize.minimumWindowSize(for: fontPointSize).width,
             minHeight: AppFontSize.minimumWindowSize(for: fontPointSize).height)
         .task(id: detachPath) {
+            initialSetupComplete = false
+            installation.onPowerSnapshot = { [weak notifications] snapshot in
+                await notifications?.observePower(snapshot)
+            }
+            installation.startPowerObservation()
+            sessionLogSnapshots.configure(
+                cli: ProcessDetachCLI(
+                    executable: URL(fileURLWithPath: detachPath)),
+                configurationID: detachPath,
+                sessions: store.sessions)
+            terminalScreens.configure(
+                cli: ProcessDetachCLI(
+                    executable: URL(fileURLWithPath: detachPath)),
+                configurationID: detachPath,
+                sessions: store.sessions)
             // The store outlives this window; rewire it to the active CLI and
             // keep notifications fed from the same event source. The
             // transition detector baselines on its first successful snapshot,
             // so historical sessions never fire as fresh notifications.
-            store.onSnapshot = { [weak notifications, weak shortcuts] sessions in
-                shortcuts?.reconcile(sessions)
+            store.onSnapshot = { [weak notifications] sessions in
                 await notifications?.observe(sessions)
             }
             await store.configure(cli: ProcessDetachCLI(
                 executable: URL(fileURLWithPath: detachPath)))
             await installation.bootstrap()
+            // An upgrade can replace an older CLI that did not support this
+            // stream after the first snapshot. Restart only if it exited.
+            store.startObserving()
+            initialSetupComplete = true
         }
         .task(id: notificationsEnabled) {
             guard AppSettings.uiE2E == nil else { return }
@@ -115,7 +141,7 @@ struct RootView: View {
         }
 // quality-coverage:end ui-e2e-instrumentation
         .onChange(of: scenePhase) { _, phase in
-            guard phase == .active else { return }
+            guard phase == .active, initialSetupComplete else { return }
             Task {
                 guard AppSettings.uiE2E == nil else { return }
                 await store.resynchronize()
@@ -132,6 +158,11 @@ struct RootView: View {
             navigation.requestedSessionID = nil
         }
         .onChange(of: store.sessions, initial: true) { _, sessions in
+            // A cached presentation snapshot is already present on the first
+            // body pass. Warm passive screens and logs while typed truth
+            // refreshes; both caches remain bounded and leave no live process.
+            sessionLogSnapshots.schedulePrefetch(for: sessions)
+            terminalScreens.schedulePrefetch(for: sessions)
             shortcuts.reconcile(sessions)
         }
         .onReceive(shortcuts.$assignments) { assignments in
@@ -151,5 +182,154 @@ struct RootView: View {
 // quality-coverage:end ui-e2e-instrumentation
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("detach-dashboard")
+    }
+}
+
+/// Keeps only the last passive terminal or log frame inside the new detail's
+/// log surface until that target confirms its first drawable frame. The new
+/// metadata and actions determine layout immediately, with no hidden PTY.
+@MainActor
+struct SessionDetailSwitcher: View {
+    let session: Session
+    let store: SessionStore
+    let detachPath: String
+    let sessionLogSnapshots: SessionLogSnapshotCache
+    let terminalScreens: SessionTerminalScreenCache
+
+    @State private var transition: SessionDetailTransitionState
+    @State private var deadlineTask: Task<Void, Never>?
+
+    init(
+        session: Session,
+        store: SessionStore,
+        detachPath: String,
+        sessionLogSnapshots: SessionLogSnapshotCache,
+        terminalScreens: SessionTerminalScreenCache
+    ) {
+        self.session = session
+        self.store = store
+        self.detachPath = detachPath
+        self.sessionLogSnapshots = sessionLogSnapshots
+        self.terminalScreens = terminalScreens
+        _transition = State(initialValue: SessionDetailTransitionState(
+            presented: session))
+    }
+
+    var body: some View {
+        SessionDetailView(
+            session: transition.presented,
+            store: store,
+            detachPath: detachPath,
+            terminalScreens: terminalScreens,
+            cachedLog: cachedLog(for: transition.presented),
+            retainedFrame: transition.outgoing.flatMap {
+                transitionFrame(outgoing: $0)
+            },
+            onPresentationReady: {
+                completeTransition(
+                    sessionID: transition.presented.id,
+                    generation: transition.generation)
+            })
+        .onChange(of: session) { _, updated in
+            guard let generation = transition.present(updated) else { return }
+            scheduleDeadline(
+                sessionID: updated.id,
+                generation: generation)
+        }
+        .onDisappear {
+            deadlineTask?.cancel()
+            deadlineTask = nil
+        }
+    }
+
+    private func cachedLog(for layer: Session) -> LogPoller? {
+        guard SessionLogSnapshotCache.shouldCache(layer) else { return nil }
+        return sessionLogSnapshots.poller(for: layer)
+    }
+
+    private func retainedFrame(for layer: Session) -> SessionDetailRetainedFrame? {
+        if SessionLogSnapshotCache.shouldCache(layer) {
+            let attributed = sessionLogSnapshots.poller(for: layer).attributed
+            return attributed.length > 0 ? .text(attributed) : nil
+        }
+        return nil
+    }
+
+    private func transitionFrame(
+        outgoing: Session
+    ) -> SessionDetailRetainedFrame? {
+        let target = transition.presented
+        // A non-live target already has its final NSTextView presentation.
+        // A live target prefers a real SwiftTerm capture. If it has never been
+        // shown, the outgoing live capture still has identical terminal
+        // typography, colors, and edges while the target fallback mounts.
+        if SessionLogSnapshotCache.shouldCache(target) {
+            return retainedFrame(for: target) ?? retainedFrame(for: outgoing)
+        }
+        // A live target owns the same visible SwiftTerm across live switches,
+        // or installs a passive SwiftTerm text screen inside a new PTY host.
+        // Neither path needs a separate SwiftUI raster/text cover.
+        return nil
+    }
+
+    private func completeTransition(sessionID: String, generation: UInt64) {
+        guard sessionID == transition.presented.id,
+              generation == transition.generation,
+              transition.outgoing != nil else { return }
+        // Draw the installed target hierarchy behind the retained passive
+        // frame before state removes it. This keeps the handoff atomic at the
+        // AppKit display boundary, not only in SwiftUI's logical tree.
+        NSApp.mainWindow?.contentView?.layoutSubtreeIfNeeded()
+        NSApp.mainWindow?.displayIfNeeded()
+        _ = transition.complete(
+            sessionID: sessionID,
+            generation: generation)
+        deadlineTask?.cancel()
+        deadlineTask = nil
+    }
+
+    private func scheduleDeadline(sessionID: String, generation: UInt64) {
+        deadlineTask?.cancel()
+        deadlineTask = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            _ = transition.complete(
+                sessionID: sessionID,
+                generation: generation)
+            deadlineTask = nil
+        }
+    }
+}
+
+struct SessionDetailTransitionState: Equatable {
+    private(set) var presented: Session
+    private(set) var outgoing: Session?
+    private(set) var generation: UInt64 = 0
+
+    mutating func present(_ session: Session) -> UInt64? {
+        guard session.id != presented.id else {
+            presented = session
+            return nil
+        }
+        if outgoing == nil { outgoing = presented }
+        presented = session
+        generation &+= 1
+        return generation
+    }
+
+    @discardableResult
+    mutating func complete(
+        sessionID: String,
+        generation: UInt64
+    ) -> Bool {
+        guard sessionID == presented.id,
+              generation == self.generation,
+              outgoing != nil else { return false }
+        outgoing = nil
+        return true
     }
 }

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -118,7 +118,7 @@ struct RootView: View {
             // transition detector baselines on its first successful snapshot,
             // so historical sessions never fire as fresh notifications.
             store.onSnapshot = { [weak notifications] sessions in
-                await notifications?.observe(sessions)
+                notifications?.observeFromSessionStore(sessions)
             }
             await store.configure(cli: ProcessDetachCLI(
                 executable: URL(fileURLWithPath: detachPath)))

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -137,6 +137,7 @@ struct RootView: View {
             await UIE2ETestDriver.runIfRequested(
                 installation: installation,
                 store: store,
+                sessionLogSnapshots: sessionLogSnapshots,
                 shortcuts: shortcuts)
         }
 // quality-coverage:end ui-e2e-instrumentation

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -3,6 +3,17 @@ import AppKit
 import DetachKit
 
 @MainActor
+enum AppRuntimeActivationSequence {
+    static func run(
+        activatePayload: () async -> Void,
+        activateSessionSource: () async -> Void
+    ) async {
+        await activatePayload()
+        await activateSessionSource()
+    }
+}
+
+@MainActor
 struct RootView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.openSettings) private var openSettings
@@ -103,16 +114,6 @@ struct RootView: View {
                 await notifications?.observePower(snapshot)
             }
             installation.startPowerObservation()
-            sessionLogSnapshots.configure(
-                cli: ProcessDetachCLI(
-                    executable: URL(fileURLWithPath: detachPath)),
-                configurationID: detachPath,
-                sessions: store.sessions)
-            terminalScreens.configure(
-                cli: ProcessDetachCLI(
-                    executable: URL(fileURLWithPath: detachPath)),
-                configurationID: detachPath,
-                sessions: store.sessions)
             // The store outlives this window; rewire it to the active CLI and
             // keep notifications fed from the same event source. The
             // transition detector baselines on its first successful snapshot,
@@ -120,12 +121,25 @@ struct RootView: View {
             store.onSnapshot = { [weak notifications] sessions in
                 notifications?.observeFromSessionStore(sessions)
             }
-            await store.configure(cli: ProcessDetachCLI(
-                executable: URL(fileURLWithPath: detachPath)))
-            await installation.bootstrap()
-            // An upgrade can replace an older CLI that did not support this
-            // stream after the first snapshot. Restart only if it exited.
-            store.startObserving()
+            // Activate the immutable payload before starting any long-lived
+            // source. Otherwise an upgrade leaves the app's watcher on the
+            // previous payload until the whole app is restarted.
+            await AppRuntimeActivationSequence.run(
+                activatePayload: { await installation.bootstrap() },
+                activateSessionSource: {
+                    sessionLogSnapshots.configure(
+                        cli: ProcessDetachCLI(
+                            executable: URL(fileURLWithPath: detachPath)),
+                        configurationID: detachPath,
+                        sessions: store.sessions)
+                    terminalScreens.configure(
+                        cli: ProcessDetachCLI(
+                            executable: URL(fileURLWithPath: detachPath)),
+                        configurationID: detachPath,
+                        sessions: store.sessions)
+                    await store.configure(cli: ProcessDetachCLI(
+                        executable: URL(fileURLWithPath: detachPath)))
+                })
             initialSetupComplete = true
         }
         .task(id: notificationsEnabled) {

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -12,10 +12,9 @@ struct RootView: View {
     @AppStorage(AppSettings.tipsEnabledKey, store: AppSettings.defaults)
     private var tipsEnabled = true
     let detachPath: String
-    let pollInterval: Double
     let installation: InstallationStore
-    /// App-level shared store: the window only adjusts its cadence and never
-    /// stops it, so notifications and the menu bar stay fed after close.
+    /// App-level shared store: its event stream outlives this window, so
+    /// notifications and the menu bar stay current after close.
     let store: SessionStore
     @ObservedObject var navigation: MainNavigation
     @ObservedObject var shortcuts: SessionShortcutRegistry
@@ -90,10 +89,9 @@ struct RootView: View {
         .frame(
             minWidth: AppFontSize.minimumWindowSize(for: fontPointSize).width,
             minHeight: AppFontSize.minimumWindowSize(for: fontPointSize).height)
-        .task(id: pollInterval) { store.startPolling(interval: pollInterval) }
         .task(id: detachPath) {
             // The store outlives this window; rewire it to the active CLI and
-            // keep notifications fed from the same single poller. The
+            // keep notifications fed from the same event source. The
             // transition detector baselines on its first successful snapshot,
             // so historical sessions never fire as fresh notifications.
             store.onSnapshot = { [weak notifications, weak shortcuts] sessions in
@@ -120,6 +118,7 @@ struct RootView: View {
             guard phase == .active else { return }
             Task {
                 guard AppSettings.uiE2E == nil else { return }
+                await store.resynchronize()
                 await installation.refreshContext()
                 await notifications.refreshAuthorizationStatus()
             }
@@ -138,8 +137,6 @@ struct RootView: View {
         .onReceive(shortcuts.$assignments) { assignments in
             shortcutAssignments = assignments
         }
-        .onAppear { store.updateCadence(foreground: true) }
-        .onDisappear { store.updateCadence(foreground: false) }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
         .background {

--- a/app/Sources/DetachApp/ServiceManagementMutationAdmission.swift
+++ b/app/Sources/DetachApp/ServiceManagementMutationAdmission.swift
@@ -1,0 +1,108 @@
+import DetachKit
+import Foundation
+import Security
+
+/// Keeps local and ad-hoc app copies read-only at the ServiceManagement
+/// boundary. A preview may inspect status, but only the complete Developer ID
+/// release identity may replace the shared watchdog or root helper.
+enum ServiceManagementMutationAdmission {
+    private static let expectedBundleIdentifier = "dev.tsarev.detach"
+    private static let managedCodeIdentifiers = [
+        "dev.tsarev.detach",
+        "dev.tsarev.detach.power-helper",
+        "dev.tsarev.detach.power-watchdog",
+    ]
+
+    static let currentBundleIsReleaseSigned = releaseSignedBundle(.main)
+
+    static func permits(
+        bundleIdentifier: String?,
+        validatedTeams: [String: String]
+    ) -> Bool {
+        guard bundleIdentifier == expectedBundleIdentifier,
+              validatedTeams.count == managedCodeIdentifiers.count,
+              let team = validatedTeams[expectedBundleIdentifier],
+              PowerHelperCodeSigningRequirement.client(
+                teamIdentifier: team) != nil else {
+            return false
+        }
+        return managedCodeIdentifiers.allSatisfy {
+            validatedTeams[$0] == team
+        }
+    }
+
+    static func releaseSignedBundle(_ bundle: Bundle) -> Bool {
+        guard let executable = bundle.executableURL else { return false }
+        let contents = bundle.bundleURL.appendingPathComponent(
+            "Contents", isDirectory: true)
+        let locations = [
+            expectedBundleIdentifier: executable,
+            "dev.tsarev.detach.power-helper": contents.appendingPathComponent(
+                "MacOS/DetachPowerHelper"),
+            "dev.tsarev.detach.power-watchdog": contents.appendingPathComponent(
+                "MacOS/DetachWatchdog"),
+        ]
+        var teams: [String: String] = [:]
+        for identifier in managedCodeIdentifiers {
+            guard let location = locations[identifier],
+                  let team = validatedTeamIdentifier(
+                    at: location,
+                    expectedIdentifier: identifier) else {
+                return false
+            }
+            teams[identifier] = team
+        }
+        return permits(
+            bundleIdentifier: bundle.bundleIdentifier,
+            validatedTeams: teams)
+    }
+
+    private static func validatedTeamIdentifier(
+        at location: URL,
+        expectedIdentifier: String
+    ) -> String? {
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(
+            location as CFURL, [], &staticCode) == errSecSuccess,
+            let staticCode else { return nil }
+
+        let validationFlags = SecCSFlags(
+            rawValue: kSecCSStrictValidate | kSecCSCheckAllArchitectures)
+        guard SecStaticCodeCheckValidity(
+            staticCode, validationFlags, nil) == errSecSuccess else {
+            return nil
+        }
+
+        var information: CFDictionary?
+        guard SecCodeCopySigningInformation(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &information) == errSecSuccess,
+            let values = information as? [String: Any],
+            let identifier = values[kSecCodeInfoIdentifier as String]
+                as? String,
+            identifier == expectedIdentifier,
+            let team = values[kSecCodeInfoTeamIdentifier as String]
+                as? String,
+            PowerHelperCodeSigningRequirement.client(
+                teamIdentifier: team) != nil else {
+            return nil
+        }
+
+        let source = "anchor apple generic and identifier "
+            + "\"\(expectedIdentifier)\" and certificate "
+            + "1[field.1.2.840.113635.100.6.2.6] /* exists */ and "
+            + "certificate leaf[field.1.2.840.113635.100.6.1.13] "
+            + "/* exists */ and certificate "
+            + "leaf[subject.OU] = \"\(team)\""
+        var requirement: SecRequirement?
+        guard SecRequirementCreateWithString(
+            source as CFString, [], &requirement) == errSecSuccess,
+            let requirement,
+            SecStaticCodeCheckValidity(
+                staticCode, validationFlags, requirement) == errSecSuccess else {
+            return nil
+        }
+        return team
+    }
+}

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -17,6 +17,21 @@ final class SessionTerminalScreenCache {
         let sessionName: String
     }
 
+    private struct RunIdentity: Equatable {
+        let lifecycleID: String?
+        let createdAt: Date?
+        let agentSessionID: String?
+
+        init(_ session: Session) {
+            lifecycleID = session.lifecycleID
+            // New runtimes supply an opaque exact identity. Retain the older
+            // heuristic only for cached rows produced by compatible payloads.
+            createdAt = session.lifecycleID == nil ? session.createdAt : nil
+            agentSessionID = session.lifecycleID == nil
+                ? session.agentSessionId : nil
+        }
+    }
+
     /// The typed turn identity a warm-up last read for a session. A blank or
     /// failed read is not repeated until that identity changes, so a session
     /// with an empty pane cannot spawn one process per snapshot.
@@ -25,6 +40,7 @@ final class SessionTerminalScreenCache {
         let turnState: AgentTurnState?
         let turnID: String?
         let checkpoint: Date?
+        let lifecycleID: String?
         /// A new run may reuse an explicit name; its creation time and, once
         /// bound, its provider identity differ.
         let created: Date?
@@ -35,7 +51,7 @@ final class SessionTerminalScreenCache {
     private var attempted: [Key: Revision] = [:]
     /// The run a stored screen belongs to. A later run with the same name
     /// must not inherit it.
-    private var screenRuns: [Key: Date?] = [:]
+    private var screenRuns: [Key: RunIdentity] = [:]
     private var recency: [Key] = []
     private var cli: (any DetachCLIRunning)?
     private var configurationID = ""
@@ -111,7 +127,9 @@ final class SessionTerminalScreenCache {
                                 session.sessionName,
                             ],
                             timeout: 5)
-                        guard result.exitCode == 0, !result.timedOut else {
+                        guard result.exitCode == 0,
+                              !result.timedOut,
+                              !result.stdoutTruncated else {
                             return (session, nil)
                         }
                         return (session, Data(result.stdout.utf8))
@@ -137,7 +155,13 @@ final class SessionTerminalScreenCache {
 
     func screen(for session: Session) -> Data? {
         let key = Key(provider: session.provider, sessionName: session.sessionName)
-        guard let screen = screens[key] else { return nil }
+        guard let screen = screens[key],
+              screenRuns[key] == RunIdentity(session) else {
+            screens.removeValue(forKey: key)
+            screenRuns.removeValue(forKey: key)
+            recency.removeAll { $0 == key }
+            return nil
+        }
         touch(key)
         return screen
     }
@@ -149,8 +173,13 @@ final class SessionTerminalScreenCache {
             recency.removeAll { $0 == key }
             return
         }
+        storeNormalized(screen, for: session)
+    }
+
+    func storeNormalized(_ screen: Data, for session: Session) {
+        let key = Key(provider: session.provider, sessionName: session.sessionName)
         screens[key] = screen
-        screenRuns[key] = session.createdAt
+        screenRuns[key] = RunIdentity(session)
         touch(key)
         trimToCapacity()
     }
@@ -168,7 +197,8 @@ final class SessionTerminalScreenCache {
     private func dropScreensOfReplacedRuns(_ sessions: [Session]) {
         for session in sessions {
             let key = key(for: session)
-            if let storedRun = screenRuns[key], storedRun != session.createdAt {
+            if let storedRun = screenRuns[key],
+               storedRun != RunIdentity(session) {
                 screens.removeValue(forKey: key)
                 screenRuns.removeValue(forKey: key)
                 recency.removeAll { $0 == key }
@@ -218,6 +248,7 @@ final class SessionTerminalScreenCache {
             turnState: session.agentTurnState,
             turnID: session.agentTurnID,
             checkpoint: session.lastCheckpointAt,
+            lifecycleID: session.lifecycleID,
             created: session.createdAt,
             agentSessionID: session.agentSessionId)
     }
@@ -820,10 +851,10 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         func captureScreen(from view: LocalProcessTerminalView) {
             let data = view.terminal.getBufferAsData()
             MainActor.assumeIsolated {
-                guard SessionTerminalScreenCache.normalized(data) != nil else {
+                guard let screen = SessionTerminalScreenCache.normalized(data) else {
                     return
                 }
-                screenCache.store(data, for: session)
+                screenCache.storeNormalized(screen, for: session)
             }
         }
 

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -10,14 +10,32 @@ import DetachKit
 final class SessionTerminalScreenCache {
     nonisolated static let capacity = 9
     nonisolated static let lineLimit = 500
-    nonisolated static let maximumConcurrentPrefetches = 3
+    nonisolated static let maximumConcurrentPrefetches = 2
 
     private struct Key: Hashable {
         let provider: Provider
         let sessionName: String
     }
 
+    /// The typed turn identity a warm-up last read for a session. A blank or
+    /// failed read is not repeated until that identity changes, so a session
+    /// with an empty pane cannot spawn one process per snapshot.
+    private struct Revision: Equatable {
+        let status: EffectiveStatus
+        let turnState: AgentTurnState?
+        let turnID: String?
+        let checkpoint: Date?
+        /// A new run may reuse an explicit name; its creation time and, once
+        /// bound, its provider identity differ.
+        let created: Date?
+        let agentSessionID: String?
+    }
+
     private var screens: [Key: Data] = [:]
+    private var attempted: [Key: Revision] = [:]
+    /// The run a stored screen belongs to. A later run with the same name
+    /// must not inherit it.
+    private var screenRuns: [Key: Date?] = [:]
     private var recency: [Key] = []
     private var cli: (any DetachCLIRunning)?
     private var configurationID = ""
@@ -39,6 +57,8 @@ final class SessionTerminalScreenCache {
         prefetchTask = nil
         pendingPrefetch = []
         screens = [:]
+        attempted = [:]
+        screenRuns = [:]
         recency = []
         self.cli = cli
         self.configurationID = configurationID
@@ -51,8 +71,8 @@ final class SessionTerminalScreenCache {
     /// Warms recent live screens once from retained output. The work is a
     /// bounded event-triggered burst; it keeps no process after completion.
     func schedulePrefetch(for sessions: [Session]) {
+        dropScreensOfReplacedRuns(sessions)
         let targets = prefetchTargets(in: sessions, limit: Self.capacity)
-            .filter { screens[key(for: $0)] == nil }
         guard !targets.isEmpty else { return }
         pendingPrefetch = targets
         guard prefetchTask == nil else { return }
@@ -65,19 +85,23 @@ final class SessionTerminalScreenCache {
     /// Deterministic entry point for focused tests.
     func prefetch(_ sessions: [Session], limit: Int = capacity) async {
         guard let cli else { return }
-        let targets = prefetchTargets(in: sessions, limit: limit).filter {
-            screens[key(for: $0)] == nil
-        }
+        dropScreensOfReplacedRuns(sessions)
+        let targets = prefetchTargets(in: sessions, limit: limit)
         guard !targets.isEmpty else { return }
+        let marks = targets.map { (key(for: $0), revision(for: $0)) }
 
         await withTaskGroup(of: (Session, Data?).self) { group in
             var nextIndex = 0
             func enqueueNext() {
                 guard nextIndex < targets.count else { return }
                 let session = targets[nextIndex]
+                let (key, revision) = marks[nextIndex]
                 nextIndex += 1
-                group.addTask {
+                group.addTask { [weak self] in
+                    // Mark the attempt only once the read is really starting,
+                    // so a cancelled warm-up leaves unstarted sessions eligible.
                     guard !Task.isCancelled else { return (session, nil) }
+                    await self?.recordAttempt(key: key, revision: revision)
                     do {
                         let result = try await cli.run(
                             arguments: [
@@ -126,6 +150,7 @@ final class SessionTerminalScreenCache {
             return
         }
         screens[key] = screen
+        screenRuns[key] = session.createdAt
         touch(key)
         trimToCapacity()
     }
@@ -134,6 +159,20 @@ final class SessionTerminalScreenCache {
         while recency.count > Self.capacity {
             let removed = recency.removeFirst()
             screens.removeValue(forKey: removed)
+            screenRuns.removeValue(forKey: removed)
+        }
+    }
+
+    /// A stored screen or attempt belongs to one run. When typed state shows
+    /// a different run under the same name, forget both.
+    private func dropScreensOfReplacedRuns(_ sessions: [Session]) {
+        for session in sessions {
+            let key = key(for: session)
+            if let storedRun = screenRuns[key], storedRun != session.createdAt {
+                screens.removeValue(forKey: key)
+                screenRuns.removeValue(forKey: key)
+                recency.removeAll { $0 == key }
+            }
         }
     }
 
@@ -165,7 +204,26 @@ final class SessionTerminalScreenCache {
         guard limit > 0 else { return [] }
         return Array(sessions.lazy
             .filter { SessionAttachInvocation.isEligible($0) }
+            .filter { session in
+                let key = self.key(for: session)
+                return self.screens[key] == nil
+                    && self.attempted[key] != self.revision(for: session)
+            }
             .prefix(limit))
+    }
+
+    private func revision(for session: Session) -> Revision {
+        Revision(
+            status: session.effectiveStatus,
+            turnState: session.agentTurnState,
+            turnID: session.agentTurnID,
+            checkpoint: session.lastCheckpointAt,
+            created: session.createdAt,
+            agentSessionID: session.agentSessionId)
+    }
+
+    private func recordAttempt(key: Key, revision: Revision) {
+        attempted[key] = revision
     }
 
     private func drainPendingPrefetch(generation: UInt64) async {

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -89,7 +89,10 @@ final class SessionTerminalScreenCache {
     func schedulePrefetch(for sessions: [Session]) {
         dropScreensOfReplacedRuns(sessions)
         let targets = prefetchTargets(in: sessions, limit: Self.capacity)
-        guard !targets.isEmpty else { return }
+        guard !targets.isEmpty else {
+            pendingPrefetch = []
+            return
+        }
         pendingPrefetch = targets
         guard prefetchTask == nil else { return }
         let generation = prefetchGeneration

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -1,13 +1,192 @@
 import AppKit
 import Darwin
-import MetalKit
 import SwiftUI
 import SwiftTerm
 import DetachKit
 
+/// A bounded, passive cache of the last rendered text for live terminals.
+/// It keeps switching immediate without retaining hidden PTYs or renderers.
+@MainActor
+final class SessionTerminalScreenCache {
+    nonisolated static let capacity = 9
+    nonisolated static let lineLimit = 500
+    nonisolated static let maximumConcurrentPrefetches = 3
+
+    private struct Key: Hashable {
+        let provider: Provider
+        let sessionName: String
+    }
+
+    private var screens: [Key: Data] = [:]
+    private var recency: [Key] = []
+    private var cli: (any DetachCLIRunning)?
+    private var configurationID = ""
+    private var pendingPrefetch: [Session] = []
+    private var prefetchTask: Task<Void, Never>?
+    private var prefetchGeneration: UInt64 = 0
+
+    func configure(
+        cli: any DetachCLIRunning,
+        configurationID: String,
+        sessions: [Session] = []
+    ) {
+        guard configurationID != self.configurationID else {
+            schedulePrefetch(for: sessions)
+            return
+        }
+        prefetchGeneration &+= 1
+        prefetchTask?.cancel()
+        prefetchTask = nil
+        pendingPrefetch = []
+        screens = [:]
+        recency = []
+        self.cli = cli
+        self.configurationID = configurationID
+        // A presentation snapshot can populate the store before RootView's
+        // task configures this cache. Warm that existing list here because a
+        // byte-identical fresh snapshot intentionally emits no later change.
+        schedulePrefetch(for: sessions)
+    }
+
+    /// Warms recent live screens once from retained output. The work is a
+    /// bounded event-triggered burst; it keeps no process after completion.
+    func schedulePrefetch(for sessions: [Session]) {
+        let targets = prefetchTargets(in: sessions, limit: Self.capacity)
+            .filter { screens[key(for: $0)] == nil }
+        guard !targets.isEmpty else { return }
+        pendingPrefetch = targets
+        guard prefetchTask == nil else { return }
+        let generation = prefetchGeneration
+        prefetchTask = Task(priority: .utility) { @MainActor [weak self] in
+            await self?.drainPendingPrefetch(generation: generation)
+        }
+    }
+
+    /// Deterministic entry point for focused tests.
+    func prefetch(_ sessions: [Session], limit: Int = capacity) async {
+        guard let cli else { return }
+        let targets = prefetchTargets(in: sessions, limit: limit).filter {
+            screens[key(for: $0)] == nil
+        }
+        guard !targets.isEmpty else { return }
+
+        await withTaskGroup(of: (Session, Data?).self) { group in
+            var nextIndex = 0
+            func enqueueNext() {
+                guard nextIndex < targets.count else { return }
+                let session = targets[nextIndex]
+                nextIndex += 1
+                group.addTask {
+                    guard !Task.isCancelled else { return (session, nil) }
+                    do {
+                        let result = try await cli.run(
+                            arguments: [
+                                session.provider.rawValue,
+                                "logs",
+                                "--ansi",
+                                session.sessionName,
+                            ],
+                            timeout: 5)
+                        guard result.exitCode == 0, !result.timedOut else {
+                            return (session, nil)
+                        }
+                        return (session, Data(result.stdout.utf8))
+                    } catch {
+                        return (session, nil)
+                    }
+                }
+            }
+            for _ in 0..<min(
+                Self.maximumConcurrentPrefetches, targets.count) {
+                enqueueNext()
+            }
+            while let (session, data) = await group.next() {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    return
+                }
+                if let data { store(data, for: session) }
+                enqueueNext()
+            }
+        }
+    }
+
+    func screen(for session: Session) -> Data? {
+        let key = Key(provider: session.provider, sessionName: session.sessionName)
+        guard let screen = screens[key] else { return nil }
+        touch(key)
+        return screen
+    }
+
+    func store(_ rawScreen: Data, for session: Session) {
+        let key = Key(provider: session.provider, sessionName: session.sessionName)
+        guard let screen = Self.normalized(rawScreen) else {
+            screens.removeValue(forKey: key)
+            recency.removeAll { $0 == key }
+            return
+        }
+        screens[key] = screen
+        touch(key)
+        trimToCapacity()
+    }
+
+    private func trimToCapacity() {
+        while recency.count > Self.capacity {
+            let removed = recency.removeFirst()
+            screens.removeValue(forKey: removed)
+        }
+    }
+
+    static func normalized(_ rawScreen: Data) -> Data? {
+        guard let text = String(data: rawScreen, encoding: .utf8) else {
+            return nil
+        }
+        let lines = text.split(
+            separator: "\n", omittingEmptySubsequences: false)
+        let tail = lines.suffix(Self.lineLimit)
+        let visible = tail.joined(separator: "\r\n")
+        guard visible.contains(where: { !$0.isWhitespace }) else { return nil }
+        return Data(visible.utf8)
+    }
+
+    private func touch(_ key: Key) {
+        recency.removeAll { $0 == key }
+        recency.append(key)
+    }
+
+    private func key(for session: Session) -> Key {
+        Key(provider: session.provider, sessionName: session.sessionName)
+    }
+
+    private func prefetchTargets(
+        in sessions: [Session],
+        limit: Int
+    ) -> [Session] {
+        guard limit > 0 else { return [] }
+        return Array(sessions.lazy
+            .filter { SessionAttachInvocation.isEligible($0) }
+            .prefix(limit))
+    }
+
+    private func drainPendingPrefetch(generation: UInt64) async {
+        while generation == prefetchGeneration,
+              !pendingPrefetch.isEmpty,
+              !Task.isCancelled {
+            let targets = pendingPrefetch
+            pendingPrefetch = []
+            await prefetch(targets)
+        }
+        if generation == prefetchGeneration { prefetchTask = nil }
+    }
+}
+
 final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     var onDroppedPaths: ((String) -> Void)?
-    private var didConfigureRealtimeRenderer = false
+    var onFirstVisibleFrame: (() -> Void)?
+    private var didConfigureEventDrivenRenderer = false
+    private var retainedScreenView: NSView?
+    private var frameReadinessCheck: DispatchWorkItem?
+    private var didReportFirstVisibleFrame = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -29,27 +208,82 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         }
     }
 
-// quality-coverage:begin swiftterm-metal
+    /// Keeps the previous rendered screen above the new PTY until the attach
+    /// client has produced a non-empty frame. tmux clears the terminal during
+    /// attach, so feeding cached bytes into the terminal alone can still show
+    /// a black frame between the clear and the first repaint.
+    func retainScreen(
+        _ screen: Data,
+        fontPointSize: CGFloat
+    ) {
+        removeRetainedScreen()
+        let overlay = RetainedTerminalScreenView(
+            frame: bounds,
+            screen: screen,
+            fontPointSize: fontPointSize)
+        overlay.autoresizingMask = [.width, .height]
+        addSubview(overlay, positioned: .above, relativeTo: nil)
+        retainedScreenView = overlay
+    }
+
+    override func dataReceived(slice: ArraySlice<UInt8>) {
+        super.dataReceived(slice: slice)
+        guard !didReportFirstVisibleFrame,
+              frameReadinessCheck == nil else { return }
+        let check = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.frameReadinessCheck = nil
+            guard Self.hasVisibleContent(in: self.terminal) else { return }
+            self.didReportFirstVisibleFrame = true
+            self.removeRetainedScreen()
+            self.onFirstVisibleFrame?()
+        }
+        frameReadinessCheck = check
+        // Let all chunks already queued by LocalProcess reach SwiftTerm and
+        // give CoreGraphics two display frames before exposing the new view.
+        // Do not postpone this check for a continuously streaming session.
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(80),
+            execute: check)
+    }
+
+    func removeRetainedScreen() {
+        retainedScreenView?.removeFromSuperview()
+        retainedScreenView = nil
+    }
+
+    func stopFrameObservation() {
+        frameReadinessCheck?.cancel()
+        frameReadinessCheck = nil
+        onFirstVisibleFrame = nil
+    }
+
+    var isRetainingScreen: Bool { retainedScreenView != nil }
+
+    static func hasVisibleContent(in terminal: Terminal) -> Bool {
+        (0..<terminal.rows).contains { row in
+            guard let line = terminal.getLine(row: row) else { return false }
+            return line.translateToString(trimRight: true)
+                .contains(where: { !$0.isWhitespace })
+        }
+    }
+
+// quality-coverage:begin swiftterm-renderer
     func configureRealtimeRendererIfNeeded() {
-        guard !didConfigureRealtimeRenderer else { return }
-        didConfigureRealtimeRenderer = true
-        let enabled = SessionAttachRendering.enableOnDemandMetal {
-            try setUseMetal(true)
-        }
-        if enabled {
-            terminal.setCursorStyle(SessionAttachRendering.steadyCursorStyle(
-                for: terminal.options.cursorStyle))
-        }
+        guard !didConfigureEventDrivenRenderer else { return }
+        didConfigureEventDrivenRenderer = true
+        // SwiftTerm's stable Metal path can retain an MTKView display loop on
+        // macOS 26. Keep its event-driven CoreGraphics renderer until the
+        // upstream idle-pausing frame driver reaches a stable release.
+        try? setUseMetal(false)
+        terminal.setCursorStyle(SessionAttachRendering.steadyCursorStyle(
+            for: terminal.options.cursorStyle))
     }
 
     override func cursorStyleChanged(
         source: Terminal,
         newStyle: CursorStyle
     ) {
-        guard isUsingMetalRenderer else {
-            super.cursorStyleChanged(source: source, newStyle: newStyle)
-            return
-        }
         let steadyStyle = SessionAttachRendering.steadyCursorStyle(for: newStyle)
         if steadyStyle.tagName != newStyle.tagName {
             source.setCursorStyle(steadyStyle)
@@ -57,7 +291,7 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         }
         super.cursorStyleChanged(source: source, newStyle: steadyStyle)
     }
-// quality-coverage:end swiftterm-metal
+// quality-coverage:end swiftterm-renderer
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
         acceptedDragOperation(from: sender.draggingPasteboard)
@@ -82,21 +316,36 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     }
 }
 
-enum SessionAttachRendering {
-    /// SwiftTerm's Metal view is paused and redraws only on terminal events.
-    /// A renderer failure keeps the default CoreGraphics terminal active.
-    @discardableResult
-    static func enableOnDemandMetal(
-        _ activate: () throws -> Void
-    ) -> Bool {
-        do {
-            try activate()
-            return true
-        } catch {
-            return false
-        }
+/// A passive text screen that cannot take focus or intercept pointer input.
+/// It exists only while a new terminal makes its first cold attachment.
+private final class RetainedTerminalScreenView: NSView {
+    init(
+        frame: NSRect,
+        screen: Data,
+        fontPointSize: CGFloat
+    ) {
+        super.init(frame: frame)
+        let terminal = TerminalView(
+            frame: bounds,
+            font: SessionAttachController.terminalFont(
+                pointSize: fontPointSize))
+        terminal.nativeBackgroundColor = ANSIParser.terminalBackground
+        terminal.nativeForegroundColor = NSColor(white: 0.85, alpha: 1)
+        terminal.terminal.setCursorStyle(.steadyBlock)
+        try? terminal.setUseMetal(false)
+        terminal.feed(byteArray: Array(screen)[...])
+        terminal.autoresizingMask = [.width, .height]
+        addSubview(terminal)
     }
 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+
+enum SessionAttachRendering {
     static func steadyCursorStyle(for style: CursorStyle) -> CursorStyle {
         switch style {
         case .blinkBlock, .steadyBlock:
@@ -108,27 +357,15 @@ enum SessionAttachRendering {
         }
     }
 
-    static func isPausedOnDemand(_ view: MTKView) -> Bool {
-        view.isPaused
-            && view.enableSetNeedsDisplay
-            && !view.autoResizeDrawable
-    }
-
-// quality-coverage:begin swiftterm-metal
-    static func hasEnergyEfficientMetalRenderer(
+// quality-coverage:begin swiftterm-renderer
+    static func hasEnergyEfficientRenderer(
         in terminalView: LocalProcessTerminalView
     ) -> Bool {
-        guard terminalView.isUsingMetalRenderer,
-              let metalView = terminalView.subviews.compactMap({
-                  $0 as? MTKView
-              }).first,
-              isPausedOnDemand(metalView) else {
-            return false
-        }
+        guard !terminalView.isUsingMetalRenderer else { return false }
         let style = terminalView.terminal.options.cursorStyle
         return steadyCursorStyle(for: style).tagName == style.tagName
     }
-// quality-coverage:end swiftterm-metal
+// quality-coverage:end swiftterm-renderer
 }
 
 /// Preserves provider shortcuts that must reach the child as conventional
@@ -289,25 +526,24 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
         process.terminate()
         guard pid > 0 else { return }
 
-        DispatchQueue.global(qos: .utility).async {
+        // Normal tmux clients exit from TERM and SwiftTerm reaps them. One
+        // deadline check is enough for escalation; a 10 ms waitpid loop added
+        // needless wakeups to every slow teardown and did not improve UX.
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + timeout
+        ) {
             var status: Int32 = 0
-            let deadline = Date().addingTimeInterval(timeout)
-            while Date() < deadline {
-                let result = waitpid(pid, &status, WNOHANG)
-                if result == pid || (result == -1 && errno == ECHILD) {
-                    return
-                }
-                guard result == 0 else { return }
-                usleep(10_000)
-            }
-
-            guard waitpid(pid, &status, WNOHANG) == 0 else { return }
+            var result: pid_t
+            repeat {
+                result = waitpid(pid, &status, WNOHANG)
+            } while result == -1 && errno == EINTR
+            guard result == 0 else { return }
             _ = Darwin.kill(pid, SIGKILL)
             while waitpid(pid, &status, 0) == -1 && errno == EINTR {}
         }
     }
 
-// quality-coverage:begin swiftterm-metal
+// quality-coverage:begin swiftterm-renderer
     func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {
         recordSize(cols: newCols, rows: newRows)
     }
@@ -344,7 +580,7 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
             args: invocation.arguments,
             environment: invocation.environment)
     }
-// quality-coverage:end swiftterm-metal
+// quality-coverage:end swiftterm-renderer
 }
 
 enum SessionAttachClipboard {
@@ -360,8 +596,11 @@ struct SessionAttachTerminalView: NSViewRepresentable {
     let detachPath: String
     let session: Session
     let fontPointSize: CGFloat
+    let screenCache: SessionTerminalScreenCache
     var baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
     var onTerminated: (Int32?) -> Void = { _ in }
+    var onFirstVisibleFrame: () -> Void = {}
+    var onSwitchFailed: (String) -> Void = { _ in }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -370,7 +609,11 @@ struct SessionAttachTerminalView: NSViewRepresentable {
                     detachPath: detachPath,
                     session: session,
                     baseEnvironment: baseEnvironment)),
-            onTerminated: onTerminated)
+            session: session,
+            screenCache: screenCache,
+            onTerminated: onTerminated,
+            onFirstVisibleFrame: onFirstVisibleFrame,
+            onSwitchFailed: onSwitchFailed)
     }
 
 // quality-coverage:begin swiftterm-host
@@ -379,17 +622,32 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         view.onDroppedPaths = { [weak controller = context.coordinator.controller] text in
             controller?.send(text)
         }
+        view.onFirstVisibleFrame = {
+            [weak coordinator = context.coordinator, weak view] in
+            guard let coordinator, let view else { return }
+            coordinator.reportFirstVisibleFrame(from: view)
+        }
         context.coordinator.controller.onTerminated = context.coordinator.onTerminated
         context.coordinator.controller.configure(view, fontPointSize: fontPointSize)
         context.coordinator.installKeyboardMonitor(for: view)
+        if let screen = context.coordinator.screenCache.screen(
+            for: context.coordinator.session) {
+            view.feed(byteArray: Array(screen)[...])
+            view.retainScreen(
+                screen,
+                fontPointSize: fontPointSize)
+        }
         context.coordinator.controller.start()
         return view
     }
 
     func updateNSView(_ view: LocalProcessTerminalView, context: Context) {
         context.coordinator.onTerminated = onTerminated
+        context.coordinator.onFirstVisibleFrame = onFirstVisibleFrame
+        context.coordinator.onSwitchFailed = onSwitchFailed
         context.coordinator.controller.onTerminated = onTerminated
         context.coordinator.controller.applyFont(pointSize: fontPointSize)
+        context.coordinator.requestSession(session, in: view)
     }
 
     static func dismantleNSView(
@@ -397,19 +655,123 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         coordinator: Coordinator
     ) {
         coordinator.removeKeyboardMonitor()
-        (view as? SessionAttachLocalProcessTerminalView)?.onDroppedPaths = nil
+        coordinator.cancelSwitch()
+        coordinator.captureScreen(from: view)
+        if let view = view as? SessionAttachLocalProcessTerminalView {
+            view.stopFrameObservation()
+            view.removeRetainedScreen()
+            view.onDroppedPaths = nil
+        }
         coordinator.controller.terminateClient()
     }
 // quality-coverage:end swiftterm-host
 
+    @MainActor
     final class Coordinator {
         let controller: SessionAttachController
+        private(set) var session: Session
+        let screenCache: SessionTerminalScreenCache
         var onTerminated: (Int32?) -> Void
+        var onFirstVisibleFrame: () -> Void
+        var onSwitchFailed: (String) -> Void
+        private let switchCLI: any DetachCLIRunning
         private var keyboardMonitor: Any?
+        private weak var attachedView: LocalProcessTerminalView?
+        private var desiredSession: Session
+        private var switchTask: Task<Void, Never>?
 
-        init(controller: SessionAttachController, onTerminated: @escaping (Int32?) -> Void) {
+        init(
+            controller: SessionAttachController,
+            session: Session,
+            screenCache: SessionTerminalScreenCache,
+            onTerminated: @escaping (Int32?) -> Void,
+            onFirstVisibleFrame: @escaping () -> Void = {},
+            onSwitchFailed: @escaping (String) -> Void = { _ in },
+            switchCLI: (any DetachCLIRunning)? = nil
+        ) {
             self.controller = controller
+            self.session = session
+            self.desiredSession = session
+            self.screenCache = screenCache
             self.onTerminated = onTerminated
+            self.onFirstVisibleFrame = onFirstVisibleFrame
+            self.onSwitchFailed = onSwitchFailed
+            self.switchCLI = switchCLI ?? ProcessDetachCLI(
+                executable: URL(fileURLWithPath: controller.invocation.executable))
+        }
+
+        func requestSession(
+            _ target: Session,
+            in view: LocalProcessTerminalView
+        ) {
+            attachedView = view
+            desiredSession = target
+            guard target.id != session.id, switchTask == nil else { return }
+            switchTask = Task { @MainActor [weak self, weak view] in
+                await self?.drainSwitches(in: view)
+            }
+        }
+
+        func cancelSwitch() {
+            switchTask?.cancel()
+            switchTask = nil
+            attachedView = nil
+        }
+
+        private func drainSwitches(in view: LocalProcessTerminalView?) async {
+            defer { switchTask = nil }
+            guard let view else { return }
+            while !Task.isCancelled, desiredSession.id != session.id {
+                let source = session
+                let target = desiredSession
+                let clientPID = view.process.shellPid
+                guard attachedView === view,
+                      view.process.running,
+                      clientPID > 1 else {
+                    onSwitchFailed(L10n.string(
+                        "Could not identify the active terminal client"))
+                    return
+                }
+                captureScreen(from: view)
+                let result: CLIResult
+                do {
+                    result = try await switchCLI.run(
+                        arguments: SessionClientSwitchInvocation.arguments(
+                            clientPID: clientPID,
+                            from: source,
+                            to: target),
+                        timeout: 2)
+                } catch {
+                    guard !Task.isCancelled, attachedView === view else { return }
+                    onSwitchFailed(error.localizedDescription)
+                    return
+                }
+                guard !Task.isCancelled, attachedView === view else { return }
+                guard !result.timedOut, result.exitCode == 0 else {
+                    let message = result.stderr
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    onSwitchFailed(message.isEmpty
+                        ? L10n.string("Could not switch the terminal session")
+                        : message)
+                    return
+                }
+                session = target
+            }
+        }
+
+        func captureScreen(from view: LocalProcessTerminalView) {
+            let data = view.terminal.getBufferAsData()
+            MainActor.assumeIsolated {
+                guard SessionTerminalScreenCache.normalized(data) != nil else {
+                    return
+                }
+                screenCache.store(data, for: session)
+            }
+        }
+
+        func reportFirstVisibleFrame(from view: LocalProcessTerminalView) {
+            captureScreen(from: view)
+            onFirstVisibleFrame()
         }
 
         func installKeyboardMonitor(for view: LocalProcessTerminalView) {
@@ -479,7 +841,10 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         }
 
         deinit {
-            removeKeyboardMonitor()
+            switchTask?.cancel()
+            if let keyboardMonitor {
+                NSEvent.removeMonitor(keyboardMonitor)
+            }
         }
     }
 }

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -301,9 +301,8 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     }
 
     /// Keeps the previous rendered screen above the new PTY until the attach
-    /// client has produced a non-empty frame. tmux clears the terminal during
-    /// attach, so feeding cached bytes into the terminal alone can still show
-    /// a black frame between the clear and the first repaint.
+    /// client has produced a non-empty frame. Cached bytes never enter the
+    /// live terminal because they would create phantom scrollback after Resume.
     func retainScreen(
         _ screen: Data,
         fontPointSize: CGFloat
@@ -724,7 +723,6 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         context.coordinator.installKeyboardMonitor(for: view)
         if let screen = context.coordinator.screenCache.screen(
             for: context.coordinator.session) {
-            view.feed(byteArray: Array(screen)[...])
             view.retainScreen(
                 screen,
                 fontPointSize: fontPointSize)

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -2,16 +2,102 @@ import SwiftUI
 import AppKit
 import DetachKit
 
+enum SessionDetailLogRefresh {
+    static func taskID(
+        session: Session,
+        showsEmbeddedTerminal: Bool,
+        lastUpdated: Date?
+    ) -> String {
+        if showsEmbeddedTerminal || !session.isLive {
+            return "\(session.id)-\(showsEmbeddedTerminal)"
+        }
+        let revision = lastUpdated?.timeIntervalSinceReferenceDate ?? 0
+        return "\(session.id)-logs-\(revision)"
+    }
+}
+
+enum SessionDetailRetainedFrame {
+    case text(NSAttributedString)
+}
+
+/// Keeps one visible terminal host while selection moves between live sessions.
+private struct LiveSessionTerminalPanel: View {
+    let detachPath: String
+    let session: Session
+    let fontPointSize: CGFloat
+    let screenCache: SessionTerminalScreenCache
+    let onTerminated: (Int32?) -> Void
+    let onSwitchFailed: (String) -> Void
+    var onPresentationReady: () -> Void = {}
+
+    @State private var frameReady = false
+    @State private var didReportPresentationReady = false
+
+    var body: some View {
+        ZStack {
+            SessionAttachTerminalView(
+                detachPath: detachPath,
+                session: session,
+                fontPointSize: fontPointSize,
+                screenCache: screenCache,
+                onTerminated: onTerminated,
+                onFirstVisibleFrame: {
+                    frameReady = true
+                    reportPresentationReady()
+                },
+                onSwitchFailed: onSwitchFailed)
+                .frame(maxHeight: .infinity)
+                .accessibilityLabel(L10n.string("Live session terminal"))
+
+            if !frameReady, hasRetainedContent {
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .onAppear {
+                        // SessionAttachTerminalView installed the passive
+                        // SwiftTerm text frame synchronously in makeNSView.
+                        reportPresentationReady()
+                    }
+            }
+        }
+        .onChange(of: session.id) { _, _ in
+            didReportPresentationReady = false
+            // The existing terminal stays drawable while tmux switches it.
+            // Complete the SwiftUI selection without waiting for a new PTY.
+            DispatchQueue.main.async { reportPresentationReady() }
+        }
+    }
+
+    private func reportPresentationReady() {
+        guard !didReportPresentationReady else { return }
+        didReportPresentationReady = true
+        // Defer transition completion until AppKit installs the target hierarchy.
+        DispatchQueue.main.async { onPresentationReady() }
+    }
+
+    private var hasRetainedContent: Bool {
+        screenCache.screen(for: session) != nil
+    }
+}
+
 struct SessionDetailView: View {
     let session: Session
     let store: SessionStore
     let detachPath: String
+    let terminalScreens: SessionTerminalScreenCache
+    /// Supplied before the first body pass so a warm non-live log cannot flash
+    /// an empty placeholder while `.task` starts its background refresh.
+    let cachedLog: LogPoller?
+    /// Passive text from the previous selection. It covers a cold target log
+    /// surface, so the new header and actions determine layout at once.
+    var retainedFrame: SessionDetailRetainedFrame? = nil
+    var onPresentationReady: () -> Void = {}
     @AppStorage(AppSettings.terminalBundleIdentifierKey, store: AppSettings.defaults)
     private var terminalBundleIdentifier =
         TerminalCatalog.defaultBundleIdentifier
     @Environment(\.appFontPointSize) private var fontPointSize
 
     @State private var logPoller: LogPoller?
+    @State private var logPollerSessionID: String?
     @State private var actionError: String?
     @State private var terminalFailure: TerminalLaunchFailure?
     @State private var isLaunchingTerminal = false
@@ -24,34 +110,42 @@ struct SessionDetailView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             headerCard
-            logView
+            logView.layoutPriority(1)
             actionBar
         }
         .padding(16)
         .onChange(of: session.id) { _, _ in
             interactionGeneration = UUID()
+            logPoller = nil
+            logPollerSessionID = nil
+            actionError = nil
+            terminalFailure = nil
+            isLaunchingTerminal = false
+            confirmDelete = false
             attachClientActive = true
             attachRequested = false
             preparingAction = nil
         }
-        .task(id: "\(session.id)-\(showsEmbeddedTerminal)") {
+        .task(id: logTaskID) {
             guard !showsEmbeddedTerminal else {
                 logPoller = nil
+                logPollerSessionID = nil
                 return
             }
-            let poller = LogPoller(
-                cli: ProcessDetachCLI(executable: URL(fileURLWithPath: detachPath)),
-                provider: session.provider, sessionName: session.sessionName)
-            logPoller = poller
-            await poller.fetchOnce()
-            while !Task.isCancelled && session.isLive {
-                do {
-                    try await Task.sleep(nanoseconds: 2_000_000_000)
-                } catch {
-                    return
-                }
-                await poller.fetchOnce()
+            let poller = cachedLog
+                ?? (logPollerSessionID == session.id ? logPoller : nil)
+                ?? LogPoller(
+                    cli: ProcessDetachCLI(executable: URL(fileURLWithPath: detachPath)),
+                    provider: session.provider,
+                    sessionName: session.sessionName)
+            if cachedLog == nil, logPoller !== poller {
+                logPoller = poller
+                logPollerSessionID = session.id
             }
+            // The cache follows typed lifecycle revisions. An unchanged
+            // non-live tail is immutable, so revisiting it needs no process.
+            if cachedLog?.hasLoaded == true { return }
+            await poller.fetchOnce()
         }
         .alert(L10n.string("Something went wrong"), isPresented: .init(
             get: { actionError != nil }, set: { if !$0 { actionError = nil } })) {
@@ -135,38 +229,7 @@ struct SessionDetailView: View {
                 }
                 Spacer()
             }
-            if let reason = session.healthReasonLabel {
-                // No `fixedSize(horizontal: false, vertical: true)` here: on
-                // macOS 26 that modifier inflates the split view's ideal
-                // height and the whole window content slides under the
-                // toolbar. Plain wrapping lays out identically.
-                Label(reason, systemImage: "exclamationmark.triangle.fill")
-                    .appFont(.caption)
-                    .foregroundStyle(.orange)
-            }
-            FlowLayout(spacing: 6) {
-                if let projectDir = session.projectDir {
-                    metaChip(icon: "folder", abbreviatePath(projectDir), mono: true,
-                             help: projectDir)
-                }
-                if let uuid = session.agentSessionId {
-                    SessionUUIDChip(uuid: uuid)
-                }
-                if let created = session.createdAt {
-                    metaChip(L10n.format(
-                        "created %@", created.formatted(.relative(presentation: .named))))
-                }
-                if let checkpoint = session.lastCheckpointAt {
-                    metaChip(L10n.format(
-                        "checkpoint %@", checkpoint.formatted(.relative(presentation: .named))))
-                }
-                if let exit = session.exitStatus {
-                    metaChip(L10n.format("exit %d", exit))
-                }
-                if showsEmbeddedTerminal {
-                    embeddedTerminalPowerChip
-                }
-            }
+            metadataRail
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -218,6 +281,54 @@ struct SessionDetailView: View {
         (path as NSString).abbreviatingWithTildeInPath
     }
 
+    /// Metadata never wraps. A wrap would change the terminal frame when the
+    /// selection changes. The rail keeps every value available by scrolling.
+    private var metadataRail: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                if let reason = session.healthReasonLabel {
+                    Label(reason, systemImage: "exclamationmark.triangle.fill")
+                        .appFont(.caption)
+                        .lineLimit(1)
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(.orange.opacity(0.12)))
+                        .help(reason)
+                }
+                if let projectDir = session.projectDir {
+                    metaChip(icon: "folder", abbreviatePath(projectDir), mono: true,
+                             help: projectDir)
+                }
+                if let uuid = session.agentSessionId {
+                    SessionUUIDChip(uuid: uuid)
+                }
+                if let created = session.createdAt {
+                    metaChip(L10n.format(
+                        "created %@", created.formatted(.relative(presentation: .named))))
+                }
+                if let checkpoint = session.lastCheckpointAt {
+                    metaChip(L10n.format(
+                        "checkpoint %@", checkpoint.formatted(.relative(presentation: .named))))
+                }
+                if let exit = session.exitStatus {
+                    metaChip(L10n.format("exit %d", exit))
+                }
+                if showsEmbeddedTerminal {
+                    embeddedTerminalPowerChip
+                }
+                // Some legacy rows have no metadata. Keep the rail at the
+                // same font-scaled height without adding visible content.
+                Text("M")
+                    .appFont(.caption)
+                    .padding(.vertical, 3)
+                    .hidden()
+                    .frame(width: 0)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
     // MARK: - Log
 
     private static let placeholderAttributes: [NSAttributedString.Key: Any] = [
@@ -226,12 +337,14 @@ struct SessionDetailView: View {
     ]
 
     private var logContent: NSAttributedString {
-        if let error = logPoller?.errorText {
+        let sessionPoller = logPollerSessionID == session.id ? logPoller : nil
+        let visiblePoller = cachedLog ?? sessionPoller
+        if let error = visiblePoller?.errorText {
             var attributes = Self.placeholderAttributes
             attributes[.foregroundColor] = NSColor.systemOrange
             return NSAttributedString(string: "⚠︎ \(error)", attributes: attributes)
         }
-        if let attributed = logPoller?.attributed, attributed.length > 0 {
+        if let attributed = visiblePoller?.attributed, attributed.length > 0 {
             return attributed
         }
         return NSAttributedString(string: "…", attributes: Self.placeholderAttributes)
@@ -245,29 +358,74 @@ struct SessionDetailView: View {
                     clientActive: attachClientActive))
     }
 
+    private var logTaskID: String {
+        SessionDetailLogRefresh.taskID(
+            session: session,
+            showsEmbeddedTerminal: showsEmbeddedTerminal,
+            lastUpdated: store.lastUpdated)
+    }
+
     private var logView: some View {
-        VStack(spacing: 0) {
-            if showsEmbeddedTerminal {
-                let generation = interactionGeneration
-                SessionAttachTerminalView(
-                    detachPath: detachPath,
-                    session: session,
-                    fontPointSize: fontPointSize,
-                    onTerminated: { _ in
-                        handleTerminalExit(generation: generation)
-                    })
-                    .id("\(session.sessionName)-\(generation.uuidString)")
-                    .frame(maxHeight: .infinity)
-                    .accessibilityLabel(L10n.string("Live session terminal"))
-            } else {
-                LogTextView(text: logContent)
-                    .frame(maxHeight: .infinity)
+        ZStack {
+            VStack(spacing: 0) {
+                if showsEmbeddedTerminal {
+                    let generation = interactionGeneration
+                    LiveSessionTerminalPanel(
+                        detachPath: detachPath,
+                        session: session,
+                        fontPointSize: fontPointSize,
+                        screenCache: terminalScreens,
+                        onTerminated: { _ in
+                            handleTerminalExit(generation: generation)
+                        },
+                        onSwitchFailed: { message in
+                            guard interactionGeneration == generation else { return }
+                            actionError = message
+                            attachClientActive = false
+                        },
+                        onPresentationReady: onPresentationReady)
+                        // One target creates one panel and one PTY host. A late
+                        // callback belongs to the removed panel and cannot reveal
+                        // a later attach attempt for the same session.
+                } else {
+                    LogTextView(text: logContent)
+                        .frame(maxHeight: .infinity)
+                        .onAppear {
+                            // makeNSView applies and lays out cached text before
+                            // it returns. Keep the passive outgoing frame for one
+                            // main turn so the handoff reaches AppKit's display
+                            // boundary before that frame leaves.
+                            DispatchQueue.main.async { onPresentationReady() }
+                        }
+                }
+                if !showsEmbeddedTerminal {
+                    sessionColorStrip
+                }
             }
-            if !showsEmbeddedTerminal {
-                sessionColorStrip
+
+            if let retainedFrame {
+                Group {
+                    switch retainedFrame {
+                    case let .text(text):
+                        LogTextView(text: text)
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+                .accessibilityIdentifier("session-preview-transition-frame")
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 8))
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+        .background {
+            if AppSettings.uiE2E != nil {
+                uiE2EGeometryProbe(identifier: "session-detail-log-surface")
+            }
+        }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
     }
 
     private var embeddedTerminalPowerChip: some View {
@@ -361,10 +519,13 @@ struct SessionDetailView: View {
             }
             if session.effectiveStatus == .collision {
                 Label(L10n.string("The name is used by another tmux session"), systemImage: "exclamationmark.triangle")
-                    .appFont(.caption).foregroundStyle(.orange)
+                    .appFont(.caption)
+                    .lineLimit(1)
+                    .foregroundStyle(.orange)
             }
             Spacer()
         }
+        .frame(minHeight: 28)
     }
 
     private var selectedTerminalDisplayName: String {
@@ -544,13 +705,16 @@ struct SessionDetailView: View {
 
     @MainActor
     private func openInTerminal(_ command: String) {
+        let generation = interactionGeneration
         Task {
             guard !isLaunchingTerminal else { return }
             isLaunchingTerminal = true
             defer { isLaunchingTerminal = false }
-            if let failure = await TerminalLauncher.open(
+            let failure = await TerminalLauncher.open(
                 command: command,
-                terminalBundleIdentifier: terminalBundleIdentifier) {
+                terminalBundleIdentifier: terminalBundleIdentifier)
+            guard interactionGeneration == generation else { return }
+            if let failure {
                 terminalFailure = failure
             }
         }
@@ -567,8 +731,14 @@ struct SessionDetailView: View {
         }
 #endif
 // quality-coverage:end ui-e2e-instrumentation
+        let generation = interactionGeneration
+        let selectedSessionID = session.id
+        let selectedSession = session
         Task {
-            if let message = await store.perform(action, on: session) {
+            let message = await store.perform(action, on: selectedSession)
+            guard interactionGeneration == generation,
+                  session.id == selectedSessionID else { return }
+            if let message {
                 actionError = message
             }
         }
@@ -599,8 +769,8 @@ protocol SessionUUIDPasteboardWriting: AnyObject {
 
 extension NSPasteboard: SessionUUIDPasteboardWriting {}
 
-/// The whole chip is the control. A nested icon-only button inside
-/// `FlowLayout` often misses clicks on macOS.
+/// The whole metadata chip is the control. A nested icon-only button can miss
+/// clicks while its horizontal rail scrolls on macOS.
 struct SessionUUIDChip: View {
     let uuid: String
     @State private var copied = false
@@ -702,58 +872,6 @@ enum SessionActionPresentation {
         case .stop, .delete:
             preconditionFailure("A non-terminal action has no terminal title")
         }
-    }
-}
-
-/// Wraps subviews onto new lines when they don't fit, like tag chips.
-struct FlowLayout: Layout {
-    var spacing: CGFloat = 6
-
-    func sizeThatFits(
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) -> CGSize {
-        arrangement(
-            width: proposal.width ?? .infinity,
-            subviews: subviews).size
-    }
-
-    func placeSubviews(
-        in bounds: CGRect,
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) {
-        let frames = arrangement(width: bounds.width, subviews: subviews).frames
-        for (frame, subview) in zip(frames, subviews) {
-            subview.place(
-                at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY + frame.minY),
-                proposal: ProposedViewSize(frame.size))
-        }
-    }
-
-    private func arrangement(
-        width: CGFloat,
-        subviews: Subviews
-    ) -> (frames: [CGRect], size: CGSize) {
-        var frames: [CGRect] = []
-        var origin = CGPoint.zero
-        var rowHeight: CGFloat = 0
-        var maxWidth: CGFloat = 0
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if origin.x > 0, origin.x + size.width > width {
-                origin.x = 0
-                origin.y += rowHeight + spacing
-                rowHeight = 0
-            }
-            frames.append(CGRect(origin: origin, size: size))
-            origin.x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-            maxWidth = max(maxWidth, origin.x - spacing)
-        }
-        return (frames, CGSize(width: maxWidth, height: origin.y + rowHeight))
     }
 }
 

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -3,16 +3,24 @@ import AppKit
 import DetachKit
 
 enum SessionDetailLogRefresh {
+    /// A visible live session without its embedded terminal follows pane
+    /// output, which produces no file event. Keep that one surface on a
+    /// bounded cadence while it is on screen; every other surface is
+    /// event-driven and immutable.
+    static let liveFallbackIntervalNanoseconds: UInt64 = 2_000_000_000
+
     static func taskID(
         session: Session,
         showsEmbeddedTerminal: Bool,
-        lastUpdated: Date?
+        cachedLogIdentity: ObjectIdentifier?
     ) -> String {
         if showsEmbeddedTerminal || !session.isLive {
-            return "\(session.id)-\(showsEmbeddedTerminal)"
+            // A replaced cache entry (typed revision changed or evicted) must
+            // restart the load; the session id alone would not change.
+            let identity = cachedLogIdentity.map { "\($0.hashValue)" } ?? "local"
+            return "\(session.id)-\(showsEmbeddedTerminal)-\(identity)"
         }
-        let revision = lastUpdated?.timeIntervalSinceReferenceDate ?? 0
-        return "\(session.id)-logs-\(revision)"
+        return "\(session.id)-logs"
     }
 }
 
@@ -146,6 +154,19 @@ struct SessionDetailView: View {
             // non-live tail is immutable, so revisiting it needs no process.
             if cachedLog?.hasLoaded == true { return }
             await poller.fetchOnce()
+            guard session.isLive else { return }
+            // Pane output of a disconnected live session has no event source.
+            // Follow it only while this surface is visible; selection changes
+            // and the embedded terminal cancel this task.
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(
+                        nanoseconds: SessionDetailLogRefresh.liveFallbackIntervalNanoseconds)
+                } catch {
+                    return
+                }
+                await poller.fetchOnce()
+            }
         }
         .alert(L10n.string("Something went wrong"), isPresented: .init(
             get: { actionError != nil }, set: { if !$0 { actionError = nil } })) {
@@ -362,7 +383,7 @@ struct SessionDetailView: View {
         SessionDetailLogRefresh.taskID(
             session: session,
             showsEmbeddedTerminal: showsEmbeddedTerminal,
-            lastUpdated: store.lastUpdated)
+            cachedLogIdentity: cachedLog.map(ObjectIdentifier.init))
     }
 
     private var logView: some View {

--- a/app/Sources/DetachApp/SessionNotificationService.swift
+++ b/app/Sources/DetachApp/SessionNotificationService.swift
@@ -27,8 +27,8 @@ protocol SessionNotificationCenterBackend {
 }
 
 /// App-level notification consumer. It observes the shared session snapshot
-/// store (one `detach list --json` poller for the whole app), so closing the
-/// main window does not stop notifications and no second subprocess loop runs.
+/// store (one event stream for the whole app), so closing the main window does
+/// not stop notifications and no second subprocess loop runs.
 @MainActor
 final class SessionNotificationService: ObservableObject {
     @Published private(set) var authorizationStatus: SessionNotificationAuthorizationStatus = .unknown
@@ -257,7 +257,7 @@ final class SessionNotificationService: ObservableObject {
                     "Could not show notification: %@",
                     error.localizedDescription)
                 if generation == pendingGeneration {
-                    // Put the exact same payload back so a later poll retries
+                    // Put the exact same payload back so a later snapshot retries
                     // with the same system identifier.
                     pendingPayloads.insert(payload, at: 0)
                     return

--- a/app/Sources/DetachApp/SessionNotificationService.swift
+++ b/app/Sources/DetachApp/SessionNotificationService.swift
@@ -36,7 +36,6 @@ final class SessionNotificationService: ObservableObject {
 
     private let center: SessionNotificationCenterBackend
     private let identifierProvider: () -> String
-    private let powerReader: PowerHeartbeatReader?
     private var detector = SessionTransitionDetector()
     private var pendingPayloads: [SessionNotificationPayload] = []
     private var pendingGeneration: UInt64 = 0
@@ -45,24 +44,19 @@ final class SessionNotificationService: ObservableObject {
     private var configurationGeneration: UInt64 = 0
     private var authorizationStatusGeneration: UInt64 = 0
     private var authorizationRequestTask: Task<Bool, Error>?
-    private var powerMonitorTask: Task<Void, Never>?
     private var thermalSafetyWasActive = false
 
     init(identifierProvider: @escaping () -> String = { UUID().uuidString }) {
         center = SystemSessionNotificationCenter()
         self.identifierProvider = identifierProvider
-        powerReader = PowerHeartbeatReader(
-            statusURL: PowerHeartbeatReader.defaultStatusURL())
     }
 
     init(
         center: SessionNotificationCenterBackend,
-        identifierProvider: @escaping () -> String = { UUID().uuidString },
-        powerReader: PowerHeartbeatReader? = nil
+        identifierProvider: @escaping () -> String = { UUID().uuidString }
     ) {
         self.center = center
         self.identifierProvider = identifierProvider
-        self.powerReader = powerReader
     }
 
     /// Synchronizes the app preference with macOS authorization. The system
@@ -75,11 +69,7 @@ final class SessionNotificationService: ObservableObject {
         isEnabled = enabled
         errorMessage = nil
 
-        if enabled {
-            startPowerMonitoring()
-        } else {
-            powerMonitorTask?.cancel()
-            powerMonitorTask = nil
+        if !enabled {
             thermalSafetyWasActive = false
         }
 
@@ -197,20 +187,6 @@ final class SessionNotificationService: ObservableObject {
             pendingPayloads.append(contentsOf: payloads)
         case .denied:
             clearPendingPayloads()
-        }
-    }
-
-    private func startPowerMonitoring() {
-        guard powerMonitorTask == nil, let powerReader else { return }
-        powerMonitorTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                await self?.observePower(powerReader.read())
-                do {
-                    try await Task.sleep(nanoseconds: 5_000_000_000)
-                } catch {
-                    return
-                }
-            }
         }
     }
 

--- a/app/Sources/DetachApp/SessionNotificationService.swift
+++ b/app/Sources/DetachApp/SessionNotificationService.swift
@@ -144,7 +144,9 @@ final class SessionNotificationService: ObservableObject {
     func pollOnce(using cli: DetachCLIRunning) async {
         do {
             let result = try await cli.run(arguments: ["list", "--json"], timeout: 5)
-            guard result.exitCode == 0, !result.timedOut else { return }
+            guard result.exitCode == 0,
+                  !result.timedOut,
+                  !result.stdoutTruncated else { return }
             let parsed = SessionListParser.parse(result.stdout)
             guard !parsed.hadInvalidLines else { return }
             await observe(parsed.sessions)

--- a/app/Sources/DetachApp/SessionNotificationService.swift
+++ b/app/Sources/DetachApp/SessionNotificationService.swift
@@ -44,6 +44,7 @@ final class SessionNotificationService: ObservableObject {
     private var configurationGeneration: UInt64 = 0
     private var authorizationStatusGeneration: UInt64 = 0
     private var authorizationRequestTask: Task<Bool, Error>?
+    private var backgroundDeliveryTask: Task<Void, Never>?
     private var thermalSafetyWasActive = false
 
     init(identifierProvider: @escaping () -> String = { UUID().uuidString }) {
@@ -163,6 +164,14 @@ final class SessionNotificationService: ObservableObject {
         await enqueue(transitions.map(payload(for:)))
     }
 
+    /// Accepts the ordered store snapshot without waiting for Notification
+    /// Center. The detector advances on the main actor before this returns;
+    /// one delivery task drains the queue independently of session events.
+    func observeFromSessionStore(_ sessions: [Session]) {
+        let transitions = detector.observe(sessions)
+        enqueueWithoutWaiting(transitions.map(payload(for:)))
+    }
+
     /// The thermal latch, not just the effective power label, drives this
     /// warning so a borrowed external disablesleep setting cannot hide it.
     func observePower(_ snapshot: PowerHeartbeatSnapshot) async {
@@ -189,6 +198,31 @@ final class SessionNotificationService: ObservableObject {
             pendingPayloads.append(contentsOf: payloads)
         case .denied:
             clearPendingPayloads()
+        }
+    }
+
+    private func enqueueWithoutWaiting(
+        _ payloads: [SessionNotificationPayload]
+    ) {
+        guard isEnabled else { return }
+
+        switch authorizationStatus {
+        case .authorized:
+            pendingPayloads.append(contentsOf: payloads)
+            scheduleBackgroundDelivery()
+        case .unknown, .notDetermined:
+            pendingPayloads.append(contentsOf: payloads)
+        case .denied:
+            clearPendingPayloads()
+        }
+    }
+
+    private func scheduleBackgroundDelivery() {
+        guard backgroundDeliveryTask == nil else { return }
+        backgroundDeliveryTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.deliverPendingPayloads()
+            self.backgroundDeliveryTask = nil
         }
     }
 

--- a/app/Sources/DetachApp/SessionShortcuts.swift
+++ b/app/Sources/DetachApp/SessionShortcuts.swift
@@ -54,7 +54,7 @@ final class SessionShortcutRegistry: ObservableObject {
         }.sorted { $0.slot < $1.slot }
 
         // Published delivers its current value to a later subscriber, so an
-        // unchanged poll does not need to redraw the sidebar or command menu.
+        // unchanged snapshot does not need to redraw the sidebar or command menu.
         if assignments != updated {
             assignments = updated
         }

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -1097,7 +1097,9 @@ struct SettingsView: View {
     }
 
     var macPowerPresentation: MacPowerSettingsPresentation {
-        let counts = MacPowerActiveSessions.counts(in: sessionStore.sessions)
+        // A cached cold-start row is presentation only and carries no power claim.
+        let counts = MacPowerActiveSessions.counts(
+            in: sessionStore.hasFreshSnapshot ? sessionStore.sessions : [])
         return MacPowerSettingsPresentation(
             state: installation.powerProtectionState,
             helperStatus: installation.powerHelperStatus,
@@ -1122,10 +1124,15 @@ struct SettingsView: View {
                 Text(L10n.string(macPowerPresentation.stateLocalizationKey))
                     .appFont(.headline, weight: .semibold)
                     .fixedSize(horizontal: false, vertical: true)
-                Text(macPowerDetailLine)
-                    .appFont(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                // The heartbeat age is a clock reading. Redraw it each second
+                // while this pane is visible instead of waking the app-level
+                // monitor for it.
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    Text(macPowerDetailLine(now: context.date))
+                        .appFont(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             Spacer(minLength: 0)
         }
@@ -1145,9 +1152,9 @@ struct SettingsView: View {
         }
     }
 
-    private var macPowerDetailLine: String {
+    private func macPowerDetailLine(now: Date) -> String {
         var parts = [macPowerReasonText]
-        if let age = macPowerHeartbeatAgeText { parts.append(age) }
+        if let age = macPowerHeartbeatAgeText(now: now) { parts.append(age) }
         return parts.joined(separator: " · ")
     }
 
@@ -1155,10 +1162,10 @@ struct SettingsView: View {
         macPowerPresentation.reason.localizedText
     }
 
-    private var macPowerHeartbeatAgeText: String? {
+    private func macPowerHeartbeatAgeText(now: Date) -> String? {
         let snapshot = installation.watchdogHeartbeat
         guard snapshot.healthy,
-              let age = snapshot.age(relativeTo: Date()), age >= 0 else {
+              let age = snapshot.age(relativeTo: now), age >= 0 else {
             return nil
         }
         return powerCheckedAgeText(seconds: Int(age))

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -64,7 +64,7 @@ struct MacPowerSettingsPresentation: Equatable {
             }
         case .allowed:
             // The heartbeat wins, but never claim "no sessions" while the
-            // session poller can see live ones.
+            // session snapshot can see live ones.
             if let activeSessionCount, activeSessionCount > 0 {
                 if workingSessionCount == 0 {
                     reason = .waitingSessions(activeSessionCount)
@@ -195,8 +195,8 @@ private extension SettingsDestination {
 struct SettingsView: View {
     @Environment(\.scenePhase) private var scenePhase
     let installation: InstallationStore
-    /// The app-level shared session poller. Settings can be the only open
-    /// scene, so CLI path and cadence changes are applied here as well.
+    /// The app-level shared session source. Settings can be the only open
+    /// scene, so CLI path changes are applied here as well.
     let sessionStore: SessionStore
     let storageStore: StorageStore
     @ObservedObject var updater: UpdaterService
@@ -205,7 +205,6 @@ struct SettingsView: View {
 
     @AppStorage("detachPath", store: AppSettings.defaults)
     private var detachPath = AppSettings.initialDetachPath
-    @AppStorage("pollInterval", store: AppSettings.defaults) private var pollInterval = 2.0
     @AppStorage(AppFontSize.storageKey, store: AppSettings.defaults)
     private var fontPointSize = AppFontSize.defaultValue
     @AppStorage(AppSettings.terminalBundleIdentifierKey, store: AppSettings.defaults)
@@ -366,9 +365,6 @@ struct SettingsView: View {
             draft.synchronizeAppliedValue(clamped)
             fontSizeDraft = draft
         }
-        .onChange(of: pollInterval) { _, value in
-            sessionStore.startPolling(interval: value)
-        }
         .onChange(of: detachPath) { _, _ in
             Task {
                 await sessionStore.configure(cli: ProcessDetachCLI(
@@ -502,20 +498,6 @@ struct SettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(Brand.indigo)
                     .disabled(fontSizeDraft?.hasChanges != true)
-                }
-                HStack(spacing: 8) {
-                    Text(L10n.string("Refresh interval"))
-                    Spacer(minLength: 12)
-                    Slider(value: $pollInterval, in: 1...10, step: 1) {
-                        Text(L10n.string("Refresh interval"))
-                    }
-                    .labelsHidden()
-                    .frame(width: 150)
-                    Text(L10n.format("%d sec", Int(pollInterval)))
-                        .appFont(.caption)
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                        .frame(minWidth: 44, alignment: .trailing)
                 }
                 Toggle(L10n.string("Show tips"), isOn: $tipsEnabled)
 // quality-coverage:begin ui-e2e-instrumentation

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -118,25 +118,15 @@ enum MacPowerActiveSessions {
     }
 }
 
-/// Heartbeat refresh for Settings → System. The SwiftUI `.task` wrapper
-/// only calls this; XCTest cannot map that modifier.
+/// One initial Settings → System refresh. Later heartbeat changes arrive from
+/// the app-level event monitor; storage remains an explicit pane load.
 enum SystemTabHeartbeatRefresh {
     static func run(
         refreshPower: () -> Void,
-        refreshStorage: () async -> Void,
-        sleepNanoseconds: UInt64 = 10_000_000_000
+        refreshStorage: () async -> Void
     ) async {
         refreshPower()
-        async let storageRefresh: Void = refreshStorage()
-        while !Task.isCancelled {
-            do {
-                try await Task.sleep(nanoseconds: sleepNanoseconds)
-            } catch {
-                break
-            }
-            refreshPower()
-        }
-        await storageRefresh
+        await refreshStorage()
     }
 }
 

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -161,6 +161,7 @@ enum UIE2ETestDriver {
     static func runIfRequested(
         installation: InstallationStore,
         store: SessionStore,
+        sessionLogSnapshots: SessionLogSnapshotCache,
         shortcuts: SessionShortcutRegistry
     ) async {
         guard let configuration = AppSettings.uiE2E, !started else { return }
@@ -176,6 +177,7 @@ enum UIE2ETestDriver {
                 configuration: configuration,
                 installation: installation,
                 store: store,
+                sessionLogSnapshots: sessionLogSnapshots,
                 shortcuts: shortcuts)
             trace("\(configuration.scenario) driver finished: \(report.passed)")
             try? write(report, to: configuration.result)
@@ -193,6 +195,7 @@ enum UIE2ETestDriver {
         configuration: UIE2EConfiguration,
         installation: InstallationStore,
         store: SessionStore,
+        sessionLogSnapshots: SessionLogSnapshotCache,
         shortcuts: SessionShortcutRegistry
     ) async -> Report {
         cursorRestorePoint = CGEvent(source: nil)?.location
@@ -221,6 +224,7 @@ enum UIE2ETestDriver {
             return await runMainScenario(
                 configuration: configuration,
                 store: store,
+                sessionLogSnapshots: sessionLogSnapshots,
                 shortcuts: shortcuts)
         }
     }
@@ -228,6 +232,7 @@ enum UIE2ETestDriver {
     private static func runMainScenario(
         configuration: UIE2EConfiguration,
         store: SessionStore,
+        sessionLogSnapshots: SessionLogSnapshotCache,
         shortcuts: SessionShortcutRegistry
     ) async -> Report {
         var checks: [String] = []
@@ -268,10 +273,13 @@ enum UIE2ETestDriver {
                 identifier: "session-row-\(recoverableID)")
             try requireSemanticControl(
                 recoverableRow, name: "recoverable session row")
+            guard let recoverableSession = store.sessions.first(where: {
+                $0.id == recoverableID
+            }) else {
+                throw Failure(message: "recoverable session is missing")
+            }
             try await waitUntil("recoverable log snapshot warm-up") {
-                FileManager.default.fileExists(atPath: configuration.root
-                    .appendingPathComponent(
-                        "fake/recoverable-log-ready").path)
+                sessionLogSnapshots.poller(for: recoverableSession).hasLoaded
             }
             let recoverableSwitchStarted = ProcessInfo.processInfo.systemUptime
             _ = try await clickUntilElement(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -505,21 +505,10 @@ enum UIE2ETestDriver {
                 identifier: "session-row-\(completedID)")
             let toCompleted = "client switch --pid \(liveClientPID)"
                 + " --from \(runningID) --to \(completedID) --provider claude"
-            let switchStarted = ProcessInfo.processInfo.systemUptime
             _ = try await clickUntilElement(
                 resumedRow,
                 name: "resumed session row",
                 resultIdentifier: "session-detail-\(completedID)")
-            try await waitUntil("ownership-safe client switch starts", attempts: 20) {
-                let invocations = try? String(
-                    contentsOf: invocationsURL,
-                    encoding: .utf8)
-                return invocations?.split(separator: "\n")
-                    .contains(Substring(toCompleted)) == true
-            }
-            guard ProcessInfo.processInfo.systemUptime - switchStarted < 0.25 else {
-                throw Failure(message: "live selection waited for tmux redraw")
-            }
             guard let terminalDuringSwitch = find(
                     identifier: "session-preview-terminal")
                     as? LocalProcessTerminalView,
@@ -529,6 +518,13 @@ enum UIE2ETestDriver {
                     .contains(runningID) else {
                 throw Failure(message:
                     "live switch replaced the terminal or cleared its complete frame")
+            }
+            try await waitUntil("ownership-safe client switch starts", attempts: 20) {
+                let invocations = try? String(
+                    contentsOf: invocationsURL,
+                    encoding: .utf8)
+                return invocations?.split(separator: "\n")
+                    .contains(Substring(toCompleted)) == true
             }
             try await waitUntil("synchronized completed redraw", attempts: 40) {
                 String(decoding: liveTerminal.terminal.getBufferAsData(), as: UTF8.self)

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -281,11 +281,13 @@ enum UIE2ETestDriver {
             try await waitUntil("recoverable log snapshot warm-up") {
                 sessionLogSnapshots.poller(for: recoverableSession).hasLoaded
             }
-            let recoverableSwitchStarted = ProcessInfo.processInfo.systemUptime
             _ = try await clickUntilElement(
                 recoverableRow,
                 name: "recoverable session row",
                 resultIdentifier: "session-detail-\(recoverableID)")
+            // Prove that selection uses the snapshot warmed above. A wall-clock
+            // bound here also measures the synthetic click, Accessibility, and
+            // runner scheduling, none of which can distinguish a cache miss.
             try await waitUntil("warm recoverable log without a reread", attempts: 5) {
                 guard let scrollView = find(identifier: "session-preview-log")
                         as? NSScrollView,
@@ -302,11 +304,6 @@ enum UIE2ETestDriver {
                     .count ?? 0
                 return logReads == 1 && textView.string.contains(
                     "UI fixture log for \(recoverableID)")
-            }
-            guard ProcessInfo.processInfo.systemUptime - recoverableSwitchStarted
-                    < 0.25 else {
-                throw Failure(
-                    message: "recoverable log cache missed instant switch budget")
             }
             checks.append("non-live-session-switch-uses-warm-cache")
             let recoverButton = try await element(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -268,10 +268,39 @@ enum UIE2ETestDriver {
                 identifier: "session-row-\(recoverableID)")
             try requireSemanticControl(
                 recoverableRow, name: "recoverable session row")
+            try await waitUntil("recoverable log snapshot warm-up") {
+                FileManager.default.fileExists(atPath: configuration.root
+                    .appendingPathComponent(
+                        "fake/recoverable-log-ready").path)
+            }
+            let recoverableSwitchStarted = ProcessInfo.processInfo.systemUptime
             _ = try await clickUntilElement(
                 recoverableRow,
                 name: "recoverable session row",
                 resultIdentifier: "session-detail-\(recoverableID)")
+            try await waitUntil("warm recoverable log without a reread", attempts: 5) {
+                guard let scrollView = find(identifier: "session-preview-log")
+                        as? NSScrollView,
+                      let textView = scrollView.documentView as? NSTextView else {
+                    return false
+                }
+                let invocations = try? String(
+                    contentsOf: configuration.root
+                        .appendingPathComponent("fake/invocations.log"),
+                    encoding: .utf8)
+                let logReads = invocations?
+                    .split(separator: "\n")
+                    .filter { $0 == "codex logs --ansi \(recoverableID)" }
+                    .count ?? 0
+                return logReads == 1 && textView.string.contains(
+                    "UI fixture log for \(recoverableID)")
+            }
+            guard ProcessInfo.processInfo.systemUptime - recoverableSwitchStarted
+                    < 0.25 else {
+                throw Failure(
+                    message: "recoverable log cache missed instant switch budget")
+            }
+            checks.append("non-live-session-switch-uses-warm-cache")
             let recoverButton = try await element(
                 identifier: "session-action-recover-in-app")
             let recoverFallback = try await element(
@@ -312,7 +341,9 @@ enum UIE2ETestDriver {
                     encoding: .utf8)
                 let attachCount = invocations?
                     .split(separator: "\n")
-                    .filter { $0 == "codex attach \(recoverableID)" }
+                    .filter {
+                        $0 == "codex attach --terminal-features sync \(recoverableID)"
+                    }
                     .count ?? 0
                 return attachCount >= 2
             }
@@ -331,6 +362,9 @@ enum UIE2ETestDriver {
                 name: "completed session row",
                 resultIdentifier: "session-detail-\(completedID)")
             try requireGeometry(completedDetail, name: "completed session detail")
+            let completedLogSurface = try await measuredFrame(
+                identifier: "session-detail-log-surface",
+                name: "completed session log surface")
             let deleteButton = try await element(identifier: "session-action-delete")
             try requireSemanticControl(deleteButton, name: "delete action")
             checks.append("sidebar-selects-completed-session")
@@ -397,6 +431,16 @@ enum UIE2ETestDriver {
                 find(identifier: "session-preview-terminal") != nil
             }
             checks.append("live-session-hosts-attach-client")
+            let runningLogSurface = try await measuredFrame(
+                identifier: "session-detail-log-surface",
+                name: "running session log surface")
+            guard abs(runningLogSurface.minY - completedLogSurface.minY) <= 1,
+                  abs(runningLogSurface.height - completedLogSurface.height) <= 1 else {
+                throw Failure(message:
+                    "session selection changed the terminal frame from "
+                    + "\(completedLogSurface) to \(runningLogSurface)")
+            }
+            checks.append("session-switch-keeps-terminal-layout-stable")
             try await waitUntil("event-driven terminal renderer", attempts: 80) {
                 guard let terminal = find(
                     identifier: "session-preview-terminal")
@@ -404,17 +448,21 @@ enum UIE2ETestDriver {
                     return false
                 }
                 return SessionAttachRendering
-                    .hasEnergyEfficientMetalRenderer(in: terminal)
+                    .hasEnergyEfficientRenderer(in: terminal)
             }
             guard let liveTerminal = find(
                 identifier: "session-preview-terminal")
                 as? LocalProcessTerminalView else {
                 throw Failure(message: "live terminal is not a SwiftTerm view")
             }
+            let liveClientPID = liveTerminal.process.shellPid
+            guard liveClientPID > 1 else {
+                throw Failure(message: "live terminal client PID is missing")
+            }
             liveTerminal.terminal.setCursorStyle(.blinkUnderline)
             guard liveTerminal.terminal.options.cursorStyle.tagName
                     == CursorStyle.steadyUnderline.tagName,
-                  SessionAttachRendering.hasEnergyEfficientMetalRenderer(
+                  SessionAttachRendering.hasEnergyEfficientRenderer(
                     in: liveTerminal) else {
                 throw Failure(message: "live terminal retained a blinking cursor timer")
             }
@@ -429,6 +477,83 @@ enum UIE2ETestDriver {
                     .appendingPathComponent("fake/control-v.bin"))) == Data([0x16])
             }
             checks.append("live-terminal-routes-control-v")
+
+            try await waitUntil("running terminal frame") {
+                String(decoding: liveTerminal.terminal.getBufferAsData(), as: UTF8.self)
+                    .contains(runningID)
+            }
+            let invocationsURL = configuration.root
+                .appendingPathComponent("fake/invocations.log")
+            let attachCountBefore = try String(
+                contentsOf: invocationsURL,
+                encoding: .utf8)
+                .split(separator: "\n")
+                .filter { $0.contains(" attach --terminal-features sync ") }
+                .count
+
+            // Both rows are live. Selection must preserve the exact SwiftTerm
+            // object and PTY while the public client-switch command is delayed.
+            let resumedRow = try await element(
+                identifier: "session-row-\(completedID)")
+            let toCompleted = "client switch --pid \(liveClientPID)"
+                + " --from \(runningID) --to \(completedID) --provider claude"
+            let switchStarted = ProcessInfo.processInfo.systemUptime
+            _ = try await clickUntilElement(
+                resumedRow,
+                name: "resumed session row",
+                resultIdentifier: "session-detail-\(completedID)")
+            try await waitUntil("ownership-safe client switch starts", attempts: 20) {
+                let invocations = try? String(
+                    contentsOf: invocationsURL,
+                    encoding: .utf8)
+                return invocations?.split(separator: "\n")
+                    .contains(Substring(toCompleted)) == true
+            }
+            guard ProcessInfo.processInfo.systemUptime - switchStarted < 0.25 else {
+                throw Failure(message: "live selection waited for tmux redraw")
+            }
+            guard let terminalDuringSwitch = find(
+                    identifier: "session-preview-terminal")
+                    as? LocalProcessTerminalView,
+                  terminalDuringSwitch === liveTerminal,
+                  terminalDuringSwitch.process.shellPid == liveClientPID,
+                  String(decoding: terminalDuringSwitch.terminal.getBufferAsData(), as: UTF8.self)
+                    .contains(runningID) else {
+                throw Failure(message:
+                    "live switch replaced the terminal or cleared its complete frame")
+            }
+            try await waitUntil("synchronized completed redraw", attempts: 40) {
+                String(decoding: liveTerminal.terminal.getBufferAsData(), as: UTF8.self)
+                    .contains(completedID)
+            }
+
+            let toRunning = "client switch --pid \(liveClientPID)"
+                + " --from \(completedID) --to \(runningID) --provider codex"
+            try await keyPress("1", keyCode: 18, modifiers: [.command])
+            try await waitUntil("same client switches back", attempts: 40) {
+                guard let terminal = find(identifier: "session-preview-terminal")
+                        as? LocalProcessTerminalView,
+                      terminal === liveTerminal,
+                      terminal.process.shellPid == liveClientPID else { return false }
+                let invocations = try? String(
+                    contentsOf: invocationsURL,
+                    encoding: .utf8)
+                return invocations?.split(separator: "\n")
+                    .contains(Substring(toRunning)) == true
+                    && String(decoding: terminal.terminal.getBufferAsData(), as: UTF8.self)
+                        .contains(runningID)
+            }
+            let attachCountAfter = try String(
+                contentsOf: invocationsURL,
+                encoding: .utf8)
+                .split(separator: "\n")
+                .filter { $0.contains(" attach --terminal-features sync ") }
+                .count
+            guard attachCountAfter == attachCountBefore else {
+                throw Failure(message:
+                    "live switches launched a replacement attach client")
+            }
+            checks.append("live-session-switch-reuses-synchronized-client")
             let identityMarker = try await measuredFrame(
                 identifier: "session-detail-identity-marker",
                 name: "session identity marker")

--- a/app/Sources/DetachApp/WatchdogService.swift
+++ b/app/Sources/DetachApp/WatchdogService.swift
@@ -188,7 +188,7 @@ final class WatchdogService {
     ) async throws {
         var transaction: WatchdogHandoffTransaction?
         if let targetDigest {
-            transaction = try transactionForInstall(
+            transaction = try await transactionForInstall(
                 targetDigest,
                 forceReplacement: forceReplacement)
         } else {
@@ -248,10 +248,16 @@ final class WatchdogService {
         throw WatchdogServiceError.registrationDidNotComplete
     }
 
+    /// Login starts the app and the BTM watchdog concurrently. An enabled
+    /// record whose lifetime lock is not yet held can simply be a watchdog
+    /// that has not finished spawning; re-read once after this grace before
+    /// treating it as a stale job.
+    static let staleRegistrationGraceNanoseconds: UInt64 = 3_000_000_000
+
     private func transactionForInstall(
         _ digest: String,
         forceReplacement: Bool
-    ) throws -> WatchdogHandoffTransaction? {
+    ) async throws -> WatchdogHandoffTransaction? {
         if var transaction = try handoffStore.load() {
             if transaction.targetDigest != digest {
                 switch transaction.phase {
@@ -276,16 +282,22 @@ final class WatchdogService {
         let pending = defaults.bool(forKey: pendingDigestKey)
         let definitionChanged = previous != digest
         let currentStatus = status
-        let enabledRegistrationNeedsRepair: Bool
-        if currentStatus == .enabled,
-           try lifetimeBarrierStatus() != .busy {
+        var enabledRegistrationNeedsRepair = false
+        // A changed or pending definition replaces the registration anyway;
+        // only an otherwise matching record needs this liveness inference.
+        if !forceReplacement, !definitionChanged, !pending,
+           currentStatus == .enabled,
+           try lifetimeBarrierStatus() != .busy,
+           try !legacyWatchdogIsRunning() {
             // A matching digest identifies the bundled bytes, not the BTM
             // parent UUID that launchd resolves. Keep a pre-lock legacy
             // watchdog if its exact executable is still alive. Otherwise an
-            // enabled record without a lifetime holder is a stale job.
-            enabledRegistrationNeedsRepair = try !legacyWatchdogIsRunning()
-        } else {
-            enabledRegistrationNeedsRepair = false
+            // enabled record without a lifetime holder is a stale job, unless
+            // the holder simply has not started yet.
+            try await sleep(Self.staleRegistrationGraceNanoseconds)
+            enabledRegistrationNeedsRepair =
+                try lifetimeBarrierStatus() != .busy
+                && !legacyWatchdogIsRunning()
         }
         if !forceReplacement, !definitionChanged, !pending,
            !enabledRegistrationNeedsRepair,

--- a/app/Sources/DetachApp/WatchdogService.swift
+++ b/app/Sources/DetachApp/WatchdogService.swift
@@ -60,6 +60,7 @@ private final class SystemWatchdogRegistrationBackend: WatchdogRegistrationBacke
 
 enum WatchdogServiceError: LocalizedError {
     case bundledDefinitionMissing
+    case releaseSignatureRequired
     case registrationDidNotComplete
     case unregistrationBarrierDidNotComplete
 
@@ -67,6 +68,9 @@ enum WatchdogServiceError: LocalizedError {
         switch self {
         case .bundledDefinitionMissing:
             L10n.string("The bundled watchdog definition is missing or incomplete.")
+        case .releaseSignatureRequired:
+            L10n.string(
+                "Only a signed Detach release can update the background monitor.")
         case .registrationDidNotComplete:
             L10n.string("macOS did not finish registering the watchdog.")
         case .unregistrationBarrierDidNotComplete:
@@ -85,6 +89,7 @@ final class WatchdogService {
     private let digestProvider: () -> String?
     private let lifetimeBarrierStatus: () throws -> WatchdogLifetimeBarrierStatus
     private let legacyWatchdogIsRunning: () throws -> Bool
+    private let serviceMutationAllowed: () -> Bool
     private let sleep: (UInt64) async throws -> Void
     private var operationInFlight = false
 
@@ -102,6 +107,9 @@ final class WatchdogService {
         digestProvider = Self.bundleDefinitionDigest
         lifetimeBarrierStatus = { try WatchdogLifetimeBarrier().status() }
         legacyWatchdogIsRunning = Self.bundledWatchdogProcessIsRunning
+        serviceMutationAllowed = {
+            ServiceManagementMutationAdmission.currentBundleIsReleaseSigned
+        }
         sleep = { try await Task.sleep(nanoseconds: $0) }
     }
 
@@ -113,6 +121,7 @@ final class WatchdogService {
         lifetimeBarrierStatus: @escaping () throws
             -> WatchdogLifetimeBarrierStatus = { .released },
         legacyWatchdogIsRunning: @escaping () throws -> Bool = { false },
+        serviceMutationAllowed: @escaping () -> Bool = { true },
         sleep: @escaping (UInt64) async throws -> Void = {
             try await Task.sleep(nanoseconds: $0)
         }
@@ -123,12 +132,14 @@ final class WatchdogService {
         self.digestProvider = digestProvider
         self.lifetimeBarrierStatus = lifetimeBarrierStatus
         self.legacyWatchdogIsRunning = legacyWatchdogIsRunning
+        self.serviceMutationAllowed = serviceMutationAllowed
         self.sleep = sleep
     }
 
     var status: WatchdogStatus { backend.status }
 
     func reconcileAfterAppUpdate(forceReplacement: Bool = false) async throws {
+        try requireReleaseSignature()
         guard let digest = digestProvider() else {
             throw WatchdogServiceError.bundledDefinitionMissing
         }
@@ -142,6 +153,7 @@ final class WatchdogService {
     }
 
     func disable() async throws {
+        try requireReleaseSignature()
         try await performExclusiveOperation {
             try await drive(to: nil, forceReplacement: false)
         }
@@ -263,8 +275,21 @@ final class WatchdogService {
         let previous = defaults.string(forKey: digestKey)
         let pending = defaults.bool(forKey: pendingDigestKey)
         let definitionChanged = previous != digest
+        let currentStatus = status
+        let enabledRegistrationNeedsRepair: Bool
+        if currentStatus == .enabled,
+           try lifetimeBarrierStatus() != .busy {
+            // A matching digest identifies the bundled bytes, not the BTM
+            // parent UUID that launchd resolves. Keep a pre-lock legacy
+            // watchdog if its exact executable is still alive. Otherwise an
+            // enabled record without a lifetime holder is a stale job.
+            enabledRegistrationNeedsRepair = try !legacyWatchdogIsRunning()
+        } else {
+            enabledRegistrationNeedsRepair = false
+        }
         if !forceReplacement, !definitionChanged, !pending,
-           status == .enabled || status == .requiresApproval {
+           !enabledRegistrationNeedsRepair,
+           currentStatus == .enabled || currentStatus == .requiresApproval {
             return nil
         }
 
@@ -272,10 +297,12 @@ final class WatchdogService {
         // unregister submission. Replaying from `unregisterSubmitted` is the
         // only safe migration even when status already says notRegistered.
         let priorRegistrationMayNeedRemoval = forceReplacement
+            || enabledRegistrationNeedsRepair
             || pending
             || (previous != nil && definitionChanged)
             || (definitionChanged
-                && (status == .enabled || status == .requiresApproval))
+                && (currentStatus == .enabled
+                    || currentStatus == .requiresApproval))
         let transaction = WatchdogHandoffTransaction(
             phase: priorRegistrationMayNeedRemoval
                 ? .unregisterSubmitted : .registering,
@@ -382,6 +409,12 @@ final class WatchdogService {
     private func rememberDefinition(_ digest: String) {
         defaults.set(digest, forKey: digestKey)
         defaults.set(false, forKey: pendingDigestKey)
+    }
+
+    private func requireReleaseSignature() throws {
+        guard serviceMutationAllowed() else {
+            throw WatchdogServiceError.releaseSignatureRequired
+        }
     }
 
     private static func bundledWatchdogProcessIsRunning() throws -> Bool {

--- a/app/Sources/DetachKit/BoundedProcessRunner.swift
+++ b/app/Sources/DetachKit/BoundedProcessRunner.swift
@@ -37,6 +37,8 @@ public struct BoundedProcessResult: Equatable, Sendable {
     public let standardOutput: Data
     public let standardError: Data
     public let timedOut: Bool
+    public let standardOutputTruncated: Bool
+    public let standardErrorTruncated: Bool
 }
 
 public enum BoundedProcessError: Error, Equatable, Sendable {
@@ -59,6 +61,7 @@ private final class NonblockingPipeCapture: @unchecked Sendable {
     private let lock = NSLock()
     private var shouldStop = false
     private var captured = Data()
+    private var didTruncate = false
 
     init(descriptor: Int32, maximumBytes: Int) {
         self.descriptor = descriptor
@@ -107,8 +110,9 @@ private final class NonblockingPipeCapture: @unchecked Sendable {
         group.wait(timeout: .now() + max(0, deadline.timeIntervalSinceNow)) == .success
     }
 
-    func stopAndWait() {
+    func stopAndWait(markIncomplete: Bool = false) {
         lock.lock()
+        if markIncomplete { didTruncate = true }
         shouldStop = true
         lock.unlock()
         group.wait()
@@ -120,6 +124,12 @@ private final class NonblockingPipeCapture: @unchecked Sendable {
         return captured
     }
 
+    var isTruncated: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didTruncate
+    }
+
     private var stopping: Bool {
         lock.lock()
         defer { lock.unlock() }
@@ -129,9 +139,10 @@ private final class NonblockingPipeCapture: @unchecked Sendable {
     private func append(_ bytes: [UInt8], count: Int) {
         lock.lock()
         defer { lock.unlock() }
-        guard captured.count < maximumBytes else { return }
-        captured.append(contentsOf: bytes.prefix(
-            min(count, maximumBytes - captured.count)))
+        let remaining = max(0, maximumBytes - captured.count)
+        if count > remaining { didTruncate = true }
+        guard remaining > 0 else { return }
+        captured.append(contentsOf: bytes.prefix(min(count, remaining)))
     }
 }
 
@@ -244,14 +255,20 @@ public struct BoundedProcessRunner: Sendable {
                 signalGroup(childPID, SIGKILL)
             }
         }
-        stdout.stopAndWait()
-        stderr.stopAndWait()
+        // A reader that did not reach EOF before the bounded drain deadline
+        // may still have unread bytes behind an inherited descriptor. Treat
+        // that uncertainty as incomplete output instead of publishing a
+        // prefix as a complete response.
+        stdout.stopAndWait(markIncomplete: !stdoutFinished)
+        stderr.stopAndWait(markIncomplete: !stderrFinished)
 
         return BoundedProcessResult(
             exitCode: exitCode(from: waitStatus),
             standardOutput: stdout.data,
             standardError: stderr.data,
-            timedOut: timedOut)
+            timedOut: timedOut,
+            standardOutputTruncated: stdout.isTruncated,
+            standardErrorTruncated: stderr.isTruncated)
     }
 
     private func makePipe() throws -> (read: Int32, write: Int32) {

--- a/app/Sources/DetachKit/BoundedProcessRunner.swift
+++ b/app/Sources/DetachKit/BoundedProcessRunner.swift
@@ -74,7 +74,12 @@ private final class NonblockingPipeCapture: @unchecked Sendable {
 
     func start() {
         group.enter()
-        DispatchQueue.global(qos: .utility).async { [self] in
+        // The synchronous runner waits for both readers after reaping the
+        // child. Scheduling those readers on the same bounded global pool as
+        // several concurrent runners can starve every reader on a low-core
+        // host. A dedicated short-lived thread keeps pipe progress independent
+        // from Swift and libdispatch worker availability.
+        Thread.detachNewThread { [self] in
             defer {
                 _ = Darwin.close(descriptor)
                 group.leave()

--- a/app/Sources/DetachKit/DetachCLI.swift
+++ b/app/Sources/DetachKit/DetachCLI.swift
@@ -156,14 +156,24 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
     ) {
         self.executable = executable
         self.environment = Self.runtimeEnvironment(
-            environment ?? ProcessInfo.processInfo.environment)
+            environment ?? ProcessInfo.processInfo.environment,
+            allowsDetachOverrides: environment != nil)
         self.processRunner = processRunner
         self.terminationGrace = terminationGrace
         self.outputDrainGrace = outputDrainGrace
     }
 
-    static func runtimeEnvironment(_ base: [String: String]) -> [String: String] {
+    static func runtimeEnvironment(
+        _ base: [String: String],
+        allowsDetachOverrides: Bool = true
+    ) -> [String: String] {
         var environment = base
+        if !allowsDetachOverrides {
+            for key in environment.keys where key.hasPrefix("DETACH_")
+                    && !key.hasPrefix("DETACH_UI_E2E_") {
+                environment.removeValue(forKey: key)
+            }
+        }
         var paths = (base["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin")
             .split(separator: ":", omittingEmptySubsequences: true)
             .map(String.init)

--- a/app/Sources/DetachKit/DetachCLI.swift
+++ b/app/Sources/DetachKit/DetachCLI.swift
@@ -99,12 +99,23 @@ public struct CLIResult: Equatable, Sendable {
     public var stdout: String
     public var stderr: String
     public var timedOut: Bool
+    public var stdoutTruncated: Bool
+    public var stderrTruncated: Bool
 
-    public init(exitCode: Int32, stdout: String, stderr: String, timedOut: Bool) {
+    public init(
+        exitCode: Int32,
+        stdout: String,
+        stderr: String,
+        timedOut: Bool,
+        stdoutTruncated: Bool = false,
+        stderrTruncated: Bool = false
+    ) {
         self.exitCode = exitCode
         self.stdout = stdout
         self.stderr = stderr
         self.timedOut = timedOut
+        self.stdoutTruncated = stdoutTruncated
+        self.stderrTruncated = stderrTruncated
     }
 }
 
@@ -146,13 +157,15 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
     private let processRunner: BoundedProcessRunner
     private let terminationGrace: TimeInterval
     private let outputDrainGrace: TimeInterval
+    private let maximumOutputBytes: Int
 
     public init(
         executable: URL,
         environment: [String: String]? = nil,
         processRunner: BoundedProcessRunner = BoundedProcessRunner(),
         terminationGrace: TimeInterval = 2,
-        outputDrainGrace: TimeInterval = 0.05
+        outputDrainGrace: TimeInterval = 0.05,
+        maximumOutputBytes: Int = 4 * 1_024 * 1_024
     ) {
         self.executable = executable
         self.environment = Self.runtimeEnvironment(
@@ -161,6 +174,7 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
         self.processRunner = processRunner
         self.terminationGrace = terminationGrace
         self.outputDrainGrace = outputDrainGrace
+        self.maximumOutputBytes = max(0, maximumOutputBytes)
     }
 
     static func runtimeEnvironment(
@@ -240,7 +254,8 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
             currentDirectoryURL: currentDirectoryURL,
             timeout: timeout,
             terminationGrace: terminationGrace,
-            outputDrainGrace: outputDrainGrace)
+            outputDrainGrace: outputDrainGrace,
+            maximumOutputBytes: maximumOutputBytes)
         let runner = processRunner
         let result = try await Task.detached {
             try runner.run(request)
@@ -249,7 +264,9 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
             exitCode: result.exitCode,
             stdout: String(decoding: result.standardOutput, as: UTF8.self),
             stderr: String(decoding: result.standardError, as: UTF8.self),
-            timedOut: result.timedOut)
+            timedOut: result.timedOut,
+            stdoutTruncated: result.standardOutputTruncated,
+            stderrTruncated: result.standardErrorTruncated)
     }
 
     public func sessionEvents() -> AsyncThrowingStream<SessionEvent, Error> {

--- a/app/Sources/DetachKit/DetachCLI.swift
+++ b/app/Sources/DetachKit/DetachCLI.swift
@@ -108,6 +108,12 @@ public struct CLIResult: Equatable, Sendable {
     }
 }
 
+public enum DetachCLIStreamError: Error, Equatable, Sendable {
+    case unavailable
+    case invalidEvent
+    case exited(Int32)
+}
+
 public protocol DetachCLIRunning: Sendable {
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult
     func run(
@@ -115,6 +121,7 @@ public protocol DetachCLIRunning: Sendable {
         timeout: TimeInterval,
         currentDirectoryURL: URL?
     ) async throws -> CLIResult
+    func sessionEvents() -> AsyncThrowingStream<SessionEvent, Error>
 }
 
 public extension DetachCLIRunning {
@@ -124,6 +131,12 @@ public extension DetachCLIRunning {
         currentDirectoryURL _: URL?
     ) async throws -> CLIResult {
         try await run(arguments: arguments, timeout: timeout)
+    }
+
+    func sessionEvents() -> AsyncThrowingStream<SessionEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: DetachCLIStreamError.unavailable)
+        }
     }
 }
 
@@ -227,5 +240,53 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
             stdout: String(decoding: result.standardOutput, as: UTF8.self),
             stderr: String(decoding: result.standardError, as: UTF8.self),
             timedOut: result.timedOut)
+    }
+
+    public func sessionEvents() -> AsyncThrowingStream<SessionEvent, Error> {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = executable
+        process.arguments = ["watch", "--json"]
+        process.environment = environment
+        process.currentDirectoryURL = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath,
+            isDirectory: true)
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+
+        return AsyncThrowingStream(bufferingPolicy: .bufferingNewest(1)) {
+            continuation in
+            let task = Task.detached {
+                defer {
+                    if process.isRunning { process.terminate() }
+                    try? output.fileHandleForReading.close()
+                }
+                do {
+                    try Task.checkCancellation()
+                    try process.run()
+                    for try await line in output.fileHandleForReading.bytes.lines {
+                        try Task.checkCancellation()
+                        guard let event = SessionEventParser.parse(line) else {
+                            throw DetachCLIStreamError.invalidEvent
+                        }
+                        continuation.yield(event)
+                    }
+                    process.waitUntilExit()
+                    guard Task.isCancelled || process.terminationStatus == 0 else {
+                        throw DetachCLIStreamError.exited(process.terminationStatus)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+                if process.isRunning { process.terminate() }
+                try? output.fileHandleForReading.close()
+            }
+        }
     }
 }

--- a/app/Sources/DetachKit/DetachCLI.swift
+++ b/app/Sources/DetachKit/DetachCLI.swift
@@ -274,6 +274,13 @@ public final class ProcessDetachCLI: DetachCLIRunning, Sendable {
                 do {
                     try Task.checkCancellation()
                     try process.run()
+                    // A cancellation that landed between the check above and
+                    // launch would otherwise leave this watcher running with
+                    // no owner until its first line.
+                    if Task.isCancelled {
+                        process.terminate()
+                        throw CancellationError()
+                    }
                     for try await line in output.fileHandleForReading.bytes.lines {
                         try Task.checkCancellation()
                         guard let event = SessionEventParser.parse(line) else {

--- a/app/Sources/DetachKit/DetachPowerCommand.swift
+++ b/app/Sources/DetachKit/DetachPowerCommand.swift
@@ -454,6 +454,18 @@ public struct DetachPowerStatusReport: Equatable, Codable, Sendable {
     }
 }
 
+/// Minimal list-only power state derived from the signed watchdog heartbeat.
+/// It deliberately omits live helper and lease claims that require XPC.
+public struct DetachPowerQuickStatusReport: Equatable, Codable, Sendable {
+    public let schema: Int
+    public let state: PowerProtectionState
+
+    public init(snapshot: PowerHeartbeatSnapshot) {
+        schema = 1
+        state = snapshot.effectivePowerState
+    }
+}
+
 public enum DetachPowerCommandResult: Equatable, Sendable {
     case statusJSON(Data)
     case child(ChildCommandResult)
@@ -728,6 +740,7 @@ public struct DetachPowerCommand: Sendable {
     private let thermalCooldown: TimeInterval
     private let clamshellLockRunner: ClamshellLockRunner
     private let readinessMarker: any PowerRunReadinessMarking
+    private let quickStatusReader: @Sendable () -> PowerHeartbeatSnapshot
 
     public init(
         helperClient: any PowerHelperClient,
@@ -741,7 +754,11 @@ public struct DetachPowerCommand: Sendable {
         thermalNow: @escaping @Sendable () -> Date = { Date() },
         thermalCooldown: TimeInterval = PowerThermalSafetyLatch.defaultCooldown,
         clamshellLockRunner: ClamshellLockRunner = ClamshellLockRunner(),
-        readinessMarker: any PowerRunReadinessMarking = FilePowerRunReadinessMarker()
+        readinessMarker: any PowerRunReadinessMarking = FilePowerRunReadinessMarker(),
+        quickStatusReader: @escaping @Sendable () -> PowerHeartbeatSnapshot = {
+            let url = PowerHeartbeatReader.defaultStatusURL()
+            return PowerHeartbeatReader(statusURL: url).read()
+        }
     ) {
         self.helperClient = helperClient
         self.assertionController = assertionController
@@ -753,17 +770,24 @@ public struct DetachPowerCommand: Sendable {
         self.thermalCooldown = max(0, thermalCooldown)
         self.clamshellLockRunner = clamshellLockRunner
         self.readinessMarker = readinessMarker
+        self.quickStatusReader = quickStatusReader
     }
 
     public func execute(arguments: [String]) throws -> DetachPowerCommandResult {
         switch arguments.first {
         case "status":
-            guard arguments == ["status", "--json"] else {
-                throw DetachPowerCommandError.usage("usage: detach-power status --json")
+            guard arguments == ["status", "--json"]
+                    || arguments == ["status", "--json", "--quick"] else {
+                throw DetachPowerCommandError.usage(
+                    "usage: detach-power status --json [--quick]")
             }
-            let report = DetachPowerStatusReport(status: try helperClient.status())
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
+            if arguments.last == "--quick" {
+                return .statusJSON(try encoder.encode(
+                    DetachPowerQuickStatusReport(snapshot: quickStatusReader())))
+            }
+            let report = DetachPowerStatusReport(status: try helperClient.status())
             return .statusJSON(try encoder.encode(report))
         case "run":
             let parsed = try parseRunArguments(Array(arguments.dropFirst()))

--- a/app/Sources/DetachKit/DetachState.swift
+++ b/app/Sources/DetachKit/DetachState.swift
@@ -445,9 +445,10 @@ public enum TranscriptDocument {
     /// ignored because a byte tail commonly begins in the middle of a record.
     public static func summary(
         ofTail data: Data,
-        provider: Provider
+        provider: Provider,
+        startingFrom initial: TranscriptSummary = TranscriptSummary()
     ) -> TranscriptSummary {
-        var result = TranscriptSummary()
+        var result = initial
         var emitted = false
         _ = try? scanRecords(
             tolerateInvalid: true,

--- a/app/Sources/DetachKit/DetachState.swift
+++ b/app/Sources/DetachKit/DetachState.swift
@@ -37,6 +37,8 @@ public enum DetachStateError: Error, Equatable, Sendable {
     case invalidJSON
     case invalidMetadata
     case staleRunToken
+    case invalidLifecyclePhase
+    case invalidLifecycleTransition
     case unsupportedScalar
 }
 
@@ -91,9 +93,13 @@ public enum SessionMetadataDocument {
             throw DetachStateError.staleRunToken
         }
 
+        let original = object
+
         for change in changes {
             object[change.key] = foundationValue(change.value)
         }
+
+        try validateLifecycleMutation(from: original, to: object, changes: changes)
 
         guard JSONSerialization.isValidJSONObject(object) else {
             throw DetachStateError.invalidMetadata
@@ -112,6 +118,14 @@ public enum SessionMetadataDocument {
         var object: [String: Any] = [:]
         for change in changes {
             object[change.key] = foundationValue(change.value)
+        }
+
+        if let rawPhase = object["lifecycle_phase"] {
+            guard rawPhase is NSNull
+                    || (rawPhase as? String).flatMap(RuntimeLifecyclePhase.init(rawValue:)) != nil
+            else {
+                throw DetachStateError.invalidLifecyclePhase
+            }
         }
 
         guard JSONSerialization.isValidJSONObject(object) else {
@@ -245,6 +259,52 @@ public enum SessionMetadataDocument {
         integer(from: object["schema"]) == 1
             && object["session_name"] as? String == expectedSessionName
             && object["project_dir"] is String
+    }
+
+    /// Validates only runtime-owned phase changes. Ordinary scalar patches do
+    /// not need to know the lifecycle graph and remain forward-compatible.
+    private static func validateLifecycleMutation(
+        from original: [String: Any],
+        to updated: [String: Any],
+        changes: [Change]
+    ) throws {
+        guard let change = changes.last(where: { $0.key == "lifecycle_phase" }) else {
+            return
+        }
+        guard case .string(let rawTarget) = change.value,
+              let target = RuntimeLifecyclePhase(rawValue: rawTarget) else {
+            throw DetachStateError.invalidLifecyclePhase
+        }
+
+        let current: RuntimeLifecyclePhase
+        if let rawCurrent = original["lifecycle_phase"] as? String {
+            guard let parsed = RuntimeLifecyclePhase(rawValue: rawCurrent) else {
+                throw DetachStateError.invalidLifecyclePhase
+            }
+            current = parsed
+        } else {
+            current = RuntimeLifecyclePhase.inferred(
+                fromMetadataStatus: original["status"] as? String)
+        }
+        guard current.allows(target) else {
+            throw DetachStateError.invalidLifecycleTransition
+        }
+
+        let stopRequested = (updated["stop_requested_at"] as? String)
+            .map { !$0.isEmpty } ?? false
+        let status = updated["status"] as? String
+        if target == .stopping,
+           !stopRequested || status != "stopped" {
+            throw DetachStateError.invalidLifecycleTransition
+        }
+        if target == .finalizing, stopRequested {
+            throw DetachStateError.invalidLifecycleTransition
+        }
+        if target == .terminal, stopRequested, status != "stopped" {
+            // Stop intent wins a same-run race with worker finalization. This
+            // check runs under the metadata transaction lock.
+            throw DetachStateError.invalidLifecycleTransition
+        }
     }
 
     private static func foundationValue(_ scalar: DetachStateScalar) -> Any {

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -19,6 +19,11 @@ public enum DetachStateCommandError: Error, Equatable, Sendable {
     case unsafeEventSignal
 }
 
+struct ManagedTranscriptRegistry: Equatable, Sendable {
+    let all: Set<String>
+    let live: Set<String>
+}
+
 /// The command contract shared by the `detach-state` executable and unit
 /// tests. Successful commands return the exact bytes to write to stdout.
 public enum DetachStateCommand {
@@ -963,11 +968,26 @@ public enum DetachStateCommand {
         sessionsRoots: [String],
         allowedRoots: [String]
     ) -> Set<String> {
+        managedTranscriptRegistry(
+            sessionsRoots: sessionsRoots,
+            allowedRoots: allowedRoots).all
+    }
+
+    /// Live transcripts also receive an exact vnode source. This closes the
+    /// compatibility gap for an older runtime that cannot publish the newer
+    /// lifecycle hint itself.
+    static func managedTranscriptRegistry(
+        sessionsRoots: [String],
+        allowedRoots: [String]
+    ) -> ManagedTranscriptRegistry {
         guard let transcriptIndex = metadataSnapshotFields.firstIndex(where: {
             $0.0 == "transcript_path"
-        }) else { return [] }
+        }), let statusIndex = metadataSnapshotFields.firstIndex(where: {
+            $0.0 == "status"
+        }) else { return ManagedTranscriptRegistry(all: [], live: []) }
 
-        var result: Set<String> = []
+        var all: Set<String> = []
+        var live: Set<String> = []
         for sessionsRoot in sessionsRoots {
             guard let snapshots = try? metadataSnapshots(at: sessionsRoot) else {
                 continue
@@ -985,10 +1005,15 @@ public enum DetachStateCommand {
                 guard allowedRoots.contains(where: {
                     path == $0 || path.hasPrefix($0 + "/")
                 }) else { continue }
-                result.insert(path)
+                all.insert(path)
+                if values.indices.contains(statusIndex),
+                   case .string(let status)? = values[statusIndex],
+                   ["starting", "running", "recovering"].contains(status) {
+                    live.insert(path)
+                }
             }
         }
-        return result
+        return ManagedTranscriptRegistry(all: all, live: live)
     }
 
     private static func readOwnedMetadataFile(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -16,6 +16,7 @@ public enum DetachStateCommandError: Error, Equatable, Sendable {
     case invalidStorageInventory
     case invalidStorageReport
     case unsafeStorageSelection(String)
+    case unsafeEventSignal
 }
 
 /// The command contract shared by the `detach-state` executable and unit
@@ -101,9 +102,23 @@ public enum DetachStateCommand {
             return try maintenanceReconcile(
                 Array(arguments.dropFirst(2)),
                 standardInput: injectedStandardInput)
+        case ("events", "publish"):
+            return try eventPublish(Array(arguments.dropFirst(2)))
         default:
             throw DetachStateCommandError.invalidArguments
         }
+    }
+
+    private static func eventPublish(_ arguments: [String]) throws -> Data {
+        guard arguments.count == 1 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        do {
+            try SessionEventSignal.publish(atPath: arguments[0])
+        } catch {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+        return Data()
     }
 
     private static func storageReport(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -116,7 +116,7 @@ public enum DetachStateCommand {
             throw DetachStateCommandError.invalidArguments
         }
         do {
-            try SessionEventSignal.publish(atPath: arguments[0])
+            try SessionEventSignal.publish(inStateRoot: arguments[0])
         } catch {
             throw DetachStateCommandError.unsafeEventSignal
         }
@@ -447,6 +447,7 @@ public enum DetachStateCommand {
             "exit_status": NSNull(),
             "finished_at": NSNull(),
             "stop_requested_at": NSNull(),
+            "lifecycle_id": NSNull(),
             "model": NSNull(),
             "context_used_tokens": NSNull(),
             "context_window": NSNull(),
@@ -554,6 +555,8 @@ public enum DetachStateCommand {
                 object["worker_heartbeat_at"] = optionalString(value)
             case "--stop-requested-at":
                 object["stop_requested_at"] = optionalString(value)
+            case "--lifecycle-id":
+                object["lifecycle_id"] = optionalString(value)
             default:
                 throw DetachStateCommandError.invalidArguments
             }
@@ -596,6 +599,7 @@ public enum DetachStateCommand {
         ("session_color", ["session_color"]),
         ("transcript_path", ["transcript_path", "rollout_path"]),
         ("run_token", ["run_token"]),
+        ("lifecycle_id", ["lifecycle_id"]),
         ("worker_heartbeat_epoch", ["worker_heartbeat_epoch"]),
         ("last_checkpoint_epoch", ["last_checkpoint_epoch"]),
         ("health_schema", ["health_schema"]),
@@ -643,9 +647,8 @@ public enum DetachStateCommand {
             throw DetachStateCommandError.invalidArguments
         }
         let includesTranscriptSummary = arguments.count == 2
-        let sessions = try metadataSnapshots(at: arguments[0])
         var output = Data()
-        for (session, values) in sessions {
+        try forEachMetadataSnapshot(at: arguments[0]) { session, values, directory in
             appendNULTerminated(session, to: &output)
             appendNULTerminated(values == nil ? "false" : "true", to: &output)
             for value in values ?? Array(repeating: nil, count: metadataSnapshotFields.count) {
@@ -654,7 +657,8 @@ public enum DetachStateCommand {
             if includesTranscriptSummary {
                 for value in transcriptSummarySnapshotValues(
                     session: session,
-                    metadataValues: values) {
+                    metadataValues: values,
+                    sessionDirectory: directory) {
                     appendNULTerminated(value, to: &output)
                 }
             }
@@ -670,7 +674,8 @@ public enum DetachStateCommand {
     /// and never invalidates the independently validated metadata record.
     private static func transcriptSummarySnapshotValues(
         session: String,
-        metadataValues: [DetachStateScalar?]?
+        metadataValues: [DetachStateScalar?]?,
+        sessionDirectory: Int32
     ) -> [String] {
         let empty = Array(repeating: "", count: 5)
         guard let metadataValues,
@@ -689,21 +694,114 @@ public enum DetachStateCommand {
         } else {
             return empty
         }
-        // The removed shell path required a regular file before it read the
-        // transcript. A FIFO or device here would block the whole list, so
-        // open without blocking and check the opened descriptor itself.
-        guard transcriptPath.hasPrefix("/"),
-              let tail = try? regularFileTail(
-                atPath: transcriptPath,
-                maximumByteCount: 262_144) else { return empty }
+        // Open without blocking and validate the descriptor. A FIFO, device, or
+        // final-component symlink must not stall or redirect the complete list.
+        guard transcriptPath.hasPrefix("/") else { return empty }
+        let descriptor = open(
+            transcriptPath, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else { return empty }
+        defer { close(descriptor) }
+        var beforeMetadata = stat()
+        guard fstat(descriptor, &beforeMetadata) == 0,
+              let before = TranscriptValidationIdentity(beforeMetadata) else {
+            return empty
+        }
+
+        let receiptName = ".transcript-summary-cache.json"
+        if let receiptData = readOwnedMetadataFile(
+                in: sessionDirectory, name: receiptName),
+           let receipt = try? JSONDecoder().decode(
+                TranscriptSummaryReceipt.self, from: receiptData),
+           let values = receipt.snapshotValues(
+                provider: provider,
+                transcriptPath: transcriptPath,
+                identity: before) {
+            return values
+        }
+
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+        let size = UInt64(beforeMetadata.st_size)
+        let maximumByteCount: UInt64 = 262_144
+        guard (try? handle.seek(
+                toOffset: size > maximumByteCount ? size - maximumByteCount : 0)) != nil
+        else { return empty }
+        var tail = Data()
+        while tail.count < Int(maximumByteCount) {
+            let remaining = Int(maximumByteCount) - tail.count
+            let chunk: Data
+            do {
+                chunk = try handle.read(
+                    upToCount: min(64 * 1_024, remaining)) ?? Data()
+            } catch {
+                return empty
+            }
+            guard !chunk.isEmpty else { break }
+            tail.append(chunk)
+        }
+        var afterMetadata = stat()
+        guard fstat(descriptor, &afterMetadata) == 0,
+              let after = TranscriptValidationIdentity(afterMetadata),
+              before == after else { return empty }
         let summary = TranscriptDocument.summary(ofTail: tail, provider: provider)
-        return [
+        let values = [
             summary.model ?? "",
             summary.contextUsed.map(String.init) ?? "",
             summary.contextWindow.map(String.init) ?? "",
             summary.agentTurnState?.rawValue ?? "",
             summary.agentTurnID ?? "",
         ]
+        let receipt = TranscriptSummaryReceipt(
+            schema: 1,
+            provider: provider.rawValue,
+            transcriptPath: transcriptPath,
+            identity: after,
+            model: summary.model,
+            contextUsed: summary.contextUsed,
+            contextWindow: summary.contextWindow,
+            agentTurnState: summary.agentTurnState?.rawValue,
+            agentTurnID: summary.agentTurnID)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        if var receiptData = try? encoder.encode(receipt) {
+            receiptData.append(0x0A)
+            try? replaceOwnedFileAtomically(
+                receiptData, in: sessionDirectory, name: receiptName)
+        }
+        return values
+    }
+
+    private struct TranscriptSummaryReceipt: Codable {
+        var schema: Int
+        var provider: String
+        var transcriptPath: String
+        var identity: TranscriptValidationIdentity
+        var model: String?
+        var contextUsed: Int?
+        var contextWindow: Int?
+        var agentTurnState: String?
+        var agentTurnID: String?
+
+        func snapshotValues(
+            provider expectedProvider: Provider,
+            transcriptPath expectedPath: String,
+            identity expectedIdentity: TranscriptValidationIdentity
+        ) -> [String]? {
+            guard schema == 1,
+                  provider == expectedProvider.rawValue,
+                  transcriptPath == expectedPath,
+                  identity == expectedIdentity,
+                  contextUsed.map({ $0 >= 0 }) ?? true,
+                  contextWindow.map({ $0 >= 0 }) ?? true,
+                  agentTurnState.map({ AgentTurnState(rawValue: $0) != nil }) ?? true
+            else { return nil }
+            return [
+                model ?? "",
+                contextUsed.map(String.init) ?? "",
+                contextWindow.map(String.init) ?? "",
+                agentTurnState ?? "",
+                agentTurnID ?? "",
+            ]
+        }
     }
 
     private static func metadataSnapshotValues(
@@ -758,6 +856,17 @@ public enum DetachStateCommand {
     static func metadataSnapshots(
         at root: String
     ) throws -> [(String, [DetachStateScalar?]?)] {
+        var snapshots: [(String, [DetachStateScalar?]?)] = []
+        try forEachMetadataSnapshot(at: root) { name, values, _ in
+            snapshots.append((name, values))
+        }
+        return snapshots
+    }
+
+    private static func forEachMetadataSnapshot(
+        at root: String,
+        visit: (String, [DetachStateScalar?]?, Int32) throws -> Void
+    ) throws {
         let components = root.split(separator: "/", omittingEmptySubsequences: false)
         guard root.hasPrefix("/"),
               root != "/",
@@ -794,7 +903,6 @@ public enum DetachStateCommand {
             }
             if name != "." && name != ".." { names.append(name) }
         }
-        var sessions: [(String, [DetachStateScalar?]?)] = []
         for name in names.sorted() {
             var item = stat()
             if fstatat(rootDescriptor, name, &item, AT_SYMLINK_NOFOLLOW) != 0 {
@@ -826,14 +934,13 @@ public enum DetachStateCommand {
             let values: [DetachStateScalar?]?
             do {
                 values = try metadataSnapshotValues(in: session, session: name)
+                try visit(name, values, session)
             } catch {
                 close(session)
                 throw error
             }
             close(session)
-            sessions.append((name, values))
         }
-        return sessions
     }
 
     /// Returns only transcript files recorded by usable Detach metadata.
@@ -1455,25 +1562,6 @@ public enum DetachStateCommand {
 
         try data.write(to: temporaryURL, options: .withoutOverwriting)
         try FileManager.default.linkItem(at: temporaryURL, to: url)
-    }
-
-    /// Reads the tail of one regular file without a path race. The
-    /// non-blocking open cannot stall on a FIFO or device, and the check runs
-    /// on the descriptor that is read, not on a name that may be replaced.
-    private static func regularFileTail(
-        atPath path: String,
-        maximumByteCount: UInt64
-    ) throws -> Data? {
-        let descriptor = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC)
-        guard descriptor >= 0 else { return nil }
-        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
-        var metadata = stat()
-        guard fstat(descriptor, &metadata) == 0,
-              isRegularFile(metadata),
-              metadata.st_size > 0 else { return nil }
-        let size = UInt64(metadata.st_size)
-        try handle.seek(toOffset: size > maximumByteCount ? size - maximumByteCount : 0)
-        return try handle.readToEnd() ?? Data()
     }
 
     private static func tail(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -685,10 +685,13 @@ public enum DetachStateCommand {
         } else {
             return empty
         }
-        guard let tail = try? tail(
+        // The removed shell path required a regular file before it read the
+        // transcript. A FIFO or device here would block the whole list, so
+        // open without blocking and check the opened descriptor itself.
+        guard transcriptPath.hasPrefix("/"),
+              let tail = try? regularFileTail(
                 atPath: transcriptPath,
-                maximumByteCount: 262_144,
-                standardInput: nil) else { return empty }
+                maximumByteCount: 262_144) else { return empty }
         let summary = TranscriptDocument.summary(ofTail: tail, provider: provider)
         return [
             summary.model ?? "",
@@ -837,16 +840,22 @@ public enum DetachStateCommand {
         atStateRoot stateRoot: String,
         allowedRoots: [String]
     ) -> Set<String> {
+        managedTranscriptPaths(
+            sessionsRoots: SessionEventWatchConfiguration
+                .defaultSessionsRoots(stateRoot: stateRoot),
+            allowedRoots: allowedRoots)
+    }
+
+    static func managedTranscriptPaths(
+        sessionsRoots: [String],
+        allowedRoots: [String]
+    ) -> Set<String> {
         guard let transcriptIndex = metadataSnapshotFields.firstIndex(where: {
             $0.0 == "transcript_path"
         }) else { return [] }
 
         var result: Set<String> = []
-        for provider in [Provider.codex.rawValue, Provider.claude.rawValue] {
-            let sessionsRoot = URL(fileURLWithPath: stateRoot, isDirectory: true)
-                .appendingPathComponent(provider, isDirectory: true)
-                .appendingPathComponent("sessions", isDirectory: true)
-                .standardizedFileURL.path
+        for sessionsRoot in sessionsRoots {
             guard let snapshots = try? metadataSnapshots(at: sessionsRoot) else {
                 continue
             }
@@ -1442,6 +1451,25 @@ public enum DetachStateCommand {
 
         try data.write(to: temporaryURL, options: .withoutOverwriting)
         try FileManager.default.linkItem(at: temporaryURL, to: url)
+    }
+
+    /// Reads the tail of one regular file without a path race. The
+    /// non-blocking open cannot stall on a FIFO or device, and the check runs
+    /// on the descriptor that is read, not on a name that may be replaced.
+    private static func regularFileTail(
+        atPath path: String,
+        maximumByteCount: UInt64
+    ) throws -> Data? {
+        let descriptor = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC)
+        guard descriptor >= 0 else { return nil }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0,
+              isRegularFile(metadata),
+              metadata.st_size > 0 else { return nil }
+        let size = UInt64(metadata.st_size)
+        try handle.seek(toOffset: size > maximumByteCount ? size - maximumByteCount : 0)
+        return try handle.readToEnd() ?? Data()
     }
 
     private static func tail(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -1,6 +1,10 @@
 import Darwin
 import Foundation
 
+// Swift imports Darwin's `struct flock` under the same name as flock(2).
+@_silgen_name("flock")
+private func metadataFileLock(_ descriptor: Int32, _ operation: Int32) -> Int32
+
 public enum DetachStateCommandError: Error, Equatable, Sendable {
     case invalidArguments
     case invalidInteger(String)
@@ -334,7 +338,9 @@ public enum DetachStateCommand {
         let processInspection = Set([
             "--inspect-processes", "--worker-pid", "--provider-pid", "--pane-pid",
         ])
-        let allowed = required.union(processInspection).union(["--stop-requested"])
+        let allowed = required.union(processInspection).union([
+            "--stop-requested", "--lifecycle-phase",
+        ])
         var values: [String: String] = [:]
         var index = 0
         while index < arguments.count {
@@ -368,6 +374,15 @@ public enum DetachStateCommand {
             throw DetachStateCommandError.invalidArguments
         }
         let stopRequested = try values["--stop-requested"].map(boolean) ?? false
+        let lifecyclePhase: RuntimeLifecyclePhase?
+        if let rawPhase = values["--lifecycle-phase"] {
+            guard let parsed = RuntimeLifecyclePhase(rawValue: rawPhase) else {
+                throw DetachStateCommandError.invalidArguments
+            }
+            lifecyclePhase = parsed
+        } else {
+            lifecyclePhase = nil
+        }
         if let inspectRaw = values["--inspect-processes"] {
             guard try boolean(inspectRaw),
                   processInspection.allSatisfy({ values[$0] != nil }),
@@ -398,7 +413,8 @@ public enum DetachStateCommand {
             checkpointFreshness: checkpoint,
             checkpointRecoverable: try boolean(recoverableRaw),
             agentSessionKnown: try boolean(knownRaw),
-            stopRequested: stopRequested))
+            stopRequested: stopRequested,
+            lifecyclePhase: lifecyclePhase))
     }
 
     private static func maintenanceReconcile(
@@ -611,6 +627,7 @@ public enum DetachStateCommand {
         ("last_checkpoint_epoch", ["last_checkpoint_epoch"]),
         ("health_schema", ["health_schema"]),
         ("stop_requested_at", ["stop_requested_at"]),
+        ("lifecycle_phase", ["lifecycle_phase"]),
     ]
 
     /// Emits fixed key/value pairs separated by NUL bytes. The final complete
@@ -1167,13 +1184,48 @@ public enum DetachStateCommand {
             Array(arguments.dropFirst()),
             allowRunToken: true)
         let url = fileURL(path)
-        let original = try Data(contentsOf: url)
-        let updated = try SessionMetadataDocument.patch(
-            original,
-            expectedRunToken: mutation.expectedRunToken,
-            changes: mutation.changes)
-        try updated.write(to: url, options: .atomic)
+        try withMetadataPatchLock(for: url) {
+            let original = try Data(contentsOf: url)
+            let updated = try SessionMetadataDocument.patch(
+                original,
+                expectedRunToken: mutation.expectedRunToken,
+                changes: mutation.changes)
+            try updated.write(to: url, options: .atomic)
+        }
         return Data()
+    }
+
+    /// Serializes the complete read-modify-replace transaction across helper
+    /// processes. Atomic rename prevents torn JSON but does not prevent two
+    /// readers from replacing each other's disjoint changes.
+    private static func withMetadataPatchLock<T>(
+        for metadataURL: URL,
+        operation: () throws -> T
+    ) throws -> T {
+        let lockURL = metadataURL.deletingLastPathComponent()
+            .appendingPathComponent(".meta-patch.lock")
+        let descriptor = open(
+            lockURL.path,
+            O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+            S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        defer { close(descriptor) }
+
+        var information = stat()
+        guard fstat(descriptor, &information) == 0,
+              information.st_mode & S_IFMT == S_IFREG,
+              information.st_uid == geteuid() else {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        while metadataFileLock(descriptor, LOCK_EX) != 0 {
+            guard errno == EINTR else {
+                throw CocoaError(.fileWriteNoPermission)
+            }
+        }
+        defer { _ = metadataFileLock(descriptor, LOCK_UN) }
+        return try operation()
     }
 
     private struct MetaMutationArguments {

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -715,11 +715,12 @@ public enum DetachStateCommand {
         }
 
         let receiptName = ".transcript-summary-cache.json"
-        if let receiptData = readOwnedMetadataFile(
-                in: sessionDirectory, name: receiptName),
-           let receipt = try? JSONDecoder().decode(
-                TranscriptSummaryReceipt.self, from: receiptData),
-           let values = receipt.snapshotValues(
+        let cachedReceipt = readOwnedMetadataFile(
+            in: sessionDirectory, name: receiptName).flatMap {
+                try? JSONDecoder().decode(
+                    TranscriptSummaryReceipt.self, from: $0)
+            }
+        if let values = cachedReceipt?.snapshotValues(
                 provider: provider,
                 transcriptPath: transcriptPath,
                 identity: before) {
@@ -729,8 +730,14 @@ public enum DetachStateCommand {
         let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
         let size = UInt64(beforeMetadata.st_size)
         let maximumByteCount: UInt64 = 262_144
-        guard (try? handle.seek(
-                toOffset: size > maximumByteCount ? size - maximumByteCount : 0)) != nil
+        let continuation = cachedReceipt?.continuation(
+            provider: provider,
+            transcriptPath: transcriptPath,
+            identity: before,
+            maximumByteCount: maximumByteCount)
+        let startOffset = continuation?.offset
+            ?? (size > maximumByteCount ? size - maximumByteCount : 0)
+        guard (try? handle.seek(toOffset: startOffset)) != nil
         else { return empty }
         var tail = Data()
         while tail.count < Int(maximumByteCount) {
@@ -749,7 +756,10 @@ public enum DetachStateCommand {
         guard fstat(descriptor, &afterMetadata) == 0,
               let after = TranscriptValidationIdentity(afterMetadata),
               before == after else { return empty }
-        let summary = TranscriptDocument.summary(ofTail: tail, provider: provider)
+        let summary = TranscriptDocument.summary(
+            ofTail: tail,
+            provider: provider,
+            startingFrom: continuation?.summary ?? TranscriptSummary())
         let values = [
             summary.model ?? "",
             summary.contextUsed.map(String.init) ?? "",
@@ -778,6 +788,8 @@ public enum DetachStateCommand {
     }
 
     private struct TranscriptSummaryReceipt: Codable {
+        private static let overlapByteCount: UInt64 = 64 * 1_024
+
         var schema: Int
         var provider: String
         var transcriptPath: String
@@ -808,6 +820,44 @@ public enum DetachStateCommand {
                 agentTurnState ?? "",
                 agentTurnID ?? "",
             ]
+        }
+
+        /// Continues a cached reduction only across a bounded append to the
+        /// same file. The overlap completes a record that may have been
+        /// partial at the previous identity. A larger unobserved gap falls
+        /// back to a cold tail so stale answer-ready state cannot survive an
+        /// unseen turn transition.
+        func continuation(
+            provider expectedProvider: Provider,
+            transcriptPath expectedPath: String,
+            identity expectedIdentity: TranscriptValidationIdentity,
+            maximumByteCount: UInt64
+        ) -> (offset: UInt64, summary: TranscriptSummary)? {
+            guard schema == 1,
+                  provider == expectedProvider.rawValue,
+                  transcriptPath == expectedPath,
+                  identity.device == expectedIdentity.device,
+                  identity.inode == expectedIdentity.inode,
+                  identity.size >= 0,
+                  expectedIdentity.size > identity.size,
+                  contextUsed.map({ $0 >= 0 }) ?? true,
+                  contextWindow.map({ $0 >= 0 }) ?? true,
+                  agentTurnState.map({ AgentTurnState(rawValue: $0) != nil }) ?? true
+            else { return nil }
+
+            let previousSize = UInt64(identity.size)
+            let currentSize = UInt64(expectedIdentity.size)
+            let overlap = min(previousSize, Self.overlapByteCount)
+            let offset = previousSize - overlap
+            guard currentSize - offset <= maximumByteCount else { return nil }
+            return (
+                offset,
+                TranscriptSummary(
+                    model: model,
+                    contextUsed: contextUsed,
+                    contextWindow: contextWindow,
+                    agentTurnState: agentTurnState.flatMap(AgentTurnState.init(rawValue:)),
+                    agentTurnID: agentTurnID))
         }
     }
 

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -446,6 +446,7 @@ public enum DetachStateCommand {
             "last_checkpoint_at": NSNull(),
             "exit_status": NSNull(),
             "finished_at": NSNull(),
+            "stop_requested_at": NSNull(),
             "model": NSNull(),
             "context_used_tokens": NSNull(),
             "context_window": NSNull(),
@@ -551,6 +552,8 @@ public enum DetachStateCommand {
                     ? NSNull() : try integer(value)
             case "--worker-heartbeat-at":
                 object["worker_heartbeat_at"] = optionalString(value)
+            case "--stop-requested-at":
+                object["stop_requested_at"] = optionalString(value)
             default:
                 throw DetachStateCommandError.invalidArguments
             }
@@ -596,6 +599,7 @@ public enum DetachStateCommand {
         ("worker_heartbeat_epoch", ["worker_heartbeat_epoch"]),
         ("last_checkpoint_epoch", ["last_checkpoint_epoch"]),
         ("health_schema", ["health_schema"]),
+        ("stop_requested_at", ["stop_requested_at"]),
     ]
 
     /// Emits fixed key/value pairs separated by NUL bytes. The final complete

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -329,7 +329,7 @@ public enum DetachStateCommand {
         let processInspection = Set([
             "--inspect-processes", "--worker-pid", "--provider-pid", "--pane-pid",
         ])
-        let allowed = required.union(processInspection)
+        let allowed = required.union(processInspection).union(["--stop-requested"])
         var values: [String: String] = [:]
         var index = 0
         while index < arguments.count {
@@ -362,6 +362,7 @@ public enum DetachStateCommand {
               let knownRaw = values["--agent-session-known"] else {
             throw DetachStateCommandError.invalidArguments
         }
+        let stopRequested = try values["--stop-requested"].map(boolean) ?? false
         if let inspectRaw = values["--inspect-processes"] {
             guard try boolean(inspectRaw),
                   processInspection.allSatisfy({ values[$0] != nil }),
@@ -391,7 +392,8 @@ public enum DetachStateCommand {
             heartbeatFreshness: heartbeat,
             checkpointFreshness: checkpoint,
             checkpointRecoverable: try boolean(recoverableRaw),
-            agentSessionKnown: try boolean(knownRaw)))
+            agentSessionKnown: try boolean(knownRaw),
+            stopRequested: stopRequested))
     }
 
     private static func maintenanceReconcile(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -78,6 +78,8 @@ public enum DetachStateCommand {
             return try jsonlValidate(
                 Array(arguments.dropFirst(2)),
                 standardInput: injectedStandardInput)
+        case ("jsonl", "validate-cached"):
+            return try jsonlValidateCached(Array(arguments.dropFirst(2)))
         case ("jsonl", "summary"):
             return try jsonlSummary(
                 Array(arguments.dropFirst(2)),
@@ -318,12 +320,16 @@ public enum DetachStateCommand {
     private static func healthAssessment(
         _ arguments: [String]
     ) throws -> SessionHealthAssessment {
-        let allowed = Set([
+        let required = Set([
             "--metadata-valid", "--runtime-identity-expected", "--meta-status",
             "--tmux", "--run-token",
             "--worker", "--provider-process", "--heartbeat", "--checkpoint",
             "--checkpoint-recoverable", "--agent-session-known",
         ])
+        let processInspection = Set([
+            "--inspect-processes", "--worker-pid", "--provider-pid", "--pane-pid",
+        ])
+        let allowed = required.union(processInspection)
         var values: [String: String] = [:]
         var index = 0
         while index < arguments.count {
@@ -335,7 +341,7 @@ public enum DetachStateCommand {
             values[arguments[index]] = arguments[index + 1]
             index += 2
         }
-        guard values.count == allowed.count,
+        guard required.allSatisfy({ values[$0] != nil }),
               let metadataRaw = values["--metadata-valid"],
               let identityExpectedRaw = values["--runtime-identity-expected"],
               let statusRaw = values["--meta-status"],
@@ -345,15 +351,33 @@ public enum DetachStateCommand {
               let tokenRaw = values["--run-token"],
               let token = RunTokenHealthState(rawValue: tokenRaw),
               let workerRaw = values["--worker"],
-              let worker = ProcessHealthState(rawValue: workerRaw),
+              var worker = ProcessHealthState(rawValue: workerRaw),
               let providerRaw = values["--provider-process"],
-              let providerProcess = ProcessHealthState(rawValue: providerRaw),
+              var providerProcess = ProcessHealthState(rawValue: providerRaw),
               let heartbeatRaw = values["--heartbeat"],
               let heartbeat = FreshnessState(rawValue: heartbeatRaw),
               let checkpointRaw = values["--checkpoint"],
               let checkpoint = FreshnessState(rawValue: checkpointRaw),
               let recoverableRaw = values["--checkpoint-recoverable"],
               let knownRaw = values["--agent-session-known"] else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        if let inspectRaw = values["--inspect-processes"] {
+            guard try boolean(inspectRaw),
+                  processInspection.allSatisfy({ values[$0] != nil }),
+                  let workerPID = values["--worker-pid"],
+                  let providerPID = values["--provider-pid"],
+                  let panePID = values["--pane-pid"] else {
+                throw DetachStateCommandError.invalidArguments
+            }
+            let processHealth = SessionProcessHealthInspector.inspect(
+                tmuxState: tmux,
+                workerPID: workerPID,
+                providerPID: providerPID,
+                panePID: panePID)
+            worker = processHealth.worker
+            providerProcess = processHealth.provider
+        } else if !processInspection.isDisjoint(with: values.keys) {
             throw DetachStateCommandError.invalidArguments
         }
         return SessionHealthEvaluator.evaluate(SessionHealthEvidence(
@@ -609,9 +633,12 @@ public enum DetachStateCommand {
         _ arguments: [String],
         standardInput _: Data?
     ) throws -> Data {
-        guard arguments.count == 1 else {
+        guard arguments.count == 1
+                || (arguments.count == 2
+                    && arguments[1] == "--with-transcript-summary") else {
             throw DetachStateCommandError.invalidArguments
         }
+        let includesTranscriptSummary = arguments.count == 2
         let sessions = try metadataSnapshots(at: arguments[0])
         var output = Data()
         for (session, values) in sessions {
@@ -620,10 +647,56 @@ public enum DetachStateCommand {
             for value in values ?? Array(repeating: nil, count: metadataSnapshotFields.count) {
                 appendNULTerminated(value.map(render) ?? "", to: &output)
             }
+            if includesTranscriptSummary {
+                for value in transcriptSummarySnapshotValues(
+                    session: session,
+                    metadataValues: values) {
+                    appendNULTerminated(value, to: &output)
+                }
+            }
         }
         appendNULTerminated("", to: &output)
         appendNULTerminated("true", to: &output)
         return output
+    }
+
+    /// Batches the bounded transcript tail parse into the metadata helper.
+    /// The shell list path used to launch one helper process per session for
+    /// these five values. A failed or absent transcript stays an empty summary
+    /// and never invalidates the independently validated metadata record.
+    private static func transcriptSummarySnapshotValues(
+        session: String,
+        metadataValues: [DetachStateScalar?]?
+    ) -> [String] {
+        let empty = Array(repeating: "", count: 5)
+        guard let metadataValues,
+              let transcriptIndex = metadataSnapshotFields.firstIndex(where: {
+                  $0.0 == "transcript_path"
+              }),
+              metadataValues.indices.contains(transcriptIndex),
+              case .string(let transcriptPath)? = metadataValues[transcriptIndex]
+        else { return empty }
+
+        let provider: Provider
+        if session.hasPrefix("detach-codex-") {
+            provider = .codex
+        } else if session.hasPrefix("detach-claude-") {
+            provider = .claude
+        } else {
+            return empty
+        }
+        guard let tail = try? tail(
+                atPath: transcriptPath,
+                maximumByteCount: 262_144,
+                standardInput: nil) else { return empty }
+        let summary = TranscriptDocument.summary(ofTail: tail, provider: provider)
+        return [
+            summary.model ?? "",
+            summary.contextUsed.map(String.init) ?? "",
+            summary.contextWindow.map(String.init) ?? "",
+            summary.agentTurnState?.rawValue ?? "",
+            summary.agentTurnID ?? "",
+        ]
     }
 
     private static func metadataSnapshotValues(
@@ -675,7 +748,7 @@ public enum DetachStateCommand {
         return nil
     }
 
-    private static func metadataSnapshots(
+    static func metadataSnapshots(
         at root: String
     ) throws -> [(String, [DetachStateScalar?]?)] {
         let components = root.split(separator: "/", omittingEmptySubsequences: false)
@@ -754,6 +827,46 @@ public enum DetachStateCommand {
             sessions.append((name, values))
         }
         return sessions
+    }
+
+    /// Returns only transcript files recorded by usable Detach metadata.
+    /// The event watcher still observes the provider roots so it can follow
+    /// files that appear after startup, but this allowlist prevents unrelated
+    /// Codex or Claude sessions from waking the app.
+    static func managedTranscriptPaths(
+        atStateRoot stateRoot: String,
+        allowedRoots: [String]
+    ) -> Set<String> {
+        guard let transcriptIndex = metadataSnapshotFields.firstIndex(where: {
+            $0.0 == "transcript_path"
+        }) else { return [] }
+
+        var result: Set<String> = []
+        for provider in [Provider.codex.rawValue, Provider.claude.rawValue] {
+            let sessionsRoot = URL(fileURLWithPath: stateRoot, isDirectory: true)
+                .appendingPathComponent(provider, isDirectory: true)
+                .appendingPathComponent("sessions", isDirectory: true)
+                .standardizedFileURL.path
+            guard let snapshots = try? metadataSnapshots(at: sessionsRoot) else {
+                continue
+            }
+            for (_, values) in snapshots {
+                guard let values,
+                      values.indices.contains(transcriptIndex),
+                      case .string(let rawPath)? = values[transcriptIndex] else {
+                    continue
+                }
+                let standardized = URL(fileURLWithPath: rawPath)
+                    .standardizedFileURL.path
+                guard standardized == rawPath else { continue }
+                let path = SessionEventWatchConfiguration.canonicalPath(rawPath)
+                guard allowedRoots.contains(where: {
+                    path == $0 || path.hasPrefix($0 + "/")
+                }) else { continue }
+                result.insert(path)
+            }
+        }
+        return result
     }
 
     private static func readOwnedMetadataFile(
@@ -1056,6 +1169,178 @@ public enum DetachStateCommand {
         var output = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
         output.append(0x0A)
         return output
+    }
+
+    private struct TranscriptValidationIdentity: Codable, Equatable {
+        var device: UInt64
+        var inode: UInt64
+        var size: Int64
+        var modificationSeconds: Int64
+        var modificationNanoseconds: Int64
+
+        init?(_ item: stat) {
+            guard isRegularFile(item),
+                  item.st_uid == geteuid(),
+                  item.st_size > 0 else { return nil }
+            device = UInt64(item.st_dev)
+            inode = UInt64(item.st_ino)
+            size = Int64(item.st_size)
+            modificationSeconds = Int64(item.st_mtimespec.tv_sec)
+            modificationNanoseconds = Int64(item.st_mtimespec.tv_nsec)
+        }
+    }
+
+    private struct TranscriptValidationReceipt: Codable, Equatable {
+        var schema: Int
+        var provider: String
+        var expectedSessionID: String
+        var valid: Bool
+        var identity: TranscriptValidationIdentity
+    }
+
+    /// Caches only a health assessment for one immutable checkpoint file.
+    /// Restore paths continue to use `jsonl validate` and parse every record.
+    /// The receipt is ignored as soon as any opened-file identity field changes.
+    private static func jsonlValidateCached(_ arguments: [String]) throws -> Data {
+        guard arguments.count == 3 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let selectedProvider = try provider(arguments[0])
+        let path = arguments[1]
+        let expectedSessionID = arguments[2]
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard path.hasPrefix("/"),
+              path != "/",
+              !path.hasSuffix("/"),
+              !path.contains("\n"),
+              !path.contains("\r"),
+              !components.contains("."),
+              !components.contains(".."),
+              !expectedSessionID.isEmpty else {
+            throw DetachStateCommandError.invalidArguments
+        }
+
+        let url = fileURL(path)
+        let parentPath = url.deletingLastPathComponent().path
+        let fileName = url.lastPathComponent
+        guard !fileName.isEmpty,
+              fileName.utf8.count <= Int(NAME_MAX) else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let directory = open(
+            parentPath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard directory >= 0 else {
+            throw DetachStateCommandError.invalidTranscript
+        }
+        defer { close(directory) }
+        var directoryMetadata = stat()
+        guard fstat(directory, &directoryMetadata) == 0,
+              isDirectory(directoryMetadata),
+              directoryMetadata.st_uid == geteuid() else {
+            throw DetachStateCommandError.invalidTranscript
+        }
+
+        let descriptor = openat(
+            directory, fileName, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            throw DetachStateCommandError.invalidTranscript
+        }
+        defer { close(descriptor) }
+        var beforeMetadata = stat()
+        guard fstat(descriptor, &beforeMetadata) == 0,
+              let before = TranscriptValidationIdentity(beforeMetadata) else {
+            throw DetachStateCommandError.invalidTranscript
+        }
+
+        let receiptName = ".detach-jsonl-validation.json"
+        if let receiptData = readOwnedMetadataFile(
+                in: directory, name: receiptName),
+           let receipt = try? JSONDecoder().decode(
+                TranscriptValidationReceipt.self, from: receiptData),
+           receipt.schema == 1,
+           receipt.provider == selectedProvider.rawValue,
+           receipt.expectedSessionID == expectedSessionID,
+           receipt.identity == before {
+            guard receipt.valid else {
+                throw DetachStateCommandError.invalidTranscript
+            }
+            return Data()
+        }
+
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+        let valid = try TranscriptDocument.isValid(
+            reading: handle,
+            provider: selectedProvider,
+            expectedSessionID: expectedSessionID)
+        var afterMetadata = stat()
+        guard fstat(descriptor, &afterMetadata) == 0,
+              let after = TranscriptValidationIdentity(afterMetadata),
+              before == after else {
+            throw DetachStateCommandError.invalidTranscript
+        }
+
+        let receipt = TranscriptValidationReceipt(
+            schema: 1,
+            provider: selectedProvider.rawValue,
+            expectedSessionID: expectedSessionID,
+            valid: valid,
+            identity: after)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        if var receiptData = try? encoder.encode(receipt) {
+            receiptData.append(0x0A)
+            try? replaceOwnedFileAtomically(
+                receiptData, in: directory, name: receiptName)
+        }
+        guard valid else {
+            throw DetachStateCommandError.invalidTranscript
+        }
+        return Data()
+    }
+
+    private static func replaceOwnedFileAtomically(
+        _ data: Data,
+        in directory: Int32,
+        name: String
+    ) throws {
+        guard !name.isEmpty,
+              name != ".",
+              name != "..",
+              !name.contains("/") else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let temporaryName = ".\(name).\(UUID().uuidString).tmp"
+        let descriptor = openat(
+            directory,
+            temporaryName,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        defer {
+            close(descriptor)
+            unlinkat(directory, temporaryName, 0)
+        }
+        let wroteAll = data.withUnsafeBytes { bytes -> Bool in
+            guard let base = bytes.baseAddress else { return data.isEmpty }
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.write(
+                    descriptor, base.advanced(by: offset), bytes.count - offset)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    return false
+                }
+                guard count > 0 else { return false }
+                offset += count
+            }
+            return true
+        }
+        guard wroteAll,
+              renameat(directory, temporaryName, directory, name) == 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
     }
 
     private static func pair(

--- a/app/Sources/DetachKit/DoctorReport.swift
+++ b/app/Sources/DetachKit/DoctorReport.swift
@@ -112,9 +112,16 @@ public struct DistributionClient: Sendable {
 
     public func doctor() async throws -> DoctorReport {
         let result = try await cli.run(arguments: ["doctor", "--json"], timeout: 15)
-        guard !result.timedOut, let data = result.stdout.data(using: .utf8), !data.isEmpty else {
+        guard !result.timedOut,
+              !result.stdoutTruncated,
+              let data = result.stdout.data(using: .utf8),
+              !data.isEmpty else {
             throw DistributionClientError.doctorOutputMissing(
-                result.timedOut ? L10n.string("detach doctor timed out") : result.stderr)
+                result.timedOut
+                    ? L10n.string("detach doctor timed out")
+                    : result.stdoutTruncated
+                        ? L10n.string("detach returned incomplete output")
+                        : result.stderr)
         }
         let report = try JSONDecoder().decode(DoctorReport.self, from: data)
         guard report.schema == 1 else {

--- a/app/Sources/DetachKit/LogPoller.swift
+++ b/app/Sources/DetachKit/LogPoller.swift
@@ -39,6 +39,10 @@ public final class LogPoller {
                 errorText = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
                 return
             }
+            guard !result.stdoutTruncated else {
+                errorText = L10n.string("detach returned incomplete output")
+                return
+            }
             let all = result.stdout.split(separator: "\n", omittingEmptySubsequences: false)
                 .map(String.init)
             let tail = Array(all.suffix(Self.tailLimit))
@@ -81,6 +85,7 @@ public final class SessionLogSnapshotCache {
         let checkpoint: Date?
         let finished: Date?
         let exitStatus: Int?
+        let lifecycleID: String?
         /// A new run may reuse an explicit name; its creation time and,
         /// once bound, its provider identity differ.
         let created: Date?
@@ -262,6 +267,7 @@ public final class SessionLogSnapshotCache {
             checkpoint: session.lastCheckpointAt,
             finished: session.finishedAt,
             exitStatus: session.exitStatus,
+            lifecycleID: session.lifecycleID,
             created: session.createdAt,
             agentSessionID: session.agentSessionId)
     }

--- a/app/Sources/DetachKit/LogPoller.swift
+++ b/app/Sources/DetachKit/LogPoller.swift
@@ -63,11 +63,13 @@ public final class LogPoller {
 /// Keeps immutable non-live session tails ready for instant detail switching.
 /// The cache is bounded and has no timer. A changed session identity revision
 /// invalidates its tail; selecting an unchanged session does no process work.
+/// Warm-up never evicts a selected entry and never repeats a failed read for
+/// the same typed revision, so a snapshot burst cannot become a process storm.
 @MainActor
 public final class SessionLogSnapshotCache {
     public nonisolated static let capacity = 12
     public nonisolated static let prefetchLimit = capacity
-    public nonisolated static let maximumConcurrentPrefetches = 6
+    public nonisolated static let maximumConcurrentPrefetches = 3
 
     private struct Key: Hashable {
         let provider: Provider
@@ -79,6 +81,10 @@ public final class SessionLogSnapshotCache {
         let checkpoint: Date?
         let finished: Date?
         let exitStatus: Int?
+        /// A new run may reuse an explicit name; its creation time and,
+        /// once bound, its provider identity differ.
+        let created: Date?
+        let agentSessionID: String?
     }
 
     private struct ScheduledTarget: Equatable {
@@ -89,7 +95,12 @@ public final class SessionLogSnapshotCache {
     private var cli: DetachCLIRunning
     private var configurationID: String
     private var pollers: [Key: LogPoller] = [:]
+    /// The typed revision each entry is bound to. A different revision for
+    /// the same name invalidates the entry.
     private var revisions: [Key: Revision] = [:]
+    /// The revision a warm-up read actually started for, whether or not it
+    /// succeeded. A matching revision is never warmed again.
+    private var attempted: [Key: Revision] = [:]
     private var recency: [Key] = []
     private var scheduledTargets: [ScheduledTarget] = []
     private var prefetchTask: Task<Void, Never>?
@@ -115,6 +126,7 @@ public final class SessionLogSnapshotCache {
         scheduledTargets = []
         pollers = [:]
         revisions = [:]
+        attempted = [:]
         recency = []
         self.cli = cli
         self.configurationID = configurationID
@@ -132,9 +144,17 @@ public final class SessionLogSnapshotCache {
             provider: session.provider,
             sessionName: session.sessionName)
         pollers[key] = poller
+        // Bind the entry to the typed revision it was created for, so a
+        // tail the detail view loads directly is still invalidated when the
+        // session's lifecycle, or a replacement run under its name, changes.
+        revisions[key] = revision(for: session)
         touch(key)
         trimToCapacity()
         return poller
+    }
+
+    private func recordAttempt(key: Key, revision: Revision) {
+        attempted[key] = revision
     }
 
     /// Starts one bounded warm-up without blocking snapshot publication.
@@ -168,27 +188,29 @@ public final class SessionLogSnapshotCache {
     ) async {
         reconcile(sessions)
         let targets = prefetchTargets(in: sessions, limit: limit)
-        let coldPollers = targets
-            .map(poller(for:))
-            .filter { !$0.hasLoaded }
-        guard !coldPollers.isEmpty else {
-            recordLoadedRevisions(for: sessions)
-            return
-        }
+        let coldTargets = targets
+            .map { (key(for: $0), revision(for: $0), poller(for: $0)) }
+            .filter { !$0.2.hasLoaded }
+        guard !coldTargets.isEmpty else { return }
 
         await withTaskGroup(of: Void.self) { group in
             var nextIndex = 0
             func enqueueNext() {
-                guard nextIndex < coldPollers.count else { return }
-                let poller = coldPollers[nextIndex]
+                guard nextIndex < coldTargets.count else { return }
+                let (key, revision, poller) = coldTargets[nextIndex]
                 nextIndex += 1
-                group.addTask {
+                group.addTask { [weak self] in
+                    // Record the attempted revision only once the read is
+                    // really starting. A read that fails or returns nothing
+                    // is not repeated until the typed lifecycle changes; a
+                    // cancelled, never-started read stays eligible.
                     guard !Task.isCancelled else { return }
+                    await self?.recordAttempt(key: key, revision: revision)
                     await poller.fetchOnce()
                 }
             }
             for _ in 0..<min(
-                Self.maximumConcurrentPrefetches, coldPollers.count) {
+                Self.maximumConcurrentPrefetches, coldTargets.count) {
                 enqueueNext()
             }
             while await group.next() != nil {
@@ -199,16 +221,29 @@ public final class SessionLogSnapshotCache {
                 enqueueNext()
             }
         }
-        guard !Task.isCancelled else { return }
-        recordLoadedRevisions(for: targets)
     }
 
+    /// Selects sessions whose current typed revision has not been read. A
+    /// candidate without an entry needs a free slot; warm-up never evicts an
+    /// entry that the detail view may be showing.
     private func prefetchTargets(in sessions: [Session], limit: Int) -> [Session] {
         guard limit > 0 else { return [] }
-        return Array(sessions.lazy
-            .filter { Self.shouldCache($0) }
-            .filter { self.pollers[self.key(for: $0)]?.hasLoaded != true }
-            .prefix(limit))
+        var freeSlots = max(0, Self.capacity - pollers.count)
+        var targets: [Session] = []
+        for session in sessions where Self.shouldCache(session) {
+            guard targets.count < limit else { break }
+            let key = key(for: session)
+            if let existing = pollers[key] {
+                if existing.hasLoaded || attempted[key] == revision(for: session) {
+                    continue
+                }
+            } else {
+                guard freeSlots > 0 else { continue }
+                freeSlots -= 1
+            }
+            targets.append(session)
+        }
+        return targets
     }
 
     /// A live session owns an interactive terminal and its passive screen
@@ -226,7 +261,9 @@ public final class SessionLogSnapshotCache {
             status: session.effectiveStatus,
             checkpoint: session.lastCheckpointAt,
             finished: session.finishedAt,
-            exitStatus: session.exitStatus)
+            exitStatus: session.exitStatus,
+            created: session.createdAt,
+            agentSessionID: session.agentSessionId)
     }
 
     /// Drops only entries whose typed lifecycle identity changed. A live or
@@ -248,15 +285,6 @@ public final class SessionLogSnapshotCache {
         }
     }
 
-    private func recordLoadedRevisions(for sessions: [Session]) {
-        for session in sessions where Self.shouldCache(session) {
-            let key = key(for: session)
-            if pollers[key]?.hasLoaded == true {
-                revisions[key] = revision(for: session)
-            }
-        }
-    }
-
     private func touch(_ key: Key) {
         recency.removeAll { $0 == key }
         recency.append(key)
@@ -271,6 +299,7 @@ public final class SessionLogSnapshotCache {
     private func remove(_ key: Key) {
         pollers.removeValue(forKey: key)
         revisions.removeValue(forKey: key)
+        attempted.removeValue(forKey: key)
         recency.removeAll { $0 == key }
     }
 }

--- a/app/Sources/DetachKit/LogPoller.swift
+++ b/app/Sources/DetachKit/LogPoller.swift
@@ -135,10 +135,12 @@ public final class SessionLogSnapshotCache {
 
     public func poller(for session: Session) -> LogPoller {
         let key = Key(provider: session.provider, sessionName: session.sessionName)
-        if let poller = pollers[key] {
+        let currentRevision = revision(for: session)
+        if let poller = pollers[key], revisions[key] == currentRevision {
             touch(key)
             return poller
         }
+        remove(key)
         let poller = LogPoller(
             cli: cli,
             provider: session.provider,
@@ -147,7 +149,7 @@ public final class SessionLogSnapshotCache {
         // Bind the entry to the typed revision it was created for, so a
         // tail the detail view loads directly is still invalidated when the
         // session's lifecycle, or a replacement run under its name, changes.
-        revisions[key] = revision(for: session)
+        revisions[key] = currentRevision
         touch(key)
         trimToCapacity()
         return poller

--- a/app/Sources/DetachKit/LogPoller.swift
+++ b/app/Sources/DetachKit/LogPoller.swift
@@ -9,10 +9,12 @@ public final class LogPoller {
     public private(set) var lines: [String] = []
     public private(set) var attributed = NSAttributedString()
     public private(set) var errorText: String?
+    public private(set) var hasLoaded = false
 
     private let cli: DetachCLIRunning
     private let provider: Provider
     private let sessionName: String
+    private var isFetching = false
 
     private static let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
     private static let boldFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .bold)
@@ -27,6 +29,9 @@ public final class LogPoller {
     // No timer of its own: the detail view drives fetchOnce() from its
     // cancellable .task(id:) loop, so selection changes stop the polling.
     public func fetchOnce() async {
+        guard !isFetching else { return }
+        isFetching = true
+        defer { isFetching = false }
         do {
             let result = try await cli.run(
                 arguments: [provider.rawValue, "logs", "--ansi", sessionName], timeout: 5)
@@ -37,6 +42,7 @@ public final class LogPoller {
             let all = result.stdout.split(separator: "\n", omittingEmptySubsequences: false)
                 .map(String.init)
             let tail = Array(all.suffix(Self.tailLimit))
+            hasLoaded = true
             guard tail != lines else {
                 errorText = nil
                 return
@@ -51,5 +57,220 @@ public final class LogPoller {
         } catch {
             errorText = error.localizedDescription
         }
+    }
+}
+
+/// Keeps immutable non-live session tails ready for instant detail switching.
+/// The cache is bounded and has no timer. A changed session identity revision
+/// invalidates its tail; selecting an unchanged session does no process work.
+@MainActor
+public final class SessionLogSnapshotCache {
+    public nonisolated static let capacity = 12
+    public nonisolated static let prefetchLimit = capacity
+    public nonisolated static let maximumConcurrentPrefetches = 6
+
+    private struct Key: Hashable {
+        let provider: Provider
+        let sessionName: String
+    }
+
+    private struct Revision: Equatable {
+        let status: EffectiveStatus
+        let checkpoint: Date?
+        let finished: Date?
+        let exitStatus: Int?
+    }
+
+    private struct ScheduledTarget: Equatable {
+        let key: Key
+        let revision: Revision
+    }
+
+    private var cli: DetachCLIRunning
+    private var configurationID: String
+    private var pollers: [Key: LogPoller] = [:]
+    private var revisions: [Key: Revision] = [:]
+    private var recency: [Key] = []
+    private var scheduledTargets: [ScheduledTarget] = []
+    private var prefetchTask: Task<Void, Never>?
+    private var prefetchGeneration: UInt64 = 0
+
+    public init(cli: DetachCLIRunning, configurationID: String) {
+        self.cli = cli
+        self.configurationID = configurationID
+    }
+
+    public func configure(
+        cli: DetachCLIRunning,
+        configurationID: String,
+        sessions: [Session] = []
+    ) {
+        guard configurationID != self.configurationID else {
+            schedulePrefetch(for: sessions)
+            return
+        }
+        prefetchGeneration &+= 1
+        prefetchTask?.cancel()
+        prefetchTask = nil
+        scheduledTargets = []
+        pollers = [:]
+        revisions = [:]
+        recency = []
+        self.cli = cli
+        self.configurationID = configurationID
+        schedulePrefetch(for: sessions)
+    }
+
+    public func poller(for session: Session) -> LogPoller {
+        let key = Key(provider: session.provider, sessionName: session.sessionName)
+        if let poller = pollers[key] {
+            touch(key)
+            return poller
+        }
+        let poller = LogPoller(
+            cli: cli,
+            provider: session.provider,
+            sessionName: session.sessionName)
+        pollers[key] = poller
+        touch(key)
+        trimToCapacity()
+        return poller
+    }
+
+    /// Starts one bounded warm-up without blocking snapshot publication.
+    /// Repeated snapshots with the same cold set do no work.
+    public func schedulePrefetch(for sessions: [Session]) {
+        reconcile(sessions)
+        let targets = prefetchTargets(in: sessions, limit: Self.prefetchLimit)
+        let identities = targets.map {
+            ScheduledTarget(key: key(for: $0), revision: revision(for: $0))
+        }
+        guard !identities.isEmpty, identities != scheduledTargets else { return }
+        prefetchTask?.cancel()
+        prefetchGeneration &+= 1
+        let generation = prefetchGeneration
+        scheduledTargets = identities
+        prefetchTask = Task(priority: .utility) { @MainActor [weak self] in
+            guard let self else { return }
+            await self.prefetch(sessions, limit: Self.prefetchLimit)
+            if self.prefetchGeneration == generation,
+               self.scheduledTargets == identities {
+                self.scheduledTargets = []
+                self.prefetchTask = nil
+            }
+        }
+    }
+
+    /// Deterministic entry point used by the scheduler and focused tests.
+    public func prefetch(
+        _ sessions: [Session],
+        limit: Int = prefetchLimit
+    ) async {
+        reconcile(sessions)
+        let targets = prefetchTargets(in: sessions, limit: limit)
+        let coldPollers = targets
+            .map(poller(for:))
+            .filter { !$0.hasLoaded }
+        guard !coldPollers.isEmpty else {
+            recordLoadedRevisions(for: sessions)
+            return
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            var nextIndex = 0
+            func enqueueNext() {
+                guard nextIndex < coldPollers.count else { return }
+                let poller = coldPollers[nextIndex]
+                nextIndex += 1
+                group.addTask {
+                    guard !Task.isCancelled else { return }
+                    await poller.fetchOnce()
+                }
+            }
+            for _ in 0..<min(
+                Self.maximumConcurrentPrefetches, coldPollers.count) {
+                enqueueNext()
+            }
+            while await group.next() != nil {
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    return
+                }
+                enqueueNext()
+            }
+        }
+        guard !Task.isCancelled else { return }
+        recordLoadedRevisions(for: targets)
+    }
+
+    private func prefetchTargets(in sessions: [Session], limit: Int) -> [Session] {
+        guard limit > 0 else { return [] }
+        return Array(sessions.lazy
+            .filter { Self.shouldCache($0) }
+            .filter { self.pollers[self.key(for: $0)]?.hasLoaded != true }
+            .prefix(limit))
+    }
+
+    /// A live session owns an interactive terminal and its passive screen
+    /// cache. Every other state uses the read-only log surface.
+    public static func shouldCache(_ session: Session) -> Bool {
+        !session.isLive
+    }
+
+    private func key(for session: Session) -> Key {
+        Key(provider: session.provider, sessionName: session.sessionName)
+    }
+
+    private func revision(for session: Session) -> Revision {
+        Revision(
+            status: session.effectiveStatus,
+            checkpoint: session.lastCheckpointAt,
+            finished: session.finishedAt,
+            exitStatus: session.exitStatus)
+    }
+
+    /// Drops only entries whose typed lifecycle identity changed. A live or
+    /// deleted session cannot reuse an old passive tail when it later stops.
+    private func reconcile(_ sessions: [Session]) {
+        var current: [Key: Session] = [:]
+        for session in sessions {
+            current[key(for: session)] = session
+        }
+        for key in Array(pollers.keys) {
+            guard let session = current[key], Self.shouldCache(session) else {
+                remove(key)
+                continue
+            }
+            if let loadedRevision = revisions[key],
+               loadedRevision != revision(for: session) {
+                remove(key)
+            }
+        }
+    }
+
+    private func recordLoadedRevisions(for sessions: [Session]) {
+        for session in sessions where Self.shouldCache(session) {
+            let key = key(for: session)
+            if pollers[key]?.hasLoaded == true {
+                revisions[key] = revision(for: session)
+            }
+        }
+    }
+
+    private func touch(_ key: Key) {
+        recency.removeAll { $0 == key }
+        recency.append(key)
+    }
+
+    private func trimToCapacity() {
+        while recency.count > Self.capacity {
+            remove(recency[0])
+        }
+    }
+
+    private func remove(_ key: Key) {
+        pollers.removeValue(forKey: key)
+        revisions.removeValue(forKey: key)
+        recency.removeAll { $0 == key }
     }
 }

--- a/app/Sources/DetachKit/LogPoller.swift
+++ b/app/Sources/DetachKit/LogPoller.swift
@@ -92,11 +92,6 @@ public final class SessionLogSnapshotCache {
         let agentSessionID: String?
     }
 
-    private struct ScheduledTarget: Equatable {
-        let key: Key
-        let revision: Revision
-    }
-
     private var cli: DetachCLIRunning
     private var configurationID: String
     private var pollers: [Key: LogPoller] = [:]
@@ -107,7 +102,7 @@ public final class SessionLogSnapshotCache {
     /// succeeded. A matching revision is never warmed again.
     private var attempted: [Key: Revision] = [:]
     private var recency: [Key] = []
-    private var scheduledTargets: [ScheduledTarget] = []
+    private var pendingPrefetch: [Session] = []
     private var prefetchTask: Task<Void, Never>?
     private var prefetchGeneration: UInt64 = 0
 
@@ -128,7 +123,7 @@ public final class SessionLogSnapshotCache {
         prefetchGeneration &+= 1
         prefetchTask?.cancel()
         prefetchTask = nil
-        scheduledTargets = []
+        pendingPrefetch = []
         pollers = [:]
         revisions = [:]
         attempted = [:]
@@ -163,26 +158,21 @@ public final class SessionLogSnapshotCache {
     }
 
     /// Starts one bounded warm-up without blocking snapshot publication.
-    /// Repeated snapshots with the same cold set do no work.
+    /// Snapshot bursts queue behind active reads instead of cancelling them.
     public func schedulePrefetch(for sessions: [Session]) {
         reconcile(sessions)
         let targets = prefetchTargets(in: sessions, limit: Self.prefetchLimit)
-        let identities = targets.map {
-            ScheduledTarget(key: key(for: $0), revision: revision(for: $0))
+        guard !targets.isEmpty else {
+            pendingPrefetch = []
+            return
         }
-        guard !identities.isEmpty, identities != scheduledTargets else { return }
-        prefetchTask?.cancel()
-        prefetchGeneration &+= 1
+        // Keep the complete snapshot: reconcile treats absent rows as deleted,
+        // so draining only the remaining cold subset would evict valid tails.
+        pendingPrefetch = sessions
+        guard prefetchTask == nil else { return }
         let generation = prefetchGeneration
-        scheduledTargets = identities
         prefetchTask = Task(priority: .utility) { @MainActor [weak self] in
-            guard let self else { return }
-            await self.prefetch(sessions, limit: Self.prefetchLimit)
-            if self.prefetchGeneration == generation,
-               self.scheduledTargets == identities {
-                self.scheduledTargets = []
-                self.prefetchTask = nil
-            }
+            await self?.drainPendingPrefetch(generation: generation)
         }
     }
 
@@ -226,6 +216,17 @@ public final class SessionLogSnapshotCache {
                 enqueueNext()
             }
         }
+    }
+
+    private func drainPendingPrefetch(generation: UInt64) async {
+        while generation == prefetchGeneration,
+              !pendingPrefetch.isEmpty,
+              !Task.isCancelled {
+            let targets = pendingPrefetch
+            pendingPrefetch = []
+            await prefetch(targets, limit: Self.prefetchLimit)
+        }
+        if generation == prefetchGeneration { prefetchTask = nil }
     }
 
     /// Selects sessions whose current typed revision has not been read. A

--- a/app/Sources/DetachKit/PowerHeartbeat.swift
+++ b/app/Sources/DetachKit/PowerHeartbeat.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// One immutable read of the background monitor's heartbeat file. Every UI
@@ -50,6 +51,18 @@ public struct PowerHeartbeatSnapshot: Equatable, Sendable {
 
     public func age(relativeTo now: Date) -> TimeInterval? {
         checkedAt.map { now.timeIntervalSince($0) }
+    }
+
+    /// True when a replacement changes only the watchdog clock. The app must
+    /// retain the newest timestamp for truthful diagnostics, but that routine
+    /// liveness write does not change any state a view presents.
+    public func hasSamePresentedState(as other: Self) -> Bool {
+        statusURL == other.statusURL
+            && state == other.state
+            && powerState == other.powerState
+            && thermalState == other.thermalState
+            && thermalSafetyActive == other.thermalSafetyActive
+            && isFresh == other.isFresh
     }
 }
 
@@ -147,5 +160,168 @@ public struct PowerHeartbeatReader: Sendable {
         if let date = formatter.date(from: raw) { return date }
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter.date(from: raw)
+    }
+}
+
+/// Watches the watchdog's atomically replaced heartbeat without periodic
+/// reads. A one-shot deadline only wakes when the current heartbeat would
+/// become stale; each new write replaces that deadline.
+public final class PowerHeartbeatMonitor: @unchecked Sendable {
+    public typealias Handler = @Sendable (PowerHeartbeatSnapshot) -> Void
+
+    private let reader: PowerHeartbeatReader
+    private let handler: Handler
+    private let queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<UInt8>()
+    private var directorySource: (any DispatchSourceFileSystemObject)?
+    private var expirationSource: (any DispatchSourceTimer)?
+    private var watchedDirectory: URL?
+    private var lastSnapshot: PowerHeartbeatSnapshot?
+    private var started = false
+
+    public init(
+        reader: PowerHeartbeatReader,
+        queue: DispatchQueue = DispatchQueue(
+            label: "dev.tsarev.detach.power-heartbeat"),
+        handler: @escaping Handler
+    ) {
+        self.reader = reader
+        self.handler = handler
+        self.queue = queue
+        queue.setSpecific(key: queueKey, value: 1)
+    }
+
+    public func start() {
+        synchronized {
+            guard !started else { return }
+            started = true
+            refresh(force: true)
+            armClosestDirectory()
+        }
+    }
+
+    public func stop() {
+        synchronized {
+            guard started else { return }
+            started = false
+            directorySource?.cancel()
+            directorySource = nil
+            watchedDirectory = nil
+            expirationSource?.cancel()
+            expirationSource = nil
+        }
+        if DispatchQueue.getSpecific(key: queueKey) == nil {
+            queue.sync {}
+        }
+    }
+
+    deinit {
+        stop()
+    }
+
+    static func expirationDelay(
+        for snapshot: PowerHeartbeatSnapshot,
+        now: Date = Date()
+    ) -> TimeInterval? {
+        guard snapshot.isFresh, let checkedAt = snapshot.checkedAt else {
+            return nil
+        }
+        return max(
+            0.05,
+            PowerHeartbeatReader.maximumAge
+                - now.timeIntervalSince(checkedAt)
+                + 0.05)
+    }
+
+    private func synchronized(_ operation: () -> Void) {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            operation()
+        } else {
+            queue.sync(execute: operation)
+        }
+    }
+
+    private func refresh(force: Bool = false) {
+        guard started else { return }
+        let snapshot = reader.read()
+        scheduleExpiration(for: snapshot)
+        guard force || snapshot != lastSnapshot else { return }
+        lastSnapshot = snapshot
+        handler(snapshot)
+    }
+
+    private func scheduleExpiration(for snapshot: PowerHeartbeatSnapshot) {
+        expirationSource?.cancel()
+        expirationSource = nil
+        guard let delay = Self.expirationDelay(for: snapshot) else { return }
+        let source = DispatchSource.makeTimerSource(queue: queue)
+        source.schedule(
+            deadline: .now() + delay,
+            leeway: .milliseconds(250))
+        source.setEventHandler { [weak self, weak source] in
+            guard let self, self.expirationSource === source else { return }
+            self.expirationSource = nil
+            self.refresh()
+        }
+        expirationSource = source
+        source.resume()
+    }
+
+    private func armClosestDirectory() {
+        guard started,
+              let directory = closestExistingDirectory(
+                to: reader.statusURL.deletingLastPathComponent())
+        else { return }
+        guard watchedDirectory != directory || directorySource == nil else {
+            return
+        }
+
+        directorySource?.cancel()
+        directorySource = nil
+        watchedDirectory = nil
+        let descriptor = Darwin.open(
+            directory.path,
+            O_EVTONLY | O_CLOEXEC)
+        guard descriptor >= 0 else { return }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .delete, .rename, .revoke, .attrib, .extend],
+            queue: queue)
+        // Refresh once registration is live. This closes the gap between the
+        // earlier read and vnode readiness, including each move from an
+        // existing ancestor to a newly created power directory.
+        source.setRegistrationHandler { [weak self, weak source] in
+            guard let self, self.directorySource === source else { return }
+            self.refresh()
+            self.armClosestDirectory()
+        }
+        source.setEventHandler { [weak self, weak source] in
+            guard let self, self.directorySource === source else { return }
+            self.refresh()
+            self.armClosestDirectory()
+        }
+        source.setCancelHandler {
+            Darwin.close(descriptor)
+        }
+        watchedDirectory = directory
+        directorySource = source
+        source.resume()
+    }
+
+    private func closestExistingDirectory(to target: URL) -> URL? {
+        var candidate = target.standardizedFileURL
+        while true {
+            var isDirectory: ObjCBool = false
+            if FileManager.default.fileExists(
+                atPath: candidate.path,
+                isDirectory: &isDirectory),
+               isDirectory.boolValue {
+                return candidate
+            }
+            let parent = candidate.deletingLastPathComponent()
+            guard parent.path != candidate.path else { return nil }
+            candidate = parent
+        }
     }
 }

--- a/app/Sources/DetachKit/PowerHeartbeat.swift
+++ b/app/Sources/DetachKit/PowerHeartbeat.swift
@@ -255,8 +255,11 @@ public final class PowerHeartbeatMonitor: @unchecked Sendable {
         expirationSource = nil
         guard let delay = Self.expirationDelay(for: snapshot) else { return }
         let source = DispatchSource.makeTimerSource(queue: queue)
+        // The heartbeat age is wall-clock time. A monotonic deadline would
+        // pause with the Mac asleep and present an hour-old document as fresh
+        // for minutes after wake.
         source.schedule(
-            deadline: .now() + delay,
+            wallDeadline: .now() + delay,
             leeway: .milliseconds(250))
         source.setEventHandler { [weak self, weak source] in
             guard let self, self.expirationSource === source else { return }
@@ -267,22 +270,28 @@ public final class PowerHeartbeatMonitor: @unchecked Sendable {
         source.resume()
     }
 
-    private func armClosestDirectory() {
+    /// `force` re-opens the descriptor even for an unchanged path: after a
+    /// delete or rename the old vnode may belong to a directory that was
+    /// removed and recreated, and it would never report the new writes.
+    private func armClosestDirectory(force: Bool = false) {
         guard started,
               let directory = closestExistingDirectory(
                 to: reader.statusURL.deletingLastPathComponent())
         else { return }
-        guard watchedDirectory != directory || directorySource == nil else {
+        guard force || watchedDirectory != directory || directorySource == nil else {
             return
         }
 
-        directorySource?.cancel()
-        directorySource = nil
-        watchedDirectory = nil
+        // Open the replacement before releasing the current source. If the
+        // hierarchy changed between the existence check and this open, the
+        // old source keeps reporting and the next event retries.
         let descriptor = Darwin.open(
             directory.path,
             O_EVTONLY | O_CLOEXEC)
         guard descriptor >= 0 else { return }
+        directorySource?.cancel()
+        directorySource = nil
+        watchedDirectory = nil
 
         let source = DispatchSource.makeFileSystemObjectSource(
             fileDescriptor: descriptor,
@@ -297,9 +306,10 @@ public final class PowerHeartbeatMonitor: @unchecked Sendable {
             self.armClosestDirectory()
         }
         source.setEventHandler { [weak self, weak source] in
-            guard let self, self.directorySource === source else { return }
+            guard let self, let source, self.directorySource === source else { return }
+            let replaced = !source.data.isDisjoint(with: [.delete, .rename, .revoke])
             self.refresh()
-            self.armClosestDirectory()
+            self.armClosestDirectory(force: replaced)
         }
         source.setCancelHandler {
             Darwin.close(descriptor)

--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -21,15 +21,21 @@ public struct RootCommandResult: Equatable, Sendable {
     public let exitCode: Int32
     public let standardOutput: String
     public let standardError: String
+    public let standardOutputTruncated: Bool
+    public let standardErrorTruncated: Bool
 
     public init(
         exitCode: Int32,
         standardOutput: String = "",
-        standardError: String = ""
+        standardError: String = "",
+        standardOutputTruncated: Bool = false,
+        standardErrorTruncated: Bool = false
     ) {
         self.exitCode = exitCode
         self.standardOutput = standardOutput
         self.standardError = standardError
+        self.standardOutputTruncated = standardOutputTruncated
+        self.standardErrorTruncated = standardErrorTruncated
     }
 }
 
@@ -41,6 +47,7 @@ private final class BoundedRootCommandOutput: @unchecked Sendable {
     private let lock = NSLock()
     private let maximumBytes: Int
     private var data = Data()
+    private var didTruncate = false
 
     init(maximumBytes: Int) {
         self.maximumBytes = max(0, maximumBytes)
@@ -49,14 +56,22 @@ private final class BoundedRootCommandOutput: @unchecked Sendable {
     func append(_ chunk: Data) {
         lock.lock()
         defer { lock.unlock() }
-        guard data.count < maximumBytes else { return }
-        data.append(chunk.prefix(maximumBytes - data.count))
+        let remaining = max(0, maximumBytes - data.count)
+        if chunk.count > remaining { didTruncate = true }
+        guard remaining > 0 else { return }
+        data.append(chunk.prefix(remaining))
     }
 
     var string: String {
         lock.lock()
         defer { lock.unlock() }
         return String(decoding: data, as: UTF8.self)
+    }
+
+    var isTruncated: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didTruncate
     }
 }
 
@@ -128,7 +143,9 @@ public struct RootProcessCommandRunner: RootCommandRunning {
         return RootCommandResult(
             exitCode: process.terminationStatus,
             standardOutput: output.string,
-            standardError: errorOutput.string)
+            standardError: errorOutput.string,
+            standardOutputTruncated: output.isTruncated,
+            standardErrorTruncated: errorOutput.isTruncated)
     }
 
     private static func drain(
@@ -581,6 +598,10 @@ public struct PMSetClosedLidProtectionController: ClosedLidProtectionControlling
                 message: String(result.standardError.prefix(512))
                     .trimmingCharacters(in: .whitespacesAndNewlines))
         }
+        guard !result.standardOutputTruncated,
+              !result.standardErrorTruncated else {
+            throw PowerHelperPlatformError.unrecognizedPMSetOutput
+        }
         return result
     }
 }
@@ -611,6 +632,10 @@ public struct PMSetBatterySafetyReader: PowerBatterySafetyReading {
                 exitCode: result.exitCode,
                 message: String(result.standardError.prefix(512))
                     .trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        guard !result.standardOutputTruncated,
+              !result.standardErrorTruncated else {
+            throw PowerHelperPlatformError.unrecognizedPMSetOutput
         }
         let output = result.standardOutput
         if output.contains("'AC Power'") { return false }

--- a/app/Sources/DetachKit/Session.swift
+++ b/app/Sources/DetachKit/Session.swift
@@ -124,6 +124,9 @@ public struct Session: Identifiable, Equatable, Sendable, Codable {
     public var workerHeartbeatAt: Date?
     public var heartbeatFresh: Bool?
     public var checkpointFresh: Bool?
+    /// Set by `detach stop` before it signals the runtime. An `interrupted`
+    /// record with this intent is a user-requested stop, not a crash.
+    public var stopRequestedAt: Date?
 
     public var id: String { sessionName }
 
@@ -155,6 +158,7 @@ public struct Session: Identifiable, Equatable, Sendable, Codable {
         case workerHeartbeatAt = "worker_heartbeat_at"
         case heartbeatFresh = "heartbeat_fresh"
         case checkpointFresh = "checkpoint_fresh"
+        case stopRequestedAt = "stop_requested_at"
     }
 }
 

--- a/app/Sources/DetachKit/Session.swift
+++ b/app/Sources/DetachKit/Session.swift
@@ -124,6 +124,9 @@ public struct Session: Identifiable, Equatable, Sendable, Codable {
     public var workerHeartbeatAt: Date?
     public var heartbeatFresh: Bool?
     public var checkpointFresh: Bool?
+    /// Opaque identity for one Detach run. It is distinct from the private run
+    /// token and grants no lifecycle or power mutation authority.
+    public var lifecycleID: String?
     /// Set by `detach stop` before it signals the runtime. An `interrupted`
     /// record with this intent is a user-requested stop, not a crash.
     public var stopRequestedAt: Date?
@@ -158,6 +161,7 @@ public struct Session: Identifiable, Equatable, Sendable, Codable {
         case workerHeartbeatAt = "worker_heartbeat_at"
         case heartbeatFresh = "heartbeat_fresh"
         case checkpointFresh = "checkpoint_fresh"
+        case lifecycleID = "lifecycle_id"
         case stopRequestedAt = "stop_requested_at"
     }
 }

--- a/app/Sources/DetachKit/SessionAttach.swift
+++ b/app/Sources/DetachKit/SessionAttach.swift
@@ -31,7 +31,13 @@ public struct SessionAttachInvocation: Equatable, Sendable {
     }
 
     public static func arguments(for session: Session) -> [String] {
-        [session.provider.rawValue, "attach", session.sessionName]
+        [
+            session.provider.rawValue,
+            "attach",
+            "--terminal-features",
+            "sync",
+            session.sessionName,
+        ]
     }
 
     public static func environment(
@@ -48,5 +54,22 @@ public struct SessionAttachInvocation: Equatable, Sendable {
         return env.keys.sorted().map { key in
             "\(key)=\(env[key] ?? "")"
         }
+    }
+}
+
+/// Public, ownership-checked request to retarget the one visible tmux client.
+public enum SessionClientSwitchInvocation {
+    public static func arguments(
+        clientPID: Int32,
+        from source: Session,
+        to target: Session
+    ) -> [String] {
+        [
+            "client", "switch",
+            "--pid", String(clientPID),
+            "--from", source.sessionName,
+            "--to", target.sessionName,
+            "--provider", target.provider.rawValue,
+        ]
     }
 }

--- a/app/Sources/DetachKit/SessionAttach.swift
+++ b/app/Sources/DetachKit/SessionAttach.swift
@@ -44,7 +44,10 @@ public struct SessionAttachInvocation: Equatable, Sendable {
         from base: [String: String],
         termName: String = termName
     ) -> [String] {
-        var env = ProcessDetachCLI.runtimeEnvironment(base)
+        // The attach client must see the same runtime roots as every other
+        // child, so inherited `DETACH_*` overrides are removed here as well.
+        var env = ProcessDetachCLI.runtimeEnvironment(
+            base, allowsDetachOverrides: false)
         env.removeValue(forKey: "TMUX")
         env.removeValue(forKey: "TMUX_PANE")
         env["TERM"] = termName

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -1,0 +1,393 @@
+import CoreServices
+import Darwin
+import Foundation
+
+public enum SessionEventKind: String, Codable, Equatable, Sendable {
+    case ready
+    case changed
+    case resync
+}
+
+public struct SessionEvent: Codable, Equatable, Sendable {
+    public let schema: Int
+    public let event: SessionEventKind
+
+    public init(schema: Int = 1, event: SessionEventKind) {
+        self.schema = schema
+        self.event = event
+    }
+}
+
+public enum SessionEventParser {
+    public static func parse(_ line: String) -> SessionEvent? {
+        guard let data = line.data(using: .utf8),
+              let event = try? JSONDecoder().decode(SessionEvent.self, from: data),
+              event.schema == 1 else {
+            return nil
+        }
+        return event
+    }
+}
+
+/// Writes a disposable change token through an owned directory descriptor.
+/// The token is only an event hint. Session metadata remains the source of
+/// truth, so persistence and directory fsync are intentionally unnecessary.
+enum SessionEventSignal {
+    static func publish(atPath path: String) throws {
+        guard path.hasPrefix("/"), !path.utf8.contains(0) else {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard url.path == path, !url.lastPathComponent.isEmpty else {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+        let parent = url.deletingLastPathComponent()
+        let directory = Darwin.open(
+            parent.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard directory >= 0 else {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+        defer { Darwin.close(directory) }
+
+        var information = stat()
+        guard Darwin.fstat(directory, &information) == 0,
+              information.st_mode & S_IFMT == S_IFDIR,
+              information.st_uid == Darwin.geteuid() else {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+
+        let temporary = ".session-change.\(UUID().uuidString).tmp"
+        let descriptor = Darwin.openat(
+            directory,
+            temporary,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+        defer {
+            Darwin.close(descriptor)
+            _ = Darwin.unlinkat(directory, temporary, 0)
+        }
+
+        let record = Data("\(Darwin.getpid()):\(DispatchTime.now().uptimeNanoseconds)\n".utf8)
+        let written = record.withUnsafeBytes { buffer -> Bool in
+            guard var base = buffer.baseAddress else { return false }
+            var remaining = buffer.count
+            while remaining > 0 {
+                let result = Darwin.write(descriptor, base, remaining)
+                if result < 0, errno == EINTR { continue }
+                guard result > 0 else { return false }
+                remaining -= result
+                base = base.advanced(by: result)
+            }
+            return true
+        }
+        guard written,
+              Darwin.renameat(
+                  directory, temporary,
+                  directory, url.lastPathComponent) == 0 else {
+            throw DetachStateCommandError.unsafeEventSignal
+        }
+    }
+}
+
+public struct SessionEventWatchConfiguration: Equatable, Sendable {
+    public let stateRoot: String
+    public let signalPath: String
+    public let transcriptRoots: [String]
+
+    public init(
+        stateRoot: String,
+        signalPath: String,
+        transcriptRoots: [String]
+    ) {
+        self.stateRoot = stateRoot
+        self.signalPath = signalPath
+        self.transcriptRoots = transcriptRoots
+    }
+
+    public static func parse(arguments: [String]) throws -> Self {
+        var stateRoot: String?
+        var signalPath: String?
+        var transcriptRoots: [String] = []
+        var sawJSON = false
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--json" where !sawJSON:
+                sawJSON = true
+                index += 1
+            case "--state-root" where stateRoot == nil && index + 1 < arguments.count:
+                stateRoot = arguments[index + 1]
+                index += 2
+            case "--signal" where signalPath == nil && index + 1 < arguments.count:
+                signalPath = arguments[index + 1]
+                index += 2
+            case "--transcript-root" where index + 1 < arguments.count:
+                transcriptRoots.append(arguments[index + 1])
+                index += 2
+            default:
+                throw DetachStateCommandError.invalidArguments
+            }
+        }
+        guard sawJSON,
+              let rawStateRoot = stateRoot,
+              let rawSignalPath = signalPath,
+              !transcriptRoots.isEmpty,
+              rawStateRoot.hasPrefix("/"),
+              rawSignalPath.hasPrefix("/"),
+              transcriptRoots.allSatisfy({ $0.hasPrefix("/") }) else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let canonicalStateRoot = canonicalPath(rawStateRoot)
+        let canonicalSignalPath = canonicalPath(rawSignalPath)
+        let canonicalTranscriptRoots = transcriptRoots.map(canonicalPath)
+        guard canonicalSignalPath.hasPrefix(canonicalStateRoot + "/") else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        return Self(
+            stateRoot: canonicalStateRoot,
+            signalPath: canonicalSignalPath,
+            transcriptRoots: canonicalTranscriptRoots)
+    }
+
+    private static func canonicalPath(_ path: String) -> String {
+        var url = URL(fileURLWithPath: path).standardizedFileURL
+        var missingComponents: [String] = []
+        while url.path != "/", !FileManager.default.fileExists(atPath: url.path) {
+            missingComponents.append(url.lastPathComponent)
+            url.deleteLastPathComponent()
+        }
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard Darwin.realpath(url.path, &buffer) != nil else { return path }
+        var resolved = URL(fileURLWithPath: String(cString: buffer))
+        for component in missingComponents.reversed() {
+            resolved.appendPathComponent(component)
+        }
+        return resolved.standardizedFileURL.path
+    }
+}
+
+public struct SessionFileEventBatch: Equatable, Sendable {
+    public let paths: [String]
+    public let flags: [UInt32]
+
+    public init(paths: [String], flags: [UInt32]) {
+        self.paths = paths
+        self.flags = flags
+    }
+}
+
+public enum SessionFileEventClassification: Equatable, Sendable {
+    case ignored
+    case lifecycle
+    case transcript
+    case resync
+}
+
+public enum SessionFileEventClassifier {
+    private static let resyncFlags = UInt32(
+        kFSEventStreamEventFlagMustScanSubDirs
+            | kFSEventStreamEventFlagUserDropped
+            | kFSEventStreamEventFlagKernelDropped
+            | kFSEventStreamEventFlagRootChanged)
+
+    public static func classify(
+        _ batch: SessionFileEventBatch,
+        configuration: SessionEventWatchConfiguration
+    ) -> SessionFileEventClassification {
+        if batch.flags.contains(where: { $0 & resyncFlags != 0 }) {
+            return .resync
+        }
+        if batch.paths.contains(configuration.signalPath) {
+            return .lifecycle
+        }
+        for path in batch.paths where path.hasSuffix(".jsonl") {
+            if configuration.transcriptRoots.contains(where: {
+                path == $0 || path.hasPrefix($0 + "/")
+            }) {
+                return .transcript
+            }
+        }
+        return .ignored
+    }
+}
+
+/// Reduces FSEvents callbacks to one leading and one trailing transcript hint.
+/// Callers restart the quiet timer after every `.scheduleTrailing` result.
+public struct SessionEventCoalescer: Equatable, Sendable {
+    public enum Action: Equatable, Sendable {
+        case none
+        case emit(SessionEventKind)
+        case emitAndScheduleTrailing(SessionEventKind)
+        case scheduleTrailing
+    }
+
+    private var transcriptBurstActive = false
+
+    public init() {}
+
+    public mutating func consume(
+        _ classification: SessionFileEventClassification
+    ) -> Action {
+        switch classification {
+        case .ignored:
+            return .none
+        case .lifecycle:
+            return .emit(.changed)
+        case .resync:
+            transcriptBurstActive = false
+            return .emit(.resync)
+        case .transcript:
+            if transcriptBurstActive { return .scheduleTrailing }
+            transcriptBurstActive = true
+            return .emitAndScheduleTrailing(.changed)
+        }
+    }
+
+    public mutating func quietWindowElapsed() -> Action {
+        guard transcriptBurstActive else { return .none }
+        transcriptBurstActive = false
+        return .emit(.changed)
+    }
+}
+
+private func sessionFSEventsCallback(
+    _: ConstFSEventStreamRef,
+    info: UnsafeMutableRawPointer?,
+    count: Int,
+    pathsPointer: UnsafeMutableRawPointer,
+    flagsPointer: UnsafePointer<FSEventStreamEventFlags>,
+    _: UnsafePointer<FSEventStreamEventId>
+) {
+    guard let info else { return }
+    let watcher = Unmanaged<SessionFileEventWatcher>
+        .fromOpaque(info).takeUnretainedValue()
+    let pathsArray = Unmanaged<CFArray>
+        .fromOpaque(pathsPointer).takeUnretainedValue() as NSArray
+    let paths = pathsArray.compactMap { $0 as? String }
+    let flags = (0..<count).map { UInt32(flagsPointer[$0]) }
+    watcher.receive(SessionFileEventBatch(paths: paths, flags: flags))
+}
+
+/// Long-lived native event source used by `detach watch --json`.
+public final class SessionFileEventWatcher: @unchecked Sendable {
+    private let configuration: SessionEventWatchConfiguration
+    private let quietWindow: TimeInterval
+    private let queue: DispatchQueue
+    private let output: FileHandle
+    private var stream: FSEventStreamRef?
+    private var coalescer = SessionEventCoalescer()
+    private var trailingWorkItem: DispatchWorkItem?
+
+    public init(
+        configuration: SessionEventWatchConfiguration,
+        quietWindow: TimeInterval = 0.15,
+        queue: DispatchQueue = DispatchQueue(
+            label: "dev.tsarev.detach.session-events"),
+        output: FileHandle = .standardOutput
+    ) {
+        self.configuration = configuration
+        self.quietWindow = quietWindow
+        self.queue = queue
+        self.output = output
+    }
+
+    public static func run(arguments: [String]) throws -> Never {
+        let watcher = SessionFileEventWatcher(
+            configuration: try .parse(arguments: arguments))
+        try watcher.start()
+        return withExtendedLifetime(watcher) {
+            dispatchMain()
+        }
+    }
+
+    public func start() throws {
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil)
+        let paths = watchedPaths() as CFArray
+        let createFlags = FSEventStreamCreateFlags(
+            kFSEventStreamCreateFlagUseCFTypes
+                | kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagWatchRoot)
+        guard let stream = FSEventStreamCreate(
+            nil,
+            sessionFSEventsCallback,
+            &context,
+            paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.05,
+            createFlags) else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, queue)
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+            throw DetachStateCommandError.invalidArguments
+        }
+        // The callback also runs on this serial queue. Keep complete JSON
+        // records ordered even when an event arrives during startup.
+        queue.sync { emit(.ready) }
+    }
+
+    func receive(_ batch: SessionFileEventBatch) {
+        apply(coalescer.consume(SessionFileEventClassifier.classify(
+            batch,
+            configuration: configuration)))
+    }
+
+    private func apply(_ action: SessionEventCoalescer.Action) {
+        switch action {
+        case .none:
+            return
+        case .emit(let kind):
+            emit(kind)
+        case .emitAndScheduleTrailing(let kind):
+            emit(kind)
+            scheduleTrailing()
+        case .scheduleTrailing:
+            scheduleTrailing()
+        }
+    }
+
+    private func scheduleTrailing() {
+        trailingWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.apply(self.coalescer.quietWindowElapsed())
+        }
+        trailingWorkItem = work
+        queue.asyncAfter(deadline: .now() + quietWindow, execute: work)
+    }
+
+    private func emit(_ kind: SessionEventKind) {
+        guard let data = try? JSONEncoder().encode(SessionEvent(event: kind)) else {
+            return
+        }
+        output.write(data)
+        output.write(Data([0x0A]))
+    }
+
+    private func watchedPaths() -> [String] {
+        var paths = [nearestExistingRoot(configuration.stateRoot)]
+        paths.append(contentsOf: configuration.transcriptRoots.map(nearestExistingRoot))
+        return Array(Set(paths)).sorted()
+    }
+
+    private func nearestExistingRoot(_ path: String) -> String {
+        var url = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        let manager = FileManager.default
+        while url.path != "/", !manager.fileExists(atPath: url.path) {
+            url.deleteLastPathComponent()
+        }
+        return url.path
+    }
+}

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -275,6 +275,104 @@ public struct SessionEventCoalescer: Equatable, Sendable {
     }
 }
 
+/// Supplements the root FSEvents stream with exact live transcript vnode
+/// sources. Some long-running provider processes do not produce recursive
+/// FSEvents for an already-open rollout file, while vnode writes remain
+/// observable. The root stream still discovers new and replaced files.
+final class SessionTranscriptFileMonitor: @unchecked Sendable {
+    static let maximumSources = 64
+
+    private let queue: DispatchQueue
+    private let queueKey = DispatchSpecificKey<UInt8>()
+    private let onChange: @Sendable () -> Void
+    private var targetPaths: Set<String> = []
+    private var sources: [String: any DispatchSourceFileSystemObject] = [:]
+
+    init(queue: DispatchQueue, onChange: @escaping @Sendable () -> Void) {
+        self.queue = queue
+        self.onChange = onChange
+        queue.setSpecific(key: queueKey, value: 1)
+    }
+
+    func update(paths: Set<String>) {
+        synchronized {
+            targetPaths = Set(paths.sorted().prefix(Self.maximumSources))
+            for path in Array(sources.keys) where !targetPaths.contains(path) {
+                removeSource(for: path)
+            }
+            for path in targetPaths where sources[path] == nil {
+                armSource(for: path)
+            }
+        }
+        drainRegistrationHandlers()
+    }
+
+    func stop() {
+        synchronized {
+            targetPaths = []
+            for path in Array(sources.keys) { removeSource(for: path) }
+        }
+        drainRegistrationHandlers()
+    }
+
+    deinit {
+        stop()
+    }
+
+    private func synchronized(_ operation: () -> Void) {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            operation()
+        } else {
+            queue.sync(execute: operation)
+        }
+    }
+
+    private func drainRegistrationHandlers() {
+        if DispatchQueue.getSpecific(key: queueKey) == nil { queue.sync {} }
+    }
+
+    private func armSource(for path: String) {
+        guard path.hasPrefix("/"),
+              URL(fileURLWithPath: path).standardizedFileURL.path == path else {
+            return
+        }
+        let descriptor = Darwin.open(path, O_EVTONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else { return }
+        var information = stat()
+        guard Darwin.fstat(descriptor, &information) == 0,
+              information.st_mode & S_IFMT == S_IFREG,
+              information.st_uid == Darwin.geteuid() else {
+            Darwin.close(descriptor)
+            return
+        }
+
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor,
+            eventMask: [.write, .extend, .delete, .rename, .revoke],
+            queue: queue)
+        source.setEventHandler { [weak self, weak source] in
+            guard let self, let source, self.sources[path] === source else { return }
+            let replaced = !source.data.isDisjoint(with: [.delete, .rename, .revoke])
+            self.onChange()
+            guard replaced else { return }
+            self.removeSource(for: path)
+            self.queue.asyncAfter(deadline: .now() + .milliseconds(50)) { [weak self] in
+                guard let self,
+                      self.targetPaths.contains(path),
+                      self.sources[path] == nil else { return }
+                self.armSource(for: path)
+            }
+        }
+        source.setCancelHandler { Darwin.close(descriptor) }
+        sources[path] = source
+        source.resume()
+    }
+
+    private func removeSource(for path: String) {
+        sources.removeValue(forKey: path)?.cancel()
+    }
+}
+
 private func sessionFSEventsCallback(
     _: ConstFSEventStreamRef,
     info: UnsafeMutableRawPointer?,
@@ -333,6 +431,12 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     private var trailingWorkItem: DispatchWorkItem?
     private var managedTranscriptPaths: Set<String> = []
     private var activeWatchedPaths: [String] = []
+    private lazy var transcriptMonitor = SessionTranscriptFileMonitor(
+        queue: queue,
+        onChange: { [weak self] in
+            guard let self else { return }
+            self.apply(self.coalescer.consume(.transcript))
+        })
 
     public init(
         configuration: SessionEventWatchConfiguration,
@@ -365,6 +469,7 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     /// the stream before the pointer can dangle for a late callback.
     deinit {
         trailingWorkItem?.cancel()
+        transcriptMonitor.stop()
         if let stream {
             FSEventStreamStop(stream)
             FSEventStreamInvalidate(stream)
@@ -436,9 +541,11 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     }
 
     private func refreshManagedTranscriptPaths() {
-        managedTranscriptPaths = DetachStateCommand.managedTranscriptPaths(
+        let registry = DetachStateCommand.managedTranscriptRegistry(
             sessionsRoots: configuration.sessionsRoots,
             allowedRoots: configuration.transcriptRoots)
+        managedTranscriptPaths = registry.all
+        transcriptMonitor.update(paths: registry.live)
     }
 
     private func scheduleStreamRootRefreshIfNeeded() {

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -152,7 +152,7 @@ public struct SessionEventWatchConfiguration: Equatable, Sendable {
             transcriptRoots: canonicalTranscriptRoots)
     }
 
-    private static func canonicalPath(_ path: String) -> String {
+    static func canonicalPath(_ path: String) -> String {
         var url = URL(fileURLWithPath: path).standardizedFileURL
         var missingComponents: [String] = []
         while url.path != "/", !FileManager.default.fileExists(atPath: url.path) {
@@ -195,7 +195,8 @@ public enum SessionFileEventClassifier {
 
     public static func classify(
         _ batch: SessionFileEventBatch,
-        configuration: SessionEventWatchConfiguration
+        configuration: SessionEventWatchConfiguration,
+        managedTranscriptPaths: Set<String>
     ) -> SessionFileEventClassification {
         if batch.flags.contains(where: { $0 & resyncFlags != 0 }) {
             return .resync
@@ -203,12 +204,8 @@ public enum SessionFileEventClassifier {
         if batch.paths.contains(configuration.signalPath) {
             return .lifecycle
         }
-        for path in batch.paths where path.hasSuffix(".jsonl") {
-            if configuration.transcriptRoots.contains(where: {
-                path == $0 || path.hasPrefix($0 + "/")
-            }) {
-                return .transcript
-            }
+        for path in batch.paths where managedTranscriptPaths.contains(path) {
+            return .transcript
         }
         return .ignored
     }
@@ -271,6 +268,34 @@ private func sessionFSEventsCallback(
     watcher.receive(SessionFileEventBatch(paths: paths, flags: flags))
 }
 
+/// Ends a long-lived watcher when the process that launched it exits. Task
+/// cancellation remains the normal path. This process source closes the gap
+/// during application termination, when Swift concurrency teardown is not
+/// guaranteed to run before AppKit exits.
+final class SessionEventParentMonitor: @unchecked Sendable {
+    private let source: DispatchSourceProcess
+
+    init(
+        processID: pid_t,
+        queue: DispatchQueue,
+        onExit: @escaping @Sendable () -> Void
+    ) {
+        source = DispatchSource.makeProcessSource(
+            identifier: processID,
+            eventMask: .exit,
+            queue: queue)
+        source.setEventHandler(handler: onExit)
+    }
+
+    func start() {
+        source.resume()
+    }
+
+    deinit {
+        source.cancel()
+    }
+}
+
 /// Long-lived native event source used by `detach watch --json`.
 public final class SessionFileEventWatcher: @unchecked Sendable {
     private let configuration: SessionEventWatchConfiguration
@@ -278,8 +303,11 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     private let queue: DispatchQueue
     private let output: FileHandle
     private var stream: FSEventStreamRef?
+    private var parentMonitor: SessionEventParentMonitor?
     private var coalescer = SessionEventCoalescer()
     private var trailingWorkItem: DispatchWorkItem?
+    private var managedTranscriptPaths: Set<String> = []
+    private var activeWatchedPaths: [String] = []
 
     public init(
         configuration: SessionEventWatchConfiguration,
@@ -297,20 +325,40 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     public static func run(arguments: [String]) throws -> Never {
         let watcher = SessionFileEventWatcher(
             configuration: try .parse(arguments: arguments))
-        try watcher.start()
+        try watcher.start(parentProcessID: Darwin.getppid())
         return withExtendedLifetime(watcher) {
             dispatchMain()
         }
     }
 
-    public func start() throws {
+    public func start(parentProcessID: pid_t? = nil) throws {
+        refreshManagedTranscriptPaths()
+        let paths = availableWatchedPaths()
+        guard paths.contains(configuration.stateRoot) else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        stream = try makeStream(paths: paths)
+        activeWatchedPaths = paths
+        if let parentProcessID, parentProcessID > 1 {
+            let monitor = SessionEventParentMonitor(
+                processID: parentProcessID,
+                queue: queue,
+                onExit: { Darwin._exit(EXIT_SUCCESS) })
+            parentMonitor = monitor
+            monitor.start()
+        }
+        // The callback also runs on this serial queue. Keep complete JSON
+        // records ordered even when an event arrives during startup.
+        queue.sync { emit(.ready) }
+    }
+
+    private func makeStream(paths: [String]) throws -> FSEventStreamRef {
         var context = FSEventStreamContext(
             version: 0,
             info: Unmanaged.passUnretained(self).toOpaque(),
             retain: nil,
             release: nil,
             copyDescription: nil)
-        let paths = watchedPaths() as CFArray
         let createFlags = FSEventStreamCreateFlags(
             kFSEventStreamCreateFlagUseCFTypes
                 | kFSEventStreamCreateFlagFileEvents
@@ -319,29 +367,59 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
             nil,
             sessionFSEventsCallback,
             &context,
-            paths,
+            paths as CFArray,
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
             0.05,
             createFlags) else {
             throw DetachStateCommandError.invalidArguments
         }
-        self.stream = stream
         FSEventStreamSetDispatchQueue(stream, queue)
         guard FSEventStreamStart(stream) else {
             FSEventStreamInvalidate(stream)
             FSEventStreamRelease(stream)
-            self.stream = nil
             throw DetachStateCommandError.invalidArguments
         }
-        // The callback also runs on this serial queue. Keep complete JSON
-        // records ordered even when an event arrives during startup.
-        queue.sync { emit(.ready) }
+        return stream
     }
 
     func receive(_ batch: SessionFileEventBatch) {
-        apply(coalescer.consume(SessionFileEventClassifier.classify(
+        let classification = SessionFileEventClassifier.classify(
             batch,
-            configuration: configuration)))
+            configuration: configuration,
+            managedTranscriptPaths: managedTranscriptPaths)
+        if classification == .lifecycle || classification == .resync {
+            refreshManagedTranscriptPaths()
+            scheduleStreamRootRefreshIfNeeded()
+        }
+        apply(coalescer.consume(classification))
+    }
+
+    private func refreshManagedTranscriptPaths() {
+        managedTranscriptPaths = DetachStateCommand.managedTranscriptPaths(
+            atStateRoot: configuration.stateRoot,
+            allowedRoots: configuration.transcriptRoots)
+    }
+
+    private func scheduleStreamRootRefreshIfNeeded() {
+        let paths = availableWatchedPaths()
+        guard paths.contains(configuration.stateRoot),
+              paths != activeWatchedPaths else { return }
+        queue.async { [weak self] in
+            self?.replaceStreamIfPossible(paths: paths)
+        }
+    }
+
+    private func replaceStreamIfPossible(paths: [String]) {
+        guard paths != activeWatchedPaths,
+              let replacement = try? makeStream(paths: paths) else { return }
+        let previous = stream
+        stream = replacement
+        activeWatchedPaths = paths
+        if let previous {
+            FSEventStreamStop(previous)
+            FSEventStreamInvalidate(previous)
+            FSEventStreamRelease(previous)
+        }
     }
 
     private func apply(_ action: SessionEventCoalescer.Action) {
@@ -376,18 +454,14 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
         output.write(Data([0x0A]))
     }
 
-    private func watchedPaths() -> [String] {
-        var paths = [nearestExistingRoot(configuration.stateRoot)]
-        paths.append(contentsOf: configuration.transcriptRoots.map(nearestExistingRoot))
-        return Array(Set(paths)).sorted()
-    }
-
-    private func nearestExistingRoot(_ path: String) -> String {
-        var url = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+    private func availableWatchedPaths() -> [String] {
         let manager = FileManager.default
-        while url.path != "/", !manager.fileExists(atPath: url.path) {
-            url.deleteLastPathComponent()
+        let candidates = [configuration.stateRoot] + configuration.transcriptRoots
+        let paths = candidates.filter { path in
+            var isDirectory: ObjCBool = false
+            return manager.fileExists(atPath: path, isDirectory: &isDirectory)
+                && isDirectory.boolValue
         }
-        return url.path
+        return Array(Set(paths)).sorted()
     }
 }

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -33,22 +33,18 @@ public enum SessionEventParser {
 /// The token is only an event hint. Session metadata remains the source of
 /// truth, so persistence and directory fsync are intentionally unnecessary.
 enum SessionEventSignal {
-    static func publish(atPath path: String) throws {
+    static func publish(inStateRoot path: String) throws {
         guard path.hasPrefix("/"), !path.utf8.contains(0) else {
             throw DetachStateCommandError.unsafeEventSignal
         }
-        // The runtime builds this path from environment roots that may carry
-        // a trailing slash or `//`. Standardize instead of rejecting, so a
-        // cosmetic path difference cannot silently disable every hint.
-        let url = URL(fileURLWithPath: path).standardizedFileURL
-        guard url.path.hasPrefix("/"),
-              url.path != "/",
-              !url.lastPathComponent.isEmpty,
-              url.lastPathComponent != ".",
-              url.lastPathComponent != ".." else {
+        // The runtime root may carry a trailing slash or `//`. Standardize it,
+        // then derive the fixed token name here. Callers cannot choose a final
+        // component that could replace unrelated user data.
+        let parent = URL(fileURLWithPath: path, isDirectory: true)
+            .standardizedFileURL
+        guard parent.path.hasPrefix("/"), parent.path != "/" else {
             throw DetachStateCommandError.unsafeEventSignal
         }
-        let parent = url.deletingLastPathComponent()
         let directory = Darwin.open(
             parent.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
         guard directory >= 0 else {
@@ -93,7 +89,7 @@ enum SessionEventSignal {
         guard written,
               Darwin.renameat(
                   directory, temporary,
-                  directory, url.lastPathComponent) == 0 else {
+                  directory, "session-change") == 0 else {
             throw DetachStateCommandError.unsafeEventSignal
         }
     }

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -352,9 +352,14 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     }
 
     public static func run(arguments: [String]) throws -> Never {
+        // A consumer that is already gone must not leave an orphan, and a
+        // closed pipe must end this process quietly rather than as a crash.
+        let parent = Darwin.getppid()
+        guard parent > 1 else { Darwin._exit(EXIT_SUCCESS) }
+        Darwin.signal(SIGPIPE, SIG_IGN)
         let watcher = SessionFileEventWatcher(
             configuration: try .parse(arguments: arguments))
-        try watcher.start(parentProcessID: Darwin.getppid())
+        try watcher.start(parentProcessID: parent)
         return withExtendedLifetime(watcher) {
             dispatchMain()
         }
@@ -487,11 +492,28 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
     }
 
     private func emit(_ kind: SessionEventKind) {
-        guard let data = try? JSONEncoder().encode(SessionEvent(event: kind)) else {
+        guard var data = try? JSONEncoder().encode(SessionEvent(event: kind)) else {
             return
         }
-        output.write(data)
-        output.write(Data([0x0A]))
+        data.append(0x0A)
+        let descriptor = output.fileDescriptor
+        let delivered = data.withUnsafeBytes { buffer -> Bool in
+            guard var base = buffer.baseAddress else { return true }
+            var remaining = buffer.count
+            while remaining > 0 {
+                let written = Darwin.write(descriptor, base, remaining)
+                if written < 0 {
+                    if errno == EINTR || errno == EAGAIN { continue }
+                    return false
+                }
+                remaining -= written
+                base = base.advanced(by: written)
+            }
+            return true
+        }
+        // EPIPE means the consumer closed its end. The stream has no other
+        // purpose, so end without an uncaught-exception crash report.
+        if !delivered, errno == EPIPE { Darwin._exit(EXIT_SUCCESS) }
     }
 
     private func availableWatchedPaths() -> [String] {

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -37,8 +37,15 @@ enum SessionEventSignal {
         guard path.hasPrefix("/"), !path.utf8.contains(0) else {
             throw DetachStateCommandError.unsafeEventSignal
         }
+        // The runtime builds this path from environment roots that may carry
+        // a trailing slash or `//`. Standardize instead of rejecting, so a
+        // cosmetic path difference cannot silently disable every hint.
         let url = URL(fileURLWithPath: path).standardizedFileURL
-        guard url.path == path, !url.lastPathComponent.isEmpty else {
+        guard url.path.hasPrefix("/"),
+              url.path != "/",
+              !url.lastPathComponent.isEmpty,
+              url.lastPathComponent != ".",
+              url.lastPathComponent != ".." else {
             throw DetachStateCommandError.unsafeEventSignal
         }
         let parent = url.deletingLastPathComponent()
@@ -96,21 +103,37 @@ public struct SessionEventWatchConfiguration: Equatable, Sendable {
     public let stateRoot: String
     public let signalPath: String
     public let transcriptRoots: [String]
+    /// Provider session directories whose metadata names managed transcripts.
+    /// The runtime may relocate one provider root, so these are explicit.
+    public let sessionsRoots: [String]
 
     public init(
         stateRoot: String,
         signalPath: String,
-        transcriptRoots: [String]
+        transcriptRoots: [String],
+        sessionsRoots: [String]? = nil
     ) {
         self.stateRoot = stateRoot
         self.signalPath = signalPath
         self.transcriptRoots = transcriptRoots
+        self.sessionsRoots = sessionsRoots
+            ?? Self.defaultSessionsRoots(stateRoot: stateRoot)
+    }
+
+    public static func defaultSessionsRoots(stateRoot: String) -> [String] {
+        Provider.allCases.map { provider in
+            URL(fileURLWithPath: stateRoot, isDirectory: true)
+                .appendingPathComponent(provider.rawValue, isDirectory: true)
+                .appendingPathComponent("sessions", isDirectory: true)
+                .standardizedFileURL.path
+        }
     }
 
     public static func parse(arguments: [String]) throws -> Self {
         var stateRoot: String?
         var signalPath: String?
         var transcriptRoots: [String] = []
+        var sessionsRoots: [String] = []
         var sawJSON = false
         var index = 0
         while index < arguments.count {
@@ -127,6 +150,9 @@ public struct SessionEventWatchConfiguration: Equatable, Sendable {
             case "--transcript-root" where index + 1 < arguments.count:
                 transcriptRoots.append(arguments[index + 1])
                 index += 2
+            case "--sessions-root" where index + 1 < arguments.count:
+                sessionsRoots.append(arguments[index + 1])
+                index += 2
             default:
                 throw DetachStateCommandError.invalidArguments
             }
@@ -137,7 +163,8 @@ public struct SessionEventWatchConfiguration: Equatable, Sendable {
               !transcriptRoots.isEmpty,
               rawStateRoot.hasPrefix("/"),
               rawSignalPath.hasPrefix("/"),
-              transcriptRoots.allSatisfy({ $0.hasPrefix("/") }) else {
+              transcriptRoots.allSatisfy({ $0.hasPrefix("/") }),
+              sessionsRoots.allSatisfy({ $0.hasPrefix("/") }) else {
             throw DetachStateCommandError.invalidArguments
         }
         let canonicalStateRoot = canonicalPath(rawStateRoot)
@@ -149,7 +176,9 @@ public struct SessionEventWatchConfiguration: Equatable, Sendable {
         return Self(
             stateRoot: canonicalStateRoot,
             signalPath: canonicalSignalPath,
-            transcriptRoots: canonicalTranscriptRoots)
+            transcriptRoots: canonicalTranscriptRoots,
+            sessionsRoots: sessionsRoots.isEmpty
+                ? nil : sessionsRoots.map(canonicalPath))
     }
 
     static func canonicalPath(_ path: String) -> String {
@@ -331,6 +360,17 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
         }
     }
 
+    /// The FSEvents context holds an unretained pointer to this watcher. Stop
+    /// the stream before the pointer can dangle for a late callback.
+    deinit {
+        trailingWorkItem?.cancel()
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+    }
+
     public func start(parentProcessID: pid_t? = nil) throws {
         refreshManagedTranscriptPaths()
         let paths = availableWatchedPaths()
@@ -396,7 +436,7 @@ public final class SessionFileEventWatcher: @unchecked Sendable {
 
     private func refreshManagedTranscriptPaths() {
         managedTranscriptPaths = DetachStateCommand.managedTranscriptPaths(
-            atStateRoot: configuration.stateRoot,
+            sessionsRoots: configuration.sessionsRoots,
             allowedRoots: configuration.transcriptRoots)
     }
 

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -177,6 +177,7 @@ public struct SessionHealthEvidence: Equatable, Sendable {
     public var checkpointFreshness: FreshnessState
     public var checkpointRecoverable: Bool
     public var agentSessionKnown: Bool
+    public var stopRequested: Bool
 
     public init(
         metadataValid: Bool,
@@ -189,7 +190,8 @@ public struct SessionHealthEvidence: Equatable, Sendable {
         heartbeatFreshness: FreshnessState,
         checkpointFreshness: FreshnessState,
         checkpointRecoverable: Bool,
-        agentSessionKnown: Bool
+        agentSessionKnown: Bool,
+        stopRequested: Bool = false
     ) {
         self.metadataValid = metadataValid
         self.runtimeIdentityExpected = runtimeIdentityExpected
@@ -202,6 +204,7 @@ public struct SessionHealthEvidence: Equatable, Sendable {
         self.checkpointFreshness = checkpointFreshness
         self.checkpointRecoverable = checkpointRecoverable
         self.agentSessionKnown = agentSessionKnown
+        self.stopRequested = stopRequested
     }
 }
 
@@ -301,6 +304,24 @@ public enum SessionHealthEvaluator {
                 evidence: evidence)
         case .match:
             break
+        }
+
+        // Stop records exact-run intent before signalling the process group.
+        // The provider can exit while its worker is still checkpointing and
+        // writing the final `stopped` metadata. That proven transition is an
+        // interruption in progress, not a lost provider. Keep actions closed
+        // until the worker and tmux pane have finished.
+        if evidence.stopRequested,
+           evidence.runtimeIdentityExpected,
+           isActive(evidence.metaStatus),
+           evidence.workerState == .alive,
+           evidence.providerState == .dead {
+            return assessment(
+                status: .interrupted,
+                reason: .finished,
+                actions: [],
+                ownershipProven: true,
+                evidence: evidence)
         }
 
         // The worker publishes its final status and only then exits, so a

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -362,6 +362,22 @@ public enum SessionHealthEvaluator {
             break
         }
 
+        // The worker is the first exact process identity established during a
+        // new run. It publishes `starting` before the power wrapper exposes the
+        // provider PID so event consumers can show the row immediately. This
+        // is a coherent owned startup phase, not a lost provider. The runtime
+        // promotes the record to `running` only after it proves the provider
+        // descendant; any other status with a missing PID remains hung.
+        if evidence.metaStatus == .starting,
+           evidence.providerState == .unknown {
+            return assessment(
+                status: .starting,
+                reason: .healthy,
+                actions: [.attach, .stop],
+                ownershipProven: true,
+                evidence: evidence)
+        }
+
         switch evidence.providerState {
         case .unknown:
             return hungAssessment(reason: .providerPIDMissing, evidence: evidence)

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 public enum TmuxHealthState: String, Codable, Sendable {
@@ -24,6 +25,112 @@ public enum FreshnessState: String, Codable, Sendable {
     case fresh
     case stale
     case missing
+}
+
+struct SessionProcessHealth: Equatable, Sendable {
+    var worker: ProcessHealthState
+    var provider: ProcessHealthState
+}
+
+struct SessionProcessIdentity: Equatable, Sendable {
+    var parentPID: pid_t
+    var userID: uid_t
+}
+
+/// Reads only the process identities named by one health record. The result is
+/// presentation evidence. Runtime mutations repeat their established live
+/// ownership and tmux-token checks immediately before they act.
+enum SessionProcessHealthInspector {
+    typealias Lookup = (pid_t) -> SessionProcessIdentity?
+
+    static func inspect(
+        tmuxState: TmuxHealthState,
+        workerPID rawWorkerPID: String,
+        providerPID rawProviderPID: String,
+        panePID rawPanePID: String,
+        userID: uid_t = geteuid(),
+        lookup: Lookup = liveIdentity
+    ) -> SessionProcessHealth {
+        let workerPID = validPID(rawWorkerPID)
+        let providerPID = validPID(rawProviderPID)
+        let panePID = validPID(rawPanePID)
+        var identities: [pid_t: SessionProcessIdentity?] = [:]
+        func identity(_ pid: pid_t) -> SessionProcessIdentity? {
+            if let cached = identities[pid] { return cached }
+            let value = lookup(pid)
+            identities[pid] = .some(value)
+            return value
+        }
+
+        var worker: ProcessHealthState
+        if let workerPID {
+            worker = identity(workerPID)?.userID == userID ? .alive : .dead
+        } else {
+            worker = .unknown
+        }
+
+        var provider: ProcessHealthState
+        if let providerPID {
+            if identity(providerPID)?.userID != userID {
+                provider = .dead
+            } else if let workerPID,
+                      worker == .alive,
+                      isDescendant(
+                          providerPID,
+                          of: workerPID,
+                          identity: identity) {
+                provider = .alive
+            } else {
+                provider = .mismatch
+            }
+        } else {
+            provider = .unknown
+        }
+
+        if tmuxState == .live,
+           worker == .alive,
+           panePID != workerPID {
+            worker = .mismatch
+            provider = .mismatch
+        }
+        return SessionProcessHealth(worker: worker, provider: provider)
+    }
+
+    private static func validPID(_ raw: String) -> pid_t? {
+        guard let value = Int64(raw),
+              value > 1,
+              value <= Int64(Int32.max) else { return nil }
+        return pid_t(value)
+    }
+
+    private static func isDescendant(
+        _ child: pid_t,
+        of ancestor: pid_t,
+        identity: (pid_t) -> SessionProcessIdentity?
+    ) -> Bool {
+        var current = child
+        for _ in 0..<64 {
+            if current == ancestor { return true }
+            guard let parent = identity(current)?.parentPID,
+                  parent > 1 else { return false }
+            current = parent
+        }
+        return false
+    }
+
+    private static func liveIdentity(_ pid: pid_t) -> SessionProcessIdentity? {
+        var information = proc_bsdinfo()
+        let expected = Int32(MemoryLayout<proc_bsdinfo>.size)
+        guard proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &information,
+            expected) == expected else { return nil }
+        return SessionProcessIdentity(
+            parentPID: pid_t(information.pbi_ppid),
+            userID: uid_t(information.pbi_uid))
+    }
 }
 
 public enum SessionHealthReason: String, Codable, Sendable {

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -27,6 +27,46 @@ public enum FreshnessState: String, Codable, Sendable {
     case missing
 }
 
+/// An authoritative phase owned by the runtime. Stable user outcomes remain
+/// in metadata `status`; this phase only makes multi-step transitions explicit.
+public enum RuntimeLifecyclePhase: String, Codable, Sendable {
+    case initializing
+    case starting
+    case running
+    case stopping
+    case finalizing
+    case terminal
+
+    func allows(_ target: RuntimeLifecyclePhase) -> Bool {
+        if self == target { return true }
+        return switch self {
+        case .initializing:
+            target == .starting || target == .terminal
+        case .starting:
+            target == .running || target == .stopping
+                || target == .finalizing || target == .terminal
+        case .running:
+            target == .stopping || target == .finalizing || target == .terminal
+        case .stopping:
+            // Stop can roll back only if the exact managed pane survived a
+            // failed removal and the runtime remains usable.
+            target == .running || target == .terminal
+        case .finalizing:
+            target == .terminal
+        case .terminal:
+            target == .terminal
+        }
+    }
+
+    static func inferred(fromMetadataStatus status: String?) -> RuntimeLifecyclePhase {
+        switch status {
+        case "starting": .starting
+        case "running", "recovering", "hung": .running
+        default: .terminal
+        }
+    }
+}
+
 struct SessionProcessHealth: Equatable, Sendable {
     var worker: ProcessHealthState
     var provider: ProcessHealthState
@@ -178,6 +218,7 @@ public struct SessionHealthEvidence: Equatable, Sendable {
     public var checkpointRecoverable: Bool
     public var agentSessionKnown: Bool
     public var stopRequested: Bool
+    public var lifecyclePhase: RuntimeLifecyclePhase
 
     public init(
         metadataValid: Bool,
@@ -191,7 +232,8 @@ public struct SessionHealthEvidence: Equatable, Sendable {
         checkpointFreshness: FreshnessState,
         checkpointRecoverable: Bool,
         agentSessionKnown: Bool,
-        stopRequested: Bool = false
+        stopRequested: Bool = false,
+        lifecyclePhase: RuntimeLifecyclePhase? = nil
     ) {
         self.metadataValid = metadataValid
         self.runtimeIdentityExpected = runtimeIdentityExpected
@@ -205,6 +247,8 @@ public struct SessionHealthEvidence: Equatable, Sendable {
         self.checkpointRecoverable = checkpointRecoverable
         self.agentSessionKnown = agentSessionKnown
         self.stopRequested = stopRequested
+        self.lifecyclePhase = lifecyclePhase
+            ?? RuntimeLifecyclePhase.inferred(fromMetadataStatus: metaStatus.rawValue)
     }
 }
 
@@ -249,6 +293,50 @@ public enum SessionHealthEvaluator {
                 actions: actions,
                 ownershipProven: evidence.tmuxState == .live || evidence.tmuxState == .dead,
                 evidence: evidence)
+        }
+
+        // Active transition phases close user actions while an exact runtime
+        // component can still finish them. If all runtime evidence is dead,
+        // fall through so a crashed transition converges to Resume/Delete.
+        // A foreign tmux and malformed metadata still take precedence above.
+        let liveIdentityConflict = evidence.tmuxState == .live
+            && evidence.runTokenState != .match
+        let transitionInProgress = evidence.tmuxState == .live
+            || runtimeProcessMayStillBeAlive(evidence)
+        switch evidence.lifecyclePhase {
+        case .initializing:
+            if liveIdentityConflict { break }
+            if transitionInProgress {
+                return assessment(
+                    status: .starting,
+                    reason: .healthy,
+                    actions: [],
+                    evidence: evidence)
+            }
+        case .stopping:
+            if liveIdentityConflict { break }
+            if transitionInProgress {
+                var result = assessment(
+                    status: .stopped,
+                    reason: .finished,
+                    actions: [],
+                    evidence: evidence)
+                result.cleanupEligible = false
+                return result
+            }
+        case .finalizing:
+            if liveIdentityConflict { break }
+            if transitionInProgress {
+                var result = assessment(
+                    status: isActive(evidence.metaStatus) ? .interrupted : evidence.metaStatus,
+                    reason: .finished,
+                    actions: [],
+                    evidence: evidence)
+                result.cleanupEligible = false
+                return result
+            }
+        case .starting, .running, .terminal:
+            break
         }
 
         switch evidence.tmuxState {
@@ -306,21 +394,22 @@ public enum SessionHealthEvaluator {
             break
         }
 
-        // Stop records exact-run intent before signalling the process group.
-        // The provider can exit while its worker is still checkpointing and
-        // writing the final `stopped` metadata. That proven transition is an
-        // interruption in progress, not a lost provider. Keep actions closed
-        // until the worker and tmux pane have finished.
+        // Stop records exact-run intent and its public outcome before
+        // signalling the process group. The provider can exit while its
+        // worker is still checkpointing. Keep that outcome monotonic and
+        // actions closed until the worker and tmux pane have finished.
         if evidence.stopRequested,
            evidence.runtimeIdentityExpected,
            evidence.workerState == .alive,
            evidence.providerState == .dead {
-            return assessment(
-                status: .interrupted,
+            var result = assessment(
+                status: .stopped,
                 reason: .finished,
                 actions: [],
                 ownershipProven: true,
                 evidence: evidence)
+            result.cleanupEligible = false
+            return result
         }
 
         // The worker publishes its final status and only then exits, so a

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -303,6 +303,23 @@ public enum SessionHealthEvaluator {
             break
         }
 
+        // The worker publishes its final status and only then exits, so a
+        // terminal metadata record with a live owned pane and a gone provider
+        // is a run that is finishing, not a hung one. The pane dies moments
+        // later. Reporting `hung` here would move a finished session into
+        // Problems until an unrelated event repaired it.
+        if evidence.runtimeIdentityExpected,
+           !isActive(evidence.metaStatus),
+           evidence.workerState == .alive,
+           evidence.providerState == .dead {
+            var result = finishedAssessment(evidence, reason: .finished)
+            result.ownershipProven = true
+            // The pane is still alive for a moment. Typed cleanup waits for
+            // the next snapshot, which sees the dead pane.
+            result.cleanupEligible = false
+            return result
+        }
+
         if !evidence.runtimeIdentityExpected {
             let reason: SessionHealthReason = evidence.checkpointFreshness == .stale
                 ? .checkpointStale : .heartbeatMissing

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -313,7 +313,6 @@ public enum SessionHealthEvaluator {
         // until the worker and tmux pane have finished.
         if evidence.stopRequested,
            evidence.runtimeIdentityExpected,
-           isActive(evidence.metaStatus),
            evidence.workerState == .alive,
            evidence.providerState == .dead {
             return assessment(

--- a/app/Sources/DetachKit/SessionPresentation.swift
+++ b/app/Sources/DetachKit/SessionPresentation.swift
@@ -35,7 +35,7 @@ public extension Session {
     /// Whether the provider process is still expected to produce live output.
     /// This intentionally stays independent from the sidebar section: a live
     /// session can move between Working and Answer ready without stopping log
-    /// polling.
+    /// observation.
     var isLive: Bool {
         switch effectiveStatus {
         case .starting, .running, .recovering, .hung: true

--- a/app/Sources/DetachKit/SessionSnapshotCache.swift
+++ b/app/Sources/DetachKit/SessionSnapshotCache.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+@MainActor
+public protocol SessionSnapshotCaching: AnyObject {
+    func load() -> [Session]
+    func store(_ sessions: [Session])
+}
+
+/// A bounded presentation cache for the last complete typed session list.
+/// Cached rows paint cold startup only. They carry no mutation permission and
+/// are replaced by the first fresh `list --json` snapshot.
+@MainActor
+public final class UserDefaultsSessionSnapshotCache: SessionSnapshotCaching {
+    nonisolated public static let defaultKey = "sessionPresentationSnapshotV1"
+    nonisolated public static let maximumSessionCount = 128
+    nonisolated public static let maximumByteCount = 1_048_576
+
+    private struct Document: Codable {
+        let schema: Int
+        let sessions: [Session]
+    }
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    public init(
+        defaults: UserDefaults = .standard,
+        key: String = UserDefaultsSessionSnapshotCache.defaultKey
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    public func load() -> [Session] {
+        guard let data = defaults.data(forKey: key),
+              data.count <= Self.maximumByteCount else { return [] }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let document = try? decoder.decode(Document.self, from: data),
+              document.schema == 1,
+              document.sessions.count <= Self.maximumSessionCount,
+              document.sessions.allSatisfy({ $0.schema == 1 }),
+              Set(document.sessions.map(\.id)).count == document.sessions.count
+        else { return [] }
+        return document.sessions.map(Self.presentationOnly)
+    }
+
+    public func store(_ sessions: [Session]) {
+        guard sessions.count <= Self.maximumSessionCount,
+              sessions.allSatisfy({ $0.schema == 1 }),
+              Set(sessions.map(\.id)).count == sessions.count else { return }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(Document(schema: 1, sessions: sessions)),
+              data.count <= Self.maximumByteCount else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    private static func presentationOnly(_ source: Session) -> Session {
+        var session = source
+        session.healthActions = []
+        session.healthReason = nil
+        session.reconcileAction = SessionReconcileAction.none
+        session.ownershipProven = false
+        session.cleanupEligible = false
+        session.workerPID = nil
+        session.providerPID = nil
+        session.workerHeartbeatAt = nil
+        session.heartbeatFresh = false
+        session.checkpointFresh = false
+        session.powerProtectionState = .unknown
+        return session
+    }
+}

--- a/app/Sources/DetachKit/SessionSnapshotCache.swift
+++ b/app/Sources/DetachKit/SessionSnapshotCache.swift
@@ -22,6 +22,9 @@ public final class UserDefaultsSessionSnapshotCache: SessionSnapshotCaching {
 
     private let defaults: UserDefaults
     private let key: String
+    /// The presentation form last written or loaded. Volatile fields change on
+    /// nearly every snapshot; only a presentation difference is worth a write.
+    private var lastStored: [Session]?
 
     public init(
         defaults: UserDefaults = .standard,
@@ -42,18 +45,24 @@ public final class UserDefaultsSessionSnapshotCache: SessionSnapshotCaching {
               document.sessions.allSatisfy({ $0.schema == 1 }),
               Set(document.sessions.map(\.id)).count == document.sessions.count
         else { return [] }
-        return document.sessions.map(Self.presentationOnly)
+        let sessions = document.sessions.map(Self.presentationOnly)
+        lastStored = sessions
+        return sessions
     }
 
     public func store(_ sessions: [Session]) {
         guard sessions.count <= Self.maximumSessionCount,
               sessions.allSatisfy({ $0.schema == 1 }),
               Set(sessions.map(\.id)).count == sessions.count else { return }
+        let presentation = sessions.map(Self.presentationOnly)
+        guard presentation != lastStored else { return }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(Document(schema: 1, sessions: sessions)),
+        guard let data = try? encoder.encode(
+                Document(schema: 1, sessions: presentation)),
               data.count <= Self.maximumByteCount else { return }
         defaults.set(data, forKey: key)
+        lastStored = presentation
     }
 
     private static func presentationOnly(_ source: Session) -> Session {

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -46,6 +46,7 @@ public final class SessionStore {
 
     public private(set) var sessions: [Session] = []
     public private(set) var lastUpdated: Date?
+    public private(set) var hasFreshSnapshot = false
     public private(set) var state: State = .ok
 
     /// Called after every successful typed snapshot — including an unchanged list — so
@@ -55,7 +56,12 @@ public final class SessionStore {
     @ObservationIgnored public var onSnapshot: (@MainActor ([Session]) async -> Void)?
 
     private var cli: DetachCLIRunning
+    @ObservationIgnored private let snapshotCache: (any SessionSnapshotCaching)?
     private var eventTask: Task<Void, Never>?
+    private var eventReadyGeneration: UInt64?
+    private var eventReadyWaiters:
+        [UInt64: [CheckedContinuation<Void, Never>]] = [:]
+    private var eventReadinessTimeoutTask: Task<Void, Never>?
     private var interruptedConfirmationTask: Task<Void, Never>?
     private var confirmedInterruptedSessionIDs: Set<String> = []
     private var eventGeneration: UInt64 = 0
@@ -63,41 +69,76 @@ public final class SessionStore {
     private var sessionWaiters: [UUID: SessionWaiter] = [:]
     @ObservationIgnored private let confirmationSleep:
         @Sendable (UInt64) async throws -> Void
+    @ObservationIgnored private let eventReadinessSleep:
+        @Sendable (UInt64) async throws -> Void
 
-    public init(cli: DetachCLIRunning) {
+    public init(
+        cli: DetachCLIRunning,
+        snapshotCache: (any SessionSnapshotCaching)? = nil
+    ) {
         self.cli = cli
+        self.snapshotCache = snapshotCache
+        self.sessions = snapshotCache?.load() ?? []
         self.confirmationSleep = { try await Task.sleep(nanoseconds: $0) }
+        self.eventReadinessSleep = { try await Task.sleep(nanoseconds: $0) }
     }
 
     init(
         cli: DetachCLIRunning,
-        confirmationSleep: @escaping @Sendable (UInt64) async throws -> Void
+        snapshotCache: (any SessionSnapshotCaching)? = nil,
+        confirmationSleep: @escaping @Sendable (UInt64) async throws -> Void,
+        eventReadinessSleep: @escaping @Sendable (UInt64) async throws -> Void = {
+            try await Task.sleep(nanoseconds: $0)
+        }
     ) {
         self.cli = cli
+        self.snapshotCache = snapshotCache
+        self.sessions = snapshotCache?.load() ?? []
         self.confirmationSleep = confirmationSleep
+        self.eventReadinessSleep = eventReadinessSleep
     }
 
-    /// Swaps the CLI (for example after the installed payload activates) and
-    /// establishes a fresh typed snapshot before replacing the event stream.
+    /// Swaps the CLI (for example after the installed payload activates),
+    /// installs its event stream, and then takes one fresh typed snapshot.
+    /// Waiting for `ready` closes the watch/snapshot race without the former
+    /// second full list on every cold start.
     public func configure(cli: DetachCLIRunning) async {
         stopObserving()
+        // Invalidate a list request from the previous executable before the
+        // new watcher readiness wait suspends this reconfiguration.
+        refreshGeneration &+= 1
         self.cli = cli
+        hasFreshSnapshot = false
+        let generation = beginObserving(refreshOnFirstEvent: false)
+        await waitUntilObservationIsReady(generation: generation)
+        guard generation == eventGeneration else { return }
         await refresh()
-        startObserving()
+        // A missing, old, or damaged watcher must not hold app startup. Retry
+        // in the background after the bounded snapshot path is available.
+        if eventTask == nil { startObserving() }
     }
 
     /// Starts one bounded stream of native change hints. The initial `ready`
     /// event closes the refresh/watch race by requesting another full list
     /// only after FSEvents is installed.
     public func startObserving() {
-        guard eventTask == nil else { return }
+        _ = beginObserving(refreshOnFirstEvent: true)
+    }
+
+    @discardableResult
+    private func beginObserving(refreshOnFirstEvent: Bool) -> UInt64 {
+        guard eventTask == nil else { return eventGeneration }
         eventGeneration &+= 1
         let generation = eventGeneration
         let cli = self.cli
         eventTask = Task { [weak self] in
+            var receivedFirstEvent = false
             defer {
-                if let self, generation == self.eventGeneration {
-                    self.eventTask = nil
+                if let self {
+                    self.markObservationReady(generation: generation)
+                    if generation == self.eventGeneration {
+                        self.eventTask = nil
+                    }
                 }
             }
             do {
@@ -105,6 +146,11 @@ public final class SessionStore {
                     guard !Task.isCancelled,
                           let self,
                           generation == self.eventGeneration else { return }
+                    if !receivedFirstEvent {
+                        receivedFirstEvent = true
+                        self.markObservationReady(generation: generation)
+                        if !refreshOnFirstEvent { continue }
+                    }
                     await self.refresh()
                 }
             } catch is CancellationError {
@@ -115,19 +161,70 @@ public final class SessionStore {
                 // an event-transport diagnostic.
             }
         }
+        scheduleObservationReadinessTimeout(generation: generation)
+        return generation
     }
 
     public func stopObserving() {
+        let stoppedGeneration = eventGeneration
         eventGeneration &+= 1
+        eventReadinessTimeoutTask?.cancel()
+        eventReadinessTimeoutTask = nil
         eventTask?.cancel()
         eventTask = nil
+        markObservationReady(generation: stoppedGeneration)
     }
 
     /// Repairs missed or failed event delivery without introducing a timer.
     /// App activation is a natural resynchronization boundary.
     public func resynchronize() async {
+        if eventTask == nil {
+            let generation = beginObserving(refreshOnFirstEvent: false)
+            await waitUntilObservationIsReady(generation: generation)
+            guard generation == eventGeneration else { return }
+        }
         await refresh()
-        startObserving()
+        if eventTask == nil { startObserving() }
+    }
+
+    private func waitUntilObservationIsReady(generation: UInt64) async {
+        if eventReadyGeneration == generation { return }
+        await withCheckedContinuation { continuation in
+            if eventReadyGeneration == generation {
+                continuation.resume()
+            } else {
+                eventReadyWaiters[generation, default: []].append(continuation)
+            }
+        }
+    }
+
+    private func markObservationReady(generation: UInt64) {
+        if generation == eventGeneration {
+            eventReadyGeneration = generation
+            eventReadinessTimeoutTask?.cancel()
+            eventReadinessTimeoutTask = nil
+        }
+        let waiters = eventReadyWaiters.removeValue(forKey: generation) ?? []
+        for waiter in waiters { waiter.resume() }
+    }
+
+    private func scheduleObservationReadinessTimeout(generation: UInt64) {
+        eventReadinessTimeoutTask?.cancel()
+        let sleep = eventReadinessSleep
+        eventReadinessTimeoutTask = Task { [weak self] in
+            do {
+                try await sleep(1_000_000_000)
+            } catch {
+                return
+            }
+            guard let self,
+                  generation == self.eventGeneration,
+                  self.eventReadyGeneration != generation else { return }
+            let stalledTask = self.eventTask
+            self.eventTask = nil
+            stalledTask?.cancel()
+            self.markObservationReady(generation: generation)
+        }
     }
 
     /// Returns this request's valid typed snapshot even when a newer refresh
@@ -160,10 +257,13 @@ public final class SessionStore {
             // overlap while their subprocesses are suspended. Only the latest
             // request may publish state or notify transition consumers.
             guard generation == refreshGeneration else { return snapshot }
-            if sessions != snapshot { sessions = snapshot }
+            let changed = sessions != snapshot
+            if changed { sessions = snapshot }
             resolveSessionWaiters(from: snapshot)
             lastUpdated = Date()
+            hasFreshSnapshot = true
             state = .ok
+            if changed { snapshotCache?.store(snapshot) }
             if let onSnapshot { await onSnapshot(sessions) }
             scheduleInterruptedConfirmation(for: snapshot)
             return snapshot

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -33,6 +33,11 @@ public final class SessionStore {
         let continuation: CheckedContinuation<String?, Never>
     }
 
+    private struct RefreshWaiter {
+        let generation: UInt64
+        let continuation: CheckedContinuation<[Session], Never>
+    }
+
     private enum Mutation {
         case stop
         case delete
@@ -76,7 +81,14 @@ public final class SessionStore {
     @ObservationIgnored private var transientConfirmationTask: Task<Void, Never>?
     @ObservationIgnored private var confirmedTransientSessionIDs: Set<String> = []
     @ObservationIgnored private var eventGeneration: UInt64 = 0
-    @ObservationIgnored private var refreshGeneration: UInt64 = 0
+    /// Epoch invalidates results from a previous CLI/observation lifetime.
+    @ObservationIgnored private var refreshEpoch: UInt64 = 0
+    /// Requests are serialized. A request received during an active read waits
+    /// for one trailing read instead of launching a competing `list` process.
+    @ObservationIgnored private var refreshRequestGeneration: UInt64 = 0
+    @ObservationIgnored private var refreshCompletedGeneration: UInt64 = 0
+    @ObservationIgnored private var refreshInProgress = false
+    @ObservationIgnored private var refreshWaiters: [RefreshWaiter] = []
     @ObservationIgnored private var sessionWaiters: [UUID: SessionWaiter] = [:]
     @ObservationIgnored private let confirmationSleep:
         @Sendable (UInt64) async throws -> Void
@@ -209,7 +221,7 @@ public final class SessionStore {
         // Invalidate in-flight snapshots and every delayed refresh owned by
         // this observation lifetime. A stopped store must launch no later CLI
         // work until an explicit refresh or a new watcher starts it again.
-        refreshGeneration &+= 1
+        refreshEpoch &+= 1
         refreshRetryTask?.cancel()
         refreshRetryTask = nil
         refreshRetryAttempt = 0
@@ -315,45 +327,77 @@ public final class SessionStore {
         }
     }
 
-    /// Returns this request's valid typed snapshot even when a newer refresh
-    /// owns publication to the shared store.
+    /// Serializes typed observations. A request received while one list is in
+    /// flight waits for one trailing snapshot, which closes the state-change
+    /// window without allowing out-of-order subprocess results to publish.
     @discardableResult
     public func refresh() async -> [Session] {
-        refreshGeneration &+= 1
-        let generation = refreshGeneration
+        refreshRequestGeneration &+= 1
+        let requestGeneration = refreshRequestGeneration
+        if refreshInProgress {
+            return await withCheckedContinuation { continuation in
+                refreshWaiters.append(RefreshWaiter(
+                    generation: requestGeneration,
+                    continuation: continuation))
+            }
+        }
+
+        refreshInProgress = true
+        var latestSnapshot: [Session] = []
+        repeat {
+            let servicedGeneration = refreshRequestGeneration
+            let epoch = refreshEpoch
+            latestSnapshot = await performRefresh(epoch: epoch)
+            refreshCompletedGeneration = servicedGeneration
+
+            var pending: [RefreshWaiter] = []
+            for waiter in refreshWaiters {
+                if waiter.generation <= servicedGeneration {
+                    waiter.continuation.resume(returning: latestSnapshot)
+                } else {
+                    pending.append(waiter)
+                }
+            }
+            refreshWaiters = pending
+        } while refreshCompletedGeneration != refreshRequestGeneration
+        refreshInProgress = false
+        return latestSnapshot
+    }
+
+    private func performRefresh(epoch: UInt64) async -> [Session] {
         let cli = self.cli
         do {
             let result = try await cli.run(arguments: ["list", "--json"], timeout: 5)
             guard result.exitCode == 0, !result.timedOut else {
-                if generation == refreshGeneration {
+                if epoch == refreshEpoch {
                     state = .error(result.timedOut ? L10n.string("detach list timed out")
                                    : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
-                    scheduleRefreshRetry(generation: generation)
+                    scheduleRefreshRetry(epoch: epoch)
                 }
                 return []
             }
             guard !result.stdoutTruncated else {
-                if generation == refreshGeneration {
+                if epoch == refreshEpoch {
                     state = .error(L10n.string("detach returned incomplete output"))
-                    scheduleRefreshRetry(generation: generation)
+                    scheduleRefreshRetry(epoch: epoch)
                 }
                 return []
             }
             let parsed = SessionListParser.parse(result.stdout)
             if parsed.hadInvalidLines {
-                if generation == refreshGeneration {
+                if epoch == refreshEpoch {
                     state = .incompatible // spec: never update the list from bad data
-                    scheduleRefreshRetry(generation: generation)
+                    scheduleRefreshRetry(epoch: epoch)
                 }
                 return []
             }
             let snapshot = parsed.sessions.sorted {
                 ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
             }
-            // Event refreshes, explicit refreshes, and CLI reconfiguration may
-            // overlap while their subprocesses are suspended. Only the latest
-            // request may publish state or notify transition consumers.
-            guard generation == refreshGeneration else { return snapshot }
+            // A replaced CLI can still finish after its process task is
+            // cancelled. Its decoded value belongs to the caller only and may
+            // not overwrite the new observation lifetime.
+            guard epoch == refreshEpoch else { return snapshot }
             refreshRetryTask?.cancel()
             refreshRetryTask = nil
             refreshRetryAttempt = 0
@@ -370,9 +414,9 @@ public final class SessionStore {
             if let onSnapshot { onSnapshot(sessions) }
             return snapshot
         } catch {
-            if generation == refreshGeneration {
+            if epoch == refreshEpoch {
                 state = .cliMissing
-                scheduleRefreshRetry(generation: generation)
+                scheduleRefreshRetry(epoch: epoch)
             }
             return []
         }
@@ -381,7 +425,7 @@ public final class SessionStore {
     /// One lifecycle hint arrives per transition. When the typed list that
     /// follows it fails, nothing else would repeat the request, so retry with
     /// bounded backoff until a newer refresh supersedes this one.
-    private func scheduleRefreshRetry(generation: UInt64) {
+    private func scheduleRefreshRetry(epoch: UInt64) {
         refreshRetryTask?.cancel()
         let delay = Self.backoffDelay(attempt: refreshRetryAttempt)
         refreshRetryAttempt += 1
@@ -393,7 +437,7 @@ public final class SessionStore {
                 return
             }
             guard let self, !Task.isCancelled,
-                  generation == self.refreshGeneration else { return }
+                  epoch == self.refreshEpoch else { return }
             self.refreshRetryTask = nil
             await self.refresh()
         }

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -54,7 +54,10 @@ public final class SessionStore {
     /// a transition detector can advance its baseline. The store is the single
     /// app-level session source; notifications and the menu bar consume these
     /// snapshots instead of running their own subprocess loops.
-    @ObservationIgnored public var onSnapshot: (@MainActor ([Session]) async -> Void)?
+    /// Runs synchronously after publication. Consumers may update ordered
+    /// detector state here, but must schedule external I/O independently so
+    /// one system service cannot stop the native event stream.
+    @ObservationIgnored public var onSnapshot: (@MainActor ([Session]) -> Void)?
 
     private var cli: DetachCLIRunning
     @ObservationIgnored private let snapshotCache: (any SessionSnapshotCaching)?
@@ -125,9 +128,6 @@ public final class SessionStore {
     /// second full list on every cold start.
     public func configure(cli: DetachCLIRunning) async {
         stopObserving()
-        // Invalidate a list request from the previous executable before the
-        // new watcher readiness wait suspends this reconfiguration.
-        refreshGeneration &+= 1
         self.cli = cli
         hasFreshSnapshot = false
         let generation = beginObserving(refreshOnFirstEvent: false)
@@ -206,6 +206,15 @@ public final class SessionStore {
     public func stopObserving() {
         let stoppedGeneration = eventGeneration
         eventGeneration &+= 1
+        // Invalidate in-flight snapshots and every delayed refresh owned by
+        // this observation lifetime. A stopped store must launch no later CLI
+        // work until an explicit refresh or a new watcher starts it again.
+        refreshGeneration &+= 1
+        refreshRetryTask?.cancel()
+        refreshRetryTask = nil
+        refreshRetryAttempt = 0
+        transientConfirmationTask?.cancel()
+        transientConfirmationTask = nil
         eventReadinessTimeoutTask?.cancel()
         eventReadinessTimeoutTask = nil
         eventReadinessTimedOutGeneration = nil
@@ -355,10 +364,10 @@ public final class SessionStore {
             hasFreshSnapshot = true
             state = .ok
             if changed { snapshotCache?.store(snapshot) }
-            // Schedule before the observer suspends this request: a newer
-            // snapshot may publish meanwhile and must own the confirmation.
+            // Schedule before the synchronous observer advances its detector:
+            // a later refresh must own any replacement confirmation.
             scheduleTransientConfirmation(for: snapshot)
-            if let onSnapshot { await onSnapshot(sessions) }
+            if let onSnapshot { onSnapshot(sessions) }
             return snapshot
         } catch {
             if generation == refreshGeneration {

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -329,6 +329,13 @@ public final class SessionStore {
                 }
                 return []
             }
+            guard !result.stdoutTruncated else {
+                if generation == refreshGeneration {
+                    state = .error(L10n.string("detach returned incomplete output"))
+                    scheduleRefreshRetry(generation: generation)
+                }
+                return []
+            }
             let parsed = SessionListParser.parse(result.stdout)
             if parsed.hadInvalidLines {
                 if generation == refreshGeneration {

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -108,12 +108,8 @@ public final class SessionStore {
         cli: DetachCLIRunning,
         snapshotCache: (any SessionSnapshotCaching)? = nil,
         confirmationSleep: @escaping @Sendable (UInt64) async throws -> Void,
-        eventReadinessSleep: @escaping @Sendable (UInt64) async throws -> Void = {
-            try await Task.sleep(nanoseconds: $0)
-        },
-        restartSleep: @escaping @Sendable (UInt64) async throws -> Void = {
-            try await Task.sleep(nanoseconds: $0)
-        }
+        eventReadinessSleep: @escaping @Sendable (UInt64) async throws -> Void,
+        restartSleep: @escaping @Sendable (UInt64) async throws -> Void
     ) {
         self.cli = cli
         self.snapshotCache = snapshotCache
@@ -259,11 +255,9 @@ public final class SessionStore {
     private func waitUntilObservationIsReady(generation: UInt64) async {
         if eventReadyGeneration == generation { return }
         await withCheckedContinuation { continuation in
-            if eventReadyGeneration == generation {
-                continuation.resume()
-            } else {
-                eventReadyWaiters[generation, default: []].append(continuation)
-            }
+            // This store is main-actor isolated. Nothing can change readiness
+            // between the check above and this synchronous registration.
+            eventReadyWaiters[generation, default: []].append(continuation)
         }
     }
 

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 
 public struct SessionDeletionFailure: Equatable, Sendable {
     public var sessionName: String
@@ -57,20 +58,39 @@ public final class SessionStore {
 
     private var cli: DetachCLIRunning
     @ObservationIgnored private let snapshotCache: (any SessionSnapshotCaching)?
-    private var eventTask: Task<Void, Never>?
-    private var eventReadyGeneration: UInt64?
-    private var eventReadyWaiters:
+    @ObservationIgnored private var eventTask: Task<Void, Never>?
+    @ObservationIgnored private var eventReadyGeneration: UInt64?
+    @ObservationIgnored private var eventReadyWaiters:
         [UInt64: [CheckedContinuation<Void, Never>]] = [:]
-    private var eventReadinessTimeoutTask: Task<Void, Never>?
-    private var interruptedConfirmationTask: Task<Void, Never>?
-    private var confirmedInterruptedSessionIDs: Set<String> = []
-    private var eventGeneration: UInt64 = 0
-    private var refreshGeneration: UInt64 = 0
-    private var sessionWaiters: [UUID: SessionWaiter] = [:]
+    @ObservationIgnored private var eventReadinessTimeoutTask: Task<Void, Never>?
+    /// Set when the short readiness wait elapsed before `ready`. The first
+    /// event of that generation then takes the snapshot the wait skipped.
+    @ObservationIgnored private var eventReadinessTimedOutGeneration: UInt64?
+    @ObservationIgnored private var eventRestartTask: Task<Void, Never>?
+    @ObservationIgnored private var eventRestartAttempt = 0
+    @ObservationIgnored private var refreshRetryTask: Task<Void, Never>?
+    @ObservationIgnored private var refreshRetryAttempt = 0
+    @ObservationIgnored private var transientConfirmationTask: Task<Void, Never>?
+    @ObservationIgnored private var confirmedTransientSessionIDs: Set<String> = []
+    @ObservationIgnored private var eventGeneration: UInt64 = 0
+    @ObservationIgnored private var refreshGeneration: UInt64 = 0
+    @ObservationIgnored private var sessionWaiters: [UUID: SessionWaiter] = [:]
     @ObservationIgnored private let confirmationSleep:
         @Sendable (UInt64) async throws -> Void
     @ObservationIgnored private let eventReadinessSleep:
         @Sendable (UInt64) async throws -> Void
+    @ObservationIgnored private let restartSleep:
+        @Sendable (UInt64) async throws -> Void
+    @ObservationIgnored private let logger = Logger(
+        subsystem: "dev.tsarev.detach", category: "session-events")
+
+    /// The cold-start wait for `ready` before the first typed snapshot.
+    static let readinessWaitNanoseconds: UInt64 = 1_000_000_000
+    /// A watcher that never reports `ready` is replaced after this bound.
+    static let readinessAbandonNanoseconds: UInt64 = 30_000_000_000
+    /// Restart and retry delays double from this value up to the cap.
+    static let restartBaseDelayNanoseconds: UInt64 = 2_000_000_000
+    static let restartMaximumDelayNanoseconds: UInt64 = 60_000_000_000
 
     public init(
         cli: DetachCLIRunning,
@@ -81,6 +101,7 @@ public final class SessionStore {
         self.sessions = snapshotCache?.load() ?? []
         self.confirmationSleep = { try await Task.sleep(nanoseconds: $0) }
         self.eventReadinessSleep = { try await Task.sleep(nanoseconds: $0) }
+        self.restartSleep = { try await Task.sleep(nanoseconds: $0) }
     }
 
     init(
@@ -89,6 +110,9 @@ public final class SessionStore {
         confirmationSleep: @escaping @Sendable (UInt64) async throws -> Void,
         eventReadinessSleep: @escaping @Sendable (UInt64) async throws -> Void = {
             try await Task.sleep(nanoseconds: $0)
+        },
+        restartSleep: @escaping @Sendable (UInt64) async throws -> Void = {
+            try await Task.sleep(nanoseconds: $0)
         }
     ) {
         self.cli = cli
@@ -96,6 +120,7 @@ public final class SessionStore {
         self.sessions = snapshotCache?.load() ?? []
         self.confirmationSleep = confirmationSleep
         self.eventReadinessSleep = eventReadinessSleep
+        self.restartSleep = restartSleep
     }
 
     /// Swaps the CLI (for example after the installed payload activates),
@@ -128,16 +153,28 @@ public final class SessionStore {
     @discardableResult
     private func beginObserving(refreshOnFirstEvent: Bool) -> UInt64 {
         guard eventTask == nil else { return eventGeneration }
+        eventRestartTask?.cancel()
+        eventRestartTask = nil
         eventGeneration &+= 1
         let generation = eventGeneration
         let cli = self.cli
         eventTask = Task { [weak self] in
             var receivedFirstEvent = false
+            var streamFailure: (any Error)?
             defer {
                 if let self {
                     self.markObservationReady(generation: generation)
                     if generation == self.eventGeneration {
                         self.eventTask = nil
+                        self.eventReadinessTimedOutGeneration = nil
+                        // The stream ended while still wanted: the watcher
+                        // exited, printed an invalid line, or an old CLI
+                        // lacks `watch`. Keep the last typed snapshot and
+                        // reinstall the source with bounded backoff, so the
+                        // menu bar and notifications recover without a window.
+                        self.logger.error(
+                            "session event stream ended: \(String(describing: streamFailure), privacy: .public)")
+                        self.scheduleObservationRestart()
                     }
                 }
             }
@@ -148,17 +185,22 @@ public final class SessionStore {
                           generation == self.eventGeneration else { return }
                     if !receivedFirstEvent {
                         receivedFirstEvent = true
+                        let waitElapsed =
+                            self.eventReadinessTimedOutGeneration == generation
+                        self.eventReadinessTimedOutGeneration = nil
+                        self.eventRestartAttempt = 0
                         self.markObservationReady(generation: generation)
-                        if !refreshOnFirstEvent { continue }
+                        // A cold start refreshes right after `ready` itself.
+                        // If the wait elapsed first, that snapshot raced the
+                        // watcher installation and must be repeated now.
+                        if !refreshOnFirstEvent, !waitElapsed { continue }
                     }
                     await self.refresh()
                 }
             } catch is CancellationError {
                 return
             } catch {
-                // A full refresh on app activation restarts a failed stream.
-                // Keep the last typed snapshot instead of replacing it with
-                // an event-transport diagnostic.
+                streamFailure = error
             }
         }
         scheduleObservationReadinessTimeout(generation: generation)
@@ -170,13 +212,17 @@ public final class SessionStore {
         eventGeneration &+= 1
         eventReadinessTimeoutTask?.cancel()
         eventReadinessTimeoutTask = nil
+        eventReadinessTimedOutGeneration = nil
+        eventRestartTask?.cancel()
+        eventRestartTask = nil
+        eventRestartAttempt = 0
         eventTask?.cancel()
         eventTask = nil
         markObservationReady(generation: stoppedGeneration)
     }
 
-    /// Repairs missed or failed event delivery without introducing a timer.
-    /// App activation is a natural resynchronization boundary.
+    /// Repairs missed or failed event delivery at a natural boundary such as
+    /// app activation. A pending backoff restart is replaced immediately.
     public func resynchronize() async {
         if eventTask == nil {
             let generation = beginObserving(refreshOnFirstEvent: false)
@@ -185,6 +231,29 @@ public final class SessionStore {
         }
         await refresh()
         if eventTask == nil { startObserving() }
+    }
+
+    private static func backoffDelay(attempt: Int) -> UInt64 {
+        let shift = min(attempt, 5)
+        let scaled = restartBaseDelayNanoseconds << UInt64(shift)
+        return min(scaled, restartMaximumDelayNanoseconds)
+    }
+
+    private func scheduleObservationRestart() {
+        eventRestartTask?.cancel()
+        let delay = Self.backoffDelay(attempt: eventRestartAttempt)
+        eventRestartAttempt += 1
+        let sleep = restartSleep
+        eventRestartTask = Task { [weak self] in
+            do {
+                try await sleep(delay)
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled, self.eventTask == nil else { return }
+            self.eventRestartTask = nil
+            self.startObserving()
+        }
     }
 
     private func waitUntilObservationIsReady(generation: UInt64) async {
@@ -208,22 +277,38 @@ public final class SessionStore {
         for waiter in waiters { waiter.resume() }
     }
 
+    /// Two bounds guard a watcher that has not reported `ready`. The short
+    /// wait releases cold start so a slow but healthy watcher never delays the
+    /// first snapshot; the watcher itself keeps running and refreshes on its
+    /// first event. The long bound replaces a watcher that never becomes ready.
     private func scheduleObservationReadinessTimeout(generation: UInt64) {
         eventReadinessTimeoutTask?.cancel()
         let sleep = eventReadinessSleep
         eventReadinessTimeoutTask = Task { [weak self] in
             do {
-                try await sleep(1_000_000_000)
+                try await sleep(Self.readinessWaitNanoseconds)
             } catch {
                 return
             }
             guard let self,
                   generation == self.eventGeneration,
                   self.eventReadyGeneration != generation else { return }
-            let stalledTask = self.eventTask
-            self.eventTask = nil
-            stalledTask?.cancel()
-            self.markObservationReady(generation: generation)
+            self.eventReadinessTimedOutGeneration = generation
+            let waiters = self.eventReadyWaiters.removeValue(forKey: generation) ?? []
+            for waiter in waiters { waiter.resume() }
+
+            do {
+                try await sleep(
+                    Self.readinessAbandonNanoseconds - Self.readinessWaitNanoseconds)
+            } catch {
+                return
+            }
+            guard generation == self.eventGeneration,
+                  self.eventReadyGeneration != generation else { return }
+            // Cancelling the stalled task runs its exit path, which schedules
+            // the bounded restart for this still-current generation.
+            self.logger.error("session event watcher never became ready; restarting")
+            self.eventTask?.cancel()
         }
     }
 
@@ -240,6 +325,7 @@ public final class SessionStore {
                 if generation == refreshGeneration {
                     state = .error(result.timedOut ? L10n.string("detach list timed out")
                                    : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+                    scheduleRefreshRetry(generation: generation)
                 }
                 return []
             }
@@ -247,6 +333,7 @@ public final class SessionStore {
             if parsed.hadInvalidLines {
                 if generation == refreshGeneration {
                     state = .incompatible // spec: never update the list from bad data
+                    scheduleRefreshRetry(generation: generation)
                 }
                 return []
             }
@@ -257,6 +344,9 @@ public final class SessionStore {
             // overlap while their subprocesses are suspended. Only the latest
             // request may publish state or notify transition consumers.
             guard generation == refreshGeneration else { return snapshot }
+            refreshRetryTask?.cancel()
+            refreshRetryTask = nil
+            refreshRetryAttempt = 0
             let changed = sessions != snapshot
             if changed { sessions = snapshot }
             resolveSessionWaiters(from: snapshot)
@@ -264,12 +354,38 @@ public final class SessionStore {
             hasFreshSnapshot = true
             state = .ok
             if changed { snapshotCache?.store(snapshot) }
+            // Schedule before the observer suspends this request: a newer
+            // snapshot may publish meanwhile and must own the confirmation.
+            scheduleTransientConfirmation(for: snapshot)
             if let onSnapshot { await onSnapshot(sessions) }
-            scheduleInterruptedConfirmation(for: snapshot)
             return snapshot
         } catch {
-            if generation == refreshGeneration { state = .cliMissing }
+            if generation == refreshGeneration {
+                state = .cliMissing
+                scheduleRefreshRetry(generation: generation)
+            }
             return []
+        }
+    }
+
+    /// One lifecycle hint arrives per transition. When the typed list that
+    /// follows it fails, nothing else would repeat the request, so retry with
+    /// bounded backoff until a newer refresh supersedes this one.
+    private func scheduleRefreshRetry(generation: UInt64) {
+        refreshRetryTask?.cancel()
+        let delay = Self.backoffDelay(attempt: refreshRetryAttempt)
+        refreshRetryAttempt += 1
+        let sleep = restartSleep
+        refreshRetryTask = Task { [weak self] in
+            do {
+                try await sleep(delay)
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled,
+                  generation == self.refreshGeneration else { return }
+            self.refreshRetryTask = nil
+            await self.refresh()
         }
     }
 
@@ -341,30 +457,39 @@ public final class SessionStore {
         return candidates.count == 1 ? candidates[0].id : nil
     }
 
-    private func scheduleInterruptedConfirmation(for snapshot: [Session]) {
-        let interruptedIDs = Set(snapshot.lazy
-            .filter { $0.effectiveStatus == .interrupted }
+    /// `interrupted` and `hung` can be one-frame transients: a worker that is
+    /// still writing its final status, or a provider that exited moments
+    /// before its worker. The runtime publishes no further hint for the pane
+    /// death that resolves them, so one bounded follow-up snapshot confirms
+    /// each transition exactly once.
+    private static func isTransient(_ status: EffectiveStatus) -> Bool {
+        status == .interrupted || status == .hung
+    }
+
+    private func scheduleTransientConfirmation(for snapshot: [Session]) {
+        let transientIDs = Set(snapshot.lazy
+            .filter { Self.isTransient($0.effectiveStatus) }
             .map(\.id))
-        confirmedInterruptedSessionIDs.formIntersection(interruptedIDs)
-        guard !interruptedIDs.isEmpty else {
-            interruptedConfirmationTask?.cancel()
-            interruptedConfirmationTask = nil
+        confirmedTransientSessionIDs.formIntersection(transientIDs)
+        guard !transientIDs.isEmpty else {
+            transientConfirmationTask?.cancel()
+            transientConfirmationTask = nil
             return
         }
-        let unconfirmedIDs = interruptedIDs.subtracting(
-            confirmedInterruptedSessionIDs)
+        let unconfirmedIDs = transientIDs.subtracting(
+            confirmedTransientSessionIDs)
         guard !unconfirmedIDs.isEmpty else { return }
 
-        interruptedConfirmationTask?.cancel()
-        interruptedConfirmationTask = Task { [weak self] in
+        transientConfirmationTask?.cancel()
+        transientConfirmationTask = Task { [weak self] in
             do {
                 try await self?.confirmationSleep(350_000_000)
             } catch {
                 return
             }
             guard !Task.isCancelled, let self else { return }
-            self.confirmedInterruptedSessionIDs.formUnion(unconfirmedIDs)
-            self.interruptedConfirmationTask = nil
+            self.confirmedTransientSessionIDs.formUnion(unconfirmedIDs)
+            self.transientConfirmationTask = nil
             await self.refresh()
         }
     }

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -25,6 +25,13 @@ public struct SessionStartResult: Equatable, Sendable {
 
 @Observable @MainActor
 public final class SessionStore {
+    private struct SessionWaiter {
+        let provider: Provider
+        let projectPath: String
+        let excludedIDs: Set<String>
+        let continuation: CheckedContinuation<String?, Never>
+    }
+
     private enum Mutation {
         case stop
         case delete
@@ -41,66 +48,86 @@ public final class SessionStore {
     public private(set) var lastUpdated: Date?
     public private(set) var state: State = .ok
 
-    /// Called after every successful poll — including an unchanged list — so
+    /// Called after every successful typed snapshot — including an unchanged list — so
     /// a transition detector can advance its baseline. The store is the single
-    /// app-level `list --json` poller; notifications and the menu bar consume
-    /// these snapshots instead of running their own subprocess loops.
+    /// app-level session source; notifications and the menu bar consume these
+    /// snapshots instead of running their own subprocess loops.
     @ObservationIgnored public var onSnapshot: (@MainActor ([Session]) async -> Void)?
 
     private var cli: DetachCLIRunning
-    private var pollTask: Task<Void, Never>?
-    private var baseInterval: TimeInterval = 2
-    private var foreground = true
+    private var eventTask: Task<Void, Never>?
+    private var interruptedConfirmationTask: Task<Void, Never>?
+    private var confirmedInterruptedSessionIDs: Set<String> = []
+    private var eventGeneration: UInt64 = 0
     private var refreshGeneration: UInt64 = 0
-    @ObservationIgnored private let pollSleep: @Sendable (UInt64) async throws -> Void
+    private var sessionWaiters: [UUID: SessionWaiter] = [:]
+    @ObservationIgnored private let confirmationSleep:
+        @Sendable (UInt64) async throws -> Void
 
     public init(cli: DetachCLIRunning) {
         self.cli = cli
-        self.pollSleep = { try await Task.sleep(nanoseconds: $0) }
+        self.confirmationSleep = { try await Task.sleep(nanoseconds: $0) }
     }
 
     init(
         cli: DetachCLIRunning,
-        pollSleep: @escaping @Sendable (UInt64) async throws -> Void
+        confirmationSleep: @escaping @Sendable (UInt64) async throws -> Void
     ) {
         self.cli = cli
-        self.pollSleep = pollSleep
+        self.confirmationSleep = confirmationSleep
     }
 
     /// Swaps the CLI (for example after the installed payload activates) and
-    /// refreshes immediately. The polling cadence is unchanged.
+    /// establishes a fresh typed snapshot before replacing the event stream.
     public func configure(cli: DetachCLIRunning) async {
+        stopObserving()
         self.cli = cli
         await refresh()
+        startObserving()
     }
 
-    public func startPolling(interval: TimeInterval) {
-        baseInterval = max(interval, 0.5)
-        pollTask?.cancel()
-        pollTask = Task { [weak self] in
-            while !Task.isCancelled {
-                await self?.refresh()
-                guard let delay = self?.currentInterval else { return }
-                try? await self?.pollSleep(UInt64(delay * 1_000_000_000))
+    /// Starts one bounded stream of native change hints. The initial `ready`
+    /// event closes the refresh/watch race by requesting another full list
+    /// only after FSEvents is installed.
+    public func startObserving() {
+        guard eventTask == nil else { return }
+        eventGeneration &+= 1
+        let generation = eventGeneration
+        let cli = self.cli
+        eventTask = Task { [weak self] in
+            defer {
+                if let self, generation == self.eventGeneration {
+                    self.eventTask = nil
+                }
+            }
+            do {
+                for try await _ in cli.sessionEvents() {
+                    guard !Task.isCancelled,
+                          let self,
+                          generation == self.eventGeneration else { return }
+                    await self.refresh()
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                // A full refresh on app activation restarts a failed stream.
+                // Keep the last typed snapshot instead of replacing it with
+                // an event-transport diagnostic.
             }
         }
     }
 
-    public func stopPolling() {
-        pollTask?.cancel()
-        pollTask = nil
+    public func stopObserving() {
+        eventGeneration &+= 1
+        eventTask?.cancel()
+        eventTask = nil
     }
 
-    /// Foreground (a visible window or open menu wants fresh data) polls at
-    /// the base interval. Idle polling slows down but never stops, so
-    /// notifications and the menu bar stay truthful after the last window
-    /// closes.
-    public func updateCadence(foreground: Bool) {
-        self.foreground = foreground
-    }
-
-    private var currentInterval: TimeInterval {
-        foreground ? baseInterval : max(baseInterval * 5, 10)
+    /// Repairs missed or failed event delivery without introducing a timer.
+    /// App activation is a natural resynchronization boundary.
+    public func resynchronize() async {
+        await refresh()
+        startObserving()
     }
 
     /// Returns this request's valid typed snapshot even when a newer refresh
@@ -129,18 +156,116 @@ public final class SessionStore {
             let snapshot = parsed.sessions.sorted {
                 ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
             }
-            // Polling, explicit refreshes, and CLI reconfiguration may overlap
-            // while their subprocesses are suspended. Only the latest request
-            // may publish state or notify transition consumers.
+            // Event refreshes, explicit refreshes, and CLI reconfiguration may
+            // overlap while their subprocesses are suspended. Only the latest
+            // request may publish state or notify transition consumers.
             guard generation == refreshGeneration else { return snapshot }
-            sessions = snapshot
+            if sessions != snapshot { sessions = snapshot }
+            resolveSessionWaiters(from: snapshot)
             lastUpdated = Date()
             state = .ok
             if let onSnapshot { await onSnapshot(sessions) }
+            scheduleInterruptedConfirmation(for: snapshot)
             return snapshot
         } catch {
             if generation == refreshGeneration { state = .cliMissing }
             return []
+        }
+    }
+
+    /// Suspends without polling until a valid typed snapshot contains one
+    /// unambiguous new session for the requested provider and project.
+    public func waitForSession(
+        provider: Provider,
+        projectDirectory: URL,
+        excluding excludedIDs: Set<String>
+    ) async -> String? {
+        let projectPath = Self.canonicalProjectPath(projectDirectory.path)
+        if let match = Self.matchingSessionID(
+            in: sessions,
+            provider: provider,
+            projectPath: projectPath,
+            excludedIDs: excludedIDs) {
+            return match
+        }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                sessionWaiters[waiterID] = SessionWaiter(
+                    provider: provider,
+                    projectPath: projectPath,
+                    excludedIDs: excludedIDs,
+                    continuation: continuation)
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelSessionWaiter(waiterID)
+            }
+        }
+    }
+
+    private func resolveSessionWaiters(from snapshot: [Session]) {
+        let resolved = sessionWaiters.compactMap { id, waiter -> (UUID, String)? in
+            guard let sessionID = Self.matchingSessionID(
+                in: snapshot,
+                provider: waiter.provider,
+                projectPath: waiter.projectPath,
+                excludedIDs: waiter.excludedIDs) else { return nil }
+            return (id, sessionID)
+        }
+        for (id, sessionID) in resolved {
+            sessionWaiters.removeValue(forKey: id)?
+                .continuation.resume(returning: sessionID)
+        }
+    }
+
+    private func cancelSessionWaiter(_ id: UUID) {
+        sessionWaiters.removeValue(forKey: id)?.continuation.resume(returning: nil)
+    }
+
+    private static func matchingSessionID(
+        in sessions: [Session],
+        provider: Provider,
+        projectPath: String,
+        excludedIDs: Set<String>
+    ) -> String? {
+        let candidates = sessions.filter {
+            !excludedIDs.contains($0.id)
+                && $0.provider == provider
+                && $0.projectDir.map(canonicalProjectPath) == projectPath
+        }
+        return candidates.count == 1 ? candidates[0].id : nil
+    }
+
+    private func scheduleInterruptedConfirmation(for snapshot: [Session]) {
+        let interruptedIDs = Set(snapshot.lazy
+            .filter { $0.effectiveStatus == .interrupted }
+            .map(\.id))
+        confirmedInterruptedSessionIDs.formIntersection(interruptedIDs)
+        guard !interruptedIDs.isEmpty else {
+            interruptedConfirmationTask?.cancel()
+            interruptedConfirmationTask = nil
+            return
+        }
+        let unconfirmedIDs = interruptedIDs.subtracting(
+            confirmedInterruptedSessionIDs)
+        guard !unconfirmedIDs.isEmpty else { return }
+
+        interruptedConfirmationTask?.cancel()
+        interruptedConfirmationTask = Task { [weak self] in
+            do {
+                try await self?.confirmationSleep(350_000_000)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.confirmedInterruptedSessionIDs.formUnion(unconfirmedIDs)
+            self.interruptedConfirmationTask = nil
+            await self.refresh()
         }
     }
 

--- a/app/Sources/DetachKit/SessionTransitionDetector.swift
+++ b/app/Sources/DetachKit/SessionTransitionDetector.swift
@@ -23,11 +23,13 @@ public struct SessionTransition: Equatable, Sendable {
 public struct SessionTransitionDetector: Sendable {
     private struct Lifecycle: Hashable, Sendable {
         let sessionName: String
+        let lifecycleID: String?
         let createdAt: Date?
 
         init(_ session: Session) {
             sessionName = session.sessionName
-            createdAt = session.createdAt
+            lifecycleID = session.lifecycleID
+            createdAt = session.lifecycleID == nil ? session.createdAt : nil
         }
     }
 

--- a/app/Sources/DetachKit/SessionTransitionDetector.swift
+++ b/app/Sources/DetachKit/SessionTransitionDetector.swift
@@ -18,7 +18,7 @@ public struct SessionTransition: Equatable, Sendable {
 }
 
 /// Finds attention-worthy state changes between successful `list --json`
-/// polls. The first observation only establishes a baseline, so launching the
+/// snapshots. The first observation only establishes a baseline, so launching the
 /// app does not replay notifications for every historical finished session.
 public struct SessionTransitionDetector: Sendable {
     private struct Lifecycle: Hashable, Sendable {
@@ -80,9 +80,9 @@ public struct SessionTransitionDetector: Sendable {
                     transitions.append(SessionTransition(kind: .failed, session: session))
                 } else if previousStatus != .interrupted {
                     // `detach stop` briefly passes through interrupted before
-                    // recording stopped. Require one more successful poll so
+                    // recording stopped. Require one more successful snapshot so
                     // a user-requested stop does not look like a crash. This
-                    // also covers a new session that crashed between polls.
+                    // also covers a new session that crashed between snapshots.
                     pendingInterrupted.insert(lifecycle)
                 }
                 continue

--- a/app/Sources/DetachKit/SessionTransitionDetector.swift
+++ b/app/Sources/DetachKit/SessionTransitionDetector.swift
@@ -76,6 +76,13 @@ public struct SessionTransitionDetector: Sendable {
             let previousStatus = previous?.status
 
             if session.effectiveStatus == .interrupted {
+                // Typed Stop intent: the runtime recorded the user's request
+                // before it signalled the worker, so this is not a crash no
+                // matter how long `stopped` takes to follow.
+                if session.stopRequestedAt != nil {
+                    pendingInterrupted.remove(lifecycle)
+                    continue
+                }
                 if pendingInterrupted.remove(lifecycle) != nil {
                     transitions.append(SessionTransition(kind: .failed, session: session))
                 } else if previousStatus != .interrupted {

--- a/app/Sources/DetachKit/StorageStore.swift
+++ b/app/Sources/DetachKit/StorageStore.swift
@@ -42,6 +42,10 @@ public final class StorageStore {
                     : result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
                 return
             }
+            guard !result.stdoutTruncated else {
+                state = .incompatible
+                return
+            }
             let decoder = JSONDecoder()
             guard let decoded = try? decoder.decode(StorageReport.self, from: Data(result.stdout.utf8)),
                   decoded.schema == 1 else {

--- a/app/Sources/DetachPower/main.swift
+++ b/app/Sources/DetachPower/main.swift
@@ -4,7 +4,9 @@ import Foundation
 
 _ = umask(0o077)
 
-let helperClient = PowerHelperXPCClient()
+let arguments = Array(CommandLine.arguments.dropFirst())
+let helperTransport: any PowerHelperXPCTransport = NSXPCPowerHelperTransport()
+let helperClient = PowerHelperXPCClient(transport: helperTransport)
 let command = DetachPowerCommand(
     helperClient: helperClient,
     assertionController: PowerAssertionController(),
@@ -12,4 +14,4 @@ let command = DetachPowerCommand(
     heartbeatRunner: DispatchPowerHeartbeatRunner(),
     clamshellLockRunner: ClamshellLockRunner())
 let executable = DetachPowerExecutable(command: command)
-exit(executable.run(arguments: Array(CommandLine.arguments.dropFirst())))
+exit(executable.run(arguments: arguments))

--- a/app/Sources/DetachState/main.swift
+++ b/app/Sources/DetachState/main.swift
@@ -5,8 +5,11 @@ import Foundation
 _ = umask(0o077)
 
 do {
-    let output = try DetachStateCommand.run(
-        arguments: Array(CommandLine.arguments.dropFirst()))
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    if arguments.starts(with: ["events", "watch"]) {
+        try SessionFileEventWatcher.run(arguments: Array(arguments.dropFirst(2)))
+    }
+    let output = try DetachStateCommand.run(arguments: arguments)
     FileHandle.standardOutput.write(output)
 } catch {
     let message = "detach-state: \(error)\n"

--- a/app/Tests/DetachAppTests/AppRuntimeActivationSequenceTests.swift
+++ b/app/Tests/DetachAppTests/AppRuntimeActivationSequenceTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import DetachApp
+
+@MainActor
+final class AppRuntimeActivationSequenceTests: XCTestCase {
+    func testPayloadActivationPrecedesSessionSource() async {
+        var steps: [String] = []
+
+        await AppRuntimeActivationSequence.run(
+            activatePayload: { steps.append("payload") },
+            activateSessionSource: { steps.append("sessions") })
+
+        XCTAssertEqual(steps, ["payload", "sessions"])
+    }
+}

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -488,8 +488,8 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertEqual(store.powerProtectionState, .protected)
     }
 
-    func testTimestampOnlyHeartbeatRefreshDoesNotInvalidatePresentedState()
-        throws
+    func testTimestampOnlyHeartbeatRefreshRedrawsAgeWithoutNotifying()
+        async throws
     {
         let root = try makeStateRoot()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -500,11 +500,12 @@ final class InstallationStorePowerStateTests: XCTestCase {
             detachPath: "/tmp/detach-test",
             powerStateRoot: root)
         let initialCheckedAt = try XCTUnwrap(store.watchdogHeartbeat.checkedAt)
+        var forwardedSnapshots = 0
+        store.onPowerSnapshot = { _ in forwardedSnapshots += 1 }
 
         nonisolated(unsafe) var observationInvalidated = false
         withObservationTracking {
             _ = store.watchdogHeartbeat
-            _ = store.powerProtectionState
         } onChange: {
             observationInvalidated = true
         }
@@ -513,12 +514,16 @@ final class InstallationStorePowerStateTests: XCTestCase {
             #"{"state":"ok","power_state":"allowed","checked_at":"\#(stamp())"}"#,
             to: root)
         store.refreshPowerProtectionState()
+        for _ in 0..<10 { await Task.yield() }
 
-        XCTAssertFalse(observationInvalidated)
+        // Views present `checked_at` as an age, so the routine write redraws
+        // them. It changes no semantic state and forwards nothing.
+        XCTAssertTrue(observationInvalidated)
         XCTAssertGreaterThan(
             try XCTUnwrap(store.watchdogHeartbeat.checkedAt),
             initialCheckedAt)
         XCTAssertEqual(store.powerProtectionState, .allowed)
+        XCTAssertEqual(forwardedSnapshots, 0)
     }
 
     func testPowerObservationPublishesAtomicChangesWithoutPolling() async throws {
@@ -545,6 +550,36 @@ final class InstallationStorePowerStateTests: XCTestCase {
 
         XCTAssertEqual(store.powerProtectionState, .protected)
         XCTAssertEqual(delivered?.effectivePowerState, .protected)
+    }
+
+    func testPowerObservationFollowsARecreatedStateDirectory() async throws {
+        let root = try makeStateRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(stamp())"}"#,
+            to: root)
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            powerStateRoot: root)
+        store.startPowerObservation()
+        XCTAssertEqual(store.powerProtectionState, .allowed)
+
+        // A repair removes and recreates the directory. The old vnode belongs
+        // to the unlinked directory and would never report the new writes.
+        try FileManager.default.removeItem(at: root)
+        for _ in 0..<100 where store.powerProtectionState == .allowed {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp())"}"#,
+            to: root)
+        for _ in 0..<200 where store.powerProtectionState != .protected {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(store.powerProtectionState, .protected)
     }
 
     func testCompletedOnboardingColdLaunchStartsOnDashboard() {

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -552,6 +552,32 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertEqual(delivered?.effectivePowerState, .protected)
     }
 
+    func testPowerObservationNeverForwardsConstructorSnapshotAfterNewerDocument()
+        async throws
+    {
+        let root = try makeStateRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(stamp())"}"#,
+            to: root)
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            powerStateRoot: root)
+
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp())"}"#,
+            to: root)
+        var delivered: [PowerProtectionState] = []
+        store.onPowerSnapshot = { delivered.append($0.effectivePowerState) }
+        store.startPowerObservation()
+        for _ in 0..<100 where delivered.isEmpty {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(delivered, [.protected])
+        XCTAssertEqual(store.powerProtectionState, .protected)
+    }
+
     func testPowerObservationFollowsARecreatedStateDirectory() async throws {
         let root = try makeStateRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
+++ b/app/Tests/DetachAppTests/InstallationStorePowerStateTests.swift
@@ -213,6 +213,96 @@ final class InstallationStorePowerStateTests: XCTestCase {
             .mainApp)
     }
 
+    func testCompletedOnboardingKeepsDashboardDuringPowerRetry() {
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .syncing,
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: true,
+                    isBusy: true,
+                    failureMessage: nil,
+                    distributionMatchesBundle: true,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: false,
+                    providerInstalled: true,
+                    onboardingEverCompleted: true)),
+            .mainApp)
+    }
+
+    func testCompletedOnboardingKeepsDashboardWhenPowerReadinessFails() {
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .actionRequired,
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: true,
+                    isBusy: false,
+                    failureMessage: nil,
+                    distributionMatchesBundle: true,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: false,
+                    providerInstalled: true,
+                    onboardingEverCompleted: true)),
+            .mainApp)
+    }
+
+    func testCompletedOnboardingKeepsDashboardWhenProviderIsMissing() {
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .actionRequired,
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: true,
+                    isBusy: false,
+                    failureMessage: nil,
+                    distributionMatchesBundle: true,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: true,
+                    providerInstalled: false,
+                    onboardingEverCompleted: true)),
+            .mainApp)
+    }
+
+    func testCompletedOnboardingKeepsDashboardForTransientDoctorFailure() {
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .failed("helper is unavailable"),
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: true,
+                    isBusy: false,
+                    failureMessage: "helper is unavailable",
+                    distributionMatchesBundle: true,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: false,
+                    providerInstalled: true,
+                    onboardingEverCompleted: true)),
+            .mainApp)
+    }
+
+    func testCompletedOnboardingShowsRuntimeRepairWhenPayloadDoesNotMatch() {
+        XCTAssertEqual(
+            InstallationStore.onboardingStep(
+                phase: .failed("runtime mismatch"),
+                onboardingEverCompleted: true,
+                input: .init(
+                    isStableApplicationLocation: true,
+                    isBusy: false,
+                    failureMessage: "runtime mismatch",
+                    distributionMatchesBundle: false,
+                    powerHelperEnabled: true,
+                    watchdogEnabled: true,
+                    powerReadinessConfirmed: true,
+                    providerInstalled: true,
+                    onboardingEverCompleted: true)),
+            .autoSetup(failureMessage: "runtime mismatch"))
+    }
+
     func testCompletedOnboardingShowsActionableLocationGuidance() {
         XCTAssertEqual(
             InstallationStore.onboardingStep(
@@ -396,6 +486,65 @@ final class InstallationStorePowerStateTests: XCTestCase {
         XCTAssertTrue(heartbeatObservationInvalidated)
         XCTAssertEqual(store.watchdogHeartbeat.powerState, .protected)
         XCTAssertEqual(store.powerProtectionState, .protected)
+    }
+
+    func testTimestampOnlyHeartbeatRefreshDoesNotInvalidatePresentedState()
+        throws
+    {
+        let root = try makeStateRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(stamp(offset: -30))"}"#,
+            to: root)
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            powerStateRoot: root)
+        let initialCheckedAt = try XCTUnwrap(store.watchdogHeartbeat.checkedAt)
+
+        nonisolated(unsafe) var observationInvalidated = false
+        withObservationTracking {
+            _ = store.watchdogHeartbeat
+            _ = store.powerProtectionState
+        } onChange: {
+            observationInvalidated = true
+        }
+
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(stamp())"}"#,
+            to: root)
+        store.refreshPowerProtectionState()
+
+        XCTAssertFalse(observationInvalidated)
+        XCTAssertGreaterThan(
+            try XCTUnwrap(store.watchdogHeartbeat.checkedAt),
+            initialCheckedAt)
+        XCTAssertEqual(store.powerProtectionState, .allowed)
+    }
+
+    func testPowerObservationPublishesAtomicChangesWithoutPolling() async throws {
+        let root = try makeStateRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(stamp())"}"#,
+            to: root)
+        let store = InstallationStore(
+            detachPath: "/tmp/detach-test",
+            powerStateRoot: root)
+        var delivered: PowerHeartbeatSnapshot?
+        store.onPowerSnapshot = { delivered = $0 }
+        store.startPowerObservation()
+
+        try writeHeartbeat(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(stamp())"}"#,
+            to: root)
+        for _ in 0..<100
+            where store.powerProtectionState != .protected
+                || delivered?.effectivePowerState != .protected {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(store.powerProtectionState, .protected)
+        XCTAssertEqual(delivered?.effectivePowerState, .protected)
     }
 
     func testCompletedOnboardingColdLaunchStartsOnDashboard() {

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -249,7 +249,7 @@ final class MacPowerActiveSessionTests: XCTestCase {
         XCTAssertEqual(counts.working, 1)
     }
 
-    func testInitialHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
+    func testHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
         var events: [String] = []
         var runFinished = false
         let storageGate = StorageRefreshGate()

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -282,6 +282,49 @@ final class MacPowerActiveSessionTests: XCTestCase {
         XCTAssertEqual(powerCount, 1)
     }
 
+    func testHeartbeatRepeatsAfterTheSleepInterval() throws {
+        // Keep the historical regression ID. The pane sleep loop no longer
+        // exists; repeated updates now come from atomic heartbeat events.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let status = root.appendingPathComponent("watchdog-status.json")
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        try Data(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(timestamp)"}"#.utf8
+        ).write(to: status, options: .atomic)
+
+        let protected = expectation(description: "first heartbeat change")
+        let allowed = expectation(description: "second heartbeat change")
+        protected.assertForOverFulfill = false
+        allowed.assertForOverFulfill = false
+        let lock = NSLock()
+        nonisolated(unsafe) var sawProtected = false
+        let monitor = PowerHeartbeatMonitor(
+            reader: PowerHeartbeatReader(statusURL: status)
+        ) { snapshot in
+            if snapshot.effectivePowerState == .protected {
+                lock.withLock { sawProtected = true }
+                protected.fulfill()
+            } else if snapshot.effectivePowerState == .allowed,
+                      lock.withLock({ sawProtected }) {
+                allowed.fulfill()
+            }
+        }
+        monitor.start()
+        defer { monitor.stop() }
+
+        try Data(
+            #"{"state":"ok","power_state":"protected","checked_at":"\#(timestamp)"}"#.utf8
+        ).write(to: status, options: .atomic)
+        wait(for: [protected], timeout: 1)
+        try Data(
+            #"{"state":"ok","power_state":"allowed","checked_at":"\#(timestamp)"}"#.utf8
+        ).write(to: status, options: .atomic)
+        wait(for: [allowed], timeout: 1)
+    }
+
     func testSettingsSystemPaneCountsAStartingSession() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
+++ b/app/Tests/DetachAppTests/MacPowerSettingsPresentationTests.swift
@@ -249,7 +249,7 @@ final class MacPowerActiveSessionTests: XCTestCase {
         XCTAssertEqual(counts.working, 1)
     }
 
-    func testHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
+    func testInitialHeartbeatStartsBeforeStorageFinishesAndAwaitsCancel() async {
         var events: [String] = []
         var runFinished = false
         let storageGate = StorageRefreshGate()
@@ -260,8 +260,7 @@ final class MacPowerActiveSessionTests: XCTestCase {
                     events.append("storage-start")
                     await storageGate.waitForRelease()
                     events.append("storage-end")
-                },
-                sleepNanoseconds: 1_000_000_000)
+                })
             runFinished = true
         }
         await storageGate.waitUntilEntered()
@@ -275,18 +274,12 @@ final class MacPowerActiveSessionTests: XCTestCase {
         XCTAssertTrue(events.contains("storage-end"))
     }
 
-    func testHeartbeatRepeatsAfterTheSleepInterval() async {
+    func testSystemPaneDoesNotPollHeartbeatAfterInitialRefresh() async {
         var powerCount = 0
-        let task = Task {
-            await SystemTabHeartbeatRefresh.run(
-                refreshPower: { powerCount += 1 },
-                refreshStorage: {},
-                sleepNanoseconds: 8_000_000)
-        }
-        try? await Task.sleep(nanoseconds: 25_000_000)
-        task.cancel()
-        await task.value
-        XCTAssertGreaterThanOrEqual(powerCount, 2)
+        await SystemTabHeartbeatRefresh.run(
+            refreshPower: { powerCount += 1 },
+            refreshStorage: {})
+        XCTAssertEqual(powerCount, 1)
     }
 
     func testSettingsSystemPaneCountsAStartingSession() async throws {

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -802,6 +802,34 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
+    func testPrepareRequiresHeldLifetimeBarrierBeforeUnregisterSubmit() async {
+        // Keep the historical regression ID. A helper can disappear after it
+        // acknowledges preparation; without its held lifetime barrier the
+        // durable transaction must not advance to unregister submission.
+        let backend = FakePowerHelperBackend(
+            status: .enabled,
+            registrations: [.success(.enabled)])
+        var barrierStates: [PowerHelperLifetimeBarrierStatus] = [
+            .busy, .busy, .released,
+        ]
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { barrierStates.removeFirst() })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-previous", forKey: "powerHelperDefinitionDigest")
+
+        await XCTAssertThrowsErrorAsync {
+            try await fixture.service.reconcileAfterAppUpdate()
+        }
+
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 1)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 0)
+        XCTAssertEqual(fixture.handoffStore.transaction?.phase, .preparing)
+        XCTAssertTrue(barrierStates.isEmpty)
+    }
+
     func testSubmittedPhaseIsDurableBeforeBackendUnregisterCall() async throws {
         let backend = FakePowerHelperBackend(
             status: .enabled,
@@ -1267,7 +1295,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertTrue(barrierStates.isEmpty)
     }
 
-    func testMatchingEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
+    func testEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -1243,6 +1243,30 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
+    func testMatchingEnabledRegistrationWaitsForItsLifetimeHolderBeforeRepair() async throws {
+        let backend = FakePowerHelperBackend(
+            status: .enabled,
+            registrations: [])
+        var barrierStates: [PowerHelperLifetimeBarrierStatus] = [.missing, .busy]
+        var delays: [UInt64] = []
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { barrierStates.removeFirst() },
+            sleep: { delays.append($0) })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-current", forKey: "powerHelperDefinitionDigest")
+
+        _ = try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(delays, [PowerHelperService.staleRegistrationGraceNanoseconds])
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertTrue(barrierStates.isEmpty)
+    }
+
     func testMatchingEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
         let backend = FakePowerHelperBackend(
             status: .enabled,

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -86,6 +86,10 @@ final class PowerHelperServiceTests: XCTestCase {
                 "The bundled power helper definition is missing or incomplete."
             ),
             (
+                .releaseSignatureRequired,
+                "Only a signed Detach release can update the power helper."
+            ),
+            (
                 .registrationDidNotComplete,
                 "macOS did not finish registering the power helper."
             ),
@@ -121,6 +125,30 @@ final class PowerHelperServiceTests: XCTestCase {
 
         XCTAssertEqual(backend.registerCalls, 0)
         XCTAssertEqual(backend.unregisterCalls, 0)
+    }
+
+    func testAdHocBuildCannotMutateSharedPowerHelperRegistration() async {
+        let backend = FakePowerHelperBackend(
+            status: .enabled,
+            registrations: [.success(.enabled)])
+        let fixture = makeFixture(
+            backend: backend,
+            serviceMutationAllowed: { false })
+        defer { fixture.cleanup() }
+
+        await XCTAssertThrowsErrorAsync {
+            try await fixture.service.reconcileAfterAppUpdate()
+        }
+        await XCTAssertThrowsErrorAsync {
+            try await fixture.service.disable()
+        }
+
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
+        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertFalse(fixture.defaults.bool(
+            forKey: "powerHelperDefinitionReconcilePending"))
     }
 
     func testEnableFailsAfterBoundedUnconfirmedRegistrationRetries() async {
@@ -754,7 +782,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
-    func testPrepareRequiresHeldLifetimeBarrierBeforeUnregisterSubmit() async {
+    func testReleasedLifetimeBarrierSkipsUnreachableHelperPreparation() async throws {
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])
@@ -765,14 +793,13 @@ final class PowerHelperServiceTests: XCTestCase {
         fixture.defaults.set(
             "digest-previous", forKey: "powerHelperDefinitionDigest")
 
-        await XCTAssertThrowsErrorAsync {
-            try await fixture.service.reconcileAfterAppUpdate()
-        }
+        try await fixture.service.reconcileAfterAppUpdate()
 
-        XCTAssertEqual(fixture.lifecycle.prepareCalls, 1)
-        XCTAssertEqual(backend.unregisterCalls, 0)
-        XCTAssertEqual(fixture.lifecycle.cancelCalls, 0)
-        XCTAssertEqual(fixture.handoffStore.transaction?.phase, .preparing)
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
+        XCTAssertEqual(backend.unregisterCalls, 1)
+        XCTAssertEqual(backend.registerCalls, 1)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 1)
+        XCTAssertNil(fixture.handoffStore.transaction)
     }
 
     func testSubmittedPhaseIsDurableBeforeBackendUnregisterCall() async throws {
@@ -1216,7 +1243,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
-    func testEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
+    func testMatchingEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])
@@ -1226,7 +1253,7 @@ final class PowerHelperServiceTests: XCTestCase {
             systemHandoffLockProvider: { nil })
         defer { fixture.cleanup() }
         fixture.defaults.set(
-            "digest-previous", forKey: "powerHelperDefinitionDigest")
+            "digest-current", forKey: "powerHelperDefinitionDigest")
 
         _ = try await fixture.service.reconcileAfterAppUpdate()
 
@@ -1234,6 +1261,26 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertEqual(backend.unregisterCalls, 1)
         XCTAssertEqual(backend.registerCalls, 1)
         XCTAssertEqual(fixture.lifecycle.cancelCalls, 1)
+        XCTAssertNil(fixture.handoffStore.transaction)
+    }
+
+    func testMatchingEnabledRegistrationWithBusyLifetimeBarrierNoOps() async throws {
+        let backend = FakePowerHelperBackend(
+            status: .enabled,
+            registrations: [])
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { .busy })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-current", forKey: "powerHelperDefinitionDigest")
+
+        _ = try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 0)
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
@@ -1270,6 +1317,7 @@ final class PowerHelperServiceTests: XCTestCase {
                 MemoryPowerHelperHandoffLock()
             },
         currentProcessIsActiveConsoleUser: @escaping () -> Bool = { true },
+        serviceMutationAllowed: @escaping () -> Bool = { true },
         digestProvider: @escaping () -> String? = { "digest-current" },
         sleep: @escaping (UInt64) async throws -> Void = { _ in }
     ) -> PowerHelperFixture {
@@ -1288,6 +1336,7 @@ final class PowerHelperServiceTests: XCTestCase {
             systemHandoffLockProvider: systemHandoffLockProvider,
             currentProcessIsActiveConsoleUser:
                 currentProcessIsActiveConsoleUser,
+            serviceMutationAllowed: serviceMutationAllowed,
             sleep: sleep)
         return PowerHelperFixture(
             service: service, lifecycle: lifecycle,

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -140,12 +140,11 @@ final class QuickChatTests: XCTestCase {
                     selectedID = sessionID
                     selected.fulfill()
                 },
-                createProjectDirectory: { directory, _ in directory },
-                discoverySleep: { _ in
-                    await cli.waitUntilStartBegan()
-                })
+                createProjectDirectory: { directory, _ in directory })
         }
 
+        await cli.waitUntilStartBegan()
+        await store.refresh() // the production FSEvents hint requests this snapshot
         await fulfillment(of: [selected], timeout: 1)
         XCTAssertEqual(selectedID, "detach-codex-tmp-1")
         XCTAssertEqual(store.sessions.first?.effectiveStatus, .starting)
@@ -172,12 +171,11 @@ final class QuickChatTests: XCTestCase {
                 providerRawValue: Provider.codex.rawValue,
                 directoryPath: "/tmp",
                 onSessionAvailable: { _ in selected.fulfill() },
-                createProjectDirectory: { directory, _ in directory },
-                discoverySleep: { _ in
-                    await cli.waitUntilStartBegan()
-                })
+                createProjectDirectory: { directory, _ in directory })
         }
 
+        await cli.waitUntilStartBegan()
+        await store.refresh() // the production FSEvents hint requests this snapshot
         await fulfillment(of: [selected], timeout: 1)
         await cli.finishStart(exitCode: 17, stderr: "start refused\n")
         let result = await launch.value

--- a/app/Tests/DetachAppTests/ServiceManagementMutationAdmissionTests.swift
+++ b/app/Tests/DetachAppTests/ServiceManagementMutationAdmissionTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import DetachApp
+
+final class ServiceManagementMutationAdmissionTests: XCTestCase {
+    private let identifiers = [
+        "dev.tsarev.detach",
+        "dev.tsarev.detach.power-helper",
+        "dev.tsarev.detach.power-watchdog",
+    ]
+
+    func testExactReleaseIdentityPermitsServiceManagementMutation() {
+        let teams = Dictionary(
+            uniqueKeysWithValues: identifiers.map { ($0, "JPXHBUZBNM") })
+
+        XCTAssertTrue(ServiceManagementMutationAdmission.permits(
+            bundleIdentifier: "dev.tsarev.detach",
+            validatedTeams: teams))
+    }
+
+    func testPreviewOrIncompleteIdentityCannotMutateSharedServices() {
+        let releaseTeams = Dictionary(
+            uniqueKeysWithValues: identifiers.map { ($0, "JPXHBUZBNM") })
+        var missingHelper = releaseTeams
+        missingHelper.removeValue(
+            forKey: "dev.tsarev.detach.power-helper")
+        var foreignWatchdog = releaseTeams
+        foreignWatchdog["dev.tsarev.detach.power-watchdog"] = "ABCDEFGHIJ"
+
+        XCTAssertFalse(ServiceManagementMutationAdmission.permits(
+            bundleIdentifier: "dev.tsarev.detach.preview",
+            validatedTeams: releaseTeams))
+        XCTAssertFalse(ServiceManagementMutationAdmission.permits(
+            bundleIdentifier: "dev.tsarev.detach",
+            validatedTeams: missingHelper))
+        XCTAssertFalse(ServiceManagementMutationAdmission.permits(
+            bundleIdentifier: "dev.tsarev.detach",
+            validatedTeams: foreignWatchdog))
+        XCTAssertFalse(ServiceManagementMutationAdmission.permits(
+            bundleIdentifier: "dev.tsarev.detach",
+            validatedTeams: [:]))
+    }
+
+    func testAdHocTestHostCannotPassReleaseAdmission() {
+        XCTAssertFalse(
+            ServiceManagementMutationAdmission.currentBundleIsReleaseSigned)
+    }
+
+    func testSignedReleaseFixturePassesRealSecurityAdmission() throws {
+        guard let path = ProcessInfo.processInfo.environment[
+            "DETACH_SIGNED_APP_FIXTURE"] else {
+            throw XCTSkip("A signed release fixture was not supplied")
+        }
+        let bundle = try XCTUnwrap(Bundle(path: path))
+
+        XCTAssertTrue(
+            ServiceManagementMutationAdmission.releaseSignedBundle(bundle))
+    }
+}

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -49,6 +49,24 @@ private actor BlankTerminalScreenCLI: DetachCLIRunning {
     func recordedCalls() -> [[String]] { calls }
 }
 
+private actor TruncatedTerminalScreenCLI: DetachCLIRunning {
+    private var calls = 0
+
+    func run(arguments: [String], timeout: TimeInterval) async throws
+        -> CLIResult
+    {
+        calls += 1
+        return CLIResult(
+            exitCode: 0,
+            stdout: "partial screen",
+            stderr: "",
+            timedOut: false,
+            stdoutTruncated: true)
+    }
+
+    func callCount() -> Int { calls }
+}
+
 private actor SuspendedTerminalScreenCLI: DetachCLIRunning {
     private var calls = 0
     private var continuations: [CheckedContinuation<Void, Never>] = []
@@ -624,6 +642,21 @@ final class SessionAttachTerminalTests: XCTestCase {
     }
 
     @MainActor
+    func testTerminalScreenPrefetchRejectsTruncatedOutput() async throws {
+        let session = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-truncated"))
+        let cli = TruncatedTerminalScreenCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([session])
+
+        XCTAssertNil(cache.screen(for: session))
+        let calls = await cli.callCount()
+        XCTAssertEqual(calls, 1)
+    }
+
+    @MainActor
     func testNewRunUnderTheSameNameNeverInheritsAnOldScreen() async throws {
         let first = try XCTUnwrap(Self.session(
             status: "running", name: "detach-codex-reused",
@@ -641,6 +674,47 @@ final class SessionAttachTerminalTests: XCTestCase {
         cache.schedulePrefetch(for: [replacement])
         XCTAssertNil(cache.screen(for: first))
         await waitUntilAsync { cache.screen(for: replacement) != nil }
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls.count, 2)
+    }
+
+    @MainActor
+    func testLifecycleIDInvalidatesSameSecondReplacementScreen() throws {
+        let created = "2026-09-02T10:00:00Z"
+        let first = try XCTUnwrap(Self.session(
+            name: "detach-codex-same-second",
+            createdAt: created,
+            lifecycleID: "first-run"))
+        let replacement = try XCTUnwrap(Self.session(
+            name: "detach-codex-same-second",
+            createdAt: created,
+            lifecycleID: "replacement-run"))
+        let cache = SessionTerminalScreenCache()
+        cache.store(Data("old screen".utf8), for: first)
+
+        XCTAssertNil(cache.screen(for: replacement))
+    }
+
+    @MainActor
+    func testLifecycleIDRetriesSameSecondReplacementAfterBlankPrefetch()
+        async throws
+    {
+        let created = "2026-09-02T10:00:00Z"
+        let first = try XCTUnwrap(Self.session(
+            name: "detach-codex-same-second-blank",
+            createdAt: created,
+            lifecycleID: "first-run"))
+        let replacement = try XCTUnwrap(Self.session(
+            name: "detach-codex-same-second-blank",
+            createdAt: created,
+            lifecycleID: "replacement-run"))
+        let cli = BlankTerminalScreenCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([first])
+        await cache.prefetch([replacement])
+
         let calls = await cli.recordedCalls()
         XCTAssertEqual(calls.count, 2)
     }
@@ -1066,11 +1140,13 @@ final class SessionAttachTerminalTests: XCTestCase {
     private static func session(
         status: String = "running",
         name: String = "detach-codex-proj-abcd1234",
-        createdAt: String? = nil
+        createdAt: String? = nil,
+        lifecycleID: String? = nil
     ) -> Session? {
         let created = createdAt.map { "\"\($0)\"" } ?? "null"
+        let lifecycle = lifecycleID.map { "\"\($0)\"" } ?? "null"
         return SessionListParser.parse("""
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":\(created),"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":\(created),"lifecycle_id":\(lifecycle),"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
         """).sessions.first
     }
 

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -36,6 +36,19 @@ private actor TerminalScreenPrefetchCLI: DetachCLIRunning {
     func peakConcurrency() -> Int { peakActiveCalls }
 }
 
+private actor BlankTerminalScreenCLI: DetachCLIRunning {
+    private(set) var calls: [[String]] = []
+
+    func run(arguments: [String], timeout: TimeInterval) async throws
+        -> CLIResult
+    {
+        calls.append(arguments)
+        return CLIResult(exitCode: 0, stdout: "\n   \n", stderr: "", timedOut: false)
+    }
+
+    func recordedCalls() -> [[String]] { calls }
+}
+
 private actor SuspendedTerminalScreenCLI: DetachCLIRunning {
     private var calls = 0
     private var continuations: [CheckedContinuation<Void, Never>] = []
@@ -350,39 +363,53 @@ final class SessionAttachTerminalTests: XCTestCase {
             cachedLog: cache.poller(for: session)).body
     }
 
-    func testDetachedLiveLogRefreshUsesSessionEventsInsteadOfATimer() throws {
+    func testDetachedLiveLogRefreshKeysOnSessionAndCacheIdentity() throws {
         let live = try XCTUnwrap(Self.session(status: "running"))
         let finished = try XCTUnwrap(Self.session(status: "stopped"))
-        let first = Date(timeIntervalSinceReferenceDate: 10)
-        let second = Date(timeIntervalSinceReferenceDate: 11)
+        let firstPoller = NSObject()
+        let secondPoller = NSObject()
+        let first = ObjectIdentifier(firstPoller)
+        let second = ObjectIdentifier(secondPoller)
 
+        // A detached live surface keeps one bounded refresh task for the
+        // selection; unrelated snapshots must not restart it.
+        XCTAssertEqual(
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: false,
+                cachedLogIdentity: nil),
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: false,
+                cachedLogIdentity: nil))
+        XCTAssertEqual(
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: true,
+                cachedLogIdentity: nil),
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: true,
+                cachedLogIdentity: nil))
+        // A replaced cache entry for a finished session must reload it.
         XCTAssertNotEqual(
             SessionDetailLogRefresh.taskID(
-                session: live,
+                session: finished,
                 showsEmbeddedTerminal: false,
-                lastUpdated: first),
+                cachedLogIdentity: first),
             SessionDetailLogRefresh.taskID(
-                session: live,
+                session: finished,
                 showsEmbeddedTerminal: false,
-                lastUpdated: second))
-        XCTAssertEqual(
-            SessionDetailLogRefresh.taskID(
-                session: live,
-                showsEmbeddedTerminal: true,
-                lastUpdated: first),
-            SessionDetailLogRefresh.taskID(
-                session: live,
-                showsEmbeddedTerminal: true,
-                lastUpdated: second))
+                cachedLogIdentity: second))
         XCTAssertEqual(
             SessionDetailLogRefresh.taskID(
                 session: finished,
                 showsEmbeddedTerminal: false,
-                lastUpdated: first),
+                cachedLogIdentity: first),
             SessionDetailLogRefresh.taskID(
                 session: finished,
                 showsEmbeddedTerminal: false,
-                lastUpdated: second))
+                cachedLogIdentity: first))
     }
 
     func testDetailTransitionKeepsOutgoingFrameUntilTargetIsReady() throws {
@@ -572,6 +599,50 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertEqual(callsAfterConfiguration, [[
             "codex", "logs", "--ansi", "detach-codex-startup-live",
         ]])
+    }
+
+    @MainActor
+    func testBlankScreenIsNotRefetchedUntilTheTypedTurnChanges() async throws {
+        let starting = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-blank"))
+        let cli = BlankTerminalScreenCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([starting])
+        await cache.prefetch([starting])
+        XCTAssertNil(cache.screen(for: starting))
+        let repeatedCalls = await cli.recordedCalls()
+        XCTAssertEqual(repeatedCalls.count, 1)
+
+        var working = starting
+        working.agentTurnState = .working
+        working.agentTurnID = "turn-1"
+        await cache.prefetch([working])
+        let changedCalls = await cli.recordedCalls()
+        XCTAssertEqual(changedCalls.count, 2)
+    }
+
+    @MainActor
+    func testNewRunUnderTheSameNameNeverInheritsAnOldScreen() async throws {
+        let first = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-reused",
+            createdAt: "2026-09-01T10:00:00Z"))
+        let cli = TerminalScreenPrefetchCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+        await cache.prefetch([first])
+        XCTAssertNotNil(cache.screen(for: first))
+
+        // The same explicit name starts a fresh run with a new creation time.
+        let replacement = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-reused",
+            createdAt: "2026-09-02T10:00:00Z"))
+        cache.schedulePrefetch(for: [replacement])
+        XCTAssertNil(cache.screen(for: first))
+        await waitUntilAsync { cache.screen(for: replacement) != nil }
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls.count, 2)
     }
 
     @MainActor
@@ -994,10 +1065,12 @@ final class SessionAttachTerminalTests: XCTestCase {
 
     private static func session(
         status: String = "running",
-        name: String = "detach-codex-proj-abcd1234"
+        name: String = "detach-codex-proj-abcd1234",
+        createdAt: String? = nil
     ) -> Session? {
-        SessionListParser.parse("""
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":null,"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
+        let created = createdAt.map { "\"\($0)\"" } ?? "null"
+        return SessionListParser.parse("""
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":\(created),"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
         """).sessions.first
     }
 

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Darwin
-import MetalKit
 import SwiftUI
 import XCTest
 import SwiftTerm
@@ -11,6 +10,72 @@ private final class SilentDetachCLI: DetachCLIRunning, @unchecked Sendable {
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
         CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
     }
+}
+
+private actor TerminalScreenPrefetchCLI: DetachCLIRunning {
+    private(set) var calls: [[String]] = []
+    private var activeCalls = 0
+    private var peakActiveCalls = 0
+
+    func run(arguments: [String], timeout: TimeInterval) async throws
+        -> CLIResult
+    {
+        calls.append(arguments)
+        activeCalls += 1
+        peakActiveCalls = max(peakActiveCalls, activeCalls)
+        defer { activeCalls -= 1 }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        return CLIResult(
+            exitCode: 0,
+            stdout: "\u{001B}[32mprefetched screen\u{001B}[0m\n",
+            stderr: "",
+            timedOut: false)
+    }
+
+    func recordedCalls() -> [[String]] { calls }
+    func peakConcurrency() -> Int { peakActiveCalls }
+}
+
+private actor SuspendedTerminalScreenCLI: DetachCLIRunning {
+    private var calls = 0
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func run(arguments: [String], timeout: TimeInterval) async throws
+        -> CLIResult
+    {
+        calls += 1
+        await withCheckedContinuation { continuations.append($0) }
+        return CLIResult(
+            exitCode: 0,
+            stdout: "retained screen",
+            stderr: "",
+            timedOut: false)
+    }
+
+    func callCount() -> Int { calls }
+
+    func releaseAll() {
+        let pending = continuations
+        continuations = []
+        for continuation in pending { continuation.resume() }
+    }
+}
+
+private actor RecordingSessionSwitchCLI: DetachCLIRunning {
+    private var calls: [[String]] = []
+
+    func run(arguments: [String], timeout: TimeInterval) async throws
+        -> CLIResult
+    {
+        calls.append(arguments)
+        return CLIResult(
+            exitCode: 0,
+            stdout: "",
+            stderr: "",
+            timedOut: false)
+    }
+
+    func recordedCalls() -> [[String]] { calls }
 }
 
 private final class RecordingTerminalView: LocalProcessTerminalView {
@@ -48,7 +113,7 @@ final class SessionAttachTerminalTests: XCTestCase {
         #!/bin/sh
         printf '%s\\n' "$*" > '\(record.path)'
         case "$*" in
-          "codex attach detach-codex-proj-abcd1234")
+          "codex attach --terminal-features sync detach-codex-proj-abcd1234")
             exec /bin/cat
             ;;
         esac
@@ -80,7 +145,7 @@ final class SessionAttachTerminalTests: XCTestCase {
         try waitUntil {
             (try? String(contentsOf: record, encoding: .utf8))?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-                == "codex attach detach-codex-proj-abcd1234"
+                == "codex attach --terminal-features sync detach-codex-proj-abcd1234"
         }
         XCTAssertGreaterThan(terminal.process.shellPid, 0)
         XCTAssertTrue(terminal.process.running)
@@ -115,7 +180,7 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertEqual(
             try String(contentsOf: record, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines),
-            "codex attach detach-codex-proj-abcd1234")
+            "codex attach --terminal-features sync detach-codex-proj-abcd1234")
     }
 
     func testTerminationEscalatesWhenTheClientIgnoresTerm() throws {
@@ -201,12 +266,14 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertEqual(seen, 9)
     }
 
+    @MainActor
     func testCoordinatorOwnsThePublicAttachInvocation() throws {
         let session = try XCTUnwrap(Self.session())
         let view = SessionAttachTerminalView(
             detachPath: "/tmp/detach",
             session: session,
             fontPointSize: 14,
+            screenCache: SessionTerminalScreenCache(),
             baseEnvironment: [
                 "PATH": "/bin",
                 "HOME": "/tmp",
@@ -216,7 +283,10 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertEqual(coordinator.controller.invocation.executable, "/tmp/detach")
         XCTAssertEqual(
             coordinator.controller.invocation.arguments,
-            ["codex", "attach", "detach-codex-proj-abcd1234"])
+            [
+                "codex", "attach", "--terminal-features", "sync",
+                "detach-codex-proj-abcd1234",
+            ])
         XCTAssertFalse(
             coordinator.controller.invocation.environment.contains {
                 $0.hasPrefix("TMUX=")
@@ -224,12 +294,147 @@ final class SessionAttachTerminalTests: XCTestCase {
     }
 
     @MainActor
+    func testLiveSessionSwitchKeepsTheExistingPTYAndUsesExactClientPID() async throws {
+        let source = try XCTUnwrap(Self.session(
+            name: "detach-codex-source"))
+        let target = try XCTUnwrap(Self.session(
+            name: "detach-codex-target"))
+        var invocation = Self.invocation()
+        invocation.executable = "/bin/sleep"
+        invocation.arguments = ["5"]
+        invocation.environment = ["PATH=/bin:/usr/bin"]
+        let controller = SessionAttachController(invocation: invocation)
+        let terminal = LocalProcessTerminalView(frame: NSRect(
+            x: 0, y: 0, width: 320, height: 180))
+        controller.configure(terminal, fontPointSize: 14)
+        controller.start()
+        let clientPID = terminal.process.shellPid
+        XCTAssertGreaterThan(clientPID, 1)
+        let cli = RecordingSessionSwitchCLI()
+        let coordinator = SessionAttachTerminalView.Coordinator(
+            controller: controller,
+            session: source,
+            screenCache: SessionTerminalScreenCache(),
+            onTerminated: { _ in },
+            switchCLI: cli)
+
+        coordinator.requestSession(target, in: terminal)
+        await waitUntilAsync {
+            await cli.recordedCalls().count == 1
+                && coordinator.session.id == target.id
+        }
+
+        XCTAssertTrue(terminal.process.running)
+        XCTAssertEqual(terminal.process.shellPid, clientPID)
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(
+            calls,
+            [SessionClientSwitchInvocation.arguments(
+                clientPID: clientPID,
+                from: source,
+                to: target)])
+        coordinator.cancelSwitch()
+        controller.terminateClient()
+    }
+
+    @MainActor
     func testStoppedSessionDetailUsesTheLogFallback() throws {
         let session = try XCTUnwrap(Self.session(status: "stopped"))
+        let cache = SessionLogSnapshotCache(
+            cli: SilentDetachCLI(), configurationID: "/tmp/detach")
         _ = SessionDetailView(
             session: session,
             store: SessionStore(cli: SilentDetachCLI()),
-            detachPath: "/tmp/detach").body
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: cache.poller(for: session)).body
+    }
+
+    func testDetachedLiveLogRefreshUsesSessionEventsInsteadOfATimer() throws {
+        let live = try XCTUnwrap(Self.session(status: "running"))
+        let finished = try XCTUnwrap(Self.session(status: "stopped"))
+        let first = Date(timeIntervalSinceReferenceDate: 10)
+        let second = Date(timeIntervalSinceReferenceDate: 11)
+
+        XCTAssertNotEqual(
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: false,
+                lastUpdated: first),
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: false,
+                lastUpdated: second))
+        XCTAssertEqual(
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: true,
+                lastUpdated: first),
+            SessionDetailLogRefresh.taskID(
+                session: live,
+                showsEmbeddedTerminal: true,
+                lastUpdated: second))
+        XCTAssertEqual(
+            SessionDetailLogRefresh.taskID(
+                session: finished,
+                showsEmbeddedTerminal: false,
+                lastUpdated: first),
+            SessionDetailLogRefresh.taskID(
+                session: finished,
+                showsEmbeddedTerminal: false,
+                lastUpdated: second))
+    }
+
+    func testDetailTransitionKeepsOutgoingFrameUntilTargetIsReady() throws {
+        let first = try XCTUnwrap(Self.session(name: "detach-codex-first"))
+        let second = try XCTUnwrap(Self.session(name: "detach-codex-second"))
+        var transition = SessionDetailTransitionState(presented: first)
+
+        let generation = try XCTUnwrap(transition.present(second))
+
+        XCTAssertEqual(transition.presented.id, second.id)
+        XCTAssertEqual(transition.outgoing?.id, first.id)
+        XCTAssertFalse(transition.complete(
+            sessionID: first.id,
+            generation: generation))
+        XCTAssertTrue(transition.complete(
+            sessionID: second.id,
+            generation: generation))
+        XCTAssertNil(transition.outgoing)
+    }
+
+    func testRapidDetailTransitionKeepsLastCompositedFrameAndRejectsLateReady() throws {
+        let first = try XCTUnwrap(Self.session(name: "detach-codex-first"))
+        let second = try XCTUnwrap(Self.session(name: "detach-codex-second"))
+        let third = try XCTUnwrap(Self.session(name: "detach-codex-third"))
+        var transition = SessionDetailTransitionState(presented: first)
+
+        let secondGeneration = try XCTUnwrap(transition.present(second))
+        let thirdGeneration = try XCTUnwrap(transition.present(third))
+
+        XCTAssertEqual(transition.presented.id, third.id)
+        XCTAssertEqual(transition.outgoing?.id, first.id)
+        XCTAssertFalse(transition.complete(
+            sessionID: second.id,
+            generation: secondGeneration))
+        XCTAssertEqual(transition.outgoing?.id, first.id)
+        XCTAssertTrue(transition.complete(
+            sessionID: third.id,
+            generation: thirdGeneration))
+        XCTAssertNil(transition.outgoing)
+    }
+
+    func testDetailRevisionUpdatesWithoutStartingAVisualTransition() throws {
+        let first = try XCTUnwrap(Self.session(name: "detach-codex-same"))
+        var updated = first
+        updated.displayName = "Updated title"
+        var transition = SessionDetailTransitionState(presented: first)
+
+        XCTAssertNil(transition.present(updated))
+
+        XCTAssertEqual(transition.presented.displayName, "Updated title")
+        XCTAssertNil(transition.outgoing)
+        XCTAssertEqual(transition.generation, 0)
     }
 
     @MainActor
@@ -239,7 +444,179 @@ final class SessionAttachTerminalTests: XCTestCase {
         _ = SessionDetailView(
             session: session,
             store: SessionStore(cli: SilentDetachCLI()),
-            detachPath: "/tmp/detach").body
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+                cachedLog: nil).body
+    }
+
+    @MainActor
+    func testTerminalScreenCacheBoundsAndRestoresRecentText() throws {
+        let cache = SessionTerminalScreenCache()
+        for index in 0...SessionTerminalScreenCache.capacity {
+            let session = try XCTUnwrap(Self.session(
+                name: "detach-codex-project-\(index)"))
+            cache.store(
+                Data("screen \(index)\nnext".utf8),
+                for: session)
+        }
+
+        XCTAssertNil(cache.screen(for: try XCTUnwrap(Self.session(
+            name: "detach-codex-project-0"))))
+        XCTAssertEqual(
+            cache.screen(for: try XCTUnwrap(Self.session(
+                name: "detach-codex-project-9"))),
+            Data("screen 9\r\nnext".utf8))
+    }
+
+    @MainActor
+    func testTerminalScreenCacheKeepsOnlyTheVisibleTail() {
+        let source = (0...SessionTerminalScreenCache.lineLimit)
+            .map(String.init)
+            .joined(separator: "\n")
+        let normalized = SessionTerminalScreenCache.normalized(Data(source.utf8))
+        let text = normalized.flatMap { String(data: $0, encoding: .utf8) }
+
+        XCTAssertNotNil(text)
+        XCTAssertFalse(text?.hasPrefix("0\r\n") == true)
+        XCTAssertTrue(text?.hasPrefix("1\r\n") == true)
+        XCTAssertTrue(text?.hasSuffix(String(SessionTerminalScreenCache.lineLimit)) == true)
+        XCTAssertNil(SessionTerminalScreenCache.normalized(Data("\n  \n".utf8)))
+    }
+
+    @MainActor
+    func testCoordinatorCapturesTerminalTextBeforeDismantle() throws {
+        let session = try XCTUnwrap(Self.session())
+        let cache = SessionTerminalScreenCache()
+        let terminal = LocalProcessTerminalView(frame: .zero)
+        terminal.feed(text: "visible screen")
+        let coordinator = SessionAttachTerminalView.Coordinator(
+            controller: SessionAttachController(invocation: Self.invocation()),
+            session: session,
+            screenCache: cache,
+            onTerminated: { _ in })
+
+        coordinator.captureScreen(from: terminal)
+
+        let screen = try XCTUnwrap(cache.screen(for: session))
+        XCTAssertTrue(String(decoding: screen, as: UTF8.self)
+            .contains("visible screen"))
+    }
+
+    @MainActor
+    func testFirstVisibleFrameIsCapturedBeforeReadinessIsReported() throws {
+        let session = try XCTUnwrap(Self.session())
+        let cache = SessionTerminalScreenCache()
+        let terminal = LocalProcessTerminalView(
+            frame: NSRect(x: 0, y: 0, width: 320, height: 180))
+        terminal.feed(text: "first visible frame")
+        var reportedScreen: Data?
+        let coordinator = SessionAttachTerminalView.Coordinator(
+            controller: SessionAttachController(invocation: Self.invocation()),
+            session: session,
+            screenCache: cache,
+            onTerminated: { _ in },
+            onFirstVisibleFrame: {
+                reportedScreen = cache.screen(for: session)
+            })
+
+        coordinator.reportFirstVisibleFrame(from: terminal)
+
+        let screen = try XCTUnwrap(reportedScreen)
+        XCTAssertTrue(String(decoding: screen, as: UTF8.self)
+            .contains("first visible frame"))
+    }
+
+    @MainActor
+    func testTerminalScreenPrefetchWarmsOnlyLiveAttachableSessions() async throws {
+        let live = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-live"))
+        let stopped = try XCTUnwrap(Self.session(
+            status: "stopped", name: "detach-codex-stopped"))
+        let cli = TerminalScreenPrefetchCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([live, stopped])
+        await cache.prefetch([live, stopped])
+
+        let screen = try XCTUnwrap(cache.screen(for: live))
+        XCTAssertTrue(String(decoding: screen, as: UTF8.self)
+            .contains("prefetched screen"))
+        XCTAssertNil(cache.screen(for: stopped))
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls, [[
+            "codex", "logs", "--ansi", "detach-codex-live",
+        ]])
+    }
+
+    @MainActor
+    func testConfigureWarmsLiveSessionsAlreadyPresentAtStartup() async throws {
+        let live = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-startup-live"))
+        let cli = TerminalScreenPrefetchCLI()
+        let cache = SessionTerminalScreenCache()
+
+        cache.schedulePrefetch(for: [live])
+        for _ in 0..<20 { await Task.yield() }
+        let callsBeforeConfiguration = await cli.recordedCalls()
+        XCTAssertTrue(callsBeforeConfiguration.isEmpty)
+
+        cache.configure(
+            cli: cli,
+            configurationID: "/tmp/detach",
+            sessions: [live])
+        await waitUntilAsync { cache.screen(for: live) != nil }
+
+        XCTAssertNotNil(cache.screen(for: live))
+        let callsAfterConfiguration = await cli.recordedCalls()
+        XCTAssertEqual(callsAfterConfiguration, [[
+            "codex", "logs", "--ansi", "detach-codex-startup-live",
+        ]])
+    }
+
+    @MainActor
+    func testTerminalScreenPrefetchBoundsConcurrentProcesses() async throws {
+        let sessions = try (0..<SessionTerminalScreenCache.capacity).map {
+            try XCTUnwrap(Self.session(
+                status: "running", name: "detach-codex-live-\($0)"))
+        }
+        let cli = TerminalScreenPrefetchCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch(sessions)
+
+        let peak = await cli.peakConcurrency()
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(peak, SessionTerminalScreenCache.maximumConcurrentPrefetches)
+        XCTAssertEqual(calls.count, sessions.count)
+        for session in sessions {
+            XCTAssertNotNil(cache.screen(for: session))
+        }
+    }
+
+    @MainActor
+    func testCancelledScreenPrefetchCannotClearAReplacementTask() async throws {
+        let session = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-generation"))
+        let oldCLI = SuspendedTerminalScreenCLI()
+        let newCLI = SuspendedTerminalScreenCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: oldCLI, configurationID: "old")
+        cache.schedulePrefetch(for: [session])
+        await waitUntilAsync { await oldCLI.callCount() == 1 }
+
+        cache.configure(cli: newCLI, configurationID: "new")
+        cache.schedulePrefetch(for: [session])
+        await waitUntilAsync { await newCLI.callCount() == 1 }
+        await oldCLI.releaseAll()
+        for _ in 0..<20 { await Task.yield() }
+
+        cache.schedulePrefetch(for: [session])
+        for _ in 0..<20 { await Task.yield() }
+        let replacementCallCount = await newCLI.callCount()
+        XCTAssertEqual(replacementCallCount, 1)
+        await newCLI.releaseAll()
     }
 
     func testTerminalFontMatchesTheAppSize() {
@@ -308,17 +685,6 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertTrue(window.firstResponder === terminal)
     }
 
-    func testRealtimeRendererRequiresPausedOnDemandMetal() {
-        let view = MTKView(frame: .zero)
-        view.isPaused = true
-        view.enableSetNeedsDisplay = true
-        view.autoResizeDrawable = false
-        XCTAssertTrue(SessionAttachRendering.isPausedOnDemand(view))
-
-        view.isPaused = false
-        XCTAssertFalse(SessionAttachRendering.isPausedOnDemand(view))
-    }
-
     func testRealtimeRendererUsesSteadyCursorVariants() {
         let mappings: [(CursorStyle, String)] = [
             (.blinkBlock, CursorStyle.steadyBlock.tagName),
@@ -335,24 +701,55 @@ final class SessionAttachTerminalTests: XCTestCase {
         }
     }
 
-    func testRealtimeRendererFailureKeepsTheFallbackAvailable() {
-        enum Failure: Error { case unavailable }
-        XCTAssertFalse(SessionAttachRendering.enableOnDemandMetal {
-            throw Failure.unavailable
-        })
-        XCTAssertTrue(SessionAttachRendering.enableOnDemandMetal {})
+    @MainActor
+    func testRealtimeRendererUsesEventDrivenCoreGraphics() {
+        let terminal = SessionAttachLocalProcessTerminalView(frame: .zero)
+
+        terminal.configureRealtimeRendererIfNeeded()
+        terminal.cursorStyleChanged(
+            source: terminal.terminal,
+            newStyle: .blinkUnderline)
+
+        XCTAssertFalse(terminal.isUsingMetalRenderer)
+        XCTAssertEqual(
+            terminal.terminal.options.cursorStyle.tagName,
+            CursorStyle.steadyUnderline.tagName)
+        XCTAssertTrue(
+            SessionAttachRendering.hasEnergyEfficientRenderer(in: terminal))
     }
 
     @MainActor
-    func testRealtimeRendererKeepsTheCoreGraphicsTerminalInteractive() {
-        let terminal = SessionAttachLocalProcessTerminalView(frame: .zero)
+    func testRetainedScreenSurvivesAttachClearUntilAFrameIsReady() throws {
+        let terminal = SessionAttachLocalProcessTerminalView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+        let retained = Data("retained session output".utf8)
+        terminal.feed(byteArray: Array(retained)[...])
+        terminal.retainScreen(
+            retained,
+            fontPointSize: 13)
+        var visibleFrameCount = 0
+        terminal.onFirstVisibleFrame = { visibleFrameCount += 1 }
+
+        XCTAssertTrue(terminal.isRetainingScreen)
+        terminal.dataReceived(slice: Array("\u{001B}[2J\u{001B}[H".utf8)[...])
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.12))
 
         XCTAssertFalse(
-            SessionAttachRendering.hasEnergyEfficientMetalRenderer(in: terminal))
-        terminal.cursorStyleChanged(
-            source: terminal.terminal,
-            newStyle: .steadyBlock)
-        XCTAssertFalse(terminal.isUsingMetalRenderer)
+            SessionAttachLocalProcessTerminalView.hasVisibleContent(
+                in: terminal.terminal))
+        XCTAssertTrue(terminal.isRetainingScreen)
+        XCTAssertEqual(visibleFrameCount, 0)
+
+        terminal.dataReceived(slice: Array("attached session output".utf8)[...])
+        try waitUntil(timeout: 0.5) { !terminal.isRetainingScreen }
+        XCTAssertTrue(
+            SessionAttachLocalProcessTerminalView.hasVisibleContent(
+                in: terminal.terminal))
+        XCTAssertEqual(visibleFrameCount, 1)
+
+        terminal.dataReceived(slice: Array("more output".utf8)[...])
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.12))
+        XCTAssertEqual(visibleFrameCount, 1)
     }
 
     func testDroppedPathNeverInsertsAControlCharacter() {
@@ -509,8 +906,11 @@ final class SessionAttachTerminalTests: XCTestCase {
     @MainActor
     func testScopedKeyboardRouting() throws {
         let terminal = LocalProcessTerminalView(frame: .zero)
+        let session = try XCTUnwrap(Self.session())
         let coordinator = SessionAttachTerminalView.Coordinator(
             controller: SessionAttachController(invocation: Self.invocation()),
+            session: session,
+            screenCache: SessionTerminalScreenCache(),
             onTerminated: { _ in })
 
         let controlV = try XCTUnwrap(NSEvent.keyEvent(
@@ -580,9 +980,24 @@ final class SessionAttachTerminalTests: XCTestCase {
         throw Timeout()
     }
 
-    private static func session(status: String = "running") -> Session? {
+    @MainActor
+    private func waitUntilAsync(
+        attempts: Int = 200,
+        _ predicate: @escaping () async -> Bool
+    ) async {
+        for _ in 0..<attempts {
+            if await predicate() { return }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("asynchronous condition did not become true")
+    }
+
+    private static func session(
+        status: String = "running",
+        name: String = "detach-codex-proj-abcd1234"
+    ) -> Session? {
         SessionListParser.parse("""
-        {"schema":1,"provider":"codex","session_name":"detach-codex-proj-abcd1234","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":null,"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":null,"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
         """).sessions.first
     }
 

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -890,7 +890,6 @@ final class SessionAttachTerminalTests: XCTestCase {
         let terminal = SessionAttachLocalProcessTerminalView(
             frame: NSRect(x: 0, y: 0, width: 640, height: 360))
         let retained = Data("retained session output".utf8)
-        terminal.feed(byteArray: Array(retained)[...])
         terminal.retainScreen(
             retained,
             fontPointSize: 13)
@@ -898,6 +897,9 @@ final class SessionAttachTerminalTests: XCTestCase {
         terminal.onFirstVisibleFrame = { visibleFrameCount += 1 }
 
         XCTAssertTrue(terminal.isRetainingScreen)
+        XCTAssertFalse(
+            SessionAttachLocalProcessTerminalView.hasVisibleContent(
+                in: terminal.terminal))
         terminal.dataReceived(slice: Array("\u{001B}[2J\u{001B}[H".utf8)[...])
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.12))
 

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -764,6 +764,28 @@ final class SessionAttachTerminalTests: XCTestCase {
         await newCLI.releaseAll()
     }
 
+    @MainActor
+    func testEmptySnapshotClearsQueuedScreenPrefetch() async throws {
+        let first = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-first-queued"))
+        let removed = try XCTUnwrap(Self.session(
+            status: "running", name: "detach-codex-removed-queued"))
+        let cli = SuspendedTerminalScreenCLI()
+        let cache = SessionTerminalScreenCache()
+        cache.configure(cli: cli, configurationID: "/tmp/detach")
+        cache.schedulePrefetch(for: [first])
+        await waitUntilAsync { await cli.callCount() == 1 }
+
+        cache.schedulePrefetch(for: [removed])
+        cache.schedulePrefetch(for: [])
+        await cli.releaseAll()
+        for _ in 0..<100 { await Task.yield() }
+
+        let callCount = await cli.callCount()
+        if callCount > 1 { await cli.releaseAll() }
+        XCTAssertEqual(callCount, 1)
+    }
+
     func testTerminalFontMatchesTheAppSize() {
         XCTAssertEqual(SessionAttachController.terminalFont(pointSize: 17).pointSize, 17)
         XCTAssertTrue(SessionAttachController.terminalFont(pointSize: 14).isFixedPitch)

--- a/app/Tests/DetachAppTests/SessionNotificationServiceTests.swift
+++ b/app/Tests/DetachAppTests/SessionNotificationServiceTests.swift
@@ -475,6 +475,9 @@ final class SessionNotificationServiceTests: XCTestCase {
                 exitCode: 0, stdout: sessionLine(status: .running),
                 stderr: "", timedOut: true)),
             .success(CLIResult(
+                exitCode: 0, stdout: sessionLine(status: .failed),
+                stderr: "", timedOut: false, stdoutTruncated: true)),
+            .success(CLIResult(
                 exitCode: 0, stdout: sessionLine(status: .running),
                 stderr: "", timedOut: false)),
             .success(CLIResult(
@@ -484,7 +487,7 @@ final class SessionNotificationServiceTests: XCTestCase {
         let service = SessionNotificationService(center: center)
         await service.configure(enabled: true)
 
-        for _ in 0..<5 { await service.pollOnce(using: cli) }
+        for _ in 0..<6 { await service.pollOnce(using: cli) }
 
         XCTAssertEqual(center.delivered.count, 1)
         XCTAssertEqual(center.delivered.first?.title, "Session completed")

--- a/app/Tests/DetachAppTests/SessionNotificationServiceTests.swift
+++ b/app/Tests/DetachAppTests/SessionNotificationServiceTests.swift
@@ -389,6 +389,41 @@ final class SessionNotificationServiceTests: XCTestCase {
         XCTAssertEqual(center.delivered.count, 1)
     }
 
+    func testSessionSnapshotsAdvanceWhileNotificationDeliveryIsSuspended() async {
+        let center = SuspendedDeliveryNotificationCenter()
+        let service = SessionNotificationService(
+            center: center, identifierProvider: { "realtime" })
+        await service.configure(enabled: true)
+
+        service.observeFromSessionStore([
+            makeSession(status: .running, turnState: .working, turnID: "turn-1")
+        ])
+        service.observeFromSessionStore([
+            makeSession(status: .running, turnState: .waiting, turnID: "turn-1")
+        ])
+        await center.waitUntilDeliveryStarted()
+
+        // A reply and the next completed turn must reach the detector while
+        // Notification Center still owns the first suspended delivery.
+        service.observeFromSessionStore([
+            makeSession(status: .running, turnState: .working, turnID: "turn-2")
+        ])
+        service.observeFromSessionStore([
+            makeSession(status: .running, turnState: .waiting, turnID: "turn-2")
+        ])
+
+        center.resumeDelivery()
+        for _ in 0..<100 where center.attemptedIdentifiers.count < 2 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(center.attemptedIdentifiers, [
+            "detach.session.realtime",
+            "detach.session.realtime",
+        ])
+        center.resumeDelivery()
+    }
+
     func testDisablingDuringFailedDeliveryDoesNotPublishStaleErrorOrRetry() async {
         let failure = NSError(
             domain: "SessionNotificationServiceTests", code: 41,

--- a/app/Tests/DetachAppTests/TextSizeTests.swift
+++ b/app/Tests/DetachAppTests/TextSizeTests.swift
@@ -177,4 +177,28 @@ final class TextSizeTests: XCTestCase {
         let source = NSAttributedString(string: "log")
         XCTAssertTrue(LogTextView.resizedText(source, to: 0) === source)
     }
+
+    @MainActor
+    func testLogCanvasCanBePopulatedBeforeItsFirstPresentation() throws {
+        let source = NSAttributedString(
+            string: "cached output",
+            attributes: [.font: NSFont.monospacedSystemFont(
+                ofSize: 11, weight: .regular)])
+        let scrollView = LogTextView.makeScrollView()
+        let coordinator = LogTextView.Coordinator()
+
+        XCTAssertEqual(
+            scrollView.accessibilityIdentifier(),
+            "session-preview-log")
+
+        LogTextView.apply(
+            text: source,
+            pointSize: 14,
+            to: scrollView,
+            coordinator: coordinator)
+
+        let textView = try XCTUnwrap(scrollView.documentView as? NSTextView)
+        XCTAssertEqual(textView.string, "cached output")
+        XCTAssertTrue(coordinator.lastText === source)
+    }
 }

--- a/app/Tests/DetachAppTests/UIE2EConfigurationTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EConfigurationTests.swift
@@ -184,7 +184,7 @@ final class UIE2EConfigurationTests: XCTestCase {
             XCTAssertEqual(
                 defaults.string(forKey: "detachPath"),
                 fixture.cli.resolvingSymlinksInPath().path)
-            XCTAssertEqual(defaults.double(forKey: "pollInterval"), 0.5)
+            XCTAssertNil(defaults.object(forKey: "pollInterval"))
             XCTAssertFalse(defaults.bool(forKey: AppSettings.notificationsEnabledKey))
             XCTAssertFalse(defaults.bool(forKey: AppSettings.tipsEnabledKey))
             XCTAssertFalse(defaults.bool(forKey: AppSettings.menuBarIconEnabledKey))

--- a/app/Tests/DetachAppTests/WatchdogServiceTests.swift
+++ b/app/Tests/DetachAppTests/WatchdogServiceTests.swift
@@ -212,6 +212,32 @@ final class WatchdogServiceTests: XCTestCase {
             forKey: "powerWatchdogDefinitionReconcilePending"))
     }
 
+    func testEnabledRegistrationWaitsForItsLifetimeHolderBeforeRepair() async throws {
+        // Login starts the app and the watchdog together. A record whose lock
+        // is not yet held is only stale if it stays unheld after the grace.
+        let backend = FakeWatchdogBackend(
+            status: .enabled,
+            registrations: [])
+        var barrierStates: [WatchdogLifetimeBarrierStatus] = [.missing, .busy]
+        var delays: [UInt64] = []
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { barrierStates.removeFirst() },
+            legacyWatchdogIsRunning: { false },
+            sleep: { delays.append($0) })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-current", forKey: "powerWatchdogDefinitionDigest")
+
+        try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(delays, [WatchdogService.staleRegistrationGraceNanoseconds])
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertTrue(barrierStates.isEmpty)
+    }
+
     func testMatchingLegacyRegistrationWithLiveProcessNoOps() async throws {
         let backend = FakeWatchdogBackend(
             status: .enabled,

--- a/app/Tests/DetachAppTests/WatchdogServiceTests.swift
+++ b/app/Tests/DetachAppTests/WatchdogServiceTests.swift
@@ -10,6 +10,9 @@ final class WatchdogServiceTests: XCTestCase {
             WatchdogServiceError.bundledDefinitionMissing.errorDescription,
             "The bundled watchdog definition is missing or incomplete.")
         XCTAssertEqual(
+            WatchdogServiceError.releaseSignatureRequired.errorDescription,
+            "Only a signed Detach release can update the background monitor.")
+        XCTAssertEqual(
             WatchdogServiceError.registrationDidNotComplete.errorDescription,
             "macOS did not finish registering the watchdog.")
         XCTAssertEqual(
@@ -34,6 +37,39 @@ final class WatchdogServiceTests: XCTestCase {
 
         XCTAssertEqual(backend.registerCalls, 0)
         XCTAssertEqual(backend.unregisterCalls, 0)
+    }
+
+    func testAdHocBuildCannotMutateSharedWatchdogRegistration() async {
+        let backend = FakeWatchdogBackend(
+            status: .enabled,
+            registrations: [.success(.enabled)])
+        let fixture = makeFixture(
+            backend: backend,
+            serviceMutationAllowed: { false })
+        defer { fixture.cleanup() }
+
+        do {
+            try await fixture.service.reconcileAfterAppUpdate()
+            XCTFail("Expected release-signature admission failure")
+        } catch {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Only a signed Detach release can update the background monitor.")
+        }
+        do {
+            try await fixture.service.disable()
+            XCTFail("Expected release-signature admission failure")
+        } catch {
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Only a signed Detach release can update the background monitor.")
+        }
+
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertFalse(fixture.defaults.bool(
+            forKey: "powerWatchdogDefinitionReconcilePending"))
     }
 
     func testEnableFailsAfterBoundedUnconfirmedRegistrationRetries() async {
@@ -142,7 +178,9 @@ final class WatchdogServiceTests: XCTestCase {
         let backend = FakeWatchdogBackend(
             status: .enabled,
             registrations: [])
-        let fixture = makeFixture(backend: backend)
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { .busy })
         defer { fixture.cleanup() }
         fixture.defaults.set(
             "digest-current", forKey: "powerWatchdogDefinitionDigest")
@@ -151,6 +189,46 @@ final class WatchdogServiceTests: XCTestCase {
 
         XCTAssertEqual(backend.unregisterCalls, 0)
         XCTAssertEqual(backend.registerCalls, 0)
+    }
+
+    func testMatchingEnabledRegistrationWithoutLiveProcessReregisters() async throws {
+        let backend = FakeWatchdogBackend(
+            status: .enabled,
+            registrations: [.success(.enabled)])
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { .released },
+            legacyWatchdogIsRunning: { false })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-current", forKey: "powerWatchdogDefinitionDigest")
+
+        try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(backend.unregisterCalls, 1)
+        XCTAssertEqual(backend.registerCalls, 1)
+        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertFalse(fixture.defaults.bool(
+            forKey: "powerWatchdogDefinitionReconcilePending"))
+    }
+
+    func testMatchingLegacyRegistrationWithLiveProcessNoOps() async throws {
+        let backend = FakeWatchdogBackend(
+            status: .enabled,
+            registrations: [])
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { .missing },
+            legacyWatchdogIsRunning: { true })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-current", forKey: "powerWatchdogDefinitionDigest")
+
+        try await fixture.service.reconcileAfterAppUpdate()
+
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertNil(fixture.handoffStore.transaction)
     }
 
     func testChangedDefinitionRetriesTransientRegisterFailure() async throws {
@@ -592,6 +670,7 @@ final class WatchdogServiceTests: XCTestCase {
         lifetimeBarrierStatus: @escaping () throws
             -> WatchdogLifetimeBarrierStatus = { .released },
         legacyWatchdogIsRunning: @escaping () throws -> Bool = { false },
+        serviceMutationAllowed: @escaping () -> Bool = { true },
         digestProvider: @escaping () -> String? = { "digest-current" },
         sleep: @escaping (UInt64) async throws -> Void = { _ in }
     ) -> Fixture {
@@ -603,6 +682,7 @@ final class WatchdogServiceTests: XCTestCase {
             handoffStore: handoffStore,
             lifetimeBarrierStatus: lifetimeBarrierStatus,
             legacyWatchdogIsRunning: legacyWatchdogIsRunning,
+            serviceMutationAllowed: serviceMutationAllowed,
             digestProvider: digestProvider,
             sleep: sleep)
         return Fixture(
@@ -619,6 +699,7 @@ final class WatchdogServiceTests: XCTestCase {
         lifetimeBarrierStatus: @escaping () throws
             -> WatchdogLifetimeBarrierStatus = { .released },
         legacyWatchdogIsRunning: @escaping () throws -> Bool = { false },
+        serviceMutationAllowed: @escaping () -> Bool = { true },
         digestProvider: @escaping () -> String? = { "digest-current" },
         sleep: @escaping (UInt64) async throws -> Void = { _ in }
     ) -> WatchdogService {
@@ -629,6 +710,7 @@ final class WatchdogServiceTests: XCTestCase {
             digestProvider: digestProvider,
             lifetimeBarrierStatus: lifetimeBarrierStatus,
             legacyWatchdogIsRunning: legacyWatchdogIsRunning,
+            serviceMutationAllowed: serviceMutationAllowed,
             sleep: sleep)
     }
 

--- a/app/Tests/DetachKitTests/DetachCLITests.swift
+++ b/app/Tests/DetachKitTests/DetachCLITests.swift
@@ -70,6 +70,45 @@ final class DetachCLITests: XCTestCase {
         XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), helper.path)
     }
 
+    func testInheritedGUIEnvironmentRemovesDetachRuntimeOverrides() throws {
+        let environment = ProcessDetachCLI.runtimeEnvironment([
+            "HOME": "/private/tmp/detach-cli-home",
+            "PATH": "/usr/bin:/bin",
+            "DETACH_STATE_BIN": "/old/detach-state",
+            "DETACH_POWER_BIN": "/old/detach-power",
+            "DETACH_TMUX_BIN": "/old/tmux",
+            "DETACH_CODEX_BIN": "/old/codex",
+            "DETACH_STATE_ROOT": "/old/state",
+            "DETACH_UI_E2E_ROOT": "/private/tmp/detach-ui-e2e.fixture",
+            "UNRELATED_SETTING": "kept",
+        ], allowsDetachOverrides: false)
+
+        XCTAssertNil(environment["DETACH_STATE_BIN"])
+        XCTAssertNil(environment["DETACH_POWER_BIN"])
+        XCTAssertNil(environment["DETACH_TMUX_BIN"])
+        XCTAssertNil(environment["DETACH_CODEX_BIN"])
+        XCTAssertNil(environment["DETACH_STATE_ROOT"])
+        XCTAssertEqual(
+            environment["DETACH_UI_E2E_ROOT"],
+            "/private/tmp/detach-ui-e2e.fixture")
+        XCTAssertEqual(environment["UNRELATED_SETTING"], "kept")
+    }
+
+    func testExplicitEnvironmentPreservesDetachTestOverrides() async throws {
+        let cli = ProcessDetachCLI(
+            executable: try fixture(#"printf '%s' "$DETACH_STATE_BIN""#),
+            environment: [
+                "HOME": "/private/tmp/detach-cli-home",
+                "PATH": "/usr/bin:/bin",
+                "DETACH_STATE_BIN": "/fixture/detach-state",
+            ])
+
+        let result = try await cli.run(arguments: [], timeout: 5)
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stdout, "/fixture/detach-state")
+    }
+
     func testFindsProviderInstalledByNVMFromGUIEnvironment() async throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("detach-cli-nvm-home-\(UUID().uuidString)")
@@ -125,12 +164,12 @@ final class DetachCLITests: XCTestCase {
         printf '%s\n' "$!" >"$1"
         trap '' TERM
         while :; do sleep 1; done
-        """), terminationGrace: 0.2)
+        """), terminationGrace: 0.1)
         let start = Date()
         let result = try await cli.run(
-            arguments: [descendantPID.path], timeout: 3)
+            arguments: [descendantPID.path], timeout: 0.5)
         XCTAssertTrue(result.timedOut)
-        XCTAssertLessThan(Date().timeIntervalSince(start), 6)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 3)
         let pid = try XCTUnwrap(Int32(
             String(contentsOf: descendantPID, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines)))

--- a/app/Tests/DetachKitTests/DetachCLITests.swift
+++ b/app/Tests/DetachKitTests/DetachCLITests.swift
@@ -170,6 +170,52 @@ final class DetachCLITests: XCTestCase {
         } catch {}
     }
 
+    func testSessionEventStreamUsesWatchDecodesAndEndsWithConsumer() async throws {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-cli-watch-\(UUID().uuidString)")
+        let cli = ProcessDetachCLI(executable: try fixture("""
+        [ "$1" = watch ] && [ "$2" = --json ] || exit 9
+        printf '%s\n' "$$" >'\(pidFile.path)'
+        printf '%s\n' '{"schema":1,"event":"ready"}'
+        sleep 0.05
+        printf '%s\n' '{"schema":1,"event":"changed"}'
+        exec /bin/sleep 30
+        """))
+        let events = Task {
+            var iterator = cli.sessionEvents().makeAsyncIterator()
+            return (try await iterator.next(), try await iterator.next())
+        }
+        let (ready, changed) = try await events.value
+        XCTAssertEqual(ready, SessionEvent(event: .ready))
+        XCTAssertEqual(changed, SessionEvent(event: .changed))
+        let pid = try XCTUnwrap(Int32(
+            String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)))
+        defer { _ = Darwin.kill(pid, SIGKILL) }
+
+        XCTAssertTrue(waitForProcessExit(pid, timeout: 1))
+    }
+
+    func testSessionEventStreamRejectsInvalidOrFailedOutput() async throws {
+        let invalid = ProcessDetachCLI(executable: try fixture("printf 'not-json\\n'"))
+        var invalidIterator = invalid.sessionEvents().makeAsyncIterator()
+        do {
+            _ = try await invalidIterator.next()
+            XCTFail("expected invalid event failure")
+        } catch {
+            XCTAssertEqual(error as? DetachCLIStreamError, .invalidEvent)
+        }
+
+        let failed = ProcessDetachCLI(executable: try fixture("exit 7"))
+        var failedIterator = failed.sessionEvents().makeAsyncIterator()
+        do {
+            _ = try await failedIterator.next()
+            XCTFail("expected event process failure")
+        } catch {
+            XCTAssertEqual(error as? DetachCLIStreamError, .exited(7))
+        }
+    }
+
     private func processExists(_ pid: Int32) -> Bool {
         Darwin.kill(pid, 0) == 0 || errno == EPERM
     }

--- a/app/Tests/DetachKitTests/DetachCLITests.swift
+++ b/app/Tests/DetachKitTests/DetachCLITests.swift
@@ -21,6 +21,21 @@ final class DetachCLITests: XCTestCase {
         XCTAssertEqual(result.stdout, "list\n--json\n")
         XCTAssertEqual(result.stderr, "err\n")
         XCTAssertFalse(result.timedOut)
+        XCTAssertFalse(result.stdoutTruncated)
+        XCTAssertFalse(result.stderrTruncated)
+    }
+
+    func testReportsEachTruncatedStream() async throws {
+        let cli = ProcessDetachCLI(
+            executable: try fixture("printf 123456789; printf abcdefghi >&2"),
+            maximumOutputBytes: 5)
+
+        let result = try await cli.run(arguments: [], timeout: 5)
+
+        XCTAssertEqual(result.stdout, "12345")
+        XCTAssertEqual(result.stderr, "abcde")
+        XCTAssertTrue(result.stdoutTruncated)
+        XCTAssertTrue(result.stderrTruncated)
     }
 
     func testUsesAnExplicitWorkingDirectory() async throws {
@@ -193,6 +208,7 @@ final class DetachCLITests: XCTestCase {
         XCTAssertFalse(result.timedOut)
         XCTAssertEqual(result.exitCode, 0)
         XCTAssertEqual(result.stdout, "leader done\n")
+        XCTAssertTrue(result.stdoutTruncated)
         XCTAssertLessThan(Date().timeIntervalSince(start), 3)
         let pid = try XCTUnwrap(Int32(
             String(contentsOf: descendantPID, encoding: .utf8)

--- a/app/Tests/DetachKitTests/DetachCLITests.swift
+++ b/app/Tests/DetachKitTests/DetachCLITests.swift
@@ -67,6 +67,33 @@ final class DetachCLITests: XCTestCase {
         XCTAssertEqual(result.stdout.count, 512 * 1024)
     }
 
+    func testConcurrentRunsDoNotStarveOutputDrains() async throws {
+        let cli = ProcessDetachCLI(executable: try fixture("printf ready"))
+
+        let results = try await withThrowingTaskGroup(
+            of: CLIResult.self,
+            returning: [CLIResult].self
+        ) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    try await cli.run(arguments: [], timeout: 2)
+                }
+            }
+            var results: [CLIResult] = []
+            for try await result in group { results.append(result) }
+            return results
+        }
+
+        XCTAssertEqual(results.count, 8)
+        XCTAssertTrue(results.allSatisfy {
+            $0.exitCode == 0
+                && $0.stdout == "ready"
+                && !$0.timedOut
+                && !$0.stdoutTruncated
+                && !$0.stderrTruncated
+        })
+    }
+
     func testAddsCommonExecutablePathsToSparseGUIEnvironment() async throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("detach-cli-home-\(UUID().uuidString)")

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -298,7 +298,15 @@ final class DetachPowerCommandTests: XCTestCase {
         thermalWatcher: any PowerThermalStateWatching = FakeThermalWatcher(),
         thermalNow: @escaping @Sendable () -> Date = { Date() },
         thermalCooldown: TimeInterval = PowerThermalSafetyLatch.defaultCooldown,
-        activityWatcher: any PowerRunActivityWatching = FakeActivityWatcher()
+        activityWatcher: any PowerRunActivityWatching = FakeActivityWatcher(),
+        quickStatusReader: @escaping @Sendable () -> PowerHeartbeatSnapshot = {
+            PowerHeartbeatSnapshot(
+                statusURL: URL(fileURLWithPath: "/tmp/watchdog-status.json"),
+                state: "ok",
+                powerState: .protected,
+                checkedAt: Date(),
+                isFresh: true)
+        }
     ) -> (
         DetachPowerCommand,
         EventLog,
@@ -321,7 +329,8 @@ final class DetachPowerCommandTests: XCTestCase {
                 activityWatcher: activityWatcher,
                 thermalWatcher: thermalWatcher,
                 thermalNow: thermalNow,
-                thermalCooldown: thermalCooldown),
+                thermalCooldown: thermalCooldown,
+                quickStatusReader: quickStatusReader),
             events,
             assertion,
             helper,
@@ -360,6 +369,48 @@ final class DetachPowerCommandTests: XCTestCase {
         XCTAssertEqual(result.exitCode, 0)
         XCTAssertEqual(events.values, ["helper.status"])
         XCTAssertTrue(child.commands.isEmpty)
+    }
+
+    func testQuickStatusUsesFreshTypedHeartbeatWithoutHelperXPC() throws {
+        let (command, events, _, _, child, _) = fixture()
+
+        let result = try command.execute(arguments: [
+            "status", "--json", "--quick",
+        ])
+
+        guard case let .statusJSON(data) = result else {
+            return XCTFail("expected status JSON")
+        }
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object.count, 2)
+        XCTAssertEqual(object["schema"] as? Int, 1)
+        XCTAssertEqual(object["state"] as? String, "protected")
+        XCTAssertTrue(events.values.isEmpty)
+        XCTAssertTrue(child.commands.isEmpty)
+    }
+
+    func testQuickStatusFailsSafeForAnUnhealthyHeartbeat() throws {
+        let (command, events, _, _, _, _) = fixture(quickStatusReader: {
+            PowerHeartbeatSnapshot(
+                statusURL: URL(fileURLWithPath: "/tmp/watchdog-status.json"),
+                state: "status_failed",
+                powerState: .protected,
+                checkedAt: Date(),
+                isFresh: true)
+        })
+
+        let result = try command.execute(arguments: [
+            "status", "--json", "--quick",
+        ])
+
+        guard case let .statusJSON(data) = result else {
+            return XCTFail("expected status JSON")
+        }
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["state"] as? String, "unknown")
+        XCTAssertTrue(events.values.isEmpty)
     }
 
     func testResultAndErrorContractsHaveStableExitCodesAndDescriptions() {
@@ -1167,7 +1218,7 @@ final class DetachPowerCommandTests: XCTestCase {
 
     func testStatusHelperAndReleaseParserFailuresAreSpecific() {
         let cases: [([String], String)] = [
-            (["status"], "usage: detach-power status --json"),
+            (["status"], "usage: detach-power status --json [--quick]"),
             (["helper", "unknown"],
              "usage: detach-power helper prepare-unregistration|cancel-unregistration"),
             (["release", "--session"],

--- a/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachPowerCommandTests.swift
@@ -413,6 +413,25 @@ final class DetachPowerCommandTests: XCTestCase {
         XCTAssertTrue(events.values.isEmpty)
     }
 
+    func testDefaultQuickStatusReaderAlwaysReturnsTypedJSONWithoutHelperXPC() throws {
+        let events = EventLog()
+        let helper = FakeHelperClient(events: events)
+        let command = DetachPowerCommand(helperClient: helper)
+
+        let result = try command.execute(arguments: [
+            "status", "--json", "--quick",
+        ])
+
+        guard case let .statusJSON(data) = result else {
+            return XCTFail("expected status JSON")
+        }
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["schema"] as? Int, 1)
+        XCTAssertNotNil(object["state"] as? String)
+        XCTAssertTrue(events.values.isEmpty)
+    }
+
     func testResultAndErrorContractsHaveStableExitCodesAndDescriptions() {
         XCTAssertEqual(DetachPowerCommandResult.lifecycle.exitCode, 0)
         XCTAssertEqual(

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -952,6 +952,40 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(assessment.reason, .healthy)
     }
 
+    func testHealthEvaluateTreatsExactStopTransitionAsInterrupted() throws {
+        let arguments = [
+            "health", "evaluate",
+            "--metadata-valid", "true",
+            "--runtime-identity-expected", "true",
+            "--meta-status", "running",
+            "--tmux", "live",
+            "--run-token", "match",
+            "--worker", "alive",
+            "--provider-process", "dead",
+            "--heartbeat", "fresh",
+            "--checkpoint", "fresh",
+            "--checkpoint-recoverable", "true",
+            "--agent-session-known", "true",
+            "--stop-requested", "true",
+        ]
+        let output = try DetachStateCommand.run(arguments: arguments)
+        let assessment = try JSONDecoder().decode(
+            SessionHealthAssessment.self,
+            from: output)
+
+        XCTAssertEqual(assessment.effectiveStatus, .interrupted)
+        XCTAssertEqual(assessment.reason, .finished)
+        XCTAssertTrue(assessment.actions.isEmpty)
+        XCTAssertFalse(assessment.cleanupEligible)
+        var invalidArguments = arguments
+        invalidArguments[invalidArguments.count - 1] = "yes"
+        XCTAssertThrowsError(try DetachStateCommand.run(
+            arguments: invalidArguments
+        )) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidBoolean("yes"))
+        }
+    }
+
     func testHealthEvaluateCanInspectOnlyTheRecordedLiveProcess() throws {
         let pid = String(ProcessInfo.processInfo.processIdentifier)
         let output = try DetachStateCommand.run(arguments: [

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -48,6 +48,7 @@ final class DetachStateCommandTests: XCTestCase {
             "--agent-turn-id", "turn-1",
             "--session-color", "#1aB2c3",
             "--power-state", "protected",
+            "--lifecycle-id", "opaque-run-id",
         ])
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: output) as? [String: Any])
@@ -56,7 +57,7 @@ final class DetachStateCommandTests: XCTestCase {
             "schema", "provider", "session_name", "name", "display_name", "session_color",
             "effective_status", "meta_status", "agent_session_id", "project_dir",
             "created_at", "last_checkpoint_at", "exit_status", "finished_at",
-            "stop_requested_at", "model",
+            "stop_requested_at", "lifecycle_id", "model",
             "context_used_tokens", "context_window", "agent_turn_state", "agent_turn_id",
             "power_protection_state", "health_reason", "health_actions",
             "reconcile_action", "ownership_proven", "cleanup_eligible",
@@ -75,6 +76,7 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(object["agent_turn_state"] as? String, "waiting")
         XCTAssertEqual(object["power_protection_state"] as? String, "protected")
         XCTAssertEqual(object["session_color"] as? String, "#1aB2c3")
+        XCTAssertEqual(object["lifecycle_id"] as? String, "opaque-run-id")
     }
 
     func testEmitSessionEncodesAllAbsentOptionalFieldsAsNull() throws {
@@ -88,7 +90,7 @@ final class DetachStateCommandTests: XCTestCase {
         for key in [
             "display_name", "session_color", "meta_status", "agent_session_id", "project_dir",
             "created_at", "last_checkpoint_at", "exit_status", "finished_at",
-            "stop_requested_at", "model",
+            "stop_requested_at", "lifecycle_id", "model",
             "context_used_tokens", "context_window", "agent_turn_state", "agent_turn_id",
             "power_protection_state", "health_reason", "health_actions",
             "reconcile_action", "ownership_proven", "cleanup_eligible",
@@ -393,7 +395,7 @@ final class DetachStateCommandTests: XCTestCase {
         let values = output.split(separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        let recordSize = 20
+        let recordSize = 21
         XCTAssertEqual(values.count, recordSize * 3 + 2)
         XCTAssertEqual(values[0], "detach-claude-three")
         XCTAssertEqual(values[1], "true")
@@ -563,13 +565,42 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(values.count, 25 + 2)
+        XCTAssertEqual(values.count, 26 + 2)
         XCTAssertEqual(values[0], "detach-codex-summary")
         XCTAssertEqual(values[1], "true")
-        XCTAssertEqual(Array(values[20..<25]), [
+        XCTAssertEqual(Array(values[21..<26]), [
             "gpt-batched", "", "", "working", "turn-batched",
         ])
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
+
+        let receipt = session.appendingPathComponent(
+            ".transcript-summary-cache.json")
+        var receiptObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: receipt))
+                as? [String: Any])
+        receiptObject["model"] = "cached-proof"
+        try JSONSerialization.data(withJSONObject: receiptObject).write(to: receipt)
+        let cachedOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let cachedValues = cachedOutput.split(
+            separator: 0, omittingEmptySubsequences: false)
+            .dropLast()
+            .map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(cachedValues[21], "cached-proof")
+
+        try Data("""
+        {"payload":{"model":"gpt-updated"}}
+        {"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-updated-longer"}}
+        """.utf8).write(to: transcript)
+        let changedOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let changedValues = changedOutput.split(
+            separator: 0, omittingEmptySubsequences: false)
+            .dropLast()
+            .map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(changedValues[21], "gpt-updated")
 
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
             "meta", "snapshots", root.path, "--unknown",

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -55,7 +55,8 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(Set(object.keys), Set([
             "schema", "provider", "session_name", "name", "display_name", "session_color",
             "effective_status", "meta_status", "agent_session_id", "project_dir",
-            "created_at", "last_checkpoint_at", "exit_status", "finished_at", "model",
+            "created_at", "last_checkpoint_at", "exit_status", "finished_at",
+            "stop_requested_at", "model",
             "context_used_tokens", "context_window", "agent_turn_state", "agent_turn_id",
             "power_protection_state", "health_reason", "health_actions",
             "reconcile_action", "ownership_proven", "cleanup_eligible",
@@ -86,7 +87,8 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(object["name"] as? String, "legacy-name")
         for key in [
             "display_name", "session_color", "meta_status", "agent_session_id", "project_dir",
-            "created_at", "last_checkpoint_at", "exit_status", "finished_at", "model",
+            "created_at", "last_checkpoint_at", "exit_status", "finished_at",
+            "stop_requested_at", "model",
             "context_used_tokens", "context_window", "agent_turn_state", "agent_turn_id",
             "power_protection_state", "health_reason", "health_actions",
             "reconcile_action", "ownership_proven", "cleanup_eligible",
@@ -158,9 +160,11 @@ final class DetachStateCommandTests: XCTestCase {
             "--worker-pid", "-",
             "--provider-pid", "321",
             "--worker-heartbeat-at", "?",
+            "--stop-requested-at", "2026-09-02T10:00:00Z",
         ])
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: output) as? [String: Any])
+        XCTAssertEqual(object["stop_requested_at"] as? String, "2026-09-02T10:00:00Z")
 
         XCTAssertTrue(object["agent_turn_state"] is NSNull)
         XCTAssertTrue(object["session_color"] is NSNull)
@@ -389,7 +393,7 @@ final class DetachStateCommandTests: XCTestCase {
         let values = output.split(separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        let recordSize = 19
+        let recordSize = 20
         XCTAssertEqual(values.count, recordSize * 3 + 2)
         XCTAssertEqual(values[0], "detach-claude-three")
         XCTAssertEqual(values[1], "true")
@@ -559,10 +563,10 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(values.count, 24 + 2)
+        XCTAssertEqual(values.count, 25 + 2)
         XCTAssertEqual(values[0], "detach-codex-summary")
         XCTAssertEqual(values[1], "true")
-        XCTAssertEqual(Array(values[19..<24]), [
+        XCTAssertEqual(Array(values[20..<25]), [
             "gpt-batched", "", "", "working", "turn-batched",
         ])
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -609,6 +609,108 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testMetaSnapshotsContinueTurnStateAfterStartLeavesBoundedTail() throws {
+        let root = temporaryDirectory.appendingPathComponent(
+            "incremental-summary-sessions", isDirectory: true)
+        let session = root.appendingPathComponent(
+            "detach-codex-incremental", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: session, withIntermediateDirectories: true)
+        let transcript = temporaryDirectory.appendingPathComponent(
+            "incremental-summary-rollout.jsonl")
+        try Data("""
+        {"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-long"}}
+
+        """.utf8).write(to: transcript)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-codex-incremental",
+            "project_dir": "/tmp/project",
+            "status": "running",
+            "transcript_path": transcript.path,
+        ]).write(to: session.appendingPathComponent("meta.json"))
+
+        func turnFields() throws -> [String] {
+            let output = try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", root.path, "--with-transcript-summary",
+            ])
+            let values = output.split(
+                separator: 0, omittingEmptySubsequences: false)
+                .dropLast()
+                .map { String(decoding: $0, as: UTF8.self) }
+            return Array(values[24..<26])
+        }
+
+        XCTAssertEqual(try turnFields(), ["working", "turn-long"])
+        let irrelevant = Data(String(
+            repeating: "{\"type\":\"event_msg\",\"payload\":{\"type\":\"item_completed\",\"turn_id\":\"turn-long\"}}\n",
+            count: 2_200).utf8)
+        let handle = try FileHandle(forWritingTo: transcript)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: irrelevant)
+        XCTAssertEqual(try turnFields(), ["working", "turn-long"])
+        try handle.seekToEnd()
+        try handle.write(contentsOf: irrelevant)
+        XCTAssertGreaterThan(
+            try Data(contentsOf: transcript).count, 262_144)
+        XCTAssertEqual(try turnFields(), ["working", "turn-long"])
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("""
+        {"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-long"}}
+
+        """.utf8))
+        XCTAssertEqual(try turnFields(), ["waiting", "turn-long"])
+    }
+
+    func testMetaSnapshotsClearWaitingAfterOversizedUnobservedAppend() throws {
+        let root = temporaryDirectory.appendingPathComponent(
+            "gapped-summary-sessions", isDirectory: true)
+        let session = root.appendingPathComponent(
+            "detach-codex-gapped", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: session, withIntermediateDirectories: true)
+        let transcript = temporaryDirectory.appendingPathComponent(
+            "gapped-summary-rollout.jsonl")
+        try Data("""
+        {"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-old"}}
+
+        """.utf8).write(to: transcript)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-codex-gapped",
+            "project_dir": "/tmp/project",
+            "status": "running",
+            "transcript_path": transcript.path,
+        ]).write(to: session.appendingPathComponent("meta.json"))
+
+        func turnFields() throws -> [String] {
+            let output = try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", root.path, "--with-transcript-summary",
+            ])
+            let values = output.split(
+                separator: 0, omittingEmptySubsequences: false)
+                .dropLast()
+                .map { String(decoding: $0, as: UTF8.self) }
+            return Array(values[24..<26])
+        }
+
+        XCTAssertEqual(try turnFields(), ["waiting", "turn-old"])
+        let handle = try FileHandle(forWritingTo: transcript)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("""
+        {"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-new"}}
+
+        """.utf8))
+        let irrelevant = Data(String(
+            repeating: "{\"type\":\"event_msg\",\"payload\":{\"type\":\"item_completed\",\"turn_id\":\"turn-new\"}}\n",
+            count: 4_000).utf8)
+        try handle.write(contentsOf: irrelevant)
+
+        XCTAssertEqual(try turnFields(), ["", ""])
+    }
+
     func testMetaCreateWritesTypedObjectAndRefusesAnExistingFile() throws {
         let file = temporaryDirectory.appendingPathComponent("created-meta.json")
 

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -1299,6 +1299,7 @@ final class DetachStateCommandTests: XCTestCase {
             "--checkpoint-recoverable", "true",
             "--agent-session-known", "true",
             "--stop-requested", "true",
+            "--lifecycle-phase", "stopping",
         ]
         let output = try DetachStateCommand.run(arguments: arguments)
         let assessment = try JSONDecoder().decode(
@@ -1310,11 +1311,18 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertTrue(assessment.actions.isEmpty)
         XCTAssertFalse(assessment.cleanupEligible)
         var invalidArguments = arguments
-        invalidArguments[invalidArguments.count - 1] = "yes"
+        invalidArguments[invalidArguments.count - 3] = "yes"
         XCTAssertThrowsError(try DetachStateCommand.run(
             arguments: invalidArguments
         )) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidBoolean("yes"))
+        }
+        var invalidPhase = arguments
+        invalidPhase[invalidPhase.count - 1] = "unknown"
+        XCTAssertThrowsError(try DetachStateCommand.run(
+            arguments: invalidPhase
+        )) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
         }
     }
 

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 @testable import DetachKit
 
@@ -205,7 +206,10 @@ final class DetachStateCommandTests: XCTestCase {
             ["meta", "snapshot", "only-path"],
             ["meta", "snapshots"],
             ["health", "session", "--"],
+            ["health", "session", "no-separator"],
             ["health", "sessions"],
+            ["events", "publish"],
+            ["events", "publish", "/tmp/one", "/tmp/two"],
             ["meta", "usable", "only-path"],
             ["meta", "create"],
             ["meta", "patch"],
@@ -609,6 +613,39 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testMetaSnapshotsCanBatchAClaudeTranscriptSummary() throws {
+        let root = temporaryDirectory.appendingPathComponent(
+            "claude-summary-sessions", isDirectory: true)
+        let session = root.appendingPathComponent(
+            "detach-claude-summary", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: session, withIntermediateDirectories: true)
+        let transcript = temporaryDirectory.appendingPathComponent(
+            "claude-summary.jsonl")
+        try Data("""
+        {"type":"user","uuid":"turn-claude","message":{"role":"user","content":"go"}}
+        {"type":"assistant","message":{"model":"claude-test","usage":{"input_tokens":10}}}
+        """.utf8).write(to: transcript)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-claude-summary",
+            "project_dir": "/tmp/project",
+            "status": "running",
+            "transcript_path": transcript.path,
+        ]).write(to: session.appendingPathComponent("meta.json"))
+
+        let output = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let values = output.split(separator: 0, omittingEmptySubsequences: false)
+            .dropLast()
+            .map { String(decoding: $0, as: UTF8.self) }
+
+        XCTAssertEqual(Array(values[21..<26]), [
+            "claude-test", "10", "", "working", "turn-claude",
+        ])
+    }
+
     func testMetaSnapshotsContinueTurnStateAfterStartLeavesBoundedTail() throws {
         let root = temporaryDirectory.appendingPathComponent(
             "incremental-summary-sessions", isDirectory: true)
@@ -902,6 +939,13 @@ final class DetachStateCommandTests: XCTestCase {
         ])) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
         }
+        // The second failure comes from the exact-identity negative receipt,
+        // without reparsing the same transcript.
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+        }
 
         try Data(#"{"payload":{"id":"session-1"}}"#.utf8).write(
             to: transcript, options: .atomic)
@@ -926,6 +970,62 @@ final class DetachStateCommandTests: XCTestCase {
         ])) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
         }
+    }
+
+    func testCachedJSONLValidationRejectsUnsafeAndUnavailablePaths() throws {
+        let missing = temporaryDirectory
+            .appendingPathComponent("missing", isDirectory: true)
+            .appendingPathComponent("rollout.jsonl")
+        let directory = temporaryDirectory.appendingPathComponent(
+            "directory.jsonl", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let longName = String(repeating: "a", count: Int(NAME_MAX) + 1)
+
+        for (path, expected) in [
+            ("relative/rollout.jsonl", DetachStateCommandError.invalidArguments),
+            (temporaryDirectory.path + "/" + longName,
+             DetachStateCommandError.invalidArguments),
+            (missing.path, DetachStateCommandError.invalidTranscript),
+            (directory.path, DetachStateCommandError.invalidTranscript),
+        ] {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "jsonl", "validate-cached", "codex", path, "session-1",
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, expected)
+            }
+        }
+    }
+
+    func testCachedJSONLValidationStillSucceedsWhenReceiptCannotBeCreated() throws {
+        let checkpoint = temporaryDirectory.appendingPathComponent(
+            "read-only-checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(at: checkpoint, withIntermediateDirectories: true)
+        let transcript = checkpoint.appendingPathComponent("rollout.jsonl")
+        try Data(#"{"payload":{"id":"session-1"}}"#.utf8).write(to: transcript)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o500], ofItemAtPath: checkpoint.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: checkpoint.path)
+        }
+
+        XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+        ]))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: checkpoint
+            .appendingPathComponent(".detach-jsonl-validation.json").path))
+    }
+
+    func testReadOnlyCommandsHandleEOFOnTheRealStandardInput() throws {
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "get", "-", "state",
+        ]))
+        let summary = try DetachStateCommand.run(arguments: [
+            "jsonl", "summary", "codex", "-",
+        ])
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: summary) as? [String: Any])
+        XCTAssertTrue(object.values.allSatisfy { $0 is NSNull })
     }
 
     func testJSONLSummaryUsesStableSnakeCaseJSON() throws {
@@ -1137,11 +1237,16 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: incomplete)) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
         }
+        let unrequestedPID = Array(incomplete.dropLast(4)) + [
+            "--worker-pid", "2",
+        ]
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: unrequestedPID)) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
     }
 
     func testHealthSessionEmitsTypedPublicJSONAndHidesCollisionIdentity() throws {
-        let output = try DetachStateCommand.run(arguments: [
-            "health", "session",
+        let evidence = [
             "--metadata-valid", "true",
             "--runtime-identity-expected", "true",
             "--meta-status", "running",
@@ -1153,6 +1258,15 @@ final class DetachStateCommandTests: XCTestCase {
             "--checkpoint", "missing",
             "--checkpoint-recoverable", "false",
             "--agent-session-known", "true",
+        ]
+        XCTAssertThrowsError(try DetachStateCommand.run(
+            arguments: ["health", "session"] + evidence + ["--", "codex"]
+        )) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+        let output = try DetachStateCommand.run(arguments: [
+            "health", "session",
+        ] + evidence + [
             "--", "codex", "detach-codex-session",
             "--project-dir", "/tmp/project",
             "--session-color", "#123456",

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -2,6 +2,16 @@ import Darwin
 import XCTest
 @testable import DetachKit
 
+@_silgen_name("flock")
+private func testMetadataFileLock(_ descriptor: Int32, _ operation: Int32) -> Int32
+
+private actor MetadataPatchCompletionProbe {
+    private var completed = false
+
+    func markCompleted() { completed = true }
+    func isCompleted() -> Bool { completed }
+}
+
 final class DetachStateCommandTests: XCTestCase {
     private var temporaryDirectory: URL!
 
@@ -399,7 +409,7 @@ final class DetachStateCommandTests: XCTestCase {
         let values = output.split(separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        let recordSize = 21
+        let recordSize = 22
         XCTAssertEqual(values.count, recordSize * 3 + 2)
         XCTAssertEqual(values[0], "detach-claude-three")
         XCTAssertEqual(values[1], "true")
@@ -569,10 +579,10 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(values.count, 26 + 2)
+        XCTAssertEqual(values.count, 27 + 2)
         XCTAssertEqual(values[0], "detach-codex-summary")
         XCTAssertEqual(values[1], "true")
-        XCTAssertEqual(Array(values[21..<26]), [
+        XCTAssertEqual(Array(values[22..<27]), [
             "gpt-batched", "", "", "working", "turn-batched",
         ])
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
@@ -591,7 +601,7 @@ final class DetachStateCommandTests: XCTestCase {
             separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        XCTAssertEqual(cachedValues[21], "cached-proof")
+        XCTAssertEqual(cachedValues[22], "cached-proof")
 
         try Data("""
         {"payload":{"model":"gpt-updated"}}
@@ -604,7 +614,7 @@ final class DetachStateCommandTests: XCTestCase {
             separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        XCTAssertEqual(changedValues[21], "gpt-updated")
+        XCTAssertEqual(changedValues[22], "gpt-updated")
 
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
             "meta", "snapshots", root.path, "--unknown",
@@ -641,7 +651,7 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(Array(values[21..<26]), [
+        XCTAssertEqual(Array(values[22..<27]), [
             "claude-test", "10", "", "working", "turn-claude",
         ])
     }
@@ -675,7 +685,7 @@ final class DetachStateCommandTests: XCTestCase {
                 separator: 0, omittingEmptySubsequences: false)
                 .dropLast()
                 .map { String(decoding: $0, as: UTF8.self) }
-            return Array(values[24..<26])
+            return Array(values[25..<27])
         }
 
         XCTAssertEqual(try turnFields(), ["working", "turn-long"])
@@ -729,7 +739,7 @@ final class DetachStateCommandTests: XCTestCase {
                 separator: 0, omittingEmptySubsequences: false)
                 .dropLast()
                 .map { String(decoding: $0, as: UTF8.self) }
-            return Array(values[24..<26])
+            return Array(values[25..<27])
         }
 
         XCTAssertEqual(try turnFields(), ["waiting", "turn-old"])
@@ -815,6 +825,126 @@ final class DetachStateCommandTests: XCTestCase {
             "--string", "status", "failed",
         ]))
         XCTAssertEqual(try Data(contentsOf: file), afterValidPatch)
+    }
+
+    func testConcurrentMetaPatchesPreserveEveryDisjointUpdate() async throws {
+        let file = temporaryDirectory.appendingPathComponent("concurrent-meta.json")
+        try Data(#"{"schema":1,"session_name":"s","project_dir":"/tmp/p","run_token":"current"}"#.utf8)
+            .write(to: file)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for index in 0..<64 {
+                group.addTask {
+                    _ = try DetachStateCommand.run(arguments: [
+                        "meta", "patch", file.path,
+                        "--run-token", "current",
+                        "--integer", "concurrent_\(index)", "\(index)",
+                    ])
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: file)) as? [String: Any])
+        for index in 0..<64 {
+            XCTAssertEqual(object["concurrent_\(index)"] as? Int, index)
+        }
+    }
+
+    func testMetaPatchWaitsForTheCommonInterprocessLock() async throws {
+        let file = temporaryDirectory.appendingPathComponent("blocked-meta.json")
+        let lock = temporaryDirectory.appendingPathComponent(".meta-patch.lock")
+        try Data(#"{"schema":1,"session_name":"s","project_dir":"/tmp/p","run_token":"current"}"#.utf8)
+            .write(to: file)
+        let descriptor = open(
+            lock.path,
+            O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+            S_IRUSR | S_IWUSR)
+        XCTAssertGreaterThanOrEqual(descriptor, 0)
+        defer { if descriptor >= 0 { close(descriptor) } }
+        XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_EX), 0)
+
+        let completion = MetadataPatchCompletionProbe()
+        let patch = Task.detached {
+            _ = try DetachStateCommand.run(arguments: [
+                "meta", "patch", file.path,
+                "--run-token", "current",
+                "--string", "status", "running",
+            ])
+            await completion.markCompleted()
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let completedWhileLocked = await completion.isCompleted()
+        XCTAssertFalse(completedWhileLocked)
+
+        XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_UN), 0)
+        try await patch.value
+        let completedAfterUnlock = await completion.isCompleted()
+        XCTAssertTrue(completedAfterUnlock)
+    }
+
+    func testMetaPatchEnforcesTheRuntimeLifecycleGraph() throws {
+        let file = temporaryDirectory.appendingPathComponent("lifecycle-meta.json")
+        try Data(#"{"schema":1,"session_name":"s","project_dir":"/tmp/p","run_token":"current","status":"starting","lifecycle_phase":"initializing"}"#.utf8)
+            .write(to: file)
+
+        for phase in ["starting", "running", "finalizing", "terminal"] {
+            _ = try DetachStateCommand.run(arguments: [
+                "meta", "patch", file.path,
+                "--run-token", "current",
+                "--string", "lifecycle_phase", phase,
+            ])
+        }
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "patch", file.path,
+            "--run-token", "current",
+            "--string", "lifecycle_phase", "running",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecycleTransition)
+        }
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "patch", file.path,
+            "--run-token", "current",
+            "--string", "lifecycle_phase", "almost_done",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecyclePhase)
+        }
+    }
+
+    func testStopIntentWinsARaceWithWorkerTerminalOutcome() throws {
+        let file = temporaryDirectory.appendingPathComponent("stop-race-meta.json")
+        try Data(#"{"schema":1,"session_name":"s","project_dir":"/tmp/p","run_token":"current","status":"running","lifecycle_phase":"running"}"#.utf8)
+            .write(to: file)
+
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "patch", file.path,
+            "--run-token", "current",
+            "--string", "stop_requested_at", "2026-09-03T09:00:00Z",
+            "--string", "lifecycle_phase", "stopping",
+            "--string", "status", "stopped",
+        ])
+        let stopped = try Data(contentsOf: file)
+
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "patch", file.path,
+            "--run-token", "current",
+            "--string", "lifecycle_phase", "terminal",
+            "--string", "status", "completed",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecycleTransition)
+        }
+        XCTAssertEqual(try Data(contentsOf: file), stopped)
+
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "patch", file.path,
+            "--run-token", "current",
+            "--string", "lifecycle_phase", "terminal",
+            "--string", "status", "stopped",
+        ])
+        XCTAssertEqual(
+            try DetachStateCommand.run(arguments: ["meta", "get", file.path, "status"]),
+            Data("stopped\n".utf8))
     }
 
     func testMetadataMutationParserRejectsInvalidTypedChanges() throws {
@@ -1154,7 +1284,7 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(assessment.reason, .healthy)
     }
 
-    func testHealthEvaluateTreatsExactStopTransitionAsInterrupted() throws {
+    func testHealthEvaluateKeepsExactStopTransitionStopped() throws {
         let arguments = [
             "health", "evaluate",
             "--metadata-valid", "true",
@@ -1175,7 +1305,7 @@ final class DetachStateCommandTests: XCTestCase {
             SessionHealthAssessment.self,
             from: output)
 
-        XCTAssertEqual(assessment.effectiveStatus, .interrupted)
+        XCTAssertEqual(assessment.effectiveStatus, .stopped)
         XCTAssertEqual(assessment.reason, .finished)
         XCTAssertTrue(assessment.actions.isEmpty)
         XCTAssertFalse(assessment.cleanupEligible)

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -205,6 +205,7 @@ final class DetachStateCommandTests: XCTestCase {
             ["meta", "patch"],
             ["meta", "matches", "only-path"],
             ["jsonl", "first", "only-path"],
+            ["jsonl", "validate-cached", "codex", "only-path"],
         ] {
             XCTAssertThrowsError(try DetachStateCommand.run(arguments: arguments)) { error in
                 XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
@@ -529,6 +530,50 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testMetaSnapshotsCanBatchBoundedTranscriptSummaries() throws {
+        let root = temporaryDirectory.appendingPathComponent(
+            "summary-sessions", isDirectory: true)
+        let session = root.appendingPathComponent(
+            "detach-codex-summary", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: session, withIntermediateDirectories: true)
+        let transcript = temporaryDirectory.appendingPathComponent(
+            "summary-rollout.jsonl")
+        try Data("""
+        {"payload":{"model":"gpt-batched"}}
+        {"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-batched"}}
+        """.utf8).write(to: transcript)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-codex-summary",
+            "project_dir": "/tmp/project",
+            "status": "running",
+            "transcript_path": transcript.path,
+        ]).write(to: session.appendingPathComponent("meta.json"))
+
+        let output = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let values = output.split(
+            separator: 0, omittingEmptySubsequences: false)
+            .dropLast()
+            .map { String(decoding: $0, as: UTF8.self) }
+
+        XCTAssertEqual(values.count, 24 + 2)
+        XCTAssertEqual(values[0], "detach-codex-summary")
+        XCTAssertEqual(values[1], "true")
+        XCTAssertEqual(Array(values[19..<24]), [
+            "gpt-batched", "", "", "working", "turn-batched",
+        ])
+        XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
+
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--unknown",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+    }
+
     func testMetaCreateWritesTypedObjectAndRefusesAnExistingFile() throws {
         let file = temporaryDirectory.appendingPathComponent("created-meta.json")
 
@@ -695,6 +740,57 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testCachedJSONLValidationFollowsTheExactFileIdentity() throws {
+        let checkpoint = temporaryDirectory.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: checkpoint, withIntermediateDirectories: true)
+        let transcript = checkpoint.appendingPathComponent("rollout.jsonl")
+        try Data(#"{"payload":{"id":"session-1"}}"#.utf8).write(to: transcript)
+
+        XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+        ]))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: checkpoint
+            .appendingPathComponent(".detach-jsonl-validation.json").path))
+        XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex",
+            checkpoint.path + "//rollout.jsonl", "session-1",
+        ]))
+
+        try Data(#"{"payload":{"id":"session-2"}}"#.utf8).write(
+            to: transcript, options: .atomic)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+        }
+
+        try Data(#"{"payload":{"id":"session-1"}}"#.utf8).write(
+            to: transcript, options: .atomic)
+        XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+        ]))
+    }
+
+    func testCachedJSONLValidationRejectsTranscriptSymlinks() throws {
+        let checkpoint = temporaryDirectory.appendingPathComponent(
+            "symlink-checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: checkpoint, withIntermediateDirectories: true)
+        let target = checkpoint.appendingPathComponent("target.jsonl")
+        let transcript = checkpoint.appendingPathComponent("rollout.jsonl")
+        try Data(#"{"payload":{"id":"session-1"}}"#.utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: transcript, withDestinationURL: target)
+
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+        }
+    }
+
     func testJSONLSummaryUsesStableSnakeCaseJSON() throws {
         let file = temporaryDirectory.appendingPathComponent("rollout.jsonl")
         try Data("""
@@ -819,6 +915,57 @@ final class DetachStateCommandTests: XCTestCase {
             from: output[output.index(after: newline)...])
         XCTAssertEqual(assessment.effectiveStatus, .running)
         XCTAssertEqual(assessment.reason, .healthy)
+    }
+
+    func testHealthEvaluateCanInspectOnlyTheRecordedLiveProcess() throws {
+        let pid = String(ProcessInfo.processInfo.processIdentifier)
+        let output = try DetachStateCommand.run(arguments: [
+            "health", "evaluate",
+            "--metadata-valid", "true",
+            "--runtime-identity-expected", "true",
+            "--meta-status", "running",
+            "--tmux", "live",
+            "--run-token", "match",
+            "--worker", "unknown",
+            "--provider-process", "unknown",
+            "--heartbeat", "fresh",
+            "--checkpoint", "fresh",
+            "--checkpoint-recoverable", "true",
+            "--agent-session-known", "true",
+            "--inspect-processes", "true",
+            "--worker-pid", pid,
+            "--provider-pid", pid,
+            "--pane-pid", pid,
+        ])
+        let assessment = try JSONDecoder().decode(
+            SessionHealthAssessment.self,
+            from: output)
+
+        XCTAssertEqual(assessment.effectiveStatus, .running)
+        XCTAssertEqual(assessment.reason, .healthy)
+    }
+
+    func testHealthEvaluateRequiresACompleteProcessInspectionRecord() {
+        let incomplete = [
+            "health", "evaluate",
+            "--metadata-valid", "true",
+            "--runtime-identity-expected", "true",
+            "--meta-status", "running",
+            "--tmux", "live",
+            "--run-token", "match",
+            "--worker", "unknown",
+            "--provider-process", "unknown",
+            "--heartbeat", "fresh",
+            "--checkpoint", "fresh",
+            "--checkpoint-recoverable", "true",
+            "--agent-session-known", "true",
+            "--inspect-processes", "true",
+            "--worker-pid", "2",
+        ]
+
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: incomplete)) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
     }
 
     func testHealthSessionEmitsTypedPublicJSONAndHidesCollisionIdentity() throws {

--- a/app/Tests/DetachKitTests/DetachStateTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateTests.swift
@@ -286,7 +286,10 @@ final class DetachStateTests: XCTestCase {
         let root = Data(#"{"payload":{"id":"session-1"}}"#.utf8)
         let event = Data(#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#.utf8)
         var chunkIndex = 0
-        let eventCount = 100_000
+        // Twenty thousand independently supplied records are large enough to
+        // distinguish streaming from a one-shot parser without dominating the
+        // full coverage run on every change.
+        let eventCount = 20_000
 
         let valid = try TranscriptDocument.isValid(
             provider: .codex,

--- a/app/Tests/DetachKitTests/DetachStateTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateTests.swift
@@ -39,6 +39,54 @@ final class DetachStateTests: XCTestCase {
         XCTAssertNil(try SessionMetadataDocument.scalar(in: data, paths: ["nothing"]))
     }
 
+    func testMetadataCreateAcceptsNullAndRejectsUnknownLifecyclePhase() throws {
+        let legacy = try SessionMetadataDocument.create(changes: [
+            .init(key: "lifecycle_phase", value: .null),
+        ])
+        XCTAssertNil(try SessionMetadataDocument.scalar(
+            in: legacy, paths: ["lifecycle_phase"]))
+
+        XCTAssertThrowsError(try SessionMetadataDocument.create(changes: [
+            .init(key: "lifecycle_phase", value: .string("unknown")),
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecyclePhase)
+        }
+    }
+
+    func testLifecycleValidationRejectsInvalidCurrentPhaseAndStopInvariants() throws {
+        let invalidCurrent = Data(#"{"status":"running","lifecycle_phase":"unknown"}"#.utf8)
+        XCTAssertThrowsError(try SessionMetadataDocument.patch(
+            invalidCurrent,
+            changes: [.init(key: "lifecycle_phase", value: .string("terminal"))]
+        )) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecyclePhase)
+        }
+
+        let legacyRunning = Data(#"{"status":"running"}"#.utf8)
+        XCTAssertNoThrow(try SessionMetadataDocument.patch(
+            legacyRunning,
+            changes: [
+                .init(key: "stop_requested_at", value: .string("now")),
+                .init(key: "status", value: .string("stopped")),
+                .init(key: "lifecycle_phase", value: .string("stopping")),
+            ]))
+        XCTAssertThrowsError(try SessionMetadataDocument.patch(
+            legacyRunning,
+            changes: [.init(key: "lifecycle_phase", value: .string("stopping"))]
+        )) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecycleTransition)
+        }
+        XCTAssertThrowsError(try SessionMetadataDocument.patch(
+            legacyRunning,
+            changes: [
+                .init(key: "stop_requested_at", value: .string("now")),
+                .init(key: "lifecycle_phase", value: .string("finalizing")),
+            ]
+        )) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidLifecycleTransition)
+        }
+    }
+
     func testMetadataOperationsDistinguishMalformedJSONFromNonObjectJSON() {
         XCTAssertThrowsError(try SessionMetadataDocument.scalar(
             in: Data("not-json".utf8), paths: ["value"]

--- a/app/Tests/DetachKitTests/LogPollerTests.swift
+++ b/app/Tests/DetachKitTests/LogPollerTests.swift
@@ -248,6 +248,104 @@ final class LogPollerTests: XCTestCase {
         await newCLI.releaseAll()
     }
 
+    func testFailedLogReadIsNotRepeatedForTheSameTypedRevision() async {
+        let session = makeSession(name: "missing", status: "completed")
+        let cli = ConcurrentLogCLI(responses: [
+            "codex logs --ansi missing": CLIResult(
+                exitCode: 1, stdout: "", stderr: "no logs found", timedOut: false),
+        ])
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([session])
+        await cache.prefetch([session])
+        let repeatedCallCount = await cli.recordedCalls().count
+        XCTAssertEqual(repeatedCallCount, 1)
+        XCTAssertFalse(cache.poller(for: session).hasLoaded)
+
+        let changed = makeSession(
+            name: "missing", status: "completed",
+            checkpoint: "2026-09-01T10:01:00Z")
+        await cache.prefetch([changed])
+        let changedCallCount = await cli.recordedCalls().count
+        XCTAssertEqual(changedCallCount, 2)
+    }
+
+    func testCancelledWarmUpLeavesUnstartedReadsEligible() async {
+        let cli = SuspendedLogCLI()
+        let cache = SessionLogSnapshotCache(cli: cli, configurationID: "/tmp/detach")
+        let sessions = (0..<SessionLogSnapshotCache.capacity).map {
+            makeSession(name: "cold-\($0)", status: "completed")
+        }
+
+        let warmUp = Task { await cache.prefetch(sessions) }
+        await waitUntil {
+            await cli.callCount() == SessionLogSnapshotCache.maximumConcurrentPrefetches
+        }
+        warmUp.cancel()
+        await cli.releaseAll()
+        await warmUp.value
+
+        // Only the reads that started are recorded. The rest still need a
+        // read and must not be skipped as if they had been attempted. The CLI
+        // suspends every read, so release each bounded batch as it starts.
+        let second = Task { await cache.prefetch(sessions) }
+        var released = SessionLogSnapshotCache.maximumConcurrentPrefetches
+        while released < sessions.count {
+            let target = min(
+                released + SessionLogSnapshotCache.maximumConcurrentPrefetches,
+                sessions.count)
+            await waitUntil { await cli.callCount() == target }
+            await cli.releaseAll()
+            released = target
+        }
+        await second.value
+        let total = await cli.callCount()
+        XCTAssertEqual(total, sessions.count)
+    }
+
+    func testDirectlyLoadedTailIsInvalidatedByAReplacementRun() async {
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(cli: cli, configurationID: "/tmp/detach")
+        let original = makeSession(
+            name: "reused", status: "completed", created: "2026-09-01T10:00:00Z")
+        let direct = cache.poller(for: original)
+        await direct.fetchOnce()
+        XCTAssertTrue(direct.hasLoaded)
+
+        // The detail view loaded this tail itself. A new run under the same
+        // explicit name must not show it.
+        let replacement = makeSession(
+            name: "reused", status: "completed", created: "2026-09-02T10:00:00Z")
+        await cache.prefetch([replacement])
+
+        XCTAssertFalse(direct === cache.poller(for: replacement))
+        let calls = await cli.recordedCalls().count
+        XCTAssertEqual(calls, 2)
+    }
+
+    func testPrefetchFillsFreeSlotsAndNeverEvictsASelectedEntry() async {
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+        let selected = makeSession(name: "selected", status: "completed")
+        let selectedPoller = cache.poller(for: selected)
+        await selectedPoller.fetchOnce()
+        let others = (0..<(SessionLogSnapshotCache.capacity + 4)).map {
+            makeSession(name: "other-\($0)", status: "completed")
+        }
+
+        // One direct read for the selection plus one read per free slot.
+        await cache.prefetch(others + [selected])
+        XCTAssertTrue(selectedPoller === cache.poller(for: selected))
+        let firstCallCount = await cli.recordedCalls().count
+        XCTAssertEqual(firstCallCount, SessionLogSnapshotCache.capacity)
+
+        await cache.prefetch(others + [selected])
+        let secondCallCount = await cli.recordedCalls().count
+        XCTAssertEqual(secondCallCount, SessionLogSnapshotCache.capacity)
+    }
+
     func testSnapshotCacheEvictsTheLeastRecentEntry() {
         let cache = SessionLogSnapshotCache(
             cli: FakeCLI(), configurationID: "/tmp/detach")
@@ -265,13 +363,15 @@ final class LogPollerTests: XCTestCase {
     private func makeSession(
         name: String,
         status: String,
-        checkpoint: String? = nil
+        checkpoint: String? = nil,
+        created: String? = nil
     ) -> Session {
         let checkpointField = checkpoint.map {
             ",\"last_checkpoint_at\":\"\($0)\""
         } ?? ""
+        let createdField = created.map { ",\"created_at\":\"\($0)\"" } ?? ""
         return SessionListParser.parse("""
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status)"\(checkpointField)}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status)"\(checkpointField)\(createdField)}
         """).sessions[0]
     }
 

--- a/app/Tests/DetachKitTests/LogPollerTests.swift
+++ b/app/Tests/DetachKitTests/LogPollerTests.swift
@@ -1,6 +1,50 @@
 import XCTest
 @testable import DetachKit
 
+private actor ConcurrentLogCLI: DetachCLIRunning {
+    private let responses: [String: CLIResult]
+    private var calls: [[String]] = []
+    private var activeCalls = 0
+    private var peakActiveCalls = 0
+
+    init(responses: [String: CLIResult] = [:]) {
+        self.responses = responses
+    }
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        calls.append(arguments)
+        activeCalls += 1
+        peakActiveCalls = max(peakActiveCalls, activeCalls)
+        try await Task.sleep(nanoseconds: 20_000_000)
+        activeCalls -= 1
+        return responses[arguments.joined(separator: " ")]
+            ?? CLIResult(exitCode: 0, stdout: "warm", stderr: "", timedOut: false)
+    }
+
+    func recordedCalls() -> [[String]] { calls }
+    func peakConcurrency() -> Int { peakActiveCalls }
+}
+
+private actor SuspendedLogCLI: DetachCLIRunning {
+    private var calls = 0
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        calls += 1
+        await withCheckedContinuation { continuations.append($0) }
+        return CLIResult(
+            exitCode: 0, stdout: "warm", stderr: "", timedOut: false)
+    }
+
+    func callCount() -> Int { calls }
+
+    func releaseAll() {
+        let pending = continuations
+        continuations = []
+        for continuation in pending { continuation.resume() }
+    }
+}
+
 @MainActor
 final class LogPollerTests: XCTestCase {
     func testFetchTrimsToTailLimit() async {
@@ -14,6 +58,7 @@ final class LogPollerTests: XCTestCase {
         XCTAssertEqual(poller.lines.first, "line 201")
         XCTAssertEqual(poller.lines.last, "line 700")
         XCTAssertNil(poller.errorText)
+        XCTAssertTrue(poller.hasLoaded)
     }
 
     func testFetchFailureSetsError() async {
@@ -57,5 +102,187 @@ final class LogPollerTests: XCTestCase {
         await poller.fetchOnce()
 
         XCTAssertFalse(poller.errorText?.isEmpty ?? true)
+        XCTAssertFalse(poller.hasLoaded)
+    }
+
+    func testSnapshotCacheReturnsTheReadyPollerImmediately() async {
+        let cli = FakeCLI()
+        let session = makeSession(name: "cached", status: "completed")
+        cli.responses["codex logs --ansi cached"] = .success(CLIResult(
+            exitCode: 0,
+            stdout: "ready output",
+            stderr: "",
+            timedOut: false))
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        let first = cache.poller(for: session)
+        await first.fetchOnce()
+        let second = cache.poller(for: session)
+
+        XCTAssertTrue(first === second)
+        XCTAssertEqual(second.attributed.string, "ready output")
+    }
+
+    func testSnapshotPrefetchIncludesRecoverableAndSkipsLiveSessions() async {
+        let first = makeSession(name: "first", status: "completed")
+        let live = makeSession(name: "live", status: "running")
+        let recoverable = makeSession(name: "recoverable", status: "recoverable")
+        let cli = ConcurrentLogCLI(responses: [
+            "codex logs --ansi first": CLIResult(
+                exitCode: 0, stdout: "one", stderr: "", timedOut: false),
+            "codex logs --ansi recoverable": CLIResult(
+                exitCode: 0, stdout: "two", stderr: "", timedOut: false),
+        ])
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([first, live, recoverable])
+        await cache.prefetch([first, live, recoverable])
+
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(Set(calls), Set([
+            ["codex", "logs", "--ansi", "first"],
+            ["codex", "logs", "--ansi", "recoverable"],
+        ]))
+        XCTAssertTrue(cache.poller(for: first).hasLoaded)
+        XCTAssertTrue(cache.poller(for: recoverable).hasLoaded)
+        XCTAssertFalse(cache.poller(for: live).hasLoaded)
+    }
+
+    func testConfigureWarmsNonLiveSessionsAlreadyPresentAtStartup() async {
+        let finished = makeSession(name: "startup", status: "completed")
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        cache.configure(
+            cli: cli,
+            configurationID: "/tmp/detach",
+            sessions: [finished])
+        await waitUntil { cache.poller(for: finished).hasLoaded }
+
+        XCTAssertTrue(cache.poller(for: finished).hasLoaded)
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls, [[
+            "codex", "logs", "--ansi", "startup",
+        ]])
+    }
+
+    func testSnapshotCacheInvalidatesOnlyWhenTypedRevisionChanges() async {
+        let initial = makeSession(
+            name: "finished", status: "completed",
+            checkpoint: "2026-09-01T10:00:00Z")
+        let changed = makeSession(
+            name: "finished", status: "completed",
+            checkpoint: "2026-09-01T10:01:00Z")
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([initial])
+        let firstPoller = cache.poller(for: initial)
+        await cache.prefetch([initial])
+        XCTAssertTrue(firstPoller === cache.poller(for: initial))
+        let unchangedCallCount = await cli.recordedCalls().count
+        XCTAssertEqual(unchangedCallCount, 1)
+
+        await cache.prefetch([changed])
+        XCTAssertFalse(firstPoller === cache.poller(for: changed))
+        let changedCallCount = await cli.recordedCalls().count
+        XCTAssertEqual(changedCallCount, 2)
+    }
+
+    func testSnapshotCacheDropsPassiveTailWhileSessionIsLive() async {
+        let finished = makeSession(name: "again", status: "completed")
+        let live = makeSession(name: "again", status: "running")
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([finished])
+        let passivePoller = cache.poller(for: finished)
+        await cache.prefetch([live])
+
+        XCTAssertFalse(passivePoller === cache.poller(for: finished))
+        let callCount = await cli.recordedCalls().count
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testSnapshotPrefetchBoundsConcurrentProcesses() async {
+        let cli = ConcurrentLogCLI()
+        let sessions = (0..<SessionLogSnapshotCache.capacity).map {
+            makeSession(name: "session-\($0)", status: "completed")
+        }
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch(sessions)
+        let peakConcurrency = await cli.peakConcurrency()
+        let callCount = await cli.recordedCalls().count
+
+        XCTAssertEqual(
+            peakConcurrency,
+            SessionLogSnapshotCache.maximumConcurrentPrefetches)
+        XCTAssertEqual(callCount, sessions.count)
+    }
+
+    func testCancelledLogPrefetchCannotClearAReplacementTask() async {
+        let session = makeSession(name: "generation", status: "completed")
+        let oldCLI = SuspendedLogCLI()
+        let newCLI = SuspendedLogCLI()
+        let cache = SessionLogSnapshotCache(cli: oldCLI, configurationID: "old")
+        cache.schedulePrefetch(for: [session])
+        await waitUntil { await oldCLI.callCount() == 1 }
+
+        cache.configure(cli: newCLI, configurationID: "new")
+        cache.schedulePrefetch(for: [session])
+        await waitUntil { await newCLI.callCount() == 1 }
+        await oldCLI.releaseAll()
+        for _ in 0..<20 { await Task.yield() }
+
+        cache.schedulePrefetch(for: [session])
+        for _ in 0..<20 { await Task.yield() }
+        let replacementCallCount = await newCLI.callCount()
+        XCTAssertEqual(replacementCallCount, 1)
+        await newCLI.releaseAll()
+    }
+
+    func testSnapshotCacheEvictsTheLeastRecentEntry() {
+        let cache = SessionLogSnapshotCache(
+            cli: FakeCLI(), configurationID: "/tmp/detach")
+        let firstSession = makeSession(name: "session-0", status: "completed")
+        let firstPoller = cache.poller(for: firstSession)
+
+        for index in 1...SessionLogSnapshotCache.capacity {
+            _ = cache.poller(for: makeSession(
+                name: "session-\(index)", status: "completed"))
+        }
+
+        XCTAssertFalse(firstPoller === cache.poller(for: firstSession))
+    }
+
+    private func makeSession(
+        name: String,
+        status: String,
+        checkpoint: String? = nil
+    ) -> Session {
+        let checkpointField = checkpoint.map {
+            ",\"last_checkpoint_at\":\"\($0)\""
+        } ?? ""
+        return SessionListParser.parse("""
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status)"\(checkpointField)}
+        """).sessions[0]
+    }
+
+    private func waitUntil(
+        attempts: Int = 200,
+        _ predicate: @escaping () async -> Bool
+    ) async {
+        for _ in 0..<attempts {
+            if await predicate() { return }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTFail("asynchronous condition did not become true")
     }
 }

--- a/app/Tests/DetachKitTests/LogPollerTests.swift
+++ b/app/Tests/DetachKitTests/LogPollerTests.swift
@@ -230,6 +230,30 @@ final class LogPollerTests: XCTestCase {
         XCTAssertEqual(changedCallCount, 2)
     }
 
+    func testSnapshotCacheInvalidatesChangedRevisionOnDirectLookup() async {
+        let initial = makeSession(
+            name: "direct", status: "completed",
+            checkpoint: "2026-09-01T10:00:00Z")
+        let changed = makeSession(
+            name: "direct", status: "completed",
+            checkpoint: "2026-09-01T10:01:00Z")
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(
+            cli: cli, configurationID: "/tmp/detach")
+
+        await cache.prefetch([initial])
+        let stalePoller = cache.poller(for: initial)
+        XCTAssertTrue(stalePoller.hasLoaded)
+
+        // SwiftUI can render the changed session before RootView's onChange
+        // schedules another prefetch. A direct lookup must still reject the
+        // poller that belongs to the previous typed revision.
+        let changedPoller = cache.poller(for: changed)
+
+        XCTAssertFalse(stalePoller === changedPoller)
+        XCTAssertFalse(changedPoller.hasLoaded)
+    }
+
     func testSnapshotCacheDropsPassiveTailWhileSessionIsLive() async {
         let finished = makeSession(name: "again", status: "completed")
         let live = makeSession(name: "again", status: "running")

--- a/app/Tests/DetachKitTests/LogPollerTests.swift
+++ b/app/Tests/DetachKitTests/LogPollerTests.swift
@@ -45,6 +45,23 @@ private actor SuspendedLogCLI: DetachCLIRunning {
     }
 }
 
+private actor CancellationSensitiveLogCLI: DetachCLIRunning {
+    private var calls = 0
+    private var released = false
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        calls += 1
+        while !released {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return CLIResult(
+            exitCode: 0, stdout: "warm", stderr: "", timedOut: false)
+    }
+
+    func callCount() -> Int { calls }
+    func releaseAll() { released = true }
+}
+
 @MainActor
 final class LogPollerTests: XCTestCase {
     func testFetchTrimsToTailLimit() async {
@@ -266,6 +283,27 @@ final class LogPollerTests: XCTestCase {
         let replacementCallCount = await newCLI.callCount()
         XCTAssertEqual(replacementCallCount, 1)
         await newCLI.releaseAll()
+    }
+
+    func testRepeatedSnapshotDoesNotCancelActiveLogWarmUp() async {
+        let cli = CancellationSensitiveLogCLI()
+        let cache = SessionLogSnapshotCache(cli: cli, configurationID: "/tmp/detach")
+        let sessions = (0..<4).map {
+            makeSession(name: "burst-\($0)", status: "completed")
+        }
+
+        cache.schedulePrefetch(for: sessions)
+        await waitUntil {
+            await cli.callCount() == SessionLogSnapshotCache.maximumConcurrentPrefetches
+        }
+        cache.schedulePrefetch(for: sessions)
+        await cli.releaseAll()
+        await waitUntil {
+            sessions.allSatisfy { cache.poller(for: $0).hasLoaded }
+        }
+
+        let callCount = await cli.callCount()
+        XCTAssertEqual(callCount, sessions.count)
     }
 
     func testFailedLogReadIsNotRepeatedForTheSameTypedRevision() async {

--- a/app/Tests/DetachKitTests/LogPollerTests.swift
+++ b/app/Tests/DetachKitTests/LogPollerTests.swift
@@ -70,6 +70,26 @@ final class LogPollerTests: XCTestCase {
         XCTAssertEqual(poller.errorText, "no logs found")
     }
 
+    func testTruncatedFetchDoesNotPublishPartialTail() async {
+        let cli = FakeCLI()
+        cli.responses["claude logs --ansi detach-claude-x-1"] = .success(CLIResult(
+            exitCode: 0,
+            stdout: "partial",
+            stderr: "",
+            timedOut: false,
+            stdoutTruncated: true))
+        let poller = LogPoller(
+            cli: cli, provider: .claude, sessionName: "detach-claude-x-1")
+
+        await poller.fetchOnce()
+
+        XCTAssertEqual(
+            poller.errorText,
+            L10n.string("detach returned incomplete output"))
+        XCTAssertEqual(poller.lines, [])
+        XCTAssertFalse(poller.hasLoaded)
+    }
+
     func testUnchangedSuccessfulTailClearsAnEarlierErrorWithoutReparsing() async {
         let cli = FakeCLI()
         let key = "codex logs --ansi detach-codex-x-1"
@@ -324,6 +344,26 @@ final class LogPollerTests: XCTestCase {
         XCTAssertEqual(calls, 2)
     }
 
+    func testLifecycleIDInvalidatesSameSecondPassiveTail() async {
+        let cli = ConcurrentLogCLI()
+        let cache = SessionLogSnapshotCache(cli: cli, configurationID: "/tmp/detach")
+        let created = "2026-09-02T10:00:00Z"
+        let original = makeSession(
+            name: "same-second", status: "completed", created: created,
+            lifecycleID: "first-run")
+        let direct = cache.poller(for: original)
+        await direct.fetchOnce()
+
+        let replacement = makeSession(
+            name: "same-second", status: "completed", created: created,
+            lifecycleID: "replacement-run")
+        await cache.prefetch([replacement])
+
+        XCTAssertFalse(direct === cache.poller(for: replacement))
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls.count, 2)
+    }
+
     func testPrefetchFillsFreeSlotsAndNeverEvictsASelectedEntry() async {
         let cli = ConcurrentLogCLI()
         let cache = SessionLogSnapshotCache(
@@ -364,14 +404,18 @@ final class LogPollerTests: XCTestCase {
         name: String,
         status: String,
         checkpoint: String? = nil,
-        created: String? = nil
+        created: String? = nil,
+        lifecycleID: String? = nil
     ) -> Session {
         let checkpointField = checkpoint.map {
             ",\"last_checkpoint_at\":\"\($0)\""
         } ?? ""
         let createdField = created.map { ",\"created_at\":\"\($0)\"" } ?? ""
+        let lifecycleField = lifecycleID.map {
+            ",\"lifecycle_id\":\"\($0)\""
+        } ?? ""
         return SessionListParser.parse("""
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status)"\(checkpointField)\(createdField)}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status)"\(checkpointField)\(createdField)\(lifecycleField)}
         """).sessions[0]
     }
 

--- a/app/Tests/DetachKitTests/PowerHeartbeatReaderTests.swift
+++ b/app/Tests/DetachKitTests/PowerHeartbeatReaderTests.swift
@@ -175,6 +175,84 @@ final class PowerHeartbeatReaderTests: XCTestCase {
             "/tmp/home/.local/state/detach/power/watchdog-status.json")
     }
 
+    func testMonitorPublishesAtomicHeartbeatReplacement() throws {
+        let initial = try write(document(
+            powerState: "allowed",
+            checkedAt: ISO8601DateFormatter().string(from: Date())))
+        defer { remove(initial) }
+        let updated = expectation(description: "event-driven heartbeat")
+        let monitor = PowerHeartbeatMonitor(
+            reader: PowerHeartbeatReader(statusURL: initial)
+        ) { snapshot in
+            if snapshot.effectivePowerState == .protected {
+                updated.fulfill()
+            }
+        }
+        monitor.start()
+        defer { monitor.stop() }
+
+        try Data(self.document(
+            powerState: "protected",
+            checkedAt: ISO8601DateFormatter().string(from: Date())).utf8)
+            .write(to: initial, options: .atomic)
+
+        wait(for: [updated], timeout: 1)
+    }
+
+    func testMonitorWatchesClosestExistingParentUntilPowerDirectoryAppears()
+        throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let status = root
+            .appendingPathComponent("nested/power", isDirectory: true)
+            .appendingPathComponent("watchdog-status.json")
+        let created = expectation(description: "late heartbeat directory")
+        let monitor = PowerHeartbeatMonitor(
+            reader: PowerHeartbeatReader(statusURL: status)
+        ) { snapshot in
+            if snapshot.effectivePowerState == .protected {
+                created.fulfill()
+            }
+        }
+        monitor.start()
+        defer { monitor.stop() }
+
+        try FileManager.default.createDirectory(
+            at: status.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data(self.document(
+            checkedAt: ISO8601DateFormatter().string(from: Date())).utf8)
+            .write(to: status, options: .atomic)
+
+        wait(for: [created], timeout: 1)
+    }
+
+    func testMonitorSchedulesOnlyTheFreshnessDeadline() throws {
+        let checkedAt = referenceDate.addingTimeInterval(-30)
+        let fresh = PowerHeartbeatSnapshot(
+            statusURL: URL(fileURLWithPath: "/tmp/power.json"),
+            state: "ok",
+            powerState: .protected,
+            checkedAt: checkedAt,
+            isFresh: true)
+        let delay = try XCTUnwrap(PowerHeartbeatMonitor.expirationDelay(
+            for: fresh, now: referenceDate))
+        XCTAssertEqual(delay, 150.05, accuracy: 0.001)
+
+        let stale = PowerHeartbeatSnapshot(
+            statusURL: fresh.statusURL,
+            state: "ok",
+            powerState: .protected,
+            checkedAt: checkedAt,
+            isFresh: false)
+        XCTAssertNil(PowerHeartbeatMonitor.expirationDelay(
+            for: stale, now: referenceDate))
+    }
+
     private func document(
         state: String = "ok",
         powerState: String = "protected",

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -42,6 +42,8 @@ final class PowerHelperPlatformTests: XCTestCase {
 
         XCTAssertEqual(result.exitCode, 0)
         XCTAssertLessThanOrEqual(result.standardOutput.utf8.count, 1_024)
+        XCTAssertTrue(result.standardOutputTruncated)
+        XCTAssertFalse(result.standardErrorTruncated)
     }
 
     func testRootCommandRunnerBoundsBothStreamsAndUsesFixedEnvironment() throws {
@@ -55,6 +57,8 @@ final class PowerHelperPlatformTests: XCTestCase {
         XCTAssertEqual(result.exitCode, 0)
         XCTAssertEqual(result.standardOutput, "/usr/")
         XCTAssertEqual(result.standardError, "12345")
+        XCTAssertTrue(result.standardOutputTruncated)
+        XCTAssertTrue(result.standardErrorTruncated)
     }
 
     func testRootCommandRunnerCanDiscardAllOutput() throws {
@@ -67,6 +71,8 @@ final class PowerHelperPlatformTests: XCTestCase {
         XCTAssertEqual(result.exitCode, 0)
         XCTAssertEqual(result.standardOutput, "")
         XCTAssertEqual(result.standardError, "")
+        XCTAssertTrue(result.standardOutputTruncated)
+        XCTAssertTrue(result.standardErrorTruncated)
     }
 
     func testRootCommandRunnerReturnsNonzeroProcessStatus() throws {
@@ -134,6 +140,26 @@ final class PowerHelperPlatformTests: XCTestCase {
                     error as? PowerHelperPlatformError,
                     .unrecognizedPMSetOutput)
             }
+    }
+
+    func testPowerReadersRejectTruncatedSystemOutput() {
+        let runner = FakeCommandRunner()
+        runner.results = [
+            RootCommandResult(
+                exitCode: 0,
+                standardOutput: "SleepDisabled 1\n",
+                standardOutputTruncated: true),
+            RootCommandResult(
+                exitCode: 0,
+                standardOutput: "Now drawing from 'AC Power'\n",
+                standardOutputTruncated: true),
+        ]
+
+        XCTAssertThrowsError(
+            try PMSetClosedLidProtectionController(runner: runner)
+                .protectionIsEnabled())
+        XCTAssertThrowsError(
+            try PMSetBatterySafetyReader(runner: runner).isLowBattery())
     }
 
     func testPMSetBackendRejectsAmbiguousAndExtraFieldStatus() {

--- a/app/Tests/DetachKitTests/PowerRunActivityTests.swift
+++ b/app/Tests/DetachKitTests/PowerRunActivityTests.swift
@@ -247,13 +247,13 @@ final class PowerRunActivityTests: XCTestCase {
                 try activityHandle.write(contentsOf: Data("waiting\n".utf8))
                 try activityHandle.synchronize()
                 try activityHandle.close()
-                Thread.sleep(forTimeInterval: 0.5)
+                Thread.sleep(forTimeInterval: 0.1)
 
                 // Queue a transcript event against the current watch, then
                 // refresh the handoff so the re-watch accepts the transcript.
                 try overwriteTranscript()
                 try writeHandoff()
-                Thread.sleep(forTimeInterval: 0.5)
+                Thread.sleep(forTimeInterval: 0.1)
 
                 // Release the queue: the re-watch installs a new transcript
                 // watch, then the stale event from the cancelled watch runs.

--- a/app/Tests/DetachKitTests/SessionAttachTests.swift
+++ b/app/Tests/DetachKitTests/SessionAttachTests.swift
@@ -16,7 +16,10 @@ final class SessionAttachTests: XCTestCase {
         XCTAssertEqual(invocation.executable, "/Users/me/.local/bin/detach")
         XCTAssertEqual(
             invocation.arguments,
-            ["codex", "attach", "detach-codex-proj-abcd1234"])
+            [
+                "codex", "attach", "--terminal-features", "sync",
+                "detach-codex-proj-abcd1234",
+            ])
         XCTAssertFalse(invocation.arguments.contains { $0.contains("tmux") })
         XCTAssertFalse(invocation.environment.contains { $0.hasPrefix("TMUX=") })
         XCTAssertFalse(invocation.environment.contains { $0.hasPrefix("TMUX_PANE=") })
@@ -43,7 +46,27 @@ final class SessionAttachTests: XCTestCase {
             SessionAttachInvocation.arguments(for: session(
                 provider: .claude,
                 name: "detach-claude-review")),
-            ["claude", "attach", "detach-claude-review"])
+            [
+                "claude", "attach", "--terminal-features", "sync",
+                "detach-claude-review",
+            ])
+    }
+
+    func testClientSwitchBindsExactPIDSourceAndTargetProvider() {
+        XCTAssertEqual(
+            SessionClientSwitchInvocation.arguments(
+                clientPID: 4242,
+                from: session(),
+                to: session(
+                    provider: .claude,
+                    name: "detach-claude-review")),
+            [
+                "client", "switch",
+                "--pid", "4242",
+                "--from", "detach-codex-proj-abcd1234",
+                "--to", "detach-claude-review",
+                "--provider", "claude",
+            ])
     }
 
     func testOnlyLiveAttachableSessionsAreEligible() {

--- a/app/Tests/DetachKitTests/SessionDecodingTests.swift
+++ b/app/Tests/DetachKitTests/SessionDecodingTests.swift
@@ -20,6 +20,16 @@ final class SessionDecodingTests: XCTestCase {
     {"schema":1,"provider":"codex","session_name":"detach-codex-x-ffffffff","name":"x-ffffffff","effective_status":"corrupt","meta_status":null,"agent_session_id":null,"project_dir":null,"created_at":null,"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
     """
 
+    func testStopIntentDecodesAndDefaultsToNil() throws {
+        let stopping = running.replacingOccurrences(
+            of: "\"finished_at\":null}",
+            with: "\"finished_at\":null,\"stop_requested_at\":\"2026-07-10T18:30:00Z\"}")
+        let intent = try XCTUnwrap(SessionListParser.parse(stopping).sessions.first)
+        XCTAssertNotNil(intent.stopRequestedAt)
+        let plain = try XCTUnwrap(SessionListParser.parse(running).sessions.first)
+        XCTAssertNil(plain.stopRequestedAt)
+    }
+
     func testDecodesRunningSession() throws {
         let result = SessionListParser.parse(running)
         XCTAssertFalse(result.hadInvalidLines)

--- a/app/Tests/DetachKitTests/SessionDecodingTests.swift
+++ b/app/Tests/DetachKitTests/SessionDecodingTests.swift
@@ -30,6 +30,16 @@ final class SessionDecodingTests: XCTestCase {
         XCTAssertNil(plain.stopRequestedAt)
     }
 
+    func testOpaqueLifecycleIDDecodesAndDefaultsToNil() throws {
+        let identified = running.replacingOccurrences(
+            of: "\"finished_at\":null}",
+            with: "\"finished_at\":null,\"lifecycle_id\":\"run-view-id\"}")
+        XCTAssertEqual(
+            SessionListParser.parse(identified).sessions.first?.lifecycleID,
+            "run-view-id")
+        XCTAssertNil(SessionListParser.parse(running).sessions.first?.lifecycleID)
+    }
+
     func testDecodesRunningSession() throws {
         let result = SessionListParser.parse(running)
         XCTAssertFalse(result.hadInvalidLines)

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -1,4 +1,5 @@
 import CoreServices
+import Darwin
 import XCTest
 @testable import DetachKit
 
@@ -235,6 +236,179 @@ final class SessionEventsTests: XCTestCase {
         monitor.stop()
     }
 
+    func testWatcherStreamsReadyLifecycleTranscriptAndResyncEvents() throws {
+        let temporaryRoot = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+            .appendingPathComponent(
+            "detach-session-watcher-\(UUID().uuidString)",
+            isDirectory: true)
+        let root = URL(
+            fileURLWithPath: SessionEventWatchConfiguration.canonicalPath(
+                temporaryRoot.path),
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stateRoot = root.appendingPathComponent("state", isDirectory: true)
+        let sessionsRoot = stateRoot
+            .appendingPathComponent("codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        let sessionRoot = sessionsRoot.appendingPathComponent(
+            "detach-codex-watcher", isDirectory: true)
+        let invalidSessionRoot = sessionsRoot.appendingPathComponent(
+            "detach-codex-invalid", isDirectory: true)
+        let transcriptRoot = root.appendingPathComponent(
+            "provider/sessions", isDirectory: true)
+        let lateTranscriptRoot = root.appendingPathComponent(
+            "provider/late-sessions", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: sessionRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: invalidSessionRoot, withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(
+            to: invalidSessionRoot.appendingPathComponent("meta.json"))
+        try FileManager.default.createDirectory(
+            at: transcriptRoot, withIntermediateDirectories: true)
+        let transcript = transcriptRoot.appendingPathComponent("managed.jsonl")
+        try Data().write(to: transcript)
+        let canonicalStateRoot = SessionEventWatchConfiguration.canonicalPath(
+            stateRoot.path)
+        let canonicalSessionsRoot = SessionEventWatchConfiguration.canonicalPath(
+            sessionsRoot.path)
+        let canonicalTranscriptRoot = SessionEventWatchConfiguration.canonicalPath(
+            transcriptRoot.path)
+        let canonicalLateTranscriptRoot = SessionEventWatchConfiguration.canonicalPath(
+            lateTranscriptRoot.path)
+        let canonicalTranscript = SessionEventWatchConfiguration.canonicalPath(
+            transcript.path)
+        let metadata = try SessionMetadataDocument.create(changes: [
+            .init(key: "schema", value: .integer(1)),
+            .init(key: "session_name", value: .string("detach-codex-watcher")),
+            .init(key: "project_dir", value: .string("/private/tmp/project")),
+            .init(key: "status", value: .string("running")),
+            .init(key: "transcript_path", value: .string(canonicalTranscript)),
+        ])
+        try metadata.write(to: sessionRoot.appendingPathComponent("meta.json"))
+
+        let signalPath = canonicalStateRoot + "/session-change"
+        let configuration = SessionEventWatchConfiguration(
+            stateRoot: canonicalStateRoot,
+            signalPath: signalPath,
+            transcriptRoots: [canonicalTranscriptRoot, canonicalLateTranscriptRoot],
+            sessionsRoots: [canonicalSessionsRoot])
+        let managedTranscript = try XCTUnwrap(
+            DetachStateCommand.managedTranscriptRegistry(
+                sessionsRoots: [canonicalSessionsRoot],
+                allowedRoots: [canonicalTranscriptRoot, canonicalLateTranscriptRoot])
+                .all.first)
+        let pipe = Pipe()
+        defer {
+            try? pipe.fileHandleForWriting.close()
+            try? pipe.fileHandleForReading.close()
+        }
+        let queue = DispatchQueue(label: "detach-session-watcher-test")
+        var buffer = Data()
+        let watcher = SessionFileEventWatcher(
+            configuration: configuration,
+            quietWindow: 0.02,
+            queue: queue,
+            output: pipe.fileHandleForWriting)
+
+        try watcher.start()
+        XCTAssertEqual(
+            try readEvent(from: pipe.fileHandleForReading, buffer: &buffer),
+            SessionEvent(event: .ready))
+
+        // The native stream is installed above; feed its typed callback path
+        // directly so the assertion does not depend on host FSEvents latency.
+        queue.sync {
+            watcher.receive(SessionFileEventBatch(
+                paths: [signalPath], flags: [0]))
+        }
+        XCTAssertEqual(
+            try readEvent(from: pipe.fileHandleForReading, buffer: &buffer),
+            SessionEvent(event: .changed))
+
+        // Exact transcript writes emit one leading and one bounded trailing
+        // hint even when callbacks arrive as a burst.
+        queue.sync {
+            watcher.receive(SessionFileEventBatch(
+                paths: [managedTranscript], flags: [0]))
+            watcher.receive(SessionFileEventBatch(
+                paths: [managedTranscript], flags: [0]))
+        }
+        XCTAssertEqual(
+            try readEvent(from: pipe.fileHandleForReading, buffer: &buffer),
+            SessionEvent(event: .changed))
+        XCTAssertEqual(
+            try readEvent(from: pipe.fileHandleForReading, buffer: &buffer),
+            SessionEvent(event: .changed))
+
+        queue.sync {
+            watcher.receive(SessionFileEventBatch(
+                paths: [canonicalStateRoot],
+                flags: [UInt32(kFSEventStreamEventFlagRootChanged)]))
+        }
+        XCTAssertEqual(
+            try readEvent(from: pipe.fileHandleForReading, buffer: &buffer),
+            SessionEvent(event: .resync))
+
+        // A provider root can appear after startup. A lifecycle hint must add
+        // it to the native stream without replacing the working state stream.
+        try FileManager.default.createDirectory(
+            at: lateTranscriptRoot, withIntermediateDirectories: true)
+        queue.sync {
+            watcher.receive(SessionFileEventBatch(
+                paths: [signalPath], flags: [0]))
+        }
+        XCTAssertEqual(
+            try readEvent(from: pipe.fileHandleForReading, buffer: &buffer),
+            SessionEvent(event: .changed))
+        queue.sync {}
+
+        withExtendedLifetime(watcher) {}
+    }
+
+    func testTranscriptMonitorRejectsUnsafeFilesAndRearmsAReplacement() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-session-vnode-rearm-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let transcript = root.appendingPathComponent("managed.jsonl")
+        try Data().write(to: transcript)
+
+        let first = expectation(description: "replacement observed")
+        let second = expectation(description: "replacement rearmed")
+        let lock = NSLock()
+        nonisolated(unsafe) var deliveryCount = 0
+        let queue = DispatchQueue(label: "detach-session-vnode-rearm-test")
+        let monitor = SessionTranscriptFileMonitor(queue: queue) {
+            let count = lock.withLock {
+                deliveryCount += 1
+                return deliveryCount
+            }
+            if count == 1 { first.fulfill() }
+            if count == 2 { second.fulfill() }
+        }
+        monitor.update(paths: [
+            "relative/transcript.jsonl",
+            root.path,
+            transcript.path,
+        ])
+        queue.sync { monitor.update(paths: [transcript.path]) }
+
+        try Data("replacement\n".utf8).write(to: transcript, options: .atomic)
+        wait(for: [first], timeout: 1)
+        Thread.sleep(forTimeInterval: 0.1)
+        let handle = try FileHandle(forWritingTo: transcript)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("append\n".utf8))
+        try handle.synchronize()
+        try handle.close()
+
+        wait(for: [second], timeout: 1)
+        monitor.update(paths: [])
+        monitor.stop()
+    }
+
     func testParentMonitorObservesProcessExit() throws {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sleep")
@@ -265,5 +439,40 @@ final class SessionEventsTests: XCTestCase {
             SessionFileEventBatch(paths: paths, flags: flags),
             configuration: configuration,
             managedTranscriptPaths: managedTranscriptPaths)
+    }
+
+    private func readEvent(
+        from handle: FileHandle,
+        buffer: inout Data,
+        timeoutMilliseconds: Int32 = 2_000
+    ) throws -> SessionEvent? {
+        let deadline = DispatchTime.now().uptimeNanoseconds
+            + UInt64(timeoutMilliseconds) * 1_000_000
+        while true {
+            if let newline = buffer.firstIndex(of: 0x0A) {
+                let line = buffer[..<newline]
+                buffer.removeSubrange(...newline)
+                return SessionEventParser.parse(String(decoding: line, as: UTF8.self))
+            }
+            let now = DispatchTime.now().uptimeNanoseconds
+            guard now < deadline else { return nil }
+            let remaining = Int32(min(
+                UInt64(Int32.max),
+                (deadline - now + 999_999) / 1_000_000))
+            var descriptor = pollfd(
+                fd: handle.fileDescriptor,
+                events: Int16(POLLIN),
+                revents: 0)
+            let polled = Darwin.poll(&descriptor, 1, remaining)
+            if polled < 0, errno == EINTR { continue }
+            guard polled > 0 else { return nil }
+            var chunk = [UInt8](repeating: 0, count: 4_096)
+            let count = chunk.withUnsafeMutableBytes { bytes in
+                Darwin.read(handle.fileDescriptor, bytes.baseAddress, bytes.count)
+            }
+            if count < 0, errno == EINTR { continue }
+            guard count > 0 else { return nil }
+            buffer.append(contentsOf: chunk.prefix(count))
+        }
     }
 }

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -175,6 +175,7 @@ final class SessionEventsTests: XCTestCase {
             .init(key: "schema", value: .integer(1)),
             .init(key: "session_name", value: .string(sessionName)),
             .init(key: "project_dir", value: .string("/private/tmp/project")),
+            .init(key: "status", value: .string("running")),
             .init(key: "transcript_path", value: .string(transcript.path)),
         ])
         try metadata.write(to: sessionRoot.appendingPathComponent("meta.json"))
@@ -200,6 +201,38 @@ final class SessionEventsTests: XCTestCase {
             atStateRoot: stateRoot.path,
             allowedRoots: [root.appendingPathComponent("other").path]
         ).isEmpty)
+        let registry = DetachStateCommand.managedTranscriptRegistry(
+            sessionsRoots: [sessionsRoot.path],
+            allowedRoots: [canonicalTranscriptRoot])
+        XCTAssertEqual(registry.all, [canonicalTranscript])
+        XCTAssertEqual(registry.live, [canonicalTranscript])
+    }
+
+    func testLiveTranscriptVnodeSourceReportsAnAppend() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-session-vnode-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let transcript = root.appendingPathComponent("managed.jsonl")
+        try Data().write(to: transcript)
+
+        let changed = expectation(description: "live transcript append")
+        changed.assertForOverFulfill = false
+        let queue = DispatchQueue(label: "detach-session-vnode-test")
+        let monitor = SessionTranscriptFileMonitor(queue: queue) {
+            changed.fulfill()
+        }
+        monitor.update(paths: [transcript.path])
+
+        let handle = try FileHandle(forWritingTo: transcript)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("turn\n".utf8))
+        try handle.synchronize()
+
+        wait(for: [changed], timeout: 1)
+        monitor.stop()
     }
 
     func testParentMonitorObservesProcessExit() throws {

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -1,0 +1,119 @@
+import CoreServices
+import XCTest
+@testable import DetachKit
+
+final class SessionEventsTests: XCTestCase {
+    private let configuration = SessionEventWatchConfiguration(
+        stateRoot: "/private/tmp/detach-state",
+        signalPath: "/private/tmp/detach-state/session-change",
+        transcriptRoots: [
+            "/private/tmp/codex/sessions",
+            "/private/tmp/claude/projects",
+        ])
+
+    func testEventJSONRequiresSchemaOne() throws {
+        let encoded = try JSONEncoder().encode(SessionEvent(event: .changed))
+        XCTAssertEqual(
+            SessionEventParser.parse(String(decoding: encoded, as: UTF8.self)),
+            SessionEvent(event: .changed))
+        XCTAssertNil(SessionEventParser.parse(#"{"schema":2,"event":"changed"}"#))
+        XCTAssertNil(SessionEventParser.parse("not json"))
+    }
+
+    func testWatchArgumentsRequireTypedRootsAndJSON() throws {
+        let parsed = try SessionEventWatchConfiguration.parse(arguments: [
+                "--json",
+                "--state-root", "/tmp/detach-state",
+                "--signal", "/tmp/detach-state/session-change",
+                "--transcript-root", "/tmp/codex/sessions",
+                "--transcript-root", "/tmp/claude/projects",
+            ])
+        XCTAssertEqual(parsed, configuration)
+        XCTAssertThrowsError(try SessionEventWatchConfiguration.parse(arguments: [
+            "--state-root", "/tmp/detach-state",
+            "--signal", "/tmp/detach-state/session-change",
+            "--transcript-root", "/tmp/codex/sessions",
+        ]))
+        XCTAssertThrowsError(try SessionEventWatchConfiguration.parse(arguments: [
+            "--json",
+            "--state-root", "/tmp/detach-state",
+            "--signal", "/tmp/outside",
+            "--transcript-root", "/tmp/codex/sessions",
+        ]))
+    }
+
+    func testClassifierIgnoresNoiseAndRecognizesLifecycleAndTranscripts() {
+        XCTAssertEqual(classify(paths: ["/private/tmp/detach-state/heartbeat"]), .ignored)
+        XCTAssertEqual(
+            classify(paths: ["/private/tmp/detach-state/session-change"]),
+            .lifecycle)
+        XCTAssertEqual(
+            classify(paths: ["/private/tmp/codex/sessions/2026/turn.jsonl"]),
+            .transcript)
+        XCTAssertEqual(
+            classify(paths: ["/private/tmp/claude/projects/p/turn.jsonl"]),
+            .transcript)
+        XCTAssertEqual(
+            classify(paths: ["/private/tmp/claude/projects/p/turn.txt"]),
+            .ignored)
+    }
+
+    func testDroppedOrRootChangedEventsForceResync() {
+        for flag in [
+            kFSEventStreamEventFlagMustScanSubDirs,
+            kFSEventStreamEventFlagUserDropped,
+            kFSEventStreamEventFlagKernelDropped,
+            kFSEventStreamEventFlagRootChanged,
+        ] {
+            XCTAssertEqual(
+                classify(paths: [], flags: [UInt32(flag)]),
+                .resync)
+        }
+    }
+
+    func testTranscriptBurstEmitsLeadingAndOneTrailingHint() {
+        var reducer = SessionEventCoalescer()
+        XCTAssertEqual(
+            reducer.consume(.transcript),
+            .emitAndScheduleTrailing(.changed))
+        XCTAssertEqual(reducer.consume(.transcript), .scheduleTrailing)
+        XCTAssertEqual(reducer.consume(.transcript), .scheduleTrailing)
+        XCTAssertEqual(reducer.quietWindowElapsed(), .emit(.changed))
+        XCTAssertEqual(reducer.quietWindowElapsed(), .none)
+        XCTAssertEqual(reducer.consume(.lifecycle), .emit(.changed))
+        XCTAssertEqual(reducer.consume(.resync), .emit(.resync))
+    }
+
+    func testTypedPublisherAtomicallyReplacesItsHint() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-session-events-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let signal = root.appendingPathComponent("session-change")
+
+        _ = try DetachStateCommand.run(arguments: [
+            "events", "publish", signal.path,
+        ])
+        let first = try Data(contentsOf: signal)
+        _ = try DetachStateCommand.run(arguments: [
+            "events", "publish", signal.path,
+        ])
+        let second = try Data(contentsOf: signal)
+
+        XCTAssertFalse(first.isEmpty)
+        XCTAssertFalse(second.isEmpty)
+        XCTAssertNotEqual(first, second)
+        let attributes = try FileManager.default.attributesOfItem(atPath: signal.path)
+        XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, 0o600)
+    }
+
+    private func classify(
+        paths: [String],
+        flags: [UInt32] = [0]
+    ) -> SessionFileEventClassification {
+        SessionFileEventClassifier.classify(
+            SessionFileEventBatch(paths: paths, flags: flags),
+            configuration: configuration)
+    }
+}

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -117,11 +117,11 @@ final class SessionEventsTests: XCTestCase {
         let signal = root.appendingPathComponent("session-change")
 
         _ = try DetachStateCommand.run(arguments: [
-            "events", "publish", signal.path,
+            "events", "publish", root.path,
         ])
         let first = try Data(contentsOf: signal)
         _ = try DetachStateCommand.run(arguments: [
-            "events", "publish", signal.path,
+            "events", "publish", root.path,
         ])
         let second = try Data(contentsOf: signal)
 
@@ -134,13 +134,21 @@ final class SessionEventsTests: XCTestCase {
         // Environment roots with a trailing slash produce `//`. The publisher
         // must standardize that path rather than silently disable every hint.
         _ = try DetachStateCommand.run(arguments: [
-            "events", "publish", root.path + "//session-change",
+            "events", "publish", root.path + "//",
         ])
         let third = try Data(contentsOf: signal)
         XCTAssertNotEqual(second, third)
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
-            "events", "publish", "relative/session-change",
+            "events", "publish", "relative/state",
         ]))
+
+        let unrelated = root.appendingPathComponent("unrelated")
+        let sentinel = Data("keep me".utf8)
+        try sentinel.write(to: unrelated)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "events", "publish", unrelated.path,
+        ]))
+        XCTAssertEqual(try Data(contentsOf: unrelated), sentinel)
     }
 
     func testManagedTranscriptRegistryUsesOnlyUsableInRootMetadata() throws {

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -10,6 +10,10 @@ final class SessionEventsTests: XCTestCase {
             "/private/tmp/codex/sessions",
             "/private/tmp/claude/projects",
         ])
+    private let managedTranscriptPaths: Set<String> = [
+        "/private/tmp/codex/sessions/2026/managed.jsonl",
+        "/private/tmp/claude/projects/p/managed.jsonl",
+    ]
 
     func testEventJSONRequiresSchemaOne() throws {
         let encoded = try JSONEncoder().encode(SessionEvent(event: .changed))
@@ -42,19 +46,22 @@ final class SessionEventsTests: XCTestCase {
         ]))
     }
 
-    func testClassifierIgnoresNoiseAndRecognizesLifecycleAndTranscripts() {
+    func testClassifierIgnoresNoiseAndRecognizesLifecycleAndManagedTranscripts() {
         XCTAssertEqual(classify(paths: ["/private/tmp/detach-state/heartbeat"]), .ignored)
         XCTAssertEqual(
             classify(paths: ["/private/tmp/detach-state/session-change"]),
             .lifecycle)
         XCTAssertEqual(
-            classify(paths: ["/private/tmp/codex/sessions/2026/turn.jsonl"]),
+            classify(paths: ["/private/tmp/codex/sessions/2026/managed.jsonl"]),
             .transcript)
         XCTAssertEqual(
-            classify(paths: ["/private/tmp/claude/projects/p/turn.jsonl"]),
+            classify(paths: ["/private/tmp/claude/projects/p/managed.jsonl"]),
             .transcript)
         XCTAssertEqual(
             classify(paths: ["/private/tmp/claude/projects/p/turn.txt"]),
+            .ignored)
+        XCTAssertEqual(
+            classify(paths: ["/private/tmp/codex/sessions/2026/foreign.jsonl"]),
             .ignored)
     }
 
@@ -108,12 +115,86 @@ final class SessionEventsTests: XCTestCase {
         XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, 0o600)
     }
 
+    func testManagedTranscriptRegistryUsesOnlyUsableInRootMetadata() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-session-registry-\(UUID().uuidString)",
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stateRoot = root.appendingPathComponent("state", isDirectory: true)
+        let sessionsRoot = stateRoot
+            .appendingPathComponent("codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        let sessionName = "detach-codex-managed"
+        let sessionRoot = sessionsRoot.appendingPathComponent(
+            sessionName, isDirectory: true)
+        let transcriptRoot = root.appendingPathComponent(
+            "provider/sessions", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: sessionRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: transcriptRoot, withIntermediateDirectories: true)
+        let transcript = transcriptRoot.appendingPathComponent("managed.jsonl")
+        try Data().write(to: transcript)
+        let metadata = try SessionMetadataDocument.create(changes: [
+            .init(key: "schema", value: .integer(1)),
+            .init(key: "session_name", value: .string(sessionName)),
+            .init(key: "project_dir", value: .string("/private/tmp/project")),
+            .init(key: "transcript_path", value: .string(transcript.path)),
+        ])
+        try metadata.write(to: sessionRoot.appendingPathComponent("meta.json"))
+
+        let canonicalTranscriptRoot = SessionEventWatchConfiguration
+            .canonicalPath(transcriptRoot.path)
+        let canonicalTranscript = SessionEventWatchConfiguration
+            .canonicalPath(transcript.path)
+        let snapshots = try DetachStateCommand.metadataSnapshots(
+            at: sessionsRoot.path)
+        XCTAssertEqual(snapshots.count, 1)
+        XCTAssertNotNil(snapshots.first?.1)
+        XCTAssertEqual(
+            URL(fileURLWithPath: canonicalTranscript)
+                .deletingLastPathComponent().path,
+            canonicalTranscriptRoot)
+        XCTAssertEqual(
+            DetachStateCommand.managedTranscriptPaths(
+                atStateRoot: stateRoot.path,
+                allowedRoots: [canonicalTranscriptRoot]),
+            [canonicalTranscript])
+        XCTAssertTrue(DetachStateCommand.managedTranscriptPaths(
+            atStateRoot: stateRoot.path,
+            allowedRoots: [root.appendingPathComponent("other").path]
+        ).isEmpty)
+    }
+
+    func testParentMonitorObservesProcessExit() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["30"]
+        try process.run()
+        defer {
+            if process.isRunning { process.terminate() }
+            process.waitUntilExit()
+        }
+
+        let exited = expectation(description: "parent exit")
+        let monitor = SessionEventParentMonitor(
+            processID: process.processIdentifier,
+            queue: DispatchQueue(label: "session-event-parent-test"),
+            onExit: { exited.fulfill() })
+        monitor.start()
+        process.terminate()
+
+        wait(for: [exited], timeout: 1)
+        withExtendedLifetime(monitor) {}
+    }
+
     private func classify(
         paths: [String],
         flags: [UInt32] = [0]
     ) -> SessionFileEventClassification {
         SessionFileEventClassifier.classify(
             SessionFileEventBatch(paths: paths, flags: flags),
-            configuration: configuration)
+            configuration: configuration,
+            managedTranscriptPaths: managedTranscriptPaths)
     }
 }

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -33,6 +33,23 @@ final class SessionEventsTests: XCTestCase {
                 "--transcript-root", "/tmp/claude/projects",
             ])
         XCTAssertEqual(parsed, configuration)
+        XCTAssertEqual(parsed.sessionsRoots, [
+            "/private/tmp/detach-state/codex/sessions",
+            "/private/tmp/detach-state/claude/sessions",
+        ])
+        // A relocated provider state root names its own sessions directory.
+        let relocated = try SessionEventWatchConfiguration.parse(arguments: [
+            "--json",
+            "--state-root", "/tmp/detach-state",
+            "--signal", "/tmp/detach-state/session-change",
+            "--sessions-root", "/tmp/elsewhere/codex/sessions",
+            "--sessions-root", "/tmp/detach-state/claude/sessions",
+            "--transcript-root", "/tmp/codex/sessions",
+        ])
+        XCTAssertEqual(relocated.sessionsRoots, [
+            "/private/tmp/elsewhere/codex/sessions",
+            "/private/tmp/detach-state/claude/sessions",
+        ])
         XCTAssertThrowsError(try SessionEventWatchConfiguration.parse(arguments: [
             "--state-root", "/tmp/detach-state",
             "--signal", "/tmp/detach-state/session-change",
@@ -113,6 +130,17 @@ final class SessionEventsTests: XCTestCase {
         XCTAssertNotEqual(first, second)
         let attributes = try FileManager.default.attributesOfItem(atPath: signal.path)
         XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, 0o600)
+
+        // Environment roots with a trailing slash produce `//`. The publisher
+        // must standardize that path rather than silently disable every hint.
+        _ = try DetachStateCommand.run(arguments: [
+            "events", "publish", root.path + "//session-change",
+        ])
+        let third = try Data(contentsOf: signal)
+        XCTAssertNotEqual(second, third)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "events", "publish", "relative/session-change",
+        ]))
     }
 
     func testManagedTranscriptRegistryUsesOnlyUsableInRootMetadata() throws {

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -308,6 +308,23 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertTrue(result.ownershipProven)
     }
 
+    func testOwnedStartingWorkerDoesNotEnterProblemsBeforeProviderLaunch() {
+        let result = evaluate(status: .starting, provider: .unknown)
+
+        XCTAssertEqual(result.effectiveStatus, .starting)
+        XCTAssertEqual(result.reason, .healthy)
+        XCTAssertEqual(result.actions, [.attach, .stop])
+        XCTAssertTrue(result.ownershipProven)
+        XCTAssertFalse(result.cleanupEligible)
+
+        let missingWorker = evaluate(
+            status: .starting,
+            worker: .unknown,
+            provider: .unknown)
+        XCTAssertEqual(missingWorker.effectiveStatus, .hung)
+        XCTAssertEqual(missingWorker.reason, .workerPIDMissing)
+    }
+
     func testFreshOwnedRuntimeReportsHealthy() {
         let result = evaluate()
 

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -125,6 +125,44 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertFalse(result.ownershipProven)
     }
 
+    func testFinishingWorkerWithTerminalMetadataIsNotHung() {
+        // After Ctrl+C the worker writes `interrupted`, publishes the hint,
+        // and only then exits. The list that follows sees a live owned pane
+        // with a dead provider; that is a finished run, not a hung one.
+        for status in [EffectiveStatus.interrupted, .completed, .failed, .stopped] {
+            let result = evaluate(status: status, provider: .dead)
+
+            XCTAssertEqual(result.effectiveStatus, status, "\(status)")
+            XCTAssertEqual(result.reason, .finished)
+            XCTAssertTrue(result.ownershipProven)
+            XCTAssertFalse(result.actions.contains(.attach))
+            XCTAssertEqual(result.reconcileAction, .none)
+        }
+        // An active record with a dead provider still needs the hung signal.
+        XCTAssertEqual(evaluate(status: .running, provider: .dead).effectiveStatus, .hung)
+        // Only a live worker proves a finishing run; a lost or mismatched
+        // worker with a live pane keeps the established hung verdict and
+        // grants no cleanup on that pane.
+        XCTAssertEqual(
+            evaluate(status: .stopped, worker: .dead, provider: .dead).effectiveStatus, .hung)
+        XCTAssertEqual(
+            evaluate(status: .stopped, worker: .mismatch, provider: .dead).effectiveStatus,
+            .hung)
+        XCTAssertFalse(evaluate(status: .stopped, provider: .dead).cleanupEligible)
+        // A provider that is merely unproven keeps the established rules.
+        XCTAssertEqual(
+            evaluate(status: .interrupted, provider: .mismatch).effectiveStatus, .hung)
+        // Legacy metadata without runtime identity keeps its own branch.
+        XCTAssertEqual(
+            evaluate(
+                runtimeIdentityExpected: false,
+                status: .stopped,
+                worker: .unknown,
+                provider: .unknown,
+                heartbeat: .missing).effectiveStatus,
+            .running)
+    }
+
     func testWorkerCrashNeverRecoversWhileAnUnprovenProviderPIDIsStillAlive() {
         let result = evaluate(
             tmux: .dead,

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -2,6 +2,54 @@ import XCTest
 @testable import DetachKit
 
 final class SessionHealthTests: XCTestCase {
+    func testRuntimeLifecyclePhaseAllowsOnlyTheDeclaredGraph() {
+        let allowed: [(RuntimeLifecyclePhase, [RuntimeLifecyclePhase])] = [
+            (.initializing, [.initializing, .starting, .terminal]),
+            (.starting, [.starting, .running, .stopping, .finalizing, .terminal]),
+            (.running, [.running, .stopping, .finalizing, .terminal]),
+            (.stopping, [.stopping, .running, .terminal]),
+            (.finalizing, [.finalizing, .terminal]),
+            (.terminal, [.terminal]),
+        ]
+        let phases = allowed.map(\.0)
+
+        for (source, targets) in allowed {
+            for target in phases {
+                XCTAssertEqual(
+                    source.allows(target),
+                    targets.contains { $0 == target },
+                    "\(source) -> \(target)")
+            }
+        }
+    }
+
+    func testInitializingPhaseIsActionlessUntilIdentityAppearsOrDies() {
+        let starting = evaluate(
+            status: .starting,
+            provider: .unknown,
+            lifecyclePhase: .initializing)
+        XCTAssertEqual(starting.effectiveStatus, .starting)
+        XCTAssertEqual(starting.reason, .healthy)
+        XCTAssertTrue(starting.actions.isEmpty)
+
+        let replacement = evaluate(
+            status: .starting,
+            token: .mismatch,
+            provider: .unknown,
+            lifecyclePhase: .initializing)
+        XCTAssertEqual(replacement.effectiveStatus, .corrupt)
+        XCTAssertEqual(replacement.reason, .runTokenMismatch)
+
+        let dead = evaluate(
+            status: .starting,
+            tmux: .missing,
+            worker: .dead,
+            provider: .dead,
+            lifecyclePhase: .initializing)
+        XCTAssertEqual(dead.effectiveStatus, .recoverable)
+        XCTAssertEqual(dead.actions, [.recover, .delete])
+    }
+
     func testForeignTmuxCollisionNeverOffersAnAction() {
         let result = evaluate(tmux: .foreign)
 

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -312,6 +312,83 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertEqual(result.reason, .checkpointStale)
     }
 
+    func testProcessInspectorFollowsOnlyTheBoundedOwnedParentChain() {
+        let identities: [Int32: SessionProcessIdentity] = [
+            30: SessionProcessIdentity(parentPID: 20, userID: 501),
+            20: SessionProcessIdentity(parentPID: 10, userID: 501),
+            10: SessionProcessIdentity(parentPID: 1, userID: 501),
+        ]
+        var reads: [Int32] = []
+
+        let result = SessionProcessHealthInspector.inspect(
+            tmuxState: .live,
+            workerPID: "10",
+            providerPID: "30",
+            panePID: "10",
+            userID: 501,
+            lookup: { pid in
+                reads.append(pid)
+                return identities[pid]
+            })
+
+        XCTAssertEqual(result, SessionProcessHealth(worker: .alive, provider: .alive))
+        XCTAssertEqual(Set(reads), Set([10, 20, 30]))
+        XCTAssertEqual(reads.count, 3, "one record must read each PID at most once")
+    }
+
+    func testProcessInspectorRejectsWrongPaneAndForeignOwnership() {
+        let owned: [Int32: SessionProcessIdentity] = [
+            10: SessionProcessIdentity(parentPID: 1, userID: 501),
+            30: SessionProcessIdentity(parentPID: 10, userID: 501),
+        ]
+        let paneMismatch = SessionProcessHealthInspector.inspect(
+            tmuxState: .live,
+            workerPID: "10",
+            providerPID: "30",
+            panePID: "99",
+            userID: 501,
+            lookup: { owned[$0] })
+        let foreign = SessionProcessHealthInspector.inspect(
+            tmuxState: .missing,
+            workerPID: "10",
+            providerPID: "30",
+            panePID: "-",
+            userID: 502,
+            lookup: { owned[$0] })
+
+        XCTAssertEqual(
+            paneMismatch,
+            SessionProcessHealth(worker: .mismatch, provider: .mismatch))
+        XCTAssertEqual(foreign, SessionProcessHealth(worker: .dead, provider: .dead))
+    }
+
+    func testProcessInspectorKeepsInvalidPIDsUnknownAndBoundsCycles() {
+        var reads = 0
+        let invalid = SessionProcessHealthInspector.inspect(
+            tmuxState: .missing,
+            workerPID: "-",
+            providerPID: "0",
+            panePID: "not-a-pid",
+            userID: 501,
+            lookup: { _ in reads += 1; return nil })
+        let cyclic = SessionProcessHealthInspector.inspect(
+            tmuxState: .missing,
+            workerPID: "10",
+            providerPID: "20",
+            panePID: "-",
+            userID: 501,
+            lookup: { pid in
+                reads += 1
+                return SessionProcessIdentity(
+                    parentPID: pid == 20 ? 21 : 20,
+                    userID: 501)
+            })
+
+        XCTAssertEqual(invalid, SessionProcessHealth(worker: .unknown, provider: .unknown))
+        XCTAssertEqual(cyclic, SessionProcessHealth(worker: .alive, provider: .mismatch))
+        XCTAssertLessThanOrEqual(reads, 3, "cycle identities must stay cached")
+    }
+
     private func evaluate(
         metadataValid: Bool = true,
         runtimeIdentityExpected: Bool = true,

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -230,17 +230,103 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertTrue(result.ownershipProven)
     }
 
-    func testStopIntentKeepsFinishingWorkerOutOfProblems() {
+    func testStopIntentKeepsFinishingWorkerStopped() {
         let result = evaluate(provider: .dead, stopRequested: true)
 
-        XCTAssertEqual(result.effectiveStatus, .interrupted)
+        XCTAssertEqual(result.effectiveStatus, .stopped)
         XCTAssertEqual(result.reason, .finished)
         XCTAssertTrue(result.actions.isEmpty)
         XCTAssertTrue(result.ownershipProven)
         XCTAssertFalse(result.cleanupEligible)
     }
 
-    func testStopIntentKeepsActionsClosedAfterTerminalMetadata() {
+    func testStoppingPhaseStaysActionlessWhileRuntimeTeardownRemains() {
+        let inProgress: [(TmuxHealthState, ProcessHealthState)] = [
+            (.live, .dead),
+            (.dead, .alive),
+            (.missing, .alive),
+        ]
+        for (tmux, worker) in inProgress {
+            let result = evaluate(
+                status: .stopped,
+                tmux: tmux,
+                worker: worker,
+                provider: .dead,
+                stopRequested: true,
+                lifecyclePhase: .stopping)
+
+            XCTAssertEqual(result.effectiveStatus, .stopped, "tmux=\(tmux)")
+            XCTAssertEqual(result.reason, .finished, "tmux=\(tmux)")
+            XCTAssertTrue(result.actions.isEmpty, "tmux=\(tmux)")
+            XCTAssertEqual(result.reconcileAction, .none, "tmux=\(tmux)")
+            XCTAssertFalse(result.cleanupEligible, "tmux=\(tmux)")
+        }
+
+        let replacement = evaluate(
+            token: .mismatch,
+            stopRequested: true,
+            lifecyclePhase: .stopping)
+        XCTAssertEqual(replacement.effectiveStatus, .corrupt)
+        XCTAssertEqual(replacement.reason, .runTokenMismatch)
+    }
+
+    func testCrashedStoppingPhaseConvergesAfterRuntimeIsGone() {
+        for (tmux, reconcile) in [
+            (TmuxHealthState.dead, SessionReconcileAction.removeDeadTmux),
+            (.missing, .none),
+        ] {
+            let result = evaluate(
+                status: .stopped,
+                tmux: tmux,
+                worker: .dead,
+                provider: .dead,
+                stopRequested: true,
+                lifecyclePhase: .stopping)
+
+            XCTAssertEqual(result.effectiveStatus, .stopped, "tmux=\(tmux)")
+            XCTAssertEqual(result.reason, tmux == .dead ? .paneExited : .finished)
+            XCTAssertEqual(result.actions, [.resume, .delete], "tmux=\(tmux)")
+            XCTAssertEqual(result.reconcileAction, reconcile, "tmux=\(tmux)")
+            XCTAssertTrue(result.cleanupEligible, "tmux=\(tmux)")
+        }
+    }
+
+    func testFinalizingPhaseNeverReportsADeadProviderAsHung() {
+        for (status, expected) in [
+            (EffectiveStatus.completed, EffectiveStatus.completed),
+            (.failed, .failed),
+            (.interrupted, .interrupted),
+            (.running, .interrupted),
+        ] {
+            let result = evaluate(
+                status: status,
+                tmux: .live,
+                worker: .alive,
+                provider: .dead,
+                lifecyclePhase: .finalizing)
+
+            XCTAssertEqual(result.effectiveStatus, expected, "status=\(status)")
+            XCTAssertEqual(result.reason, .finished, "status=\(status)")
+            XCTAssertTrue(result.actions.isEmpty, "status=\(status)")
+            XCTAssertFalse(result.cleanupEligible, "status=\(status)")
+        }
+    }
+
+    func testCrashedFinalizingPhaseOpensTerminalActions() {
+        let result = evaluate(
+            status: .completed,
+            tmux: .missing,
+            worker: .dead,
+            provider: .dead,
+            lifecyclePhase: .finalizing)
+
+        XCTAssertEqual(result.effectiveStatus, .completed)
+        XCTAssertEqual(result.reason, .finished)
+        XCTAssertEqual(result.actions, [.resume, .delete])
+        XCTAssertFalse(result.cleanupEligible)
+    }
+
+    func testStopIntentKeepsStoppedOutcomeAfterTerminalMetadata() {
         for status in [
             EffectiveStatus.interrupted,
             .stopped,
@@ -251,7 +337,7 @@ final class SessionHealthTests: XCTestCase {
                 provider: .dead,
                 stopRequested: true)
 
-            XCTAssertEqual(result.effectiveStatus, .interrupted)
+            XCTAssertEqual(result.effectiveStatus, .stopped)
             XCTAssertEqual(result.reason, .finished)
             XCTAssertTrue(result.actions.isEmpty)
             XCTAssertTrue(result.ownershipProven)
@@ -501,7 +587,8 @@ final class SessionHealthTests: XCTestCase {
         checkpoint: FreshnessState = .fresh,
         recoverable: Bool = true,
         agentSessionKnown: Bool = true,
-        stopRequested: Bool = false
+        stopRequested: Bool = false,
+        lifecyclePhase: RuntimeLifecyclePhase? = nil
     ) -> SessionHealthAssessment {
         SessionHealthEvaluator.evaluate(SessionHealthEvidence(
             metadataValid: metadataValid,
@@ -515,6 +602,7 @@ final class SessionHealthTests: XCTestCase {
             checkpointFreshness: checkpoint,
             checkpointRecoverable: recoverable,
             agentSessionKnown: agentSessionKnown,
-            stopRequested: stopRequested))
+            stopRequested: stopRequested,
+            lifecyclePhase: lifecyclePhase))
     }
 }

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -240,6 +240,25 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertFalse(result.cleanupEligible)
     }
 
+    func testStopIntentKeepsActionsClosedAfterTerminalMetadata() {
+        for status in [
+            EffectiveStatus.interrupted,
+            .stopped,
+            .completed,
+        ] {
+            let result = evaluate(
+                status: status,
+                provider: .dead,
+                stopRequested: true)
+
+            XCTAssertEqual(result.effectiveStatus, .interrupted)
+            XCTAssertEqual(result.reason, .finished)
+            XCTAssertTrue(result.actions.isEmpty)
+            XCTAssertTrue(result.ownershipProven)
+            XCTAssertFalse(result.cleanupEligible)
+        }
+    }
+
     func testStopIntentNeverMasksUnprovenRuntimeIdentity() {
         XCTAssertEqual(evaluate(stopRequested: true).effectiveStatus, .running)
         XCTAssertEqual(

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -230,6 +230,32 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertTrue(result.ownershipProven)
     }
 
+    func testStopIntentKeepsFinishingWorkerOutOfProblems() {
+        let result = evaluate(provider: .dead, stopRequested: true)
+
+        XCTAssertEqual(result.effectiveStatus, .interrupted)
+        XCTAssertEqual(result.reason, .finished)
+        XCTAssertTrue(result.actions.isEmpty)
+        XCTAssertTrue(result.ownershipProven)
+        XCTAssertFalse(result.cleanupEligible)
+    }
+
+    func testStopIntentNeverMasksUnprovenRuntimeIdentity() {
+        XCTAssertEqual(evaluate(stopRequested: true).effectiveStatus, .running)
+        XCTAssertEqual(
+            evaluate(worker: .dead, provider: .dead, stopRequested: true).reason,
+            .workerProcessLost)
+        XCTAssertEqual(
+            evaluate(worker: .mismatch, provider: .dead, stopRequested: true).reason,
+            .workerPIDMismatch)
+        XCTAssertEqual(
+            evaluate(provider: .mismatch, stopRequested: true).reason,
+            .providerPIDNotDescendant)
+        XCTAssertEqual(
+            evaluate(token: .mismatch, provider: .dead, stopRequested: true).reason,
+            .runTokenMismatch)
+    }
+
     func testForeignProviderPIDIsNeverTreatedAsOwned() {
         let result = evaluate(provider: .mismatch)
 
@@ -438,7 +464,8 @@ final class SessionHealthTests: XCTestCase {
         heartbeat: FreshnessState = .fresh,
         checkpoint: FreshnessState = .fresh,
         recoverable: Bool = true,
-        agentSessionKnown: Bool = true
+        agentSessionKnown: Bool = true,
+        stopRequested: Bool = false
     ) -> SessionHealthAssessment {
         SessionHealthEvaluator.evaluate(SessionHealthEvidence(
             metadataValid: metadataValid,
@@ -451,6 +478,7 @@ final class SessionHealthTests: XCTestCase {
             heartbeatFreshness: heartbeat,
             checkpointFreshness: checkpoint,
             checkpointRecoverable: recoverable,
-            agentSessionKnown: agentSessionKnown))
+            agentSessionKnown: agentSessionKnown,
+            stopRequested: stopRequested))
     }
 }

--- a/app/Tests/DetachKitTests/SessionSnapshotCacheTests.swift
+++ b/app/Tests/DetachKitTests/SessionSnapshotCacheTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import DetachKit
+
+@MainActor
+final class SessionSnapshotCacheTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var cache: UserDefaultsSessionSnapshotCache!
+
+    override func setUp() {
+        suiteName = "SessionSnapshotCacheTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        cache = UserDefaultsSessionSnapshotCache(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        cache = nil
+        defaults = nil
+        suiteName = nil
+    }
+
+    func testCachePreservesPresentationAndRemovesMutationEvidence() throws {
+        var source = session(name: "one")
+        source.healthActions = [.attach, .stop]
+        source.healthReason = .healthy
+        source.reconcileAction = .removeDeadTmux
+        source.ownershipProven = true
+        source.cleanupEligible = true
+        source.workerPID = 100
+        source.providerPID = 101
+        source.workerHeartbeatAt = Date(timeIntervalSince1970: 100)
+        source.heartbeatFresh = true
+        source.checkpointFresh = true
+        source.powerProtectionState = .protected
+
+        cache.store([source])
+        let loaded = try XCTUnwrap(cache.load().first)
+
+        XCTAssertEqual(loaded.id, source.id)
+        XCTAssertEqual(loaded.displayTitle, source.displayTitle)
+        XCTAssertEqual(loaded.effectiveStatus, .running)
+        XCTAssertEqual(loaded.healthActions, [])
+        XCTAssertTrue(loaded.availableActions.isEmpty)
+        XCTAssertNil(loaded.healthReason)
+        XCTAssertEqual(loaded.reconcileAction, SessionReconcileAction.none)
+        XCTAssertEqual(loaded.ownershipProven, false)
+        XCTAssertEqual(loaded.cleanupEligible, false)
+        XCTAssertNil(loaded.workerPID)
+        XCTAssertNil(loaded.providerPID)
+        XCTAssertNil(loaded.workerHeartbeatAt)
+        XCTAssertEqual(loaded.heartbeatFresh, false)
+        XCTAssertEqual(loaded.checkpointFresh, false)
+        XCTAssertEqual(loaded.powerProtectionState, .unknown)
+    }
+
+    func testCacheRejectsCorruptDuplicateAndOversizedDocuments() {
+        defaults.set(Data("not-json".utf8), forKey: UserDefaultsSessionSnapshotCache.defaultKey)
+        XCTAssertTrue(cache.load().isEmpty)
+
+        defaults.removeObject(forKey: UserDefaultsSessionSnapshotCache.defaultKey)
+        let duplicates = Array(repeating: session(name: "duplicate"), count: 2)
+        cache.store(duplicates)
+        XCTAssertNil(defaults.data(forKey: UserDefaultsSessionSnapshotCache.defaultKey))
+        XCTAssertTrue(cache.load().isEmpty)
+
+        defaults.set(
+            Data(repeating: 0x20, count: UserDefaultsSessionSnapshotCache.maximumByteCount + 1),
+            forKey: UserDefaultsSessionSnapshotCache.defaultKey)
+        XCTAssertTrue(cache.load().isEmpty)
+    }
+
+    func testCacheRejectsMoreThanTheBoundedSessionCount() {
+        let sessions = (0...UserDefaultsSessionSnapshotCache.maximumSessionCount).map {
+            session(name: "session-\($0)")
+        }
+
+        cache.store(sessions)
+
+        XCTAssertTrue(cache.load().isEmpty)
+    }
+
+    private func session(name: String) -> Session {
+        Session(
+            schema: 1,
+            provider: .codex,
+            sessionName: "detach-codex-\(name)",
+            name: name,
+            displayName: "Session \(name)",
+            effectiveStatus: .running,
+            metaStatus: "running",
+            agentSessionId: "agent-\(name)",
+            projectDir: "/tmp/\(name)",
+            createdAt: Date(timeIntervalSince1970: 50))
+    }
+}

--- a/app/Tests/DetachKitTests/SessionSnapshotCacheTests.swift
+++ b/app/Tests/DetachKitTests/SessionSnapshotCacheTests.swift
@@ -70,6 +70,27 @@ final class SessionSnapshotCacheTests: XCTestCase {
         XCTAssertTrue(cache.load().isEmpty)
     }
 
+    func testCacheWritesOnlyWhenThePresentationChanges() {
+        let key = UserDefaultsSessionSnapshotCache.defaultKey
+        var source = session(name: "one")
+        cache.store([source])
+        XCTAssertNotNil(defaults.data(forKey: key))
+
+        // Volatile runtime fields change on nearly every snapshot and are not
+        // part of the stored presentation, so they must not rewrite defaults.
+        defaults.removeObject(forKey: key)
+        source.workerHeartbeatAt = Date(timeIntervalSince1970: 200)
+        source.heartbeatFresh = true
+        source.powerProtectionState = .protected
+        cache.store([source])
+        XCTAssertNil(defaults.data(forKey: key))
+
+        source.effectiveStatus = .stopped
+        cache.store([source])
+        XCTAssertNotNil(defaults.data(forKey: key))
+        XCTAssertEqual(cache.load().first?.effectiveStatus, .stopped)
+    }
+
     func testCacheRejectsMoreThanTheBoundedSessionCount() {
         let sessions = (0...UserDefaultsSessionSnapshotCache.maximumSessionCount).map {
             session(name: "session-\($0)")

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -226,6 +226,30 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertNotNil(store.lastUpdated)
     }
 
+    func testCachedRowsPaintImmediatelyButStayNonAuthoritativeUntilRefresh() async throws {
+        let suite = "SessionStoreCacheTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let cache = UserDefaultsSessionSnapshotCache(defaults: defaults)
+        let cached = try XCTUnwrap(SessionListParser.parse(line).sessions.first)
+        cache.store([cached])
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line)
+
+        let store = SessionStore(cli: cli, snapshotCache: cache)
+
+        XCTAssertEqual(store.sessions.map(\.id), [cached.id])
+        XCTAssertTrue(store.sessions[0].availableActions.isEmpty)
+        XCTAssertFalse(store.hasFreshSnapshot)
+        XCTAssertNil(store.lastUpdated)
+
+        await store.refresh()
+
+        XCTAssertTrue(store.hasFreshSnapshot)
+        XCTAssertEqual(store.sessions[0].availableActions, [.attach, .stop])
+        XCTAssertNotNil(store.lastUpdated)
+    }
+
     func testRefreshSortsNewestSessionsFirstAndUsesDistantPastForMissingDates() async {
         let cli = FakeCLI()
         let olderWithoutDate = line
@@ -810,6 +834,61 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(second.calls, [["list", "--json"]])
     }
 
+    func testConfigureWaitsForReadyAndTakesOnlyOneColdStartSnapshot() async {
+        let cli = EventCLI(output: line)
+        let store = SessionStore(cli: FakeCLI())
+
+        let configuration = Task { @MainActor in
+            await store.configure(cli: cli)
+        }
+        await cli.waitUntilSubscribed()
+        XCTAssertEqual(cli.currentCallCount, 0)
+
+        cli.emit(.ready)
+        await configuration.value
+
+        XCTAssertEqual(cli.currentCallCount, 1)
+        XCTAssertEqual(store.sessions.count, 1)
+        store.stopObserving()
+    }
+
+    func testConfigureBoundsAWatcherThatNeverBecomesReady() async {
+        let cli = EventCLI(output: line)
+        let store = SessionStore(
+            cli: FakeCLI(),
+            confirmationSleep: { _ in },
+            eventReadinessSleep: { _ in })
+
+        await store.configure(cli: cli)
+
+        XCTAssertEqual(cli.currentCallCount, 1)
+        XCTAssertEqual(store.sessions.count, 1)
+        store.stopObserving()
+    }
+
+    func testOverlappingConfigureCannotPublishTheStoppedObserver() async {
+        let first = EventCLI(output: line)
+        let second = EventCLI(output: "")
+        let store = SessionStore(cli: FakeCLI())
+        let firstConfiguration = Task { @MainActor in
+            await store.configure(cli: first)
+        }
+        await first.waitUntilSubscribed()
+
+        let secondConfiguration = Task { @MainActor in
+            await store.configure(cli: second)
+        }
+        await second.waitUntilSubscribed()
+        second.emit(.ready)
+        await secondConfiguration.value
+        await firstConfiguration.value
+
+        XCTAssertEqual(first.currentCallCount, 0)
+        XCTAssertEqual(second.currentCallCount, 1)
+        XCTAssertTrue(store.sessions.isEmpty)
+        store.stopObserving()
+    }
+
     func testLateResultFromPreviousCLICannotOverwriteReconfiguredStore() async {
         let first = DelayedCLI()
         let store = SessionStore(cli: first)
@@ -826,5 +905,28 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions, [])
         XCTAssertEqual(store.state, .ok)
         XCTAssertEqual(second.calls, [["list", "--json"]])
+    }
+
+    func testPreviousCLIResultCannotPublishWhileReplacementWaitsForReady() async {
+        let first = DelayedCLI()
+        let store = SessionStore(cli: first)
+        let staleRefresh = Task { await store.refresh() }
+        await first.waitUntilStarted()
+
+        let second = EventCLI(output: "")
+        let configuration = Task { @MainActor in
+            await store.configure(cli: second)
+        }
+        await second.waitUntilSubscribed()
+        await first.finish(with: CLIResult(
+            exitCode: 0, stdout: line, stderr: "", timedOut: false))
+        _ = await staleRefresh.value
+        XCTAssertTrue(store.sessions.isEmpty)
+
+        second.emit(.ready)
+        await configuration.value
+        XCTAssertEqual(second.currentCallCount, 1)
+        XCTAssertTrue(store.sessions.isEmpty)
+        store.stopObserving()
     }
 }

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -336,6 +336,26 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions.count, 1)
     }
 
+    func testTruncatedRefreshUsesExplicitDiagnosticAndPreservesData() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line)
+        let store = SessionStore(cli: cli)
+        await store.refresh()
+        cli.responses["list --json"] = .success(CLIResult(
+            exitCode: 0,
+            stdout: line,
+            stderr: "",
+            timedOut: false,
+            stdoutTruncated: true))
+
+        await store.refresh()
+
+        XCTAssertEqual(
+            store.state,
+            .error(L10n.string("detach returned incomplete output")))
+        XCTAssertEqual(store.sessions.count, 1)
+    }
+
     func testStopCallsCliAndRefreshes() async {
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line)

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -193,11 +193,13 @@ private final class EventCLI: DetachCLIRunning, @unchecked Sendable {
 
 private actor ConfirmationSleepProbe {
     private var callCount = 0
+    private var requestedNanoseconds: [UInt64] = []
     private var callWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
     private var sleepers: [CheckedContinuation<Void, Never>] = []
 
-    func sleep() async {
+    func sleep(nanoseconds: UInt64? = nil) async {
         callCount += 1
+        if let nanoseconds { requestedNanoseconds.append(nanoseconds) }
         let ready = callWaiters.filter { $0.0 <= callCount }
         callWaiters.removeAll { $0.0 <= callCount }
         ready.forEach { $0.1.resume() }
@@ -216,6 +218,46 @@ private actor ConfirmationSleepProbe {
     }
 
     func calls() -> Int { callCount }
+    func delays() -> [UInt64] { requestedNanoseconds }
+}
+
+private actor CancellableSleepProbe {
+    private let immediateCallCount: Int
+    private var callCount = 0
+    private var cancellationCount = 0
+    private var callWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var cancellationWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(immediateCallCount: Int = 0) {
+        self.immediateCallCount = immediateCallCount
+    }
+
+    func sleep(nanoseconds: UInt64) async throws {
+        callCount += 1
+        let ready = callWaiters.filter { $0.0 <= callCount }
+        callWaiters.removeAll { $0.0 <= callCount }
+        ready.forEach { $0.1.resume() }
+        if callCount <= immediateCallCount { return }
+        do {
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+        } catch {
+            cancellationCount += 1
+            let cancelled = cancellationWaiters.filter { $0.0 <= cancellationCount }
+            cancellationWaiters.removeAll { $0.0 <= cancellationCount }
+            cancelled.forEach { $0.1.resume() }
+            throw error
+        }
+    }
+
+    func waitForCallCount(_ expected: Int) async {
+        if callCount >= expected { return }
+        await withCheckedContinuation { callWaiters.append((expected, $0)) }
+    }
+
+    func waitForCancellationCount(_ expected: Int) async {
+        if cancellationCount >= expected { return }
+        await withCheckedContinuation { cancellationWaiters.append((expected, $0)) }
+    }
 }
 
 @MainActor
@@ -815,7 +857,9 @@ final class SessionStoreTests: XCTestCase {
         let probe = ConfirmationSleepProbe()
         let store = SessionStore(
             cli: cli,
-            confirmationSleep: { _ in await probe.sleep() })
+            confirmationSleep: { _ in await probe.sleep() },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
         let confirmed = expectation(description: "confirmation snapshot")
         var snapshotCount = 0
         store.onSnapshot = { _ in
@@ -834,6 +878,25 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(confirmationCalls, 1)
     }
 
+    func testDefaultConfirmationDelayPublishesTheFollowUpSnapshot() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"interrupted""#))
+        let store = SessionStore(cli: cli)
+        let confirmed = expectation(description: "default confirmation snapshot")
+        var snapshotCount = 0
+        store.onSnapshot = { _ in
+            snapshotCount += 1
+            if snapshotCount == 2 { confirmed.fulfill() }
+        }
+
+        await store.refresh()
+        await fulfillment(of: [confirmed], timeout: 1)
+
+        XCTAssertEqual(snapshotCount, 2)
+    }
+
     func testHungConfirmationRefreshRunsOnlyOncePerTransition() async {
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line.replacingOccurrences(
@@ -842,7 +905,9 @@ final class SessionStoreTests: XCTestCase {
         let probe = ConfirmationSleepProbe()
         let store = SessionStore(
             cli: cli,
-            confirmationSleep: { _ in await probe.sleep() })
+            confirmationSleep: { _ in await probe.sleep() },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
         let confirmed = expectation(description: "confirmation snapshot")
         var snapshotCount = 0
         store.onSnapshot = { _ in
@@ -867,6 +932,7 @@ final class SessionStoreTests: XCTestCase {
         let store = SessionStore(
             cli: cli,
             confirmationSleep: { _ in },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
             restartSleep: { _ in await restart.sleep() })
         store.startObserving()
         await cli.waitUntilSubscribed()
@@ -885,12 +951,76 @@ final class SessionStoreTests: XCTestCase {
         store.stopObserving()
     }
 
+    func testForegroundPollingUsesTheBoundedBaseInterval() async {
+        // Keep the historical regression ID. Foreground polling was replaced
+        // by a native stream; this now proves the replacement uses the same
+        // bounded base delay when its watcher exits.
+        let cli = EventCLI(output: line)
+        let restart = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { delay in
+                await restart.sleep(nanoseconds: delay)
+            })
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+
+        cli.end(throwing: DetachCLIStreamError.exited(1))
+        await restart.waitForCallCount(1)
+
+        let delays = await restart.delays()
+        XCTAssertEqual(delays, [SessionStore.restartBaseDelayNanoseconds])
+        store.stopObserving()
+        await restart.resumeSleepers()
+    }
+
+    func testCancellationErrorFromEventStreamStillUsesBoundedRestart() async {
+        let cli = EventCLI(output: line)
+        let restart = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in await restart.sleep() })
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+
+        cli.end(throwing: CancellationError())
+        await restart.waitForCallCount(1)
+
+        let restartCalls = await restart.calls()
+        XCTAssertEqual(restartCalls, 1)
+        store.stopObserving()
+        await restart.resumeSleepers()
+    }
+
+    func testStoppingObserverCancelsTheLongReadinessDeadline() async {
+        let cli = EventCLI(output: line)
+        let readiness = CancellableSleepProbe(immediateCallCount: 1)
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            eventReadinessSleep: { delay in
+                try await readiness.sleep(nanoseconds: delay)
+            },
+            restartSleep: { _ in })
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+        await readiness.waitForCallCount(2)
+
+        store.stopObserving()
+        await readiness.waitForCancellationCount(1)
+    }
+
     func testStoppedObserverNeverRestarts() async {
         let cli = EventCLI(output: line)
         let restart = ConfirmationSleepProbe()
         let store = SessionStore(
             cli: cli,
             confirmationSleep: { _ in },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
             restartSleep: { _ in await restart.sleep() })
         store.startObserving()
         await cli.waitUntilSubscribed()
@@ -910,6 +1040,7 @@ final class SessionStoreTests: XCTestCase {
         let store = SessionStore(
             cli: cli,
             confirmationSleep: { _ in },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
             restartSleep: { _ in await retry.sleep() })
 
         await store.refresh()
@@ -932,7 +1063,8 @@ final class SessionStoreTests: XCTestCase {
         let store = SessionStore(
             cli: FakeCLI(),
             confirmationSleep: { _ in },
-            eventReadinessSleep: { _ in await readiness.sleep() })
+            eventReadinessSleep: { _ in await readiness.sleep() },
+            restartSleep: { _ in })
         let configuration = Task { @MainActor in
             await store.configure(cli: cli)
         }
@@ -1003,16 +1135,122 @@ final class SessionStoreTests: XCTestCase {
 
     func testConfigureBoundsAWatcherThatNeverBecomesReady() async {
         let cli = EventCLI(output: line)
+        let readiness = CancellableSleepProbe(immediateCallCount: 1)
         let store = SessionStore(
             cli: FakeCLI(),
             confirmationSleep: { _ in },
-            eventReadinessSleep: { _ in })
+            eventReadinessSleep: { delay in
+                try await readiness.sleep(nanoseconds: delay)
+            },
+            restartSleep: { _ in })
 
         await store.configure(cli: cli)
 
         XCTAssertEqual(cli.currentCallCount, 1)
         XCTAssertEqual(store.sessions.count, 1)
         store.stopObserving()
+        await readiness.waitForCancellationCount(1)
+    }
+
+    func testResynchronizeInstallsTheWatcherBeforeTakingItsSnapshot() async {
+        let cli = EventCLI(output: line)
+        let store = SessionStore(cli: cli)
+        let resynchronization = Task { @MainActor in
+            await store.resynchronize()
+        }
+        await cli.waitUntilSubscribed()
+        XCTAssertEqual(cli.currentCallCount, 0)
+
+        cli.emit(.ready)
+        await resynchronization.value
+
+        XCTAssertEqual(cli.currentCallCount, 1)
+        XCTAssertEqual(store.sessions.count, 1)
+        store.stopObserving()
+    }
+
+    func testStoppedResynchronizeCannotPublishAfterItsGenerationChanges() async {
+        let cli = EventCLI(output: line)
+        let store = SessionStore(cli: cli)
+        let resynchronization = Task { @MainActor in
+            await store.resynchronize()
+        }
+        await cli.waitUntilSubscribed()
+
+        store.stopObserving()
+        await resynchronization.value
+
+        XCTAssertEqual(cli.currentCallCount, 0)
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testWaitForSessionReturnsAnExistingUnambiguousMatch() async throws {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line)
+        let store = SessionStore(cli: cli)
+        await store.refresh()
+        let expected = try XCTUnwrap(store.sessions.first?.id)
+
+        let match = await store.waitForSession(
+            provider: .codex,
+            projectDirectory: URL(fileURLWithPath: "/tmp/p"),
+            excluding: [])
+
+        XCTAssertEqual(match, expected)
+    }
+
+    func testWaitForSessionCancellationReleasesAPendingWaiter() async {
+        let store = SessionStore(cli: FakeCLI())
+        let waiter = Task { @MainActor in
+            await store.waitForSession(
+                provider: .claude,
+                projectDirectory: URL(fileURLWithPath: "/tmp/missing"),
+                excluding: [])
+        }
+        await Task.yield()
+
+        waiter.cancel()
+
+        let result = await waiter.value
+        XCTAssertNil(result)
+    }
+
+    func testWaitForSessionHonorsCancellationBeforeRegistration() async {
+        let store = SessionStore(cli: FakeCLI())
+        let waiter = Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await store.waitForSession(
+                provider: .claude,
+                projectDirectory: URL(fileURLWithPath: "/tmp/missing"),
+                excluding: [])
+        }
+
+        let result = await waiter.value
+        XCTAssertNil(result)
+    }
+
+    func testNewStableSnapshotCancelsTransientConfirmation() async {
+        let cli = FakeCLI()
+        let interrupted = line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"interrupted""#)
+        cli.responses["list --json"] = ok(interrupted)
+        let confirmation = CancellableSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { delay in
+                try await confirmation.sleep(nanoseconds: delay)
+            },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        await store.refresh()
+        await confirmation.waitForCallCount(1)
+
+        cli.responses["list --json"] = ok(line)
+        await store.refresh()
+        await confirmation.waitForCancellationCount(1)
+
+        XCTAssertEqual(store.sessions.first?.effectiveStatus, .running)
     }
 
     func testOverlappingConfigureCannotPublishTheStoppedObserver() async {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -144,6 +144,18 @@ private final class EventCLI: DetachCLIRunning, @unchecked Sendable {
         continuation?.yield(SessionEvent(event: kind))
     }
 
+    /// Ends the current stream like a watcher exit. A later subscription
+    /// installs a fresh continuation, so `waitUntilSubscribed` waits again.
+    func end(throwing error: (any Error)?) {
+        let continuation: AsyncThrowingStream<SessionEvent, Error>.Continuation? =
+            lock.withLock {
+                let current = self.continuation
+                self.continuation = nil
+                return current
+            }
+        continuation?.finish(throwing: error)
+    }
+
     func setOutput(_ output: String) {
         lock.withLock { self.output = output }
     }
@@ -800,6 +812,123 @@ final class SessionStoreTests: XCTestCase {
 
         XCTAssertEqual(snapshotCount, 2)
         XCTAssertEqual(confirmationCalls, 1)
+    }
+
+    func testHungConfirmationRefreshRunsOnlyOncePerTransition() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"hung""#))
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in await probe.sleep() })
+        let confirmed = expectation(description: "confirmation snapshot")
+        var snapshotCount = 0
+        store.onSnapshot = { _ in
+            snapshotCount += 1
+            if snapshotCount == 2 { confirmed.fulfill() }
+        }
+
+        await store.refresh()
+        await probe.waitForCallCount(1)
+        await probe.resumeSleepers()
+        await fulfillment(of: [confirmed], timeout: 1)
+        await Task.yield()
+        let confirmationCalls = await probe.calls()
+
+        XCTAssertEqual(snapshotCount, 2)
+        XCTAssertEqual(confirmationCalls, 1)
+    }
+
+    func testEndedEventStreamRestartsAfterBoundedBackoff() async {
+        let cli = EventCLI(output: line)
+        let restart = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            restartSleep: { _ in await restart.sleep() })
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+        cli.emit(.ready)
+        await cli.waitForCallCount(1)
+
+        cli.end(throwing: DetachCLIStreamError.exited(1))
+        await restart.waitForCallCount(1)
+        await restart.resumeSleepers()
+        await cli.waitUntilSubscribed()
+        cli.emit(.ready)
+        await cli.waitForCallCount(2)
+
+        XCTAssertEqual(cli.currentCallCount, 2)
+        XCTAssertEqual(store.state, .ok)
+        store.stopObserving()
+    }
+
+    func testStoppedObserverNeverRestarts() async {
+        let cli = EventCLI(output: line)
+        let restart = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            restartSleep: { _ in await restart.sleep() })
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+        store.stopObserving()
+        cli.end(throwing: nil)
+        for _ in 0..<20 { await Task.yield() }
+
+        let restartCalls = await restart.calls()
+        XCTAssertEqual(restartCalls, 0)
+    }
+
+    func testFailedTypedSnapshotIsRetriedWithBackoff() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = .success(CLIResult(
+            exitCode: 1, stdout: "", stderr: "busy", timedOut: false))
+        let retry = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            restartSleep: { _ in await retry.sleep() })
+
+        await store.refresh()
+        XCTAssertEqual(store.state, .error("busy"))
+        cli.responses["list --json"] = ok(line)
+        await retry.waitForCallCount(1)
+        await retry.resumeSleepers()
+        for _ in 0..<200 where store.state != .ok {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        XCTAssertEqual(store.state, .ok)
+        XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertEqual(cli.calls.count, 2)
+    }
+
+    func testSlowWatcherSurvivesTheReadinessWaitAndRefreshesOnItsFirstEvent() async {
+        let cli = EventCLI(output: line)
+        let readiness = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: FakeCLI(),
+            confirmationSleep: { _ in },
+            eventReadinessSleep: { _ in await readiness.sleep() })
+        let configuration = Task { @MainActor in
+            await store.configure(cli: cli)
+        }
+        await cli.waitUntilSubscribed()
+        await readiness.waitForCallCount(1)
+        await readiness.resumeSleepers()
+        await configuration.value
+        XCTAssertEqual(cli.currentCallCount, 1)
+
+        // The watcher was slow, not broken. Its late `ready` repeats the
+        // snapshot that raced the installation instead of being discarded.
+        cli.emit(.ready)
+        await cli.waitForCallCount(2)
+
+        XCTAssertEqual(cli.currentCallCount, 2)
+        store.stopObserving()
     }
 
     func testSnapshotObserverIsNotCalledForFailedSnapshots() async {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -838,6 +838,46 @@ final class SessionStoreTests: XCTestCase {
         store.stopObserving()
     }
 
+    func testChangedEventPublishesAnswerReadyToWorkingTransition() async {
+        let waiting = line.replacingOccurrences(
+            of: #""finished_at":null"#,
+            with: #""finished_at":null,"agent_turn_state":"waiting","agent_turn_id":"turn-1""#)
+        let working = line.replacingOccurrences(
+            of: #""finished_at":null"#,
+            with: #""finished_at":null,"agent_turn_state":"working","agent_turn_id":"turn-2""#)
+        let cli = EventCLI(output: waiting)
+        let store = SessionStore(cli: cli)
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+
+        cli.emit(.ready)
+        await cli.waitForCallCount(1)
+        let answerReady = expectation(description: "answer ready snapshot")
+        store.onSnapshot = { sessions in
+            if sessions.first?.agentTurnState == .waiting {
+                answerReady.fulfill()
+            }
+        }
+        if store.sessions.first?.agentTurnState == .waiting {
+            answerReady.fulfill()
+        }
+        await fulfillment(of: [answerReady], timeout: 1)
+
+        cli.setOutput(working)
+        let resumed = expectation(description: "working snapshot")
+        store.onSnapshot = { sessions in
+            if sessions.first?.agentTurnState == .working {
+                resumed.fulfill()
+            }
+        }
+        cli.emit(.changed)
+        await fulfillment(of: [resumed], timeout: 1)
+
+        XCTAssertFalse(store.sessions[0].isWaitingForUser)
+        XCTAssertEqual(store.sessions[0].section, .active)
+        store.stopObserving()
+    }
+
     func testSnapshotObserverReceivesEverySuccessfulPoll() async {
         // Keep the historical regression ID. Native events now request these
         // typed snapshots instead of a periodic poll.
@@ -1035,6 +1075,27 @@ final class SessionStoreTests: XCTestCase {
 
         let restartCalls = await restart.calls()
         XCTAssertEqual(restartCalls, 0)
+    }
+
+    func testStoppingObserverCancelsPendingSnapshotRetry() async {
+        let cli = EventCLI(output: "invalid")
+        let retry = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in await retry.sleep() })
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+        cli.emit(.ready)
+        await cli.waitForCallCount(1)
+        await retry.waitForCallCount(1)
+
+        store.stopObserving()
+        await retry.resumeSleepers()
+        for _ in 0..<100 { await Task.yield() }
+
+        XCTAssertEqual(cli.currentCallCount, 1)
     }
 
     func testFailedTypedSnapshotIsRetriedWithBackoff() async {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -97,45 +97,113 @@ private actor OverlappingStartCLI: DetachCLIRunning {
     }
 }
 
-private actor PollSleepProbe {
-    private(set) var intervals: [UInt64] = []
-    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
-    private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
-    private var sleepContinuation: CheckedContinuation<Void, Error>?
-    private var cancelled = false
+private final class EventCLI: DetachCLIRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var output: String
+    private var continuation:
+        AsyncThrowingStream<SessionEvent, Error>.Continuation?
+    private var subscriptionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var callWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var callCount = 0
 
-    func sleep(nanoseconds: UInt64) async throws {
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                sleepContinuation = continuation
-                intervals.append(nanoseconds)
-                let waiters = startedWaiters
-                startedWaiters.removeAll()
-                waiters.forEach { $0.resume() }
+    init(output: String) {
+        self.output = output
+    }
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        let (output, ready) = lock.withLock { () -> (String, [CheckedContinuation<Void, Never>]) in
+            callCount += 1
+            let count = callCount
+            let ready = callWaiters.filter { $0.0 <= count }.map(\.1)
+            callWaiters.removeAll { $0.0 <= count }
+            return (self.output, ready)
+        }
+        ready.forEach { $0.resume() }
+        return CLIResult(
+            exitCode: 0,
+            stdout: output,
+            stderr: "",
+            timedOut: false)
+    }
+
+    func sessionEvents() -> AsyncThrowingStream<SessionEvent, Error> {
+        AsyncThrowingStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            let waiters = lock.withLock {
+                self.continuation = continuation
+                let waiters = subscriptionWaiters
+                subscriptionWaiters.removeAll()
+                return waiters
             }
-        } onCancel: {
-            Task { await self.cancelSleep() }
+            waiters.forEach { $0.resume() }
         }
     }
 
-    func waitUntilStarted() async {
-        if !intervals.isEmpty { return }
-        await withCheckedContinuation { startedWaiters.append($0) }
+    func emit(_ kind: SessionEventKind) {
+        let continuation: AsyncThrowingStream<SessionEvent, Error>.Continuation? =
+            lock.withLock { self.continuation }
+        continuation?.yield(SessionEvent(event: kind))
     }
 
-    func waitUntilCancelled() async {
-        if cancelled { return }
-        await withCheckedContinuation { cancellationWaiters.append($0) }
+    func setOutput(_ output: String) {
+        lock.withLock { self.output = output }
     }
 
-    private func cancelSleep() {
-        cancelled = true
-        sleepContinuation?.resume(throwing: CancellationError())
-        sleepContinuation = nil
-        let waiters = cancellationWaiters
-        cancellationWaiters.removeAll()
-        waiters.forEach { $0.resume() }
+    func waitUntilSubscribed() async {
+        await withCheckedContinuation { waiter in
+            let subscribed = lock.withLock {
+                if continuation != nil { return true }
+                subscriptionWaiters.append(waiter)
+                return false
+            }
+            if subscribed {
+                waiter.resume()
+            }
+        }
     }
+
+    func waitForCallCount(_ expected: Int) async {
+        await withCheckedContinuation { waiter in
+            let reached = lock.withLock {
+                if callCount >= expected { return true }
+                callWaiters.append((expected, waiter))
+                return false
+            }
+            if reached {
+                waiter.resume()
+            }
+        }
+    }
+
+    var currentCallCount: Int {
+        lock.withLock { callCount }
+    }
+}
+
+private actor ConfirmationSleepProbe {
+    private var callCount = 0
+    private var callWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var sleepers: [CheckedContinuation<Void, Never>] = []
+
+    func sleep() async {
+        callCount += 1
+        let ready = callWaiters.filter { $0.0 <= callCount }
+        callWaiters.removeAll { $0.0 <= callCount }
+        ready.forEach { $0.1.resume() }
+        await withCheckedContinuation { sleepers.append($0) }
+    }
+
+    func waitForCallCount(_ expected: Int) async {
+        if callCount >= expected { return }
+        await withCheckedContinuation { callWaiters.append((expected, $0)) }
+    }
+
+    func resumeSleepers() {
+        let current = sleepers
+        sleepers.removeAll()
+        current.forEach { $0.resume() }
+    }
+
+    func calls() -> Int { callCount }
 }
 
 @MainActor
@@ -273,7 +341,7 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(result, SessionStartResult(sessionID: "detach-codex-p-1"))
     }
 
-    func testStartDetachedKeepsItsSelectionWhenABackgroundPollSupersedesPublication() async {
+    func testStartDetachedKeepsItsSelectionWhenAnOverlappingRefreshSupersedesPublication() async {
         let cli = OverlappingStartCLI(listOutput: line)
         let store = SessionStore(cli: cli)
         let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
@@ -635,50 +703,41 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(cli.calls, callsBeforeActions)
     }
 
-    func testPollingStartsImmediatelySupportsIdleCadenceAndStopsCleanly() async {
-        let cli = FakeCLI()
-        cli.responses["list --json"] = ok(line)
-        let sleep = PollSleepProbe()
-        let store = SessionStore(
-            cli: cli,
-            pollSleep: { try await sleep.sleep(nanoseconds: $0) })
+    func testNativeEventsRequestTypedSnapshotsWithoutAPeriodicLoop() async {
+        let cli = EventCLI(output: line)
+        let store = SessionStore(cli: cli)
         var snapshots: [[Session]] = []
         store.onSnapshot = { snapshots.append($0) }
-        store.updateCadence(foreground: false)
+        store.startObserving()
+        await cli.waitUntilSubscribed()
+        XCTAssertEqual(cli.currentCallCount, 0)
 
-        store.startPolling(interval: 0.01)
-        await sleep.waitUntilStarted()
+        cli.emit(.ready)
+        await cli.waitForCallCount(1)
+        let initial = expectation(description: "initial event snapshot")
+        if !store.sessions.isEmpty { initial.fulfill() }
+        else {
+            store.onSnapshot = {
+                snapshots.append($0)
+                initial.fulfill()
+            }
+        }
+        await fulfillment(of: [initial], timeout: 1)
 
-        let intervals = await sleep.intervals
-        XCTAssertEqual(intervals, [10_000_000_000])
-        XCTAssertEqual(cli.calls, [["list", "--json"]])
-        XCTAssertEqual(snapshots.map { $0.map(\.sessionName) }, [["detach-codex-p-1"]])
-        XCTAssertEqual(store.state, .ok)
+        cli.setOutput("")
+        let changed = expectation(description: "changed event snapshot")
+        store.onSnapshot = {
+            snapshots.append($0)
+            if $0.isEmpty { changed.fulfill() }
+        }
+        cli.emit(.changed)
+        await fulfillment(of: [changed], timeout: 1)
 
-        store.stopPolling()
-        await sleep.waitUntilCancelled()
-
-        XCTAssertEqual(cli.calls, [["list", "--json"]])
+        XCTAssertEqual(snapshots.last, [])
+        store.stopObserving()
     }
 
-    func testForegroundPollingUsesTheBoundedBaseInterval() async {
-        let cli = FakeCLI()
-        cli.responses["list --json"] = ok(line)
-        let sleep = PollSleepProbe()
-        let store = SessionStore(
-            cli: cli,
-            pollSleep: { try await sleep.sleep(nanoseconds: $0) })
-
-        store.startPolling(interval: 0.01)
-        await sleep.waitUntilStarted()
-
-        let intervals = await sleep.intervals
-        XCTAssertEqual(intervals, [500_000_000])
-        store.stopPolling()
-        await sleep.waitUntilCancelled()
-    }
-
-    func testSnapshotObserverReceivesEverySuccessfulPoll() async {
+    func testSnapshotObserverReceivesEverySuccessfulTypedSnapshot() async {
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line)
         let store = SessionStore(cli: cli)
@@ -686,13 +745,40 @@ final class SessionStoreTests: XCTestCase {
         store.onSnapshot = { snapshots.append($0) }
 
         await store.refresh()
-        await store.refresh() // unchanged list still advances the observer
+        await store.refresh() // unchanged state still advances transition evidence
 
         XCTAssertEqual(snapshots.count, 2)
         XCTAssertEqual(snapshots.last?.count, 1)
     }
 
-    func testSnapshotObserverIsNotCalledForFailedPolls() async {
+    func testInterruptedConfirmationRefreshRunsOnlyOncePerTransition() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"interrupted""#))
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in await probe.sleep() })
+        let confirmed = expectation(description: "confirmation snapshot")
+        var snapshotCount = 0
+        store.onSnapshot = { _ in
+            snapshotCount += 1
+            if snapshotCount == 2 { confirmed.fulfill() }
+        }
+
+        await store.refresh()
+        await probe.waitForCallCount(1)
+        await probe.resumeSleepers()
+        await fulfillment(of: [confirmed], timeout: 1)
+        await Task.yield()
+        let confirmationCalls = await probe.calls()
+
+        XCTAssertEqual(snapshotCount, 2)
+        XCTAssertEqual(confirmationCalls, 1)
+    }
+
+    func testSnapshotObserverIsNotCalledForFailedSnapshots() async {
         let cli = FakeCLI()
         let store = SessionStore(cli: cli)
         var snapshotCount = 0

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -88,10 +88,12 @@ private actor OverlappingStartCLI: DetachCLIRunning {
         await withCheckedContinuation { listWaiters.append((call, $0)) }
     }
 
-    func finishListCall(_ call: Int) {
+    var currentListCallCount: Int { listCallCount }
+
+    func finishListCall(_ call: Int, output: String? = nil) {
         listContinuations.removeValue(forKey: call)?.resume(returning: CLIResult(
             exitCode: 0,
-            stdout: listOutput,
+            stdout: output ?? listOutput,
             stderr: "",
             timedOut: false))
     }
@@ -439,7 +441,7 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(result, SessionStartResult(sessionID: "detach-codex-p-1"))
     }
 
-    func testStartDetachedKeepsItsSelectionWhenAnOverlappingRefreshSupersedesPublication() async {
+    func testStartDetachedKeepsItsSelectionWhenAnOverlappingRefreshQueuesATrailingRead() async {
         let cli = OverlappingStartCLI(listOutput: line)
         let store = SessionStore(cli: cli)
         let project = URL(fileURLWithPath: "/tmp/p", isDirectory: true)
@@ -453,14 +455,43 @@ final class SessionStoreTests: XCTestCase {
         }
         await cli.waitForListCall(1)
         let backgroundPoll = Task { @MainActor in await store.refresh() }
-        await cli.waitForListCall(2)
+        await Task.yield()
+        let callsBeforeFirstCompletion = await cli.currentListCallCount
+        XCTAssertEqual(callsBeforeFirstCompletion, 1)
 
         await cli.finishListCall(1)
-        let result = await launch.value
+        await cli.waitForListCall(2)
         await cli.finishListCall(2)
+        let result = await launch.value
         _ = await backgroundPoll.value
 
         XCTAssertEqual(result.sessionID, "detach-codex-p-1")
+        XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
+    }
+
+    func testOverlappingRefreshesUseOneTrailingSnapshotAndPublishNewestObservation() async {
+        let cli = OverlappingStartCLI(listOutput: line)
+        let store = SessionStore(cli: cli)
+        let first = Task { @MainActor in await store.refresh() }
+        await cli.waitForListCall(1)
+
+        let second = Task { @MainActor in await store.refresh() }
+        let third = Task { @MainActor in await store.refresh() }
+        await Task.yield()
+        let callsBeforeFirstCompletion = await cli.currentListCallCount
+        XCTAssertEqual(callsBeforeFirstCompletion, 1)
+
+        await cli.finishListCall(1, output: "")
+        await cli.waitForListCall(2)
+        let callsDuringTrailingRead = await cli.currentListCallCount
+        XCTAssertEqual(callsDuringTrailingRead, 2)
+        await cli.finishListCall(2, output: line)
+        _ = await first.value
+        _ = await second.value
+        _ = await third.value
+
+        let finalCallCount = await cli.currentListCallCount
+        XCTAssertEqual(finalCallCount, 2)
         XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
     }
 
@@ -1352,9 +1383,12 @@ final class SessionStoreTests: XCTestCase {
 
         let second = FakeCLI()
         second.responses["list --json"] = ok("")
-        await store.configure(cli: second)
+        let configuration = Task { @MainActor in
+            await store.configure(cli: second)
+        }
         await first.finish(with: CLIResult(
             exitCode: 0, stdout: line, stderr: "", timedOut: false))
+        await configuration.value
         _ = await staleRefresh.value
 
         XCTAssertEqual(store.sessions, [])

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -838,7 +838,9 @@ final class SessionStoreTests: XCTestCase {
         store.stopObserving()
     }
 
-    func testSnapshotObserverReceivesEverySuccessfulTypedSnapshot() async {
+    func testSnapshotObserverReceivesEverySuccessfulPoll() async {
+        // Keep the historical regression ID. Native events now request these
+        // typed snapshots instead of a periodic poll.
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line)
         let store = SessionStore(cli: cli)
@@ -1086,7 +1088,9 @@ final class SessionStoreTests: XCTestCase {
         store.stopObserving()
     }
 
-    func testSnapshotObserverIsNotCalledForFailedSnapshots() async {
+    func testSnapshotObserverIsNotCalledForFailedPolls() async {
+        // Keep the historical regression ID. The failure boundary applies to
+        // each typed snapshot requested by the native event stream.
         let cli = FakeCLI()
         let store = SessionStore(cli: cli)
         var snapshotCount = 0

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -801,7 +801,10 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(cli.calls, callsBeforeActions)
     }
 
-    func testNativeEventsRequestTypedSnapshotsWithoutAPeriodicLoop() async {
+    func testPollingStartsImmediatelySupportsIdleCadenceAndStopsCleanly() async {
+        // Keep the historical regression ID. Polling and idle cadence were
+        // replaced by a native stream; this proves its immediate ready/change
+        // snapshots and explicit stop boundary.
         let cli = EventCLI(output: line)
         let store = SessionStore(cli: cli)
         var snapshots: [[Session]] = []

--- a/app/Tests/DetachKitTests/SessionTransitionDetectorTests.swift
+++ b/app/Tests/DetachKitTests/SessionTransitionDetectorTests.swift
@@ -304,6 +304,22 @@ final class SessionTransitionDetectorTests: XCTestCase {
         ]).map(\.kind), [.failed])
     }
 
+    func testInterruptedWithTypedStopIntentNeverReportsFailure() {
+        var detector = SessionTransitionDetector()
+        _ = detector.observe([makeSession(name: "work", status: .running)])
+
+        // `detach stop` records its intent before signalling. However many
+        // snapshots show `interrupted` before `stopped` lands, none is a crash.
+        for _ in 0..<3 {
+            XCTAssertTrue(detector.observe([
+                makeSession(name: "work", status: .interrupted, stopRequested: true)
+            ]).isEmpty)
+        }
+        XCTAssertTrue(detector.observe([
+            makeSession(name: "work", status: .stopped, stopRequested: true)
+        ]).isEmpty)
+    }
+
     func testInterruptedThenStoppedIsTreatedAsUserRequestedStop() {
         var detector = SessionTransitionDetector()
         _ = detector.observe([makeSession(name: "work", status: .running)])
@@ -320,14 +336,16 @@ final class SessionTransitionDetectorTests: XCTestCase {
         createdAt: String? = "2026-07-13T10:00:00Z",
         turnState: AgentTurnState? = nil,
         turnID: String? = nil,
-        agentSessionID: String? = "uuid"
+        agentSessionID: String? = "uuid",
+        stopRequested: Bool = false
     ) -> Session {
         let createdAtJSON = createdAt.map { "\"\($0)\"" } ?? "null"
         let turnStateJSON = turnState.map { "\"\($0.rawValue)\"" } ?? "null"
         let turnIDJSON = turnID.map { "\"\($0)\"" } ?? "null"
         let agentSessionIDJSON = agentSessionID.map { "\"\($0)\"" } ?? "null"
+        let stopRequestedJSON = stopRequested ? "\"2026-07-13T10:05:00Z\"" : "null"
         let json = """
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status.rawValue)","meta_status":null,"agent_session_id":\(agentSessionIDJSON),"project_dir":"/tmp/\(name)","created_at":\(createdAtJSON),"last_checkpoint_at":null,"exit_status":null,"finished_at":null,"agent_turn_state":\(turnStateJSON),"agent_turn_id":\(turnIDJSON)}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status.rawValue)","meta_status":null,"agent_session_id":\(agentSessionIDJSON),"project_dir":"/tmp/\(name)","created_at":\(createdAtJSON),"last_checkpoint_at":null,"exit_status":null,"finished_at":null,"stop_requested_at":\(stopRequestedJSON),"agent_turn_state":\(turnStateJSON),"agent_turn_id":\(turnIDJSON)}
         """
         return SessionListParser.parse(json).sessions[0]
     }

--- a/app/Tests/DetachKitTests/SessionTransitionDetectorTests.swift
+++ b/app/Tests/DetachKitTests/SessionTransitionDetectorTests.swift
@@ -253,6 +253,23 @@ final class SessionTransitionDetectorTests: XCTestCase {
         XCTAssertEqual(transitions.map(\.kind), [.completed])
     }
 
+    func testLifecycleIDDistinguishesSameSecondReplacement() {
+        var detector = SessionTransitionDetector()
+        _ = detector.observe([
+            makeSession(
+                name: "work", status: .completed,
+                lifecycleID: "first-run")
+        ])
+
+        let transitions = detector.observe([
+            makeSession(
+                name: "work", status: .completed,
+                lifecycleID: "replacement-run")
+        ])
+
+        XCTAssertEqual(transitions.map(\.kind), [.completed])
+    }
+
     func testDeletedLifecycleDoesNotSuppressReusedNameWithoutCreationDate() {
         var detector = SessionTransitionDetector()
         _ = detector.observe([
@@ -337,15 +354,17 @@ final class SessionTransitionDetectorTests: XCTestCase {
         turnState: AgentTurnState? = nil,
         turnID: String? = nil,
         agentSessionID: String? = "uuid",
-        stopRequested: Bool = false
+        stopRequested: Bool = false,
+        lifecycleID: String? = nil
     ) -> Session {
         let createdAtJSON = createdAt.map { "\"\($0)\"" } ?? "null"
         let turnStateJSON = turnState.map { "\"\($0.rawValue)\"" } ?? "null"
         let turnIDJSON = turnID.map { "\"\($0)\"" } ?? "null"
         let agentSessionIDJSON = agentSessionID.map { "\"\($0)\"" } ?? "null"
         let stopRequestedJSON = stopRequested ? "\"2026-07-13T10:05:00Z\"" : "null"
+        let lifecycleJSON = lifecycleID.map { "\"\($0)\"" } ?? "null"
         let json = """
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status.rawValue)","meta_status":null,"agent_session_id":\(agentSessionIDJSON),"project_dir":"/tmp/\(name)","created_at":\(createdAtJSON),"last_checkpoint_at":null,"exit_status":null,"finished_at":null,"stop_requested_at":\(stopRequestedJSON),"agent_turn_state":\(turnStateJSON),"agent_turn_id":\(turnIDJSON)}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"\(name)","effective_status":"\(status.rawValue)","meta_status":null,"agent_session_id":\(agentSessionIDJSON),"project_dir":"/tmp/\(name)","created_at":\(createdAtJSON),"lifecycle_id":\(lifecycleJSON),"last_checkpoint_at":null,"exit_status":null,"finished_at":null,"stop_requested_at":\(stopRequestedJSON),"agent_turn_state":\(turnStateJSON),"agent_turn_id":\(turnIDJSON)}
         """
         return SessionListParser.parse(json).sessions[0]
     }

--- a/app/Tests/DetachKitTests/StorageStoreTests.swift
+++ b/app/Tests/DetachKitTests/StorageStoreTests.swift
@@ -154,6 +154,25 @@ final class StorageStoreTests: XCTestCase {
         XCTAssertEqual(store.report, report)
     }
 
+    func testTruncatedStorageJSONDoesNotReplaceLastGoodReport() async throws {
+        let cli = FakeCLI()
+        let report = makeReport([makeSession(name: "detach-codex-one", bytes: 4_096)])
+        cli.responses["storage --json"] = ok(try encode(report))
+        let store = StorageStore(cli: cli)
+        await store.refresh()
+        cli.responses["storage --json"] = .success(CLIResult(
+            exitCode: 0,
+            stdout: "{}",
+            stderr: "",
+            timedOut: false,
+            stdoutTruncated: true))
+
+        await store.refresh()
+
+        XCTAssertEqual(store.state, .incompatible)
+        XCTAssertEqual(store.report, report)
+    }
+
     private func ok(_ stdout: String) -> Result<CLIResult, Error> {
         .success(CLIResult(exitCode: 0, stdout: stdout, stderr: "", timedOut: false))
     }

--- a/bin/detach
+++ b/bin/detach
@@ -466,10 +466,10 @@ list_all() {
     claude_output="$temporary_root/claude.jsonl"
     LIST_CODEX_OUTPUT="$codex_output"
     LIST_CLAUDE_OUTPUT="$claude_output"
-    DETACH_LIST_HEADER=1 run_provider codex list --json >"$codex_output" &
+    DETACH_LIST_HEADER=1 exec_provider codex list --json >"$codex_output" &
     codex_pid=$!
     LIST_CODEX_PID="$codex_pid"
-    DETACH_LIST_HEADER=0 run_provider claude list --json >"$claude_output" &
+    DETACH_LIST_HEADER=0 exec_provider claude list --json >"$claude_output" &
     claude_pid=$!
     LIST_CLAUDE_PID="$claude_pid"
     wait "$codex_pid" || codex_status=$?

--- a/bin/detach
+++ b/bin/detach
@@ -20,6 +20,7 @@ usage() {
     '  detach codex [COMMAND] [ARGS...]' \
     '  detach claude [COMMAND] [ARGS...]' \
     '  detach list [--json]' \
+    '  detach watch --json' \
     '  detach resume [--name NAME] [--detach] SESSION_ID [PROVIDER_ARGS...]' \
     '  detach storage --json' \
     '  detach storage cleanup --dry-run --json [--session NAME ...]' \
@@ -401,6 +402,19 @@ list_all() {
   return "$status"
 }
 
+watch_all() {
+  [ "$#" -eq 1 ] && [ "$1" = "--json" ] || \
+    die "watch requires --json"
+  [ -x "$STATE_BIN" ] || die "state helper not found: $STATE_BIN"
+  # The ready event is emitted only after the native stream is installed, so
+  # the app can take a fresh typed snapshot without a refresh/watch race.
+  exec "$STATE_BIN" events watch --json \
+    --state-root "$STATE_ROOT" \
+    --signal "$STATE_ROOT/session-change" \
+    --transcript-root "$CODEX_PROVIDER_ROOT/sessions" \
+    --transcript-root "$CLAUDE_PROVIDER_ROOT/projects"
+}
+
 storage_report() {
   [ -x "$STATE_BIN" ] || die "state helper not found: $STATE_BIN"
   list_all --json | "$STATE_BIN" storage report \
@@ -622,6 +636,10 @@ main() {
           die "unknown list option: $1"
           ;;
       esac
+      ;;
+    watch)
+      shift
+      watch_all "$@"
       ;;
     resume)
       shift

--- a/bin/detach
+++ b/bin/detach
@@ -21,6 +21,7 @@ usage() {
     '  detach claude [COMMAND] [ARGS...]' \
     '  detach list [--json]' \
     '  detach watch --json' \
+    '  detach client switch --pid PID --from SESSION --to SESSION --provider PROVIDER' \
     '  detach resume [--name NAME] [--detach] SESSION_ID [PROVIDER_ARGS...]' \
     '  detach storage --json' \
     '  detach storage cleanup --dry-run --json [--session NAME ...]' \
@@ -390,15 +391,106 @@ exec_provider() {
     exec "$CORE" "$@"
 }
 
+LIST_WORKSPACE=""
+LIST_CODEX_OUTPUT=""
+LIST_CLAUDE_OUTPUT=""
+LIST_CODEX_PID=""
+LIST_CLAUDE_PID=""
+
+list_workspace_cleanup() {
+  local pid
+
+  for pid in "$LIST_CODEX_PID" "$LIST_CLAUDE_PID"; do
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  LIST_CODEX_PID=""
+  LIST_CLAUDE_PID=""
+  [ -z "$LIST_CODEX_OUTPUT" ] || /bin/rm -f -- "$LIST_CODEX_OUTPUT"
+  [ -z "$LIST_CLAUDE_OUTPUT" ] || /bin/rm -f -- "$LIST_CLAUDE_OUTPUT"
+  [ -z "$LIST_WORKSPACE" ] || rmdir "$LIST_WORKSPACE" 2>/dev/null || true
+  LIST_CODEX_OUTPUT=""
+  LIST_CLAUDE_OUTPUT=""
+  LIST_WORKSPACE=""
+}
+
+list_workspace_abort() {
+  local status="$1"
+
+  list_workspace_cleanup
+  trap - EXIT HUP INT TERM
+  exit "$status"
+}
+
 list_all() {
   local status=0
   local provider_status
+  local power_status=""
+  local DETACH_LIST_POWER_STATE="unavailable"
+  local temporary_base temporary_root codex_output claude_output
+  local codex_pid claude_pid codex_status=0 claude_status=0
 
-  DETACH_LIST_HEADER=1 run_provider codex list "$@" || status=$?
-  DETACH_LIST_HEADER=0 run_provider claude list "$@" || {
-    provider_status=$?
-    [ "$status" -ne 0 ] || status="$provider_status"
-  }
+  if [ "$#" -eq 1 ] && [ "$1" = "--json" ] && \
+     [ -x "$POWER_BIN" ] && [ -x "$STATE_BIN" ]; then
+    power_status="$("$POWER_BIN" status --json --quick 2>/dev/null || true)"
+    if [ -n "$power_status" ]; then
+      DETACH_LIST_POWER_STATE="$(printf '%s' "$power_status" | \
+        "$STATE_BIN" meta get /dev/stdin state 2>/dev/null || true)"
+    fi
+    case "$DETACH_LIST_POWER_STATE" in
+      allowed|transitioning|protected|low_battery|temperature|unavailable|unknown) ;;
+      *) DETACH_LIST_POWER_STATE="unavailable" ;;
+    esac
+    export DETACH_LIST_POWER_STATE
+  fi
+
+  if [ "$#" -eq 1 ] && [ "$1" = "--json" ]; then
+    # Provider state roots are independent. Overlap the two read-only
+    # snapshots, then publish their complete outputs in stable provider order.
+    # Private files prevent interleaved JSON without retaining output in shell
+    # variables, which cannot safely carry arbitrary size or NUL bytes.
+    temporary_base="${TMPDIR:-/tmp}"
+    temporary_base="${temporary_base%/}"
+    temporary_root="$(mktemp -d "$temporary_base/detach-list.XXXXXXXX")" || \
+      die "could not create private list workspace"
+    LIST_WORKSPACE="$temporary_root"
+    trap 'list_workspace_cleanup' EXIT
+    trap 'list_workspace_abort 129' HUP
+    trap 'list_workspace_abort 130' INT
+    trap 'list_workspace_abort 143' TERM
+    chmod 0700 "$temporary_root" || {
+      die "could not protect private list workspace"
+    }
+    codex_output="$temporary_root/codex.jsonl"
+    claude_output="$temporary_root/claude.jsonl"
+    LIST_CODEX_OUTPUT="$codex_output"
+    LIST_CLAUDE_OUTPUT="$claude_output"
+    DETACH_LIST_HEADER=1 run_provider codex list --json >"$codex_output" &
+    codex_pid=$!
+    LIST_CODEX_PID="$codex_pid"
+    DETACH_LIST_HEADER=0 run_provider claude list --json >"$claude_output" &
+    claude_pid=$!
+    LIST_CLAUDE_PID="$claude_pid"
+    wait "$codex_pid" || codex_status=$?
+    LIST_CODEX_PID=""
+    wait "$claude_pid" || claude_status=$?
+    LIST_CLAUDE_PID=""
+    [ ! -f "$codex_output" ] || /bin/cat "$codex_output" || status=1
+    [ ! -f "$claude_output" ] || /bin/cat "$claude_output" || status=1
+    list_workspace_cleanup
+    trap - EXIT HUP INT TERM
+    [ "$codex_status" -eq 0 ] || status="$codex_status"
+    if [ "$claude_status" -ne 0 ] && [ "$status" -eq 0 ]; then
+      status="$claude_status"
+    fi
+  else
+    DETACH_LIST_HEADER=1 run_provider codex list "$@" || status=$?
+    DETACH_LIST_HEADER=0 run_provider claude list "$@" || {
+      provider_status=$?
+      [ "$status" -ne 0 ] || status="$provider_status"
+    }
+  fi
   return "$status"
 }
 
@@ -579,6 +671,52 @@ resume_auto() {
   die "could not resume session UUID: $session_id"
 }
 
+client_switch() {
+  local action="${1:-}"
+  local client_pid=""
+  local source_session=""
+  local target_session=""
+  local provider=""
+
+  [ "$action" = switch ] || \
+    die "usage: detach client switch --pid PID --from SESSION --to SESSION --provider PROVIDER"
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --pid)
+        [ "$#" -ge 2 ] || die "client switch --pid requires a value"
+        client_pid="$2"
+        shift 2
+        ;;
+      --from)
+        [ "$#" -ge 2 ] || die "client switch --from requires a value"
+        source_session="$2"
+        shift 2
+        ;;
+      --to)
+        [ "$#" -ge 2 ] || die "client switch --to requires a value"
+        target_session="$2"
+        shift 2
+        ;;
+      --provider)
+        [ "$#" -ge 2 ] || die "client switch --provider requires a value"
+        provider="$2"
+        shift 2
+        ;;
+      *) die "unknown client switch option: $1" ;;
+    esac
+  done
+
+  case "$client_pid" in ''|*[!0-9]*) die "client switch PID must be a positive integer" ;; esac
+  [ "$client_pid" -gt 1 ] || die "client switch PID must be greater than one"
+  [ -n "$source_session" ] || die "client switch requires --from"
+  [ -n "$target_session" ] || die "client switch requires --to"
+  case "$provider" in codex|claude) ;; *) die "client switch provider must be codex or claude" ;; esac
+
+  run_provider "$provider" __switch_client \
+    "$client_pid" "$source_session" "$target_session"
+}
+
 main() {
   local command="${1:-}"
   local repair_metadata="" local_repair_source="" local_repair_version=""
@@ -640,6 +778,10 @@ main() {
     watch)
       shift
       watch_all "$@"
+      ;;
+    client)
+      shift
+      client_switch "$@"
       ;;
     resume)
       shift

--- a/bin/detach
+++ b/bin/detach
@@ -503,6 +503,8 @@ watch_all() {
   exec "$STATE_BIN" events watch --json \
     --state-root "$STATE_ROOT" \
     --signal "$STATE_ROOT/session-change" \
+    --sessions-root "$CODEX_STATE_ROOT/sessions" \
+    --sessions-root "$CLAUDE_STATE_ROOT/sessions" \
     --transcript-root "$CODEX_PROVIDER_ROOT/sessions" \
     --transcript-root "$CLAUDE_PROVIDER_ROOT/projects"
 }

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -31,6 +31,8 @@ DEFAULT_HISTORY_LIMIT=50000
 DEFAULT_HEALTH_HEARTBEAT_INTERVAL=10
 DEFAULT_HEALTH_HEARTBEAT_STALE=45
 DEFAULT_IDLE_HEALTH_HEARTBEAT_INTERVAL=30
+STOP_TERM_ATTEMPTS=60
+STOP_WORKER_CLEANUP_ATTEMPTS=8
 
 error() {
   printf '%s: %s\n' "$PROGRAM" "$*" >&2
@@ -4877,9 +4879,12 @@ show_logs() {
 stop_session() {
   local session="$1"
   local attempts=0
+  local cleanup_attempts=0
+  local cleanup_grace_expired=0
   local pane
   local pane_pid
   local pgid
+  local provider_pid
   local run_token
   local stop_requested_at
   local stop_intent_recorded=0
@@ -4909,6 +4914,8 @@ stop_session() {
           die "could not record Stop intent for the exact managed run"
       stop_intent_recorded=1
       pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
+      provider_pid="$(read_meta_field "$session" provider_pid 2>/dev/null || true)"
+      case "$provider_pid" in ''|*[!0-9]*) provider_pid="" ;; esac
       if [ -n "$pane_pid" ]; then
         pgid="$(/bin/ps -o pgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]')"
         case "$pgid" in ''|*[!0-9]*) pgid="" ;; esac
@@ -4918,12 +4925,28 @@ stop_session() {
           2>/dev/null || true
       fi
 
-      while [ "$(tmux_pane_dead "$session")" = "0" ] && [ "$attempts" -lt 60 ]; do
+      while [ "$(tmux_pane_dead "$session")" = "0" ] && \
+            [ "$attempts" -lt "$STOP_TERM_ATTEMPTS" ]; do
         attempts=$((attempts + 1))
         sleep 0.25
+        # Old immutable workers can remain in final checkpoint work after the
+        # provider exits. Keep that safe window bounded without shortening the
+        # grace for a provider that is still the worker's exact descendant.
+        if [ -n "$provider_pid" ] && [ -n "$pgid" ] && \
+           ! process_is_descendant "$provider_pid" "$pane_pid"; then
+          cleanup_attempts=$((cleanup_attempts + 1))
+          if [ "$cleanup_attempts" -ge "$STOP_WORKER_CLEANUP_ATTEMPTS" ]; then
+            cleanup_grace_expired=1
+            break
+          fi
+        else
+          cleanup_attempts=0
+        fi
       done
       if [ "$(tmux_pane_dead "$session")" = "0" ]; then
-        error "$PROVIDER_LABEL did not stop after 15 seconds; sending KILL"
+        if [ "$cleanup_grace_expired" -eq 0 ]; then
+          error "$PROVIDER_LABEL did not stop after 15 seconds; sending KILL"
+        fi
         if [ -n "$pgid" ] && \
            ! signal_managed_pane_group "$session" "$run_token" "$pane" "$pane_pid" "$pgid" KILL \
              2>/dev/null; then

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -3801,6 +3801,10 @@ tmux_environment_args() {
   local name
   local value
 
+  # The private pane supports true color even when Finder launched Detach.app
+  # without a terminal environment. Keep provider rendering and ANSI
+  # checkpoints independent of whichever process first daemonized tmux.
+  printf '%s\0%s\0' '-e' 'COLORTERM=truecolor'
   for name in PATH HOME USER LOGNAME SHELL TMPDIR LANG LC_ALL LC_CTYPE \
               XDG_CONFIG_HOME XDG_STATE_HOME \
               NODE_EXTRA_CA_CERTS HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY \
@@ -4967,6 +4971,9 @@ stop_session() {
         --string status stopped || \
           die "could not record Stop intent for the exact managed run"
       stop_intent_recorded=1
+      # Preserve the stop-edge screen before the first signal. A bounded Stop
+      # may later terminate a worker stuck in a slow database checkpoint.
+      checkpoint_pane "$session" || true
       pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
       provider_pid="$(read_meta_field "$session" provider_pid 2>/dev/null || true)"
       case "$provider_pid" in ''|*[!0-9]*) provider_pid="" ;; esac

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -4387,11 +4387,13 @@ session_health_envelope() {
   local runtime_identity_expected=false
   local health_schema="${10:-}"
   local output_mode="${11:-assessment}"
+  local stop_requested_at="${12:-}"
+  local stop_requested=false
   local now
   local checkpoint_threshold
 
-  if [ "$#" -ge 11 ]; then
-    shift 11
+  if [ "$#" -ge 12 ]; then
+    shift 12
   else
     set --
   fi
@@ -4405,6 +4407,7 @@ session_health_envelope() {
   if [ "$metadata_valid" = "true" ]; then
     [ "$health_schema" = "1" ] && runtime_identity_expected=true
     [ -n "$id" ] && [ "$id" != "-" ] && agent_session_known=true
+    [ -z "$stop_requested_at" ] || stop_requested=true
   fi
 
   tmux_health_snapshot "$session"
@@ -4501,7 +4504,8 @@ session_health_envelope() {
     --heartbeat "$heartbeat_freshness" \
     --checkpoint "$checkpoint_freshness" \
     --checkpoint-recoverable "$checkpoint_recoverable" \
-    --agent-session-known "$agent_session_known"
+    --agent-session-known "$agent_session_known" \
+    --stop-requested "$stop_requested"
   )
   if [ "$output_mode" = "request" ]; then
     health_args+=(
@@ -4542,7 +4546,8 @@ refuse_runtime_without_managed_tmux() {
   health_output="$(session_health_envelope \
     "$session" true "$status" "$id" "$META_RUN_TOKEN" \
     "$META_WORKER_PID" "$META_PROVIDER_PID" "$META_WORKER_HEARTBEAT_EPOCH" \
-    "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA")" || \
+    "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" assessment \
+    "$META_STOP_REQUESTED_AT")" || \
     die "could not safely evaluate runtime ownership for '$session'"
   health_json="${health_output#*$'\n'}"
   [ "$health_json" != "$health_output" ] || \
@@ -4704,11 +4709,12 @@ list_session_records() {
           "" "" "" "" "" ""
         session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
-          request "${LIST_JSON_ARGS[@]}" || \
+          request "" "${LIST_JSON_ARGS[@]}" || \
           die "could not evaluate health for '$session'"
       else
         health_output="$(session_health_envelope \
-          "$session" false unknown "-" "" "" "" "" "" "")" || \
+          "$session" false unknown "-" "" "" "" "" "" "" \
+          assessment "")" || \
           die "could not evaluate health for '$session'"
       fi
       if [ "$json_mode" = "1" ]; then
@@ -4759,13 +4765,14 @@ list_session_records() {
         "$session" true "$status" "$id" "$META_RUN_TOKEN" \
         "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
         "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" \
-        request "${LIST_JSON_ARGS[@]}" || \
+        request "$META_STOP_REQUESTED_AT" "${LIST_JSON_ARGS[@]}" || \
         die "could not evaluate health for '$session'"
     else
       health_output="$(session_health_envelope \
         "$session" true "$status" "$id" "$META_RUN_TOKEN" \
         "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
-        "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA")" || \
+        "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" assessment \
+        "$META_STOP_REQUESTED_AT")" || \
         die "could not evaluate health for '$session'"
     fi
     if [ "$json_mode" = "1" ]; then

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -170,7 +170,7 @@ usage() {
     'Usage:' \
     "  $PROGRAM [start] [--name NAME] [--detach] [--] [$PROVIDER_ARGS_LABEL...]" \
     "  $PROGRAM resume [--name NAME] [--detach] SESSION_ID [$PROVIDER_ARGS_LABEL...]" \
-    "  $PROGRAM attach [NAME]" \
+    "  $PROGRAM attach [--terminal-features sync] [NAME]" \
     "  $PROGRAM list [--json]" \
     "  $PROGRAM config tmux-style [detach|inherit]" \
     "  $PROGRAM config tmux-mouse [on|off]" \
@@ -361,7 +361,7 @@ ensure_owned_state_directory() {
         die "cannot create $label: $path"
     }
   fi
-  owner_uid="$(/usr/bin/id -u)" || die "could not determine the current user"
+  owner_uid="$UID"
   [ -d "$path" ] && [ ! -L "$path" ] && \
     [ "$(/usr/bin/stat -f '%u' "$path" 2>/dev/null || true)" = "$owner_uid" ] || \
       die "$label is not a user-owned directory: $path"
@@ -684,6 +684,11 @@ reset_meta_snapshot() {
   META_WORKER_HEARTBEAT_EPOCH=""
   META_LAST_CHECKPOINT_EPOCH=""
   META_HEALTH_SCHEMA=""
+  TRANSCRIPT_MODEL=""
+  TRANSCRIPT_CTX_USED=""
+  TRANSCRIPT_CTX_WINDOW=""
+  TRANSCRIPT_AGENT_TURN_STATE=""
+  TRANSCRIPT_AGENT_TURN_ID=""
 }
 
 load_meta_snapshot_path() {
@@ -781,6 +786,166 @@ tmux_session_running() {
 
 tmux_option() {
   "${TMUX_CMD[@]}" show-options -qv -t "=$1:" "$2" 2>/dev/null || true
+}
+
+# Capture all read-only health fields from one tmux format expansion. This is
+# both faster and more internally consistent than separate has-session,
+# show-options, and display-message processes. A stored pane that is not the
+# active pane gets one exact follow-up read and must still belong to the same
+# session.
+tmux_health_snapshot() {
+  local session="$1"
+  local record=""
+  local detach_marker=""
+  local stored_provider=""
+  local stored_pane=""
+  local current_pane=""
+  local pane_dead=""
+  local pane_pid=""
+  local marker=""
+  local extra=""
+  local pane_session=""
+
+  TMUX_HEALTH_STATE="missing"
+  TMUX_HEALTH_RUN_TOKEN=""
+  TMUX_HEALTH_HEARTBEAT_EPOCH=""
+  TMUX_HEALTH_PANE_PID=""
+
+  if [ "${LIST_TMUX_HEALTH_READY:-0}" = "1" ]; then
+    tmux_health_snapshot_from_list "$session"
+    return
+  fi
+
+  record="$("${TMUX_CMD[@]}" display-message -p -t "=$session:" \
+    '#{@detach}|#{@detach_provider}|#{@detach_run_token}|#{@detach_heartbeat_epoch}|#{@detach_pane_id}|#{pane_id}|#{pane_dead}|#{pane_pid}|END' \
+    2>/dev/null || true)"
+  [ -n "$record" ] || return 0
+  IFS='|' read -r detach_marker stored_provider TMUX_HEALTH_RUN_TOKEN \
+    TMUX_HEALTH_HEARTBEAT_EPOCH stored_pane current_pane pane_dead pane_pid \
+    marker extra <<<"$record"
+  if [ "$marker" != "END" ] || [ -n "$extra" ] || \
+     [ "$detach_marker" != "1" ] || [ "$stored_provider" != "$PROVIDER" ]; then
+    TMUX_HEALTH_STATE="foreign"
+    return 0
+  fi
+  case "$TMUX_HEALTH_RUN_TOKEN" in *'|'*) TMUX_HEALTH_STATE="foreign"; return 0 ;; esac
+  case "$TMUX_HEALTH_HEARTBEAT_EPOCH" in ''|*[!0-9]*) TMUX_HEALTH_HEARTBEAT_EPOCH="" ;; esac
+  case "$current_pane" in
+    %*) case "${current_pane#%}" in ''|*[!0-9]*) TMUX_HEALTH_STATE="foreign"; return 0 ;; esac ;;
+    *) TMUX_HEALTH_STATE="foreign"; return 0 ;;
+  esac
+  if [ -z "$stored_pane" ]; then
+    stored_pane="$current_pane"
+  else
+    case "$stored_pane" in
+      %*) case "${stored_pane#%}" in ''|*[!0-9]*) TMUX_HEALTH_STATE="foreign"; return 0 ;; esac ;;
+      *) TMUX_HEALTH_STATE="foreign"; return 0 ;;
+    esac
+  fi
+  if [ "$stored_pane" != "$current_pane" ]; then
+    record="$("${TMUX_CMD[@]}" display-message -p -t "$stored_pane" \
+      '#{session_name}|#{pane_id}|#{pane_dead}|#{pane_pid}|END' \
+      2>/dev/null || true)"
+    IFS='|' read -r pane_session current_pane pane_dead pane_pid marker extra \
+      <<<"$record"
+    if [ "$pane_session" != "$session" ] || [ "$current_pane" != "$stored_pane" ] || \
+       [ "$marker" != "END" ] || [ -n "$extra" ]; then
+      TMUX_HEALTH_STATE="dead"
+      return 0
+    fi
+  fi
+  case "$pane_dead" in 0) TMUX_HEALTH_STATE="live" ;; *) TMUX_HEALTH_STATE="dead" ;; esac
+  case "$pane_pid" in ''|*[!0-9]*) TMUX_HEALTH_PANE_PID="" ;; *) TMUX_HEALTH_PANE_PID="$pane_pid" ;; esac
+}
+
+# A read-only list needs one internally consistent tmux generation, not one
+# client process per saved session. Mutations never set this cache and keep
+# their exact target revalidation immediately before every signal or change.
+prepare_list_tmux_health_snapshot() {
+  local format
+
+  format='#{session_name}|#{@detach}|#{@detach_provider}|#{@detach_run_token}|#{@detach_heartbeat_epoch}|#{@detach_pane_id}|#{pane_id}|#{pane_dead}|#{pane_pid}|#{window_active}|#{pane_active}|END'
+  LIST_TMUX_HEALTH_ROWS="$(
+    "${TMUX_CMD[@]}" list-panes -a -F "$format" 2>/dev/null || true
+  )"
+  LIST_TMUX_HEALTH_READY=1
+}
+
+tmux_health_snapshot_from_list() {
+  local session="$1"
+  local row_session detach_marker stored_provider run_token heartbeat_epoch
+  local stored_pane pane pane_dead pane_pid window_active pane_active marker extra
+  local found=0
+  local options_loaded=0
+  local expected_stored_pane=""
+  local selected_pane=""
+  local selected_dead=""
+  local selected_pid=""
+  local fallback_pane=""
+  local fallback_dead=""
+  local fallback_pid=""
+
+  while IFS='|' read -r row_session detach_marker stored_provider run_token \
+      heartbeat_epoch stored_pane pane pane_dead pane_pid window_active \
+      pane_active marker extra; do
+    [ "$row_session" = "$session" ] || continue
+    found=1
+    if [ "$marker" != "END" ] || [ -n "$extra" ] || \
+       [ "$detach_marker" != "1" ] || [ "$stored_provider" != "$PROVIDER" ]; then
+      TMUX_HEALTH_STATE="foreign"
+      return 0
+    fi
+    case "$run_token" in *'|'*) TMUX_HEALTH_STATE="foreign"; return 0 ;; esac
+    case "$heartbeat_epoch" in ''|*[!0-9]*) heartbeat_epoch="" ;; esac
+    case "$pane" in
+      %*) case "${pane#%}" in ''|*[!0-9]*) TMUX_HEALTH_STATE="foreign"; return 0 ;; esac ;;
+      *) TMUX_HEALTH_STATE="foreign"; return 0 ;;
+    esac
+    if [ -n "$stored_pane" ]; then
+      case "$stored_pane" in
+        %*) case "${stored_pane#%}" in ''|*[!0-9]*) TMUX_HEALTH_STATE="foreign"; return 0 ;; esac ;;
+        *) TMUX_HEALTH_STATE="foreign"; return 0 ;;
+      esac
+    fi
+    if [ "$options_loaded" -eq 0 ]; then
+      options_loaded=1
+      expected_stored_pane="$stored_pane"
+      TMUX_HEALTH_RUN_TOKEN="$run_token"
+      TMUX_HEALTH_HEARTBEAT_EPOCH="$heartbeat_epoch"
+    elif [ "$stored_pane" != "$expected_stored_pane" ] || \
+         [ "$run_token" != "$TMUX_HEALTH_RUN_TOKEN" ]; then
+      TMUX_HEALTH_STATE="foreign"
+      return 0
+    fi
+    if [ -z "$fallback_pane" ]; then
+      fallback_pane="$pane"
+      fallback_dead="$pane_dead"
+      fallback_pid="$pane_pid"
+    fi
+    if { [ -n "$expected_stored_pane" ] && [ "$pane" = "$expected_stored_pane" ]; } || \
+       { [ -z "$expected_stored_pane" ] && [ "$window_active" = "1" ] && \
+         [ "$pane_active" = "1" ]; }; then
+      selected_pane="$pane"
+      selected_dead="$pane_dead"
+      selected_pid="$pane_pid"
+    fi
+  done <<<"${LIST_TMUX_HEALTH_ROWS:-}"
+
+  [ "$found" -eq 1 ] || return 0
+  if [ -z "$selected_pane" ] && [ -z "$expected_stored_pane" ]; then
+    selected_pane="$fallback_pane"
+    selected_dead="$fallback_dead"
+    selected_pid="$fallback_pid"
+  fi
+  if [ -z "$selected_pane" ]; then
+    TMUX_HEALTH_STATE="dead"
+    return 0
+  fi
+  case "$selected_dead" in 0) TMUX_HEALTH_STATE="live" ;; *) TMUX_HEALTH_STATE="dead" ;; esac
+  case "$selected_pid" in
+    ''|*[!0-9]*) TMUX_HEALTH_PANE_PID="" ;;
+    *) TMUX_HEALTH_PANE_PID="$selected_pid" ;;
+  esac
 }
 
 SESSION_COLOR_PALETTE=(
@@ -1546,7 +1711,15 @@ config_tmux_extended_keys() {
 
 attach_session() {
   local session="$1"
+  local terminal_features="${2:-}"
   local current_socket target_socket
+  local -a attach_tmux=("${TMUX_CMD[@]}")
+
+  case "$terminal_features" in
+    '') ;;
+    sync) attach_tmux+=( -T sync ) ;;
+    *) die "unsupported terminal features: $terminal_features" ;;
+  esac
 
   tmux_has_session "$session" || die "tmux session '$session' is not running"
   tmux_is_managed "$session" || die "refusing to attach to unmanaged tmux session '$session'"
@@ -1559,16 +1732,67 @@ attach_session() {
     target_socket="$("${TMUX_CMD[@]}" display-message -p -t "=$session:" '#{socket_path}' 2>/dev/null)" || \
       die "could not identify the detach tmux server"
     if [ -n "$current_socket" ] && [ "$current_socket" = "$target_socket" ]; then
-      exec "${TMUX_CMD[@]}" switch-client -t "=$session"
+      exec "${attach_tmux[@]}" switch-client -t "=$session"
     fi
     # tmux cannot switch a client across servers. Unset the outer server
     # identity so tmux deliberately opens a nested client for Detach's private
     # server instead of failing after the managed session has already started.
     exec "$ENV_BIN" -u TMUX -u TMUX_PANE \
-      "${TMUX_CMD[@]}" attach-session -t "=$session"
+      "${attach_tmux[@]}" attach-session -t "=$session"
   else
-    exec "${TMUX_CMD[@]}" attach-session -t "=$session"
+    exec "${attach_tmux[@]}" attach-session -t "=$session"
   fi
+}
+
+switch_attached_client() {
+  local client_pid="$1"
+  local source_session="$2"
+  local target_session="$3"
+  local session_name
+  local format row_pid client_name client_session client_uid marker extra
+  local matched_name=""
+  local matches=0
+
+  validate_runtime_config
+  require_common_dependencies
+  ensure_state_dirs
+  case "$client_pid" in ''|*[!0-9]*) die "client PID must be a positive integer" ;; esac
+  [ "$client_pid" -gt 1 ] || die "client PID must be greater than one"
+  for session_name in "$source_session" "$target_session"; do
+    case "$session_name" in
+      ''|*$'\n'*|*$'\r'*|*$'\t'*) die "client session name is invalid" ;;
+    esac
+  done
+
+  tmux_has_session "$source_session" || \
+    die "source tmux session '$source_session' is not running"
+  tmux_is_any_managed "$source_session" || \
+    die "refusing to switch a client from unmanaged tmux session '$source_session'"
+  tmux_has_session "$target_session" || \
+    die "target tmux session '$target_session' is not running"
+  tmux_is_managed "$target_session" || \
+    die "refusing to switch a client to unmanaged tmux session '$target_session'"
+  tmux_session_running "$target_session" || \
+    die "target tmux session '$target_session' has no live pane"
+
+  format=$'#{client_pid}\t#{client_name}\t#{client_session}\t#{client_uid}\tEND'
+  while IFS=$'\t' read -r row_pid client_name client_session client_uid marker extra; do
+    [ "$row_pid" = "$client_pid" ] || continue
+    matches=$((matches + 1))
+    [ "$marker" = END ] && [ -z "$extra" ] || \
+      die "tmux returned an invalid client record"
+    [ "$client_uid" = "$UID" ] || \
+      die "refusing to switch a foreign-owned tmux client"
+    [ "$client_session" = "$source_session" ] || \
+      die "tmux client $client_pid is not attached to '$source_session'"
+    matched_name="$client_name"
+  done < <("${TMUX_CMD[@]}" list-clients -F "$format" 2>/dev/null || true)
+
+  [ "$matches" -eq 1 ] && [ -n "$matched_name" ] || \
+    die "could not identify one exact tmux client for PID $client_pid"
+  [ "$source_session" != "$target_session" ] || return 0
+  "${TMUX_CMD[@]}" switch-client -c "$matched_name" -t "=$target_session" || \
+    die "could not switch tmux client $client_pid to '$target_session'"
 }
 
 state_update_meta() {
@@ -1641,6 +1865,7 @@ write_initial_meta() {
       "$dir/checkpoint/meta.json" \
       "$dir/checkpoint/rollout.jsonl" \
       "$dir/checkpoint/transcript.jsonl" \
+      "$dir/checkpoint/.detach-jsonl-validation.json" \
       "$dir/checkpoint/claude-session.tar" \
       "$dir/checkpoint/codex-state.sqlite" \
       "$dir/checkpoint/pane.txt" \
@@ -2253,6 +2478,14 @@ valid_jsonl() {
     "$STATE_BIN" jsonl validate codex "$path" "$expected_id" >/dev/null 2>&1
 }
 
+valid_jsonl_cached() {
+  local path="$1"
+  local expected_id="$2"
+
+  [ -s "$path" ] && \
+    "$STATE_BIN" jsonl validate-cached codex "$path" "$expected_id" >/dev/null 2>&1
+}
+
 restore_matching_rollout_checkpoint() {
   local session="$1"
   local id="$2"
@@ -2667,7 +2900,7 @@ checkpoint_rollout() {
 
   for attempt in 1 2 3; do
     cp -p "$rollout" "$tmp" 2>/dev/null || true
-    if valid_jsonl "$tmp" "$expected_id"; then
+    if valid_jsonl_cached "$tmp" "$expected_id"; then
       mv -f "$tmp" "$checkpoint_dir/rollout.jsonl"
       return 0
     fi
@@ -2803,25 +3036,43 @@ checkpoint_database() {
   local db
   local checkpoint_dir
   local tmp
+  local tmp_shm
+  local tmp_wal
+  local stale_sidecar
 
   [ "$PROVIDER" = "codex" ] || return 0
   db="$(codex_state_db)"
   [ -n "$db" ] && [ -f "$db" ] || return 1
   checkpoint_dir="$(session_dir "$session")/checkpoint"
+  for stale_sidecar in \
+    "$checkpoint_dir"/codex-state.sqlite.tmp.*-shm \
+    "$checkpoint_dir"/codex-state.sqlite.tmp.*-wal; do
+    [ -f "$stale_sidecar" ] && [ ! -L "$stale_sidecar" ] || continue
+    rm -f -- "$stale_sidecar"
+  done
   tmp="$checkpoint_dir/codex-state.sqlite.tmp.$$"
-  rm -f "$tmp"
+  tmp_shm="$tmp-shm"
+  tmp_wal="$tmp-wal"
+  rm -f "$tmp" "$tmp_shm" "$tmp_wal"
 
   "$SQLITE_BIN" -cmd '.timeout 5000' "$db" ".backup \"$tmp\"" >/dev/null 2>&1 || {
-    rm -f "$tmp"
+    rm -f "$tmp" "$tmp_shm" "$tmp_wal"
     checkpoint_log "$session" "Codex SQLite backup failed"
     return 1
   }
   [ "$($SQLITE_BIN "$tmp" 'PRAGMA quick_check;' 2>/dev/null)" = "ok" ] || {
-    rm -f "$tmp"
+    rm -f "$tmp" "$tmp_shm" "$tmp_wal"
     checkpoint_log "$session" "Codex SQLite backup failed quick_check"
     return 1
   }
-  mv -f "$tmp" "$checkpoint_dir/codex-state.sqlite"
+  # Opening a WAL-mode backup for quick_check creates empty, PID-scoped
+  # companions. They are not part of the validated snapshot and must not
+  # accumulate at every checkpoint.
+  rm -f "$tmp_shm" "$tmp_wal"
+  mv -f "$tmp" "$checkpoint_dir/codex-state.sqlite" || {
+    rm -f "$tmp" "$tmp_shm" "$tmp_wal"
+    return 1
+  }
 }
 
 checkpoint_pane() {
@@ -3973,7 +4224,7 @@ process_is_owned_alive() {
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
   [ "$pid" -gt 1 ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  owner_uid="$(/usr/bin/id -u)" || return 1
+  owner_uid="$UID"
   process_uid="$(/bin/ps -o uid= -p "$pid" 2>/dev/null | tr -d '[:space:]')"
   [ "$process_uid" = "$owner_uid" ]
 }
@@ -4044,7 +4295,7 @@ checkpoint_is_recoverable() {
       valid_claude_transcript "$dir/checkpoint/transcript.jsonl" "$id"
   elif [ "$PROVIDER" = "codex" ] && \
        safe_codex_rollout_path "$transcript_path"; then
-    valid_jsonl "$dir/checkpoint/rollout.jsonl" "$id"
+    valid_jsonl_cached "$dir/checkpoint/rollout.jsonl" "$id"
   else
     return 1
   fi
@@ -4107,15 +4358,11 @@ session_health_envelope() {
     [ -n "$id" ] && [ "$id" != "-" ] && agent_session_known=true
   fi
 
-  if tmux_has_session "$session"; then
-    if ! tmux_is_managed "$session"; then
-      tmux_state="foreign"
-    elif tmux_session_running "$session"; then
-      tmux_state="live"
-    else
-      tmux_state="dead"
-    fi
-  fi
+  tmux_health_snapshot "$session"
+  tmux_state="$TMUX_HEALTH_STATE"
+  tmux_run_token="$TMUX_HEALTH_RUN_TOKEN"
+  tmux_heartbeat_epoch="$TMUX_HEALTH_HEARTBEAT_EPOCH"
+  pane_pid="$TMUX_HEALTH_PANE_PID"
 
   # Full provider checkpoint validation can be expensive. It affects the
   # transition only after an active runtime disappears, never a healthy live
@@ -4128,7 +4375,6 @@ session_health_envelope() {
   esac
 
   if [ "$tmux_state" = "live" ] || [ "$tmux_state" = "dead" ]; then
-    tmux_run_token="$(tmux_option "$session" '@detach_run_token')"
     if [ -z "$meta_run_token" ] || [ -z "$tmux_run_token" ]; then
       token_state="missing"
     elif [ "$meta_run_token" = "$tmux_run_token" ]; then
@@ -4138,39 +4384,42 @@ session_health_envelope() {
     fi
   fi
 
-  case "$worker_pid" in
-    ''|*[!0-9]*) worker_state="unknown" ;;
-    *)
-      if process_is_owned_alive "$worker_pid"; then
-        worker_state="alive"
-      else
-        worker_state="dead"
-      fi
-      ;;
-  esac
-  case "$provider_pid" in
-    ''|*[!0-9]*) provider_state="unknown" ;;
-    *)
-      if ! process_is_owned_alive "$provider_pid"; then
-        provider_state="dead"
-      elif [ "$worker_state" = "alive" ] && \
-           process_is_descendant "$provider_pid" "$worker_pid"; then
-        provider_state="alive"
-      else
-        provider_state="mismatch"
-      fi
-      ;;
-  esac
+  # The batched list helper reads only the recorded PIDs with proc_pidinfo.
+  # State-changing and single-session paths keep the established shell checks.
+  if [ "$output_mode" != "request" ]; then
+    case "$worker_pid" in
+      ''|*[!0-9]*) worker_state="unknown" ;;
+      *)
+        if process_is_owned_alive "$worker_pid"; then
+          worker_state="alive"
+        else
+          worker_state="dead"
+        fi
+        ;;
+    esac
+    case "$provider_pid" in
+      ''|*[!0-9]*) provider_state="unknown" ;;
+      *)
+        process_is_owned_alive "$provider_pid" || provider_state="dead"
+        if [ "$provider_state" = "dead" ]; then
+          :
+        elif [ "$worker_state" = "alive" ] && \
+             process_is_descendant "$provider_pid" "$worker_pid"; then
+          provider_state="alive"
+        else
+          provider_state="mismatch"
+        fi
+        ;;
+    esac
+  fi
 
   if [ "$tmux_state" = "live" ]; then
-    pane_pid="$("${TMUX_CMD[@]}" display-message -p \
-      -t "$(tmux_pane_id "$session")" '#{pane_pid}' 2>/dev/null || true)"
-    if [ "$worker_state" = "alive" ] && [ "$pane_pid" != "$worker_pid" ]; then
+    if [ "$output_mode" != "request" ] && \
+       [ "$worker_state" = "alive" ] && [ "$pane_pid" != "$worker_pid" ]; then
       worker_state="mismatch"
       provider_state="mismatch"
     fi
     if [ "$token_state" = "match" ]; then
-      tmux_heartbeat_epoch="$(tmux_option "$session" '@detach_heartbeat_epoch')"
       case "$tmux_heartbeat_epoch" in
         ''|*[!0-9]*) ;;
         *)
@@ -4184,7 +4433,8 @@ session_health_envelope() {
     fi
   fi
 
-  now="$(date '+%s')"
+  now="${LIST_HEALTH_NOW:-}"
+  case "$now" in ''|*[!0-9]*) now="$(date '+%s')" ;; esac
   checkpoint_threshold=$((CHECKPOINT_INTERVAL * 2 + 60))
   heartbeat_freshness="$(freshness_for_epoch \
     "$heartbeat_epoch" "$HEALTH_HEARTBEAT_STALE" "$now")"
@@ -4204,6 +4454,14 @@ session_health_envelope() {
     --checkpoint-recoverable "$checkpoint_recoverable" \
     --agent-session-known "$agent_session_known"
   )
+  if [ "$output_mode" = "request" ]; then
+    health_args+=(
+      --inspect-processes true
+      --worker-pid "${worker_pid:--}"
+      --provider-pid "${provider_pid:--}"
+      --pane-pid "${pane_pid:--}"
+    )
+  fi
   case "$output_mode" in
     session)
       "$STATE_BIN" health session "${health_args[@]}" -- "$@"
@@ -4287,7 +4545,7 @@ prepare_list_json_args() {
 }
 
 list_meta_snapshots() {
-  "$STATE_BIN" meta snapshots "$SESSIONS_ROOT"
+  "$STATE_BIN" meta snapshots "$SESSIONS_ROOT" --with-transcript-summary
 }
 
 list_session_records() {
@@ -4314,19 +4572,28 @@ list_session_records() {
   local worker_pid
   local provider_pid
   local worker_heartbeat_at
+  local LIST_HEALTH_NOW
 
   ensure_state_dirs
+  prepare_list_tmux_health_snapshot
+  LIST_HEALTH_NOW="$(date '+%s')"
   if [ "$json_mode" = "1" ] && [ -x "$POWER_BIN" ]; then
-    power_status="$("$POWER_BIN" status --json 2>/dev/null || true)"
-    if [ -n "$power_status" ]; then
-      reported_power_state="$(printf '%s' "$power_status" | \
-        "$STATE_BIN" meta get /dev/stdin state 2>/dev/null || true)"
-      case "$reported_power_state" in
-        allowed|transitioning|protected|low_battery|temperature|unavailable|unknown)
-          power_state="$reported_power_state"
-          ;;
-      esac
-    fi
+    reported_power_state="${DETACH_LIST_POWER_STATE:-}"
+    case "$reported_power_state" in
+      allowed|transitioning|protected|low_battery|temperature|unavailable|unknown) ;;
+      *)
+        power_status="$("$POWER_BIN" status --json --quick 2>/dev/null || true)"
+        if [ -n "$power_status" ]; then
+          reported_power_state="$(printf '%s' "$power_status" | \
+            "$STATE_BIN" meta get /dev/stdin state 2>/dev/null || true)"
+        fi
+        ;;
+    esac
+    case "$reported_power_state" in
+      allowed|transitioning|protected|low_battery|temperature|unavailable|unknown)
+        power_state="$reported_power_state"
+        ;;
+    esac
   fi
   if [ "$json_mode" != "1" ]; then
     if [ "${DETACH_LIST_HEADER:-1}" != "0" ]; then
@@ -4358,7 +4625,12 @@ list_session_records() {
       IFS= read -r -d '' META_RUN_TOKEN && \
       IFS= read -r -d '' META_WORKER_HEARTBEAT_EPOCH && \
       IFS= read -r -d '' META_LAST_CHECKPOINT_EPOCH && \
-      IFS= read -r -d '' META_HEALTH_SCHEMA || \
+      IFS= read -r -d '' META_HEALTH_SCHEMA && \
+      IFS= read -r -d '' TRANSCRIPT_MODEL && \
+      IFS= read -r -d '' TRANSCRIPT_CTX_USED && \
+      IFS= read -r -d '' TRANSCRIPT_CTX_WINDOW && \
+      IFS= read -r -d '' TRANSCRIPT_AGENT_TURN_STATE && \
+      IFS= read -r -d '' TRANSCRIPT_AGENT_TURN_ID || \
         die "could not decode metadata snapshot for '$session'"
     if [ "$metadata_valid" != true ]; then
       cwd="?"
@@ -4415,7 +4687,11 @@ list_session_records() {
     if [ -z "$session_color" ] && [ -n "$cwd" ] && [ "$cwd" != "?" ]; then
       session_color="$(session_color_for "$PROVIDER" "$cwd")" || session_color=''
     fi
-    transcript_model_context "$META_TRANSCRIPT_PATH"
+    case "$TRANSCRIPT_AGENT_TURN_STATE" in
+      working|waiting|interrupted) ;;
+      *) TRANSCRIPT_AGENT_TURN_STATE=""; TRANSCRIPT_AGENT_TURN_ID="" ;;
+    esac
+    [ -n "$TRANSCRIPT_AGENT_TURN_ID" ] || TRANSCRIPT_AGENT_TURN_STATE=""
     if [ "$json_mode" = "1" ]; then
       prepare_list_json_args \
         "$session" "$status" "$id" "$checkpoint" "$cwd" "$created" \
@@ -4631,7 +4907,7 @@ delete_locked() {
   local owner_uid
 
   dir="$(session_dir "$session")"
-  owner_uid="$(/usr/bin/id -u)" || die "could not determine the current user"
+  owner_uid="$UID"
   [ -d "$STATE_ROOT" ] && [ ! -L "$STATE_ROOT" ] && \
     [ "$(/usr/bin/stat -f '%u' "$STATE_ROOT" 2>/dev/null || true)" = "$owner_uid" ] || \
     die "refusing unsafe provider state root: $STATE_ROOT"
@@ -4810,6 +5086,7 @@ main() {
   local list_json=0
   local force=0
   local ansi=0
+  local terminal_features=""
   local default_base
 
   validate_runtime_config
@@ -4908,6 +5185,17 @@ main() {
         ansi=1
         shift
         ;;
+      --terminal-features)
+        [ "$action" = "attach" ] || die "unexpected option for $action: $1"
+        [ "$#" -ge 2 ] || die "$1 requires a value"
+        terminal_features="$2"
+        shift 2
+        ;;
+      --terminal-features=*)
+        [ "$action" = "attach" ] || die "unexpected option for $action: $1"
+        terminal_features="${1#*=}"
+        shift
+        ;;
     esac
     if [ "$#" -gt 0 ]; then
       positional_name="$1"
@@ -4951,7 +5239,7 @@ main() {
         "$resume_id" "$display_name" "$@"
       ;;
     attach)
-      attach_session "$session"
+      attach_session "$session" "$terminal_features"
       ;;
     status)
       show_status "$session"
@@ -5040,6 +5328,11 @@ case "${1:-}" in
     shift
     [ "$#" -eq 1 ] || exit 1
     new_default_session_name "$1"
+    ;;
+  __switch_client)
+    shift
+    [ "$#" -eq 3 ] || exit 1
+    switch_attached_client "$@"
     ;;
   __start_tmux_session_locked)
     shift

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -681,6 +681,7 @@ reset_meta_snapshot() {
   META_SESSION_COLOR=""
   META_TRANSCRIPT_PATH=""
   META_RUN_TOKEN=""
+  META_LIFECYCLE_ID=""
   META_WORKER_HEARTBEAT_EPOCH=""
   META_LAST_CHECKPOINT_EPOCH=""
   META_HEALTH_SCHEMA=""
@@ -715,6 +716,7 @@ load_meta_snapshot_path() {
       session_color) META_SESSION_COLOR="$value" ;;
       transcript_path) META_TRANSCRIPT_PATH="$value" ;;
       run_token) META_RUN_TOKEN="$value" ;;
+      lifecycle_id) META_LIFECYCLE_ID="$value" ;;
       worker_heartbeat_epoch) META_WORKER_HEARTBEAT_EPOCH="$value" ;;
       last_checkpoint_epoch) META_LAST_CHECKPOINT_EPOCH="$value" ;;
       health_schema) META_HEALTH_SCHEMA="$value" ;;
@@ -1832,7 +1834,7 @@ publish_session_event() {
   # cleanup suppresses the hint of its final checkpoint because its status
   # write publishes one moment later.
   [ "${DETACH_SUPPRESS_SESSION_EVENT:-0}" != "1" ] || return 0
-  "$STATE_BIN" events publish "$SESSION_EVENT_FILE" >/dev/null 2>&1 || true
+  "$STATE_BIN" events publish "$STATE_BASE_ROOT" >/dev/null 2>&1 || true
 }
 
 # tmux runs this hook when the retained provider pane dies. Nothing else
@@ -1844,7 +1846,7 @@ publish_session_event() {
 # in home directories and are allowed.
 session_event_hook_command() {
   local path
-  for path in "$STATE_BIN" "$SESSION_EVENT_FILE"; do
+  for path in "$STATE_BIN" "$STATE_BASE_ROOT"; do
     case "$path" in
       /*) ;;
       *) return 1 ;;
@@ -1854,7 +1856,7 @@ session_event_hook_command() {
     esac
   done
   printf "run-shell -b \"'%s' events publish '%s' >/dev/null 2>&1 || true\"" \
-    "$STATE_BIN" "$SESSION_EVENT_FILE"
+    "$STATE_BIN" "$STATE_BASE_ROOT"
 }
 
 install_session_event_hook() {
@@ -1892,6 +1894,7 @@ write_initial_meta() {
   local tmp
   local agent_version
   local session_color
+  local lifecycle_id
   local create_args
   local default_base
 
@@ -1919,6 +1922,7 @@ write_initial_meta() {
   fi
   agent_version="$("$agent_bin" --version 2>/dev/null || printf 'unknown')"
   session_color="$(allocate_session_color "$PROVIDER" "$cwd" "$session")" || return 1
+  lifecycle_id="$(new_run_token)" || return 1
 
   create_args=(
     --integer schema 1
@@ -1928,6 +1932,7 @@ write_initial_meta() {
     --integer created_at_ms "$start_ms"
     --string status starting
     --string run_token "$run_token"
+    --string lifecycle_id "$lifecycle_id"
     --string provider "$PROVIDER"
     --string session_color "$session_color"
     --string agent_bin "$agent_bin"
@@ -4560,6 +4565,7 @@ prepare_list_json_args() {
   local worker_heartbeat_at="${18:-}"
   local display_name="${19:-}"
   local stop_requested_at="${20:-}"
+  local lifecycle_id="${21:-}"
   local session_args
 
   [[ "$session_color" =~ ^#[0-9A-Fa-f]{6}$ ]] || session_color=''
@@ -4573,6 +4579,7 @@ prepare_list_json_args() {
     --last-checkpoint-at "$checkpoint"
     --finished-at "$finished"
     --stop-requested-at "$stop_requested_at"
+    --lifecycle-id "$lifecycle_id"
     --model "$model"
     --agent-turn-state "$agent_turn_state"
     --agent-turn-id "$agent_turn_id"
@@ -4669,6 +4676,7 @@ list_session_records() {
       IFS= read -r -d '' META_SESSION_COLOR && \
       IFS= read -r -d '' META_TRANSCRIPT_PATH && \
       IFS= read -r -d '' META_RUN_TOKEN && \
+      IFS= read -r -d '' META_LIFECYCLE_ID && \
       IFS= read -r -d '' META_WORKER_HEARTBEAT_EPOCH && \
       IFS= read -r -d '' META_LAST_CHECKPOINT_EPOCH && \
       IFS= read -r -d '' META_HEALTH_SCHEMA && \
@@ -4693,7 +4701,7 @@ list_session_records() {
         prepare_list_json_args \
           "$session" "" "-" "-" "${cwd:-?}" "" "null" "" \
           "" "null" "null" "" "" "$session_color" "$power_state" \
-          "" "" "" "" ""
+          "" "" "" "" "" ""
         session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
           request "${LIST_JSON_ARGS[@]}" || \
@@ -4746,7 +4754,7 @@ list_session_records() {
         "$TRANSCRIPT_CTX_WINDOW" "$TRANSCRIPT_AGENT_TURN_STATE" \
         "$TRANSCRIPT_AGENT_TURN_ID" "$session_color" "$power_state" \
         "$worker_pid" "$provider_pid" "$worker_heartbeat_at" "$display_name" \
-        "$META_STOP_REQUESTED_AT"
+        "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_ID"
       session_health_envelope \
         "$session" true "$status" "$id" "$META_RUN_TOKEN" \
         "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
@@ -4866,26 +4874,33 @@ stop_session() {
   local pane_pid
   local pgid
   local run_token
+  local stop_requested_at
+  local stop_intent_recorded=0
+  local tmux_run_token_proven=0
 
   refuse_runtime_without_managed_tmux "$session"
   run_token=""
   if tmux_has_session "$session"; then
+    tmux_is_managed "$session" || die "refusing to stop unmanaged tmux session '$session'"
     run_token="$(tmux_option "$session" '@detach_run_token')"
+    [ -z "$run_token" ] || tmux_run_token_proven=1
   fi
   [ -n "$run_token" ] || run_token="$(read_meta_field "$session" run_token 2>/dev/null || true)"
 
-  # Record the intent before the runtime is signalled. The worker then writes
-  # `interrupted` moments before `stopped` follows; consumers must never read
-  # that ordinary window as a crash. A fresh start clears the intent.
-  state_update_meta "$session" \
-    --string stop_requested_at "$(now_iso)" 2>/dev/null || true
-
   if tmux_has_session "$session"; then
-    tmux_is_managed "$session" || die "refusing to stop unmanaged tmux session '$session'"
     pane="$(tmux_pane_id "$session" 2>/dev/null || true)"
     pane_pid=""
     pgid=""
     if [ -n "$pane" ] && [ "$(tmux_pane_dead "$session")" = "0" ]; then
+      [ "$tmux_run_token_proven" -eq 1 ] || \
+        die "refusing to stop a live session without an exact run token"
+      # Record intent only for the exact managed run immediately before its
+      # first signal. A failed write aborts Stop; a fresh start clears intent.
+      stop_requested_at="$(now_iso)"
+      state_update_meta_for_run "$session" "$run_token" \
+        --string stop_requested_at "$stop_requested_at" || \
+          die "could not record Stop intent for the exact managed run"
+      stop_intent_recorded=1
       pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
       if [ -n "$pane_pid" ]; then
         pgid="$(/bin/ps -o pgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]')"
@@ -4910,7 +4925,24 @@ stop_session() {
       fi
     fi
 
-    "${TMUX_CMD[@]}" kill-session -t "=$session" || die "could not remove tmux session '$session'"
+    tmux_is_managed "$session" || \
+      die "refusing to remove a replacement or unmanaged tmux session '$session'"
+    if [ -n "$run_token" ] && \
+       [ "$(tmux_option "$session" '@detach_run_token')" != "$run_token" ]; then
+      die "refusing to remove a replacement tmux run for '$session'"
+    fi
+    if ! "${TMUX_CMD[@]}" kill-session -t "=$session"; then
+      # If the exact run is still alive, this Stop did not take effect. Remove
+      # its intent so a later genuine crash remains observable.
+      if [ "$stop_intent_recorded" -eq 1 ] && \
+         tmux_has_session "$session" && \
+         [ "$(tmux_pane_dead "$session")" = "0" ]; then
+        state_update_meta_for_run "$session" "$run_token" \
+          --null stop_requested_at >/dev/null 2>&1 || \
+            error "warning: could not clear failed Stop intent"
+      fi
+      die "could not remove tmux session '$session'"
+    fi
   fi
   # A recorded descendant can briefly outlive the worker or tmux server. Do
   # not turn that unowned runtime into apparently stopped saved state.
@@ -4919,9 +4951,25 @@ stop_session() {
     "$POWER_BIN" release --session "$session" --run-token "$run_token" >/dev/null 2>&1 || \
       error "warning: could not immediately release Mac sleep protection; the safety lease will expire automatically"
   fi
-  state_update_meta "$session" \
-    --string status stopped --string stopped_at "$(now_iso)" || \
-      die "tmux was stopped, but session metadata could not be updated"
+  if [ -n "$run_token" ]; then
+    if [ "$stop_intent_recorded" -eq 1 ]; then
+      state_update_meta_for_run "$session" "$run_token" \
+        --string status stopped --string stopped_at "$(now_iso)" || \
+          die "tmux was stopped, but exact-run metadata could not be updated"
+    else
+      stop_requested_at="$(now_iso)"
+      state_update_meta_for_run "$session" "$run_token" \
+        --string stop_requested_at "$stop_requested_at" \
+        --string status stopped --string stopped_at "$(now_iso)" || \
+          die "tmux was stopped, but exact-run metadata could not be updated"
+    fi
+  else
+    stop_requested_at="$(now_iso)"
+    state_update_meta "$session" \
+      --string stop_requested_at "$stop_requested_at" \
+      --string status stopped --string stopped_at "$(now_iso)" || \
+        die "tmux was stopped, but session metadata could not be updated"
+  fi
   printf 'Stopped %s\n' "$session"
 }
 
@@ -5387,6 +5435,11 @@ case "${1:-}" in
     shift
     [ "$#" -eq 3 ] || exit 1
     switch_attached_client "$@"
+    ;;
+  __session_event_hook_command)
+    shift
+    [ "$#" -eq 0 ] || exit 1
+    session_event_hook_command
     ;;
   __start_tmux_session_locked)
     shift

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -3671,17 +3671,22 @@ worker_main() {
   # project in the worker so the provider and checkpoint loop never inherit it.
   cd -P "$cwd" >/dev/null 2>&1 || die "could not enter project directory: $cwd"
 
-  state_update_meta_for_run "$session" "$run_token" \
-    --string status running \
+  state_update_meta_for_run_without_event "$session" "$run_token" \
+    --string status starting \
     --string worker_started_at "$(now_iso)" \
     --integer worker_pid "$$" \
     --string worker_heartbeat_at "$(now_iso)" \
-    --integer worker_heartbeat_epoch "$(date '+%s')" || true
+    --integer worker_heartbeat_epoch "$(date '+%s')" || \
+      die "could not record worker startup identity"
   if [ "$(tmux_option "$session" '@detach_run_token')" = "$run_token" ]; then
     "${TMUX_CMD[@]}" set-option -q -t "=$session:" @detach_running 1 2>/dev/null || true
     "${TMUX_CMD[@]}" set-option -q -t "=$session:" @detach_worker_pid "$$" 2>/dev/null || true
-    tmux_update_session_status "$session" running 2>/dev/null || true
+    tmux_update_session_status "$session" starting 2>/dev/null || true
   fi
+  # The first lifecycle hint is safe only after metadata and tmux name the
+  # exact live worker. The provider PID is intentionally absent until the
+  # power wrapper launches it and the starter completes its readiness proof.
+  publish_session_event
 
   if [ "$PROVIDER" = "claude" ]; then
     agent_session_id="$(read_meta_field "$session" agent_session_id)"
@@ -3917,10 +3922,6 @@ start_tmux_session() {
     env_args+=( "$arg" )
   done < <(tmux_environment_args)
 
-  # Publish `starting` only after tmux ownership and presentation metadata are
-  # complete. An event consumer must never observe the new managed row as a
-  # transient foreign-session collision.
-  publish_session_event
   "${TMUX_CMD[@]}" respawn-pane -k \
     -t "$pane_id" \
     -c "$cwd" \
@@ -3948,6 +3949,15 @@ start_tmux_session() {
     process_is_descendant "$provider_pid" "$worker_pid" || \
       die "$PROVIDER_LABEL exited before its managed runtime was confirmed"
   runtime_heartbeat_once "$session" "$run_token" "$worker_pid" "$provider_pid_file"
+  state_update_meta_for_run "$session" "$run_token" \
+    --string status running \
+    --integer worker_pid "$worker_pid" \
+    --integer provider_pid "$provider_pid" \
+    --string worker_heartbeat_at "$(now_iso)" \
+    --integer worker_heartbeat_epoch "$(date '+%s')" || \
+      die "could not publish confirmed runtime readiness"
+  tmux_update_session_status "$session" running || \
+    error "warning: could not publish confirmed runtime style"
   rm -f "$power_ready_file"
 
   started=1

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -688,6 +688,7 @@ reset_meta_snapshot() {
   META_LAST_CHECKPOINT_EPOCH=""
   META_HEALTH_SCHEMA=""
   META_STOP_REQUESTED_AT=""
+  META_LIFECYCLE_PHASE=""
   TRANSCRIPT_MODEL=""
   TRANSCRIPT_CTX_USED=""
   TRANSCRIPT_CTX_WINDOW=""
@@ -723,6 +724,7 @@ load_meta_snapshot_path() {
       last_checkpoint_epoch) META_LAST_CHECKPOINT_EPOCH="$value" ;;
       health_schema) META_HEALTH_SCHEMA="$value" ;;
       stop_requested_at) META_STOP_REQUESTED_AT="$value" ;;
+      lifecycle_phase) META_LIFECYCLE_PHASE="$value" ;;
       snapshot_complete) [ "$value" = true ] && META_SNAPSHOT_COMPLETE=1 ;;
       *) return 1 ;;
     esac
@@ -1933,6 +1935,7 @@ write_initial_meta() {
     --string created_at "$(now_iso)"
     --integer created_at_ms "$start_ms"
     --string status starting
+    --string lifecycle_phase initializing
     --string run_token "$run_token"
     --string lifecycle_id "$lifecycle_id"
     --string provider "$PROVIDER"
@@ -3634,13 +3637,6 @@ worker_main() {
       kill "$power_monitor_pid" 2>/dev/null || true
       wait "$power_monitor_pid" 2>/dev/null || true
     fi
-    # The final status write below publishes the lifecycle hint. A separate
-    # hint from this checkpoint would wake the app while the provider is
-    # already gone and this worker is still alive, which reads as hung.
-    DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once "$session" "$run_token" || true
-    rm -f "$provider_pid_file" "$power_activity_file" \
-      "$power_activity_source_file"
-
     if [ "$exit_status" -eq 0 ]; then
       status_label="completed"
     elif [ "$cleanup_status" -ge 128 ]; then
@@ -3648,7 +3644,32 @@ worker_main() {
       exit_status="$cleanup_status"
     fi
 
+    # Stop owns its terminal outcome from the moment its exact-run intent is
+    # recorded. Other exits first publish their intended outcome as finalizing.
+    # Health keeps both phases actionless while the final checkpoint completes.
+    if [ -n "$(read_meta_field "$session" stop_requested_at 2>/dev/null || true)" ]; then
+      status_label="stopped"
+      state_update_meta_for_run_without_event "$session" "$run_token" \
+        --string lifecycle_phase stopping \
+        --string status "$status_label" \
+        --integer exit_status "$exit_status" \
+        --string finished_at "$(now_iso)" || true
+    else
+      state_update_meta_for_run "$session" "$run_token" \
+        --string lifecycle_phase finalizing \
+        --string status "$status_label" \
+        --integer exit_status "$exit_status" \
+        --string finished_at "$(now_iso)" || true
+    fi
+
+    # The phase write above is the lifecycle hint. The checkpoint itself does
+    # not need to wake the app before the terminal phase is committed.
+    DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once "$session" "$run_token" || true
+    rm -f "$provider_pid_file" "$power_activity_file" \
+      "$power_activity_source_file"
+
     state_update_meta_for_run "$session" "$run_token" \
+      --string lifecycle_phase terminal \
       --string status "$status_label" \
       --integer exit_status "$exit_status" \
       --string finished_at "$(now_iso)" || true
@@ -3672,6 +3693,7 @@ worker_main() {
   cd -P "$cwd" >/dev/null 2>&1 || die "could not enter project directory: $cwd"
 
   state_update_meta_for_run_without_event "$session" "$run_token" \
+    --string lifecycle_phase starting \
     --string status starting \
     --string worker_started_at "$(now_iso)" \
     --integer worker_pid "$$" \
@@ -3860,6 +3882,7 @@ start_tmux_session() {
       rm -f "$power_ready_file" "$provider_pid_file" "$power_activity_file" \
         "$power_activity_source_file" "$legacy_env_file"
       state_update_meta_for_run "$session" "$run_token" \
+        --string lifecycle_phase terminal \
         --string status start_failed --string finished_at "$(now_iso)" || true
     fi
     exit "$cleanup_status"
@@ -3950,6 +3973,7 @@ start_tmux_session() {
       die "$PROVIDER_LABEL exited before its managed runtime was confirmed"
   runtime_heartbeat_once "$session" "$run_token" "$worker_pid" "$provider_pid_file"
   state_update_meta_for_run "$session" "$run_token" \
+    --string lifecycle_phase running \
     --string status running \
     --integer worker_pid "$worker_pid" \
     --integer provider_pid "$provider_pid" \
@@ -4400,12 +4424,13 @@ session_health_envelope() {
   local health_schema="${10:-}"
   local output_mode="${11:-assessment}"
   local stop_requested_at="${12:-}"
+  local lifecycle_phase="${13:-}"
   local stop_requested=false
   local now
   local checkpoint_threshold
 
-  if [ "$#" -ge 12 ]; then
-    shift 12
+  if [ "$#" -ge 13 ]; then
+    shift 13
   else
     set --
   fi
@@ -4415,6 +4440,16 @@ session_health_envelope() {
     recoverable|orphaned|corrupt|collision|unknown) ;;
     start_failed) meta_status="failed" ;;
     *) meta_status="unknown" ;;
+  esac
+  case "$lifecycle_phase" in
+    initializing|starting|running|stopping|finalizing|terminal) ;;
+    *)
+      case "$meta_status" in
+        starting) lifecycle_phase="starting" ;;
+        running|recovering|hung) lifecycle_phase="running" ;;
+        *) lifecycle_phase="terminal" ;;
+      esac
+      ;;
   esac
   if [ "$metadata_valid" = "true" ]; then
     [ "$health_schema" = "1" ] && runtime_identity_expected=true
@@ -4518,6 +4553,7 @@ session_health_envelope() {
     --checkpoint-recoverable "$checkpoint_recoverable" \
     --agent-session-known "$agent_session_known" \
     --stop-requested "$stop_requested"
+    --lifecycle-phase "$lifecycle_phase"
   )
   if [ "$output_mode" = "request" ]; then
     health_args+=(
@@ -4559,7 +4595,7 @@ refuse_runtime_without_managed_tmux() {
     "$session" true "$status" "$id" "$META_RUN_TOKEN" \
     "$META_WORKER_PID" "$META_PROVIDER_PID" "$META_WORKER_HEARTBEAT_EPOCH" \
     "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" assessment \
-    "$META_STOP_REQUESTED_AT")" || \
+    "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE")" || \
     die "could not safely evaluate runtime ownership for '$session'"
   health_json="${health_output#*$'\n'}"
   [ "$health_json" != "$health_output" ] || \
@@ -4698,6 +4734,7 @@ list_session_records() {
       IFS= read -r -d '' META_LAST_CHECKPOINT_EPOCH && \
       IFS= read -r -d '' META_HEALTH_SCHEMA && \
       IFS= read -r -d '' META_STOP_REQUESTED_AT && \
+      IFS= read -r -d '' META_LIFECYCLE_PHASE && \
       IFS= read -r -d '' TRANSCRIPT_MODEL && \
       IFS= read -r -d '' TRANSCRIPT_CTX_USED && \
       IFS= read -r -d '' TRANSCRIPT_CTX_WINDOW && \
@@ -4721,12 +4758,12 @@ list_session_records() {
           "" "" "" "" "" ""
         session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
-          request "" "${LIST_JSON_ARGS[@]}" || \
+          request "" "" "${LIST_JSON_ARGS[@]}" || \
           die "could not evaluate health for '$session'"
       else
         health_output="$(session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
-          assessment "")" || \
+          assessment "" "")" || \
           die "could not evaluate health for '$session'"
       fi
       if [ "$json_mode" = "1" ]; then
@@ -4741,6 +4778,10 @@ list_session_records() {
       fi
       continue
     fi
+    # `initializing` metadata exists only so the worker and starter can share
+    # one typed document. It is not a coherent list record until the worker has
+    # published its exact PID against the configured tmux run token.
+    [ "$META_LIFECYCLE_PHASE" != "initializing" ] || continue
     status="$META_STATUS"
     display_name="$META_DISPLAY_NAME"
     cwd="$META_PROJECT_DIR"
@@ -4777,14 +4818,15 @@ list_session_records() {
         "$session" true "$status" "$id" "$META_RUN_TOKEN" \
         "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
         "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" \
-        request "$META_STOP_REQUESTED_AT" "${LIST_JSON_ARGS[@]}" || \
+        request "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE" \
+        "${LIST_JSON_ARGS[@]}" || \
         die "could not evaluate health for '$session'"
     else
       health_output="$(session_health_envelope \
         "$session" true "$status" "$id" "$META_RUN_TOKEN" \
         "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
         "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" assessment \
-        "$META_STOP_REQUESTED_AT")" || \
+        "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE")" || \
         die "could not evaluate health for '$session'"
     fi
     if [ "$json_mode" = "1" ]; then
@@ -4920,7 +4962,9 @@ stop_session() {
       # first signal. A failed write aborts Stop; a fresh start clears intent.
       stop_requested_at="$(now_iso)"
       state_update_meta_for_run "$session" "$run_token" \
-        --string stop_requested_at "$stop_requested_at" || \
+        --string stop_requested_at "$stop_requested_at" \
+        --string lifecycle_phase stopping \
+        --string status stopped || \
           die "could not record Stop intent for the exact managed run"
       stop_intent_recorded=1
       pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
@@ -4978,7 +5022,9 @@ stop_session() {
          tmux_has_session "$session" && \
          [ "$(tmux_pane_dead "$session")" = "0" ]; then
         state_update_meta_for_run "$session" "$run_token" \
-          --null stop_requested_at >/dev/null 2>&1 || \
+          --null stop_requested_at \
+          --string lifecycle_phase running \
+          --string status running >/dev/null 2>&1 || \
             error "warning: could not clear failed Stop intent"
       fi
       die "could not remove tmux session '$session'"
@@ -4994,12 +5040,14 @@ stop_session() {
   if [ -n "$run_token" ]; then
     if [ "$stop_intent_recorded" -eq 1 ]; then
       state_update_meta_for_run "$session" "$run_token" \
+        --string lifecycle_phase terminal \
         --string status stopped --string stopped_at "$(now_iso)" || \
           die "tmux was stopped, but exact-run metadata could not be updated"
     else
       stop_requested_at="$(now_iso)"
       state_update_meta_for_run "$session" "$run_token" \
         --string stop_requested_at "$stop_requested_at" \
+        --string lifecycle_phase terminal \
         --string status stopped --string stopped_at "$(now_iso)" || \
           die "tmux was stopped, but exact-run metadata could not be updated"
     fi
@@ -5007,6 +5055,7 @@ stop_session() {
     stop_requested_at="$(now_iso)"
     state_update_meta "$session" \
       --string stop_requested_at "$stop_requested_at" \
+      --string lifecycle_phase terminal \
       --string status stopped --string stopped_at "$(now_iso)" || \
         die "tmux was stopped, but session metadata could not be updated"
   fi

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -73,6 +73,7 @@ release_version() {
 }
 
 STATE_BASE_ROOT="${DETACH_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/detach}"
+SESSION_EVENT_FILE="$STATE_BASE_ROOT/session-change"
 CONFIG_ROOT="${DETACH_CONFIG_ROOT:-${XDG_CONFIG_HOME:-$HOME/.config}/detach}"
 CONFIG_FILE="$CONFIG_ROOT/config"
 INSTALL_STATE_ROOT="${DETACH_INSTALL_STATE_ROOT:-$STATE_BASE_ROOT}"
@@ -1577,7 +1578,32 @@ state_update_meta() {
 
   meta="$(session_meta "$session")"
   [ -f "$meta" ] || return 1
+  "$STATE_BIN" meta patch "$meta" "$@" || return 1
+  publish_session_event
+}
+
+state_update_meta_without_event() {
+  local session="$1"
+  shift
+  local meta
+
+  meta="$(session_meta "$session")"
+  [ -f "$meta" ] || return 1
   "$STATE_BIN" meta patch "$meta" "$@"
+}
+
+state_update_meta_for_run_without_event() {
+  local session="$1"
+  local run_token="$2"
+  shift 2
+
+  state_update_meta_without_event "$session" --run-token "$run_token" "$@"
+}
+
+publish_session_event() {
+  # This token is a lossy wake-up hint, not durable state. A missed hint is
+  # repaired by the watch resync and app activation snapshots.
+  "$STATE_BIN" events publish "$SESSION_EVENT_FILE" >/dev/null 2>&1 || true
 }
 
 state_update_meta_for_run() {
@@ -3003,7 +3029,8 @@ runtime_heartbeat_locked() {
   if [ "$PROVIDER" = "codex" ]; then
     discover_codex_session "$session" "$run_token" >/dev/null 2>&1 || true
   fi
-  state_update_meta_for_run "$session" "$run_token" "${update_args[@]}"
+  state_update_meta_for_run_without_event \
+    "$session" "$run_token" "${update_args[@]}"
 }
 
 runtime_heartbeat_once() {
@@ -3588,6 +3615,10 @@ start_tmux_session() {
     env_args+=( "$arg" )
   done < <(tmux_environment_args)
 
+  # Publish `starting` only after tmux ownership and presentation metadata are
+  # complete. An event consumer must never observe the new managed row as a
+  # transient foreign-session collision.
+  publish_session_event
   "${TMUX_CMD[@]}" respawn-pane -k \
     -t "$pane_id" \
     -c "$cwd" \
@@ -4626,6 +4657,7 @@ delete_locked() {
     "${TMUX_CMD[@]}" kill-session -t "=$session" || die "could not remove tmux session '$session'"
   fi
   rm -rf -- "$dir" || die "could not completely remove session state: $dir"
+  publish_session_event
   printf 'Deleted %s\n' "$session"
 }
 

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1826,8 +1826,45 @@ state_update_meta_for_run_without_event() {
 
 publish_session_event() {
   # This token is a lossy wake-up hint, not durable state. A missed hint is
-  # repaired by the watch resync and app activation snapshots.
+  # repaired by the watch resync and app activation snapshots. The worker
+  # cleanup suppresses the hint of its final checkpoint because its status
+  # write publishes one moment later.
+  [ "${DETACH_SUPPRESS_SESSION_EVENT:-0}" != "1" ] || return 0
   "$STATE_BIN" events publish "$SESSION_EVENT_FILE" >/dev/null 2>&1 || true
+}
+
+# tmux runs this hook when the retained provider pane dies. Nothing else
+# writes state at that moment, so without it the app could only learn about
+# the dead pane from an unrelated event or from window activation. The hook
+# command is a tmux double-quoted string that reaches `sh -c`; both paths are
+# single-quoted for sh and limited to characters that neither tmux format
+# expansion (`#`) nor either quoting layer can reinterpret. Spaces are common
+# in home directories and are allowed.
+session_event_hook_command() {
+  local path
+  for path in "$STATE_BIN" "$SESSION_EVENT_FILE"; do
+    case "$path" in
+      /*) ;;
+      *) return 1 ;;
+    esac
+    case "$path" in
+      *[!A-Za-z0-9_./@+:,~%=' '-]*) return 1 ;;
+    esac
+  done
+  printf "run-shell -b \"'%s' events publish '%s' >/dev/null 2>&1 || true\"" \
+    "$STATE_BIN" "$SESSION_EVENT_FILE"
+}
+
+install_session_event_hook() {
+  local session="$1"
+  local command
+
+  if ! command="$(session_event_hook_command)"; then
+    error "warning: state paths contain characters the tmux hook cannot carry; the app learns about a finished pane on activation"
+    return 0
+  fi
+  "${TMUX_CMD[@]}" set-hook -t "=$session:" pane-died "$command" 2>/dev/null || \
+    error "warning: could not install the tmux pane-died hook for this session"
 }
 
 state_update_meta_for_run() {
@@ -3587,7 +3624,10 @@ worker_main() {
       kill "$power_monitor_pid" 2>/dev/null || true
       wait "$power_monitor_pid" 2>/dev/null || true
     fi
-    checkpoint_once "$session" "$run_token" || true
+    # The final status write below publishes the lifecycle hint. A separate
+    # hint from this checkpoint would wake the app while the provider is
+    # already gone and this worker is still alive, which reads as hung.
+    DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once "$session" "$run_token" || true
     rm -f "$provider_pid_file" "$power_activity_file" \
       "$power_activity_source_file"
 
@@ -3851,6 +3891,7 @@ start_tmux_session() {
   # splits inherit the window-level off value and disappear normally on exit.
   "${TMUX_CMD[@]}" set-option -q -w -t "$pane_id" remain-on-exit off
   "${TMUX_CMD[@]}" set-option -q -p -t "$pane_id" remain-on-exit on
+  install_session_event_hook "$session"
   "${TMUX_CMD[@]}" set-option -q -t "=$session:" history-limit "$HISTORY_LIMIT"
   tmux_configure_server || \
     error "warning: could not configure Detach server input options for this session"

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -684,6 +684,7 @@ reset_meta_snapshot() {
   META_WORKER_HEARTBEAT_EPOCH=""
   META_LAST_CHECKPOINT_EPOCH=""
   META_HEALTH_SCHEMA=""
+  META_STOP_REQUESTED_AT=""
   TRANSCRIPT_MODEL=""
   TRANSCRIPT_CTX_USED=""
   TRANSCRIPT_CTX_WINDOW=""
@@ -717,6 +718,7 @@ load_meta_snapshot_path() {
       worker_heartbeat_epoch) META_WORKER_HEARTBEAT_EPOCH="$value" ;;
       last_checkpoint_epoch) META_LAST_CHECKPOINT_EPOCH="$value" ;;
       health_schema) META_HEALTH_SCHEMA="$value" ;;
+      stop_requested_at) META_STOP_REQUESTED_AT="$value" ;;
       snapshot_complete) [ "$value" = true ] && META_SNAPSHOT_COMPLETE=1 ;;
       *) return 1 ;;
     esac
@@ -1939,6 +1941,7 @@ write_initial_meta() {
     --null worker_heartbeat_at
     --null worker_heartbeat_epoch
     --null exit_status
+    --null stop_requested_at
   )
   default_base="$(default_session_name "$cwd")"
   if [ -z "$display_name" ] && default_series_session_name "$session" "$default_base"; then
@@ -4556,6 +4559,7 @@ prepare_list_json_args() {
   local provider_pid="${17:-}"
   local worker_heartbeat_at="${18:-}"
   local display_name="${19:-}"
+  local stop_requested_at="${20:-}"
   local session_args
 
   [[ "$session_color" =~ ^#[0-9A-Fa-f]{6}$ ]] || session_color=''
@@ -4568,6 +4572,7 @@ prepare_list_json_args() {
     --created-at "$created"
     --last-checkpoint-at "$checkpoint"
     --finished-at "$finished"
+    --stop-requested-at "$stop_requested_at"
     --model "$model"
     --agent-turn-state "$agent_turn_state"
     --agent-turn-id "$agent_turn_id"
@@ -4667,6 +4672,7 @@ list_session_records() {
       IFS= read -r -d '' META_WORKER_HEARTBEAT_EPOCH && \
       IFS= read -r -d '' META_LAST_CHECKPOINT_EPOCH && \
       IFS= read -r -d '' META_HEALTH_SCHEMA && \
+      IFS= read -r -d '' META_STOP_REQUESTED_AT && \
       IFS= read -r -d '' TRANSCRIPT_MODEL && \
       IFS= read -r -d '' TRANSCRIPT_CTX_USED && \
       IFS= read -r -d '' TRANSCRIPT_CTX_WINDOW && \
@@ -4687,7 +4693,7 @@ list_session_records() {
         prepare_list_json_args \
           "$session" "" "-" "-" "${cwd:-?}" "" "null" "" \
           "" "null" "null" "" "" "$session_color" "$power_state" \
-          "" "" "" ""
+          "" "" "" "" ""
         session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
           request "${LIST_JSON_ARGS[@]}" || \
@@ -4739,7 +4745,8 @@ list_session_records() {
         "$exit_json" "$finished" "$TRANSCRIPT_MODEL" "$TRANSCRIPT_CTX_USED" \
         "$TRANSCRIPT_CTX_WINDOW" "$TRANSCRIPT_AGENT_TURN_STATE" \
         "$TRANSCRIPT_AGENT_TURN_ID" "$session_color" "$power_state" \
-        "$worker_pid" "$provider_pid" "$worker_heartbeat_at" "$display_name"
+        "$worker_pid" "$provider_pid" "$worker_heartbeat_at" "$display_name" \
+        "$META_STOP_REQUESTED_AT"
       session_health_envelope \
         "$session" true "$status" "$id" "$META_RUN_TOKEN" \
         "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
@@ -4866,6 +4873,12 @@ stop_session() {
     run_token="$(tmux_option "$session" '@detach_run_token')"
   fi
   [ -n "$run_token" ] || run_token="$(read_meta_field "$session" run_token 2>/dev/null || true)"
+
+  # Record the intent before the runtime is signalled. The worker then writes
+  # `interrupted` moments before `stopped` follows; consumers must never read
+  # that ordinary window as a crash. A fresh start clears the intent.
+  state_update_meta "$session" \
+    --string stop_requested_at "$(now_iso)" 2>/dev/null || true
 
   if tmux_has_session "$session"; then
     tmux_is_managed "$session" || die "refusing to stop unmanaged tmux session '$session'"

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -25,12 +25,11 @@ update held by active leases keep the dashboard. Settings shows errors; new
 starts still require both power layers. Only an invalid app location or runtime
 payload mismatch restores setup guidance. Provider installation uses the
 official command in the user's terminal through the private `.command`
-mechanism. It reports only that the CLI is not detected because it has no
-outcome channel. When helper/plist bytes change after an
+mechanism. Without an outcome channel it reports only that the CLI is not
+detected. When helper/plist bytes change after an
 app update, unregister, await completion, then use the bounded retry for the
 transient SMAppService Code=1 race. Do not replace a helper with active leases:
-defer the update. Report a normal reconciliation outcome and retry on the next
-activation.
+defer the update. Report a normal outcome; retry on the next activation.
 
 Each readiness build puts one `detach-app-build:<UUID>` in its executable and
 signed marker. UI smoke uses a stripped private copy below
@@ -38,7 +37,7 @@ signed marker. UI smoke uses a stripped private copy below
 unsafe identity, build mismatch, or payload fails closed.
 
 Smoke restores focus and the pointer, then sends ordered AppKit events to
-visible controls. It covers all main surfaces, focus, session actions, and
+controls. It covers all main surfaces, focus, session actions, and
 onboarding. Stop disconnects first. Stages have deadlines. Coverage isolates
 the normal bundle, instrumented copy, tests, binary, and profiles. The driver
 detects clipped controls before an action.
@@ -60,6 +59,9 @@ Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. One typed heartbeat source and
 one `detach watch --json` source supply them. A schema-1 hint, activation, or
 `resync` triggers `list --json`; only the newest hint waits. No list timer runs.
+A dead or never-ready watcher restarts with 2–60 s backoff; a failed list
+retries alike. Cold start waits 1 s for `ready`; a late `ready` repeats its
+snapshot.
 UI never calls `pmset` or root XPC. Closing the
 last window keeps the app, event source, and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
@@ -84,9 +86,8 @@ NVM/mise Node directories by semantic version.
 Helper replacement is a durable fail-closed transaction. One versioned journal
 records the phase, goal, target digest, boot UUID, and lifetime-barrier contract.
 Each transition uses atomic rename and file/directory fsync before its side
-effect. A per-user `flock` protects the journal. In addition, the root helper
-creates a stable root-owned `0644` inode
-under `/var/run`; every app user opens it read-only and holds one exclusive
+effect. A per-user `flock` protects the journal. The root helper also creates a
+stable root-owned `0644` inode under `/var/run`; every app user opens it read-only and holds one exclusive
 kernel `flock` across the complete asynchronous SMAppService transaction. This
 is the machine-wide single-writer barrier across Fast User Switching, and the
 kernel releases it if the app crashes. Only the current non-root console user's
@@ -115,10 +116,10 @@ Settings → System owns the only **Mac Power** status and approval block. Helpe
 Ready requires a doctor live XPC check. Registration alone is Needs attention.
 During doctor or reconciliation, show Checking, not failure. Power
 requires a healthy watchdog heartbeat no older than three minutes; otherwise it
-is `unknown`. A vnode source reads atomic changes at once. One deadline marks
-silence stale. A timestamp-only write moves that deadline and updates diagnostic
-freshness without invalidating the UI. Settings open and activation resync. No
-UI heartbeat timer runs.
+is `unknown`. A vnode source reads atomic changes at once; one wall-clock
+deadline marks silence stale. A timestamp-only write moves it and redraws the
+age silently. Settings open and activation resync. No app-level
+heartbeat timer runs.
 
 The watchdog heartbeat carries the effective power state and typed raw
 thermal state/latch. With notifications enabled, the app emits one
@@ -139,8 +140,7 @@ A first-run setup card stays mounted during retry. App Start uses `--detach`,
 keeps sheet errors, and selects the new session. Start, Resume, and Recover open
 `detach <provider> attach --terminal-features sync <session>` in one visible
 PTY. Live-to-live selection keeps it and asks the public CLI to switch its exact
-tmux client. Closing the view ends the client. The event watcher has a
-one-second bound. Failure loads one typed snapshot and retries in background.
+tmux client. Closing the view ends the client.
 
 Terminal I/O is event-driven. CoreGraphics repaints on changes and uses a
 steady cursor. No terminal poller or frame loop runs. `Command-C/V/F` provide
@@ -148,23 +148,24 @@ native copy, paste, and find. `Ctrl-V` reaches provider image paste. A Finder
 drop sends shell-safe paths without reading files. Live views move Mac Power to
 metadata. An exited client offers Reconnect.
 
-Cold startup reads at most 128 rows and 1 MiB from the last complete typed
-session snapshot in private preferences. These presentation rows grant no
-health action, ownership proof, PID, cleanup permission, or power claim. The
-first valid typed list replaces them and restores actions. A failed refresh
-keeps them visible but not authoritative. Only changed valid data updates the
-cache.
+Cold start reads at most 128 rows and 1 MiB of the last typed snapshot from
+private preferences. These rows grant no health action, ownership proof, PID,
+cleanup right, or power claim; the menu bar and Mac Power count none
+until the first fresh list restores actions. A failed refresh keeps
+them visible, not authoritative. Only a changed presentation is stored.
 
-A timer-free cache preloads 12 non-live logs with at most six reads. Lifecycle
-changes invalidate it. Live or deleted sessions cannot reuse a passive tail.
-A nine-entry cache warms three live text screens at once, 500 lines each. Both
+A timer-free cache preloads 12 non-live logs, three at once, into free entries
+only; a failed read waits for a new typed revision. Lifecycle changes
+invalidate it. Live or deleted sessions cannot reuse a passive tail. A
+nine-entry cache warms two live 500-line text screens at once; a blank one
+waits for a turn change. A detached live log rereads every 2 s. Both
 caches retain no PTY. Cancellation cannot alter a replacement. A cold attach
 can show one passive SwiftTerm text screen. Live switching uses no raster or
 replacement PTY. tmux holds the complete frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
 action geometry. A cold passive screen leaves within one second.
-New session accepts an optional printable UTF-8 name of at most 100 bytes
-and rejects invalid input. Launch runs in Detach. Advanced holds the prompt
+New session accepts an optional printable UTF-8 name up to 100 bytes and
+rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.
 Command-N opens New session. Its chooser starts at the default project or the
 selection's parent. Command-T starts the chosen provider in a private 0700
@@ -176,8 +177,8 @@ ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
-Notifications are opt-in. Snapshots deduplicate transitions. A delayed
-snapshot distinguishes `interrupted` from Stop.
+Notifications are opt-in. Snapshots deduplicate transitions. One 350 ms
+recheck confirms `interrupted` or `hung`.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is
 shipped and verified. Sparkle keeps its symlink layout and is signed inside-out.
@@ -188,9 +189,9 @@ A generated or published appcast must contain exactly one arm64 hardware
 requirement so Intel clients are never offered the update.
 A Sparkle update replaces only the app; bootstrap atomically activates its new
 immutable CLI payload without rewriting live-session binaries. Sparkle errors
-for a disk image or App Translocation tell the user to move Detach to
-`/Applications`. Temporary-directory and download errors tell the user to
-check the network and free disk space, then retry. Archive, signature,
+for a disk image or App Translocation say to move Detach to
+`/Applications`. Temporary-directory and download errors say to check the
+network and free disk space, then retry. Archive, signature,
 validation, and installation errors provide the manual DMG path and the
 Settings > System Repair path, and state that the active CLI did not
 change. If replacement completes but CLI or helper sync fails, the prior CLI

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -61,9 +61,8 @@ one `detach watch --json` source supply them. A schema-1 hint, activation, or
 `resync` triggers `list --json`; only the newest hint waits. No list timer runs.
 A dead or never-ready watcher restarts with 2–60 s backoff; a failed list
 retries alike. Cold start waits 1 s for `ready`; a late `ready` repeats its
-snapshot. UI never calls `pmset` or root XPC. The app and event source survive
-its last window.
-⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
+snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
+checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
 Mac Power status and approval controls. Settings follows the hosting screen;
 System scrolls. Temperature safety has its own warning shape and the
@@ -177,8 +176,8 @@ When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
 Notifications are opt-in and deduplicated. Stop intent is not failure;
-`interrupted` and `hung` get one 350 ms recheck. Detection is ordered. Delivery
-cannot block session events.
+`interrupted` and `hung` get one 350 ms recheck. Ordered detection never waits
+for delivery.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is
 shipped and verified. Sparkle keeps its symlink layout and is signed inside-out.
@@ -187,8 +186,9 @@ Only ad-hoc builds disable library validation.
 32-byte Ed25519 public key.
 A generated or published appcast must contain exactly one arm64 hardware
 requirement, so Intel clients never see the update.
-A Sparkle update replaces only the app; bootstrap atomically activates its new
-immutable CLI payload without rewriting live-session binaries. Sparkle errors
+A Sparkle update replaces the app. Bootstrap activates the new
+immutable CLI payload before the watcher and first fresh list start. It does
+not rewrite live-session binaries. Sparkle errors
 for a disk image or App Translocation say to move Detach to
 `/Applications`. Temporary-directory and download errors say to check the
 network and free disk space, then retry. Archive, signature,

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -153,12 +153,12 @@ metadata. An exited client offers Reconnect.
 Cold start paints at most 128 rows and 1 MiB from private preferences. Cached
 rows grant no action, ownership, PID, cleanup, or power claim until a fresh
 list arrives. A failed refresh keeps them visible but not authoritative. Only
-presentation changes are stored.
+presentation is stored.
 
-Timer-free caches preload 12 non-live logs, three at once, and nine live
-500-line screens, two at once. They retain no PTY. Empty or failed reads wait
-for a typed revision. The opaque lifecycle ID prevents a reused name from
-inheriting either cache; older rows use creation time and provider identity.
+Timer-free caches preload 12 non-live 500-line logs, three at once, and nine
+live screens, two at once. They retain no PTY. Empty and failed reads wait for
+a typed revision. Bursts keep active reads. The lifecycle ID blocks cache
+inheritance after name reuse; older rows use creation and provider identity.
 A detached live log rereads every 2 s. A cold attach can show one passive
 SwiftTerm screen. Live switching uses no raster or replacement PTY. tmux holds
 the frame until a synchronized redraw.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -66,14 +66,14 @@ UI never calls `pmset` or root XPC. Closing the
 last window keeps the app, event source, and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
-Mac Power status and approval controls. The Settings window follows the hosting
-screen; System scrolls. Temperature safety has its own warning shape and the
+Mac Power status and approval controls. Settings follows the hosting screen;
+System scrolls. Temperature safety has its own warning shape and the
 text **Mac can sleep: temperature**.
 
 The dashboard separates identity, status, and Mac Power. Identity is a thin
 tmux-colored capsule. Status is a filled circle. Power uses a neutral surface
-and semantic color. Clicking the single UUID chip copies the full UUID and
-shows **Copied**.
+and semantic color. Clicking the UUID chip copies the full UUID and shows
+**Copied**.
 
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
@@ -177,16 +177,17 @@ ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
-Notifications are opt-in. Snapshots deduplicate transitions. One 350 ms
-recheck confirms `interrupted` or `hung`.
+Notifications are opt-in. Snapshots deduplicate transitions. A typed Stop
+intent is never a failure; a 350 ms recheck confirms other `interrupted` or
+`hung` rows.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is
 shipped and verified. Sparkle keeps its symlink layout and is signed inside-out.
-Only ad-hoc builds use `com.apple.security.cs.disable-library-validation`.
+Only ad-hoc builds disable library validation.
 `UpdaterService` starts only in `/Applications` with a valid HTTPS feed URL and
 32-byte Ed25519 public key.
 A generated or published appcast must contain exactly one arm64 hardware
-requirement so Intel clients are never offered the update.
+requirement, so Intel clients never see the update.
 A Sparkle update replaces only the app; bootstrap atomically activates its new
 immutable CLI payload without rewriting live-session binaries. Sparkle errors
 for a disk image or App Translocation say to move Detach to

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -56,11 +56,11 @@ tints so power warnings stay visible. Monochrome states remain template; tints
 resolve from label or system colors. VoiceOver names
 the session state. The first menu line is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
-working session and never claims no sessions. One typed heartbeat source and
-one `detach watch --json` source supply them. A schema-1 hint, activation, or
-`resync` triggers `list --json`; only the newest hint waits. No list timer runs.
-A dead or never-ready watcher restarts with 2–60 s backoff; a failed list
-retries alike. Cold start waits 1 s for `ready`; a late `ready` repeats its
+working session and never claims no sessions. Typed heartbeat and
+`detach watch --json` sources supply them. A schema-1 hint, activation, or
+`resync` starts a serialized `list --json`. Hints during a read share one ordered
+trailing read. No list timer runs. Dead or unready watchers and failed lists retry
+with 2–60 s backoff. Cold start waits 1 s for `ready`; a late `ready` repeats the
 snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
 checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
@@ -153,13 +153,13 @@ rows grant no action, ownership, PID, cleanup, or power claim until a fresh
 list arrives. A failed refresh keeps them visible but not authoritative. Only
 presentation is stored.
 
-Timer-free caches preload 12 non-live 500-line logs, three at once, and nine
-live screens, two at once. They retain no PTY. Empty and failed reads wait for
-a typed revision. Bursts keep active reads. The lifecycle ID blocks cache
+Timer-free caches preload 12 non-live 500-line logs (three at once) and nine
+live screens (two at once), with no PTY. Empty and failed reads wait for
+a revision. Bursts keep active reads. The lifecycle ID blocks cache
 inheritance after name reuse; older rows use creation and provider identity.
-A detached live log rereads every 2 s. A cold attach can show one passive
-SwiftTerm screen. Live switching uses no raster or replacement PTY. tmux holds
-the frame until a synchronized redraw.
+Detached live logs reread every 2 s. Cold attach uses one passive SwiftTerm
+overlay; cached bytes never enter the live buffer. Live switching keeps its PTY.
+tmux holds the frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
 action geometry. A cold passive screen leaves within one second.
 New session accepts an optional printable UTF-8 name up to 100 bytes and

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -61,9 +61,8 @@ one `detach watch --json` source supply them. A schema-1 hint, activation, or
 `resync` triggers `list --json`; only the newest hint waits. No list timer runs.
 A dead or never-ready watcher restarts with 2–60 s backoff; a failed list
 retries alike. Cold start waits 1 s for `ready`; a late `ready` repeats its
-snapshot.
-UI never calls `pmset` or root XPC. Closing the
-last window keeps the app, event source, and icon.
+snapshot. UI never calls `pmset` or root XPC. The app and event source survive
+its last window.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
 Mac Power status and approval controls. Settings follows the hosting screen;
@@ -177,9 +176,9 @@ ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
-Notifications are opt-in. Snapshots deduplicate transitions. A typed Stop
-intent is never a failure; a 350 ms recheck confirms other `interrupted` or
-`hung` rows.
+Notifications are opt-in and deduplicated. Stop intent is not failure;
+`interrupted` and `hung` get one 350 ms recheck. Detection is ordered. Delivery
+cannot block session events.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is
 shipped and verified. Sparkle keeps its symlink layout and is signed inside-out.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -2,38 +2,31 @@
 
 ## Contract
 
-`app/` is a SwiftPM package with `DetachKit`, `DetachApp`,
-`DetachWatchdog`, `DetachState`, `DetachPower`, and `DetachPowerHelper`. The app
-bundles signed arm64-only executables, the immutable CLI payload, pinned tmux
-sources/licenses/provenance, Sparkle, SwiftTerm, and their license notices.
+`app/` is a SwiftPM package with app, runtime, state, power, watchdog, and
+helper targets. It bundles signed arm64 executables, the immutable CLI payload,
+pinned dependencies, provenance, and license notices.
 
 `ANSIParser` strips non-SGR sequences and preserves colors, bold, dim, italic,
 underline, strikethrough, and reverse video. Reverse swaps colors against
 `ANSIParser.terminalBackground`, also the `LogTextView` background. Font
 scaling changes only the font.
 
-Onboarding uses the pure reducer in `SetupGuidance.step(for:)`; a setup failure
-outranks provider discovery. A bare
-`SMAppService.status == .enabled` read never completes the permissions step.
-The live poller reads status without side effects and reconciles once when it
-becomes enabled. Only confirmed readiness (a
-finished helper journal and an open root gate) advances the step. Registration
-can stay in `requiresApproval`; do not treat it as enabled before macOS does.
-Each done-step poll rereads the watchdog heartbeat. The success card disables
-its dashboard action until the heartbeat is fresh. After a long wait, it offers
-a monitor retry, not a bypass. The store records completion exactly once, only
-after that action. Repair and first-run synchronization also reread the
-heartbeat before replacing a silent registration.
-If a doctor refresh fails or detects another runtime identity, the app
-withdraws the earlier helper-readiness confirmation.
+Onboarding uses `SetupGuidance.step(for:)`; failure outranks provider discovery.
+An `.enabled` service alone never completes permissions. The live poller reads
+without side effects and reconciles once after enablement. Only a finished
+helper journal and an open root gate advance the step. `requiresApproval` is
+not enabled. Done, Repair, and first-run sync reread the watchdog heartbeat.
+Success needs a fresh heartbeat and records completion once. A long wait offers
+monitor retry, never a bypass. A failed doctor refresh or a different runtime
+identity withdraws earlier helper readiness.
 
-After onboarding, `.idle`, `.syncing`, `.updateDeferred`, and `.ready` present
-`.mainApp`. Bootstrap, refresh, and an update held by active leases keep the
-dashboard. Only a completed `.actionRequired` or `.failed` result shows setup;
-a missing provider keeps the dashboard. Provider installation uses the official command,
-launched visibly in the user's own terminal through the private `.command`
-mechanism; never claim a guided install failed (there is no outcome channel),
-only that the CLI is not detected yet. When helper/plist bytes change after an
+After onboarding, bootstrap, refresh, power or provider regressions, and an
+update held by active leases keep the dashboard. Settings shows errors; new
+starts still require both power layers. Only an invalid app location or runtime
+payload mismatch restores setup guidance. Provider installation uses the
+official command in the user's terminal through the private `.command`
+mechanism. It reports only that the CLI is not detected because it has no
+outcome channel. When helper/plist bytes change after an
 app update, unregister, await completion, then use the bounded retry for the
 transient SMAppService Code=1 race. Do not replace a helper with active leases:
 defer the update. Report a normal reconciliation outcome and retry on the next
@@ -44,14 +37,11 @@ signed marker. UI smoke uses a stripped private copy below
 `/private/tmp/detach-ui-e2e.*` without production payloads. An escaped path,
 unsafe identity, build mismatch, or payload fails closed.
 
-Smoke restores focus and the pointer and sends ordered AppKit events to measured
-visible controls; semantic probes have no actions. It covers main surfaces,
-Settings, onboarding, focus, Codex Recover, Claude Resume, reconnect, and App
-Start through typed selection and PTY attach. Stop disconnects before control
-invocation. Each stage has a deadline. Coverage isolates the normal bundle,
-instrumented copy, Swift tests, binary, and profiles. UI precedes metrics; only
-the private copy is instrumented. The driver reveals clipped controls before
-posting an action.
+Smoke restores focus and the pointer, then sends ordered AppKit events to
+visible controls. It covers all main surfaces, focus, session actions, and
+onboarding. Stop disconnects first. Stages have deadlines. Coverage isolates
+the normal bundle, instrumented copy, tests, binary, and profiles. The driver
+detects clipped controls before an action.
 
 The per-user watchdog adds a launch-readiness rule: macOS can report an approved
 agent as enabled while no launchd job loaded after approval. During first
@@ -67,11 +57,10 @@ tints so power warnings stay visible. Monochrome states remain template; tints
 resolve from label or system colors. VoiceOver names
 the session state. The first menu line is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
-working session and never claims no sessions. The shared `checked_at` heartbeat
-reader and one `detach watch --json` source supply them. Each
-schema-1 hint, activation, or `resync` triggers `list --json`; only the
-newest hint waits. No list timer runs. UI never
-calls `pmset` or root XPC. Freshness uses the document timestamp. Closing the
+working session and never claims no sessions. One typed heartbeat source and
+one `detach watch --json` source supply them. A schema-1 hint, activation, or
+`resync` triggers `list --json`; only the newest hint waits. No list timer runs.
+UI never calls `pmset` or root XPC. Closing the
 last window keeps the app, event source, and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
@@ -92,9 +81,8 @@ KILL at the deadline. Pipe-only descendants cannot extend that deadline. The
 native event process uses `exec` and ends on cancellation. GUI PATH sorts
 NVM/mise Node directories by semantic version.
 
-Helper replacement is a durable fail-closed transaction. One versioned JSON
-journal records `preparing`, `unregisterSubmitted`, `removed`, or `registering`,
-the install/remove goal, target digest, boot UUID, and lifetime-barrier contract.
+Helper replacement is a durable fail-closed transaction. One versioned journal
+records the phase, goal, target digest, boot UUID, and lifetime-barrier contract.
 Each transition uses atomic rename and file/directory fsync before its side
 effect. A per-user `flock` protects the journal. In addition, the root helper
 creates a stable root-owned `0644` inode
@@ -107,20 +95,14 @@ before each mutation. Root persists `unregistration_pending`, blocks
 acquire/renew without a wall-clock expiry, and restores and reads back only the
 setting Detach owns.
 
-The helper takes an exclusive, root-owned lifetime `flock` before its listener
-can answer prepare and holds it until exit. An enabled job with no
-lifetime barrier this boot is dead; unregister may proceed. The app writes
-`unregisterSubmitted` only after observing that lock. A fresh successful async
-SMAppService callback is the normal process-reaped barrier. If a crash loses the
-callback, exact `notRegistered` status plus acquisition of the released lifetime
-lock (or a changed boot UUID) is required before registration; generic
-`unavailable` is not sufficient. An unregister error keeps the journal and root
-gate closed for retry rather than reopening it while a callback may be
-pending. If a different user acquires the system lock after the original app
-crashed and has no local journal, the existing root-created lock/lifetime files
-prove this is not a pristine install: it bootstraps at `unregisterSubmitted`,
-replays asynchronous unregister, and cannot register until that fresh callback
-or the exact absent-job plus released-lifetime recovery barrier completes.
+The helper takes a root-owned lifetime `flock` before its listener answers and
+holds it until exit. An enabled job without this boot's lock is dead. The app
+writes `unregisterSubmitted` only after it observes that lock. Registration
+needs the fresh unregister callback, or exact `notRegistered` status plus the
+released lock or a changed boot UUID; `unavailable` is insufficient. Errors
+keep the journal and root gate closed. After an app crash, another console user
+uses the root-created files to resume at `unregisterSubmitted`, never as a
+pristine install.
 
 Before registering a replacement the app fsyncs `registering` with the target
 digest. After macOS reports the new helper enabled, a successful cancel XPC
@@ -133,14 +115,16 @@ Settings → System owns the only **Mac Power** status and approval block. Helpe
 Ready requires a doctor live XPC check. Registration alone is Needs attention.
 During doctor or reconciliation, show Checking, not failure. Power
 requires a healthy watchdog heartbeat no older than three minutes; otherwise it
-is `unknown`. Refresh on Settings open, app activation, and every ten seconds
-while visible.
+is `unknown`. A vnode source reads atomic changes at once. One deadline marks
+silence stale. A timestamp-only write moves that deadline and updates diagnostic
+freshness without invalidating the UI. Settings open and activation resync. No
+UI heartbeat timer runs.
 
 The watchdog heartbeat carries the effective power state and typed raw
 thermal state/latch. With notifications enabled, the app emits one
 localized temperature-safety warning on each inactive-to-active latch
 transition, including when borrowed external protection makes the effective
-power state unavailable; repeated polls never duplicate the warning.
+power state unavailable; repeated documents never duplicate the warning.
 
 The watchdog is a signed per-user LaunchAgent with an embedded
 `__TEXT,__info_plist`. It resolves `~/.local/bin/detach` at runtime, calls
@@ -151,16 +135,34 @@ user-specific path. Native power protection requires no Apple Events or
 Automation entitlement.
 
 Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
-App Start uses `--detach`, keeps sheet errors, and selects one new session.
-Start, Resume, and Recover use an ephemeral PTY on
-`detach <provider> attach <session>`. Closing its view ends the client.
-Terminal I/O is event-driven. Paused Metal redraws changes with a steady
-cursor and no timer. Failure keeps CoreGraphics. No poller or continuous frame
-loop runs. In a focused terminal, `Command-C/V/F`
-stay native copy, paste, and find. `Ctrl-V` reaches provider image paste. A
-Finder drop sends shell-safe paths without reading or storing files. Live views
-move typed Mac Power to metadata and omit its strip. An exited client offers
-Reconnect. The external terminal stays a `.command` fallback.
+A first-run setup card stays mounted during retry. App Start uses `--detach`,
+keeps sheet errors, and selects the new session. Start, Resume, and Recover open
+`detach <provider> attach --terminal-features sync <session>` in one visible
+PTY. Live-to-live selection keeps it and asks the public CLI to switch its exact
+tmux client. Closing the view ends the client. The event watcher has a
+one-second bound. Failure loads one typed snapshot and retries in background.
+
+Terminal I/O is event-driven. CoreGraphics repaints on changes and uses a
+steady cursor. No terminal poller or frame loop runs. `Command-C/V/F` provide
+native copy, paste, and find. `Ctrl-V` reaches provider image paste. A Finder
+drop sends shell-safe paths without reading files. Live views move Mac Power to
+metadata. An exited client offers Reconnect.
+
+Cold startup reads at most 128 rows and 1 MiB from the last complete typed
+session snapshot in private preferences. These presentation rows grant no
+health action, ownership proof, PID, cleanup permission, or power claim. The
+first valid typed list replaces them and restores actions. A failed refresh
+keeps them visible but not authoritative. Only changed valid data updates the
+cache.
+
+A timer-free cache preloads 12 non-live logs with at most six reads. Lifecycle
+changes invalidate it. Live or deleted sessions cannot reuse a passive tail.
+A nine-entry cache warms three live text screens at once, 500 lines each. Both
+caches retain no PTY. Cancellation cannot alter a replacement. A cold attach
+can show one passive SwiftTerm text screen. Live switching uses no raster or
+replacement PTY. tmux holds the complete frame until a synchronized redraw.
+Metadata stays in one scrolling row. Selection keeps header, terminal, and
+action geometry. A cold passive screen leaves within one second.
 New session accepts an optional printable UTF-8 name of at most 100 bytes
 and rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -78,10 +78,10 @@ and semantic color. Clicking the UUID chip copies the full UUID and shows
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
 
-Bounded CLI calls drain both outputs and use process-group TERM then KILL.
-They report truncation; typed consumers reject incomplete output and keep the
-last valid state. Pipe-only descendants cannot extend the deadline. The native
-event process uses `exec` and ends on cancellation. GUI PATH sorts
+Bounded CLI calls drain outputs on dedicated threads and use process-group
+TERM then KILL. Parallel calls cannot starve drains. Truncation makes typed
+consumers keep the last valid state. Pipe descendants cannot extend deadlines.
+The event process uses `exec` and ends on cancellation. GUI PATH sorts
 NVM/mise Node directories by semantic version.
 
 Helper replacement is a durable fail-closed transaction. One versioned journal

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -68,11 +68,11 @@ resolve from label or system colors. VoiceOver names
 the session state. The first menu line is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. The shared `checked_at` heartbeat
-reader and session poller supply the glyph and words. UI never calls `pmset` or
-root XPC. Freshness uses the document timestamp, not file mtime. One
-`detach list --json` poller serves the window, notifications, and menu. It runs
-faster with a window, slower without, and never stops. Closing the last
-window keeps the app and icon.
+reader and one `detach watch --json` source supply them. Each
+schema-1 hint, activation, or `resync` triggers `list --json`; only the
+newest hint waits. No list timer runs. UI never
+calls `pmset` or root XPC. Freshness uses the document timestamp. Closing the
+last window keeps the app, event source, and icon.
 ⌘Q and Quit end the app while sessions, checkpoints, and protection continue.
 Settings → General owns both menu bar toggles. Settings → System keeps the only
 Mac Power status and approval controls. The Settings window follows the hosting
@@ -87,10 +87,10 @@ shows **Copied**.
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
 
-Every app CLI invocation runs in a fresh process group that drains stdout and
-stderr. Its deadline sends TERM then KILL to the group. A pipe-only descendant
-cannot hold the caller past the drain deadline. GUI PATH orders NVM and mise
-Node directories by semantic version.
+Bounded CLI calls use process groups, drain both outputs, and send TERM then
+KILL at the deadline. Pipe-only descendants cannot extend that deadline. The
+native event process uses `exec` and ends on cancellation. GUI PATH sorts
+NVM/mise Node directories by semantic version.
 
 Helper replacement is a durable fail-closed transaction. One versioned JSON
 journal records `preparing`, `unregisterSubmitted`, `removed`, or `registering`,
@@ -166,15 +166,16 @@ and rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.
 Command-N opens New session. Its chooser starts at the default project or the
 selection's parent. Command-T starts the chosen provider in a private 0700
-`detach-chat-<UUID>` directory in the quick-chat folder (`/tmp` default). It
-selects the typed `starting` session despite an overlapping poll, before runtime
-readiness. Invalid folders block launch.
+`detach-chat-<UUID>` below its folder (`/tmp` default). An event
+selects an unambiguous `starting` session before readiness, without polling.
+Invalid folders block launch.
 Command-1 through Command-9 open main and select numbered Working or Answer
 ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
-Notifications are opt-in. One poller deduplicates baseline and transitions.
+Notifications are opt-in. Snapshots deduplicate transitions. A delayed
+snapshot distinguishes `interrupted` from Stop.
 
 Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is
 shipped and verified. Sparkle keeps its symlink layout and is signed inside-out.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -78,9 +78,10 @@ and semantic color. Clicking the UUID chip copies the full UUID and shows
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
 
-Bounded CLI calls use process groups, drain both outputs, and send TERM then
-KILL at the deadline. Pipe-only descendants cannot extend that deadline. The
-native event process uses `exec` and ends on cancellation. GUI PATH sorts
+Bounded CLI calls drain both outputs and use process-group TERM then KILL.
+They report truncation; typed consumers reject incomplete output and keep the
+last valid state. Pipe-only descendants cannot extend the deadline. The native
+event process uses `exec` and ends on cancellation. GUI PATH sorts
 NVM/mise Node directories by semantic version.
 
 Helper replacement is a durable fail-closed transaction. One versioned journal
@@ -119,7 +120,8 @@ requires a healthy watchdog heartbeat no older than three minutes; otherwise it
 is `unknown`. A vnode source reads atomic changes at once; one wall-clock
 deadline marks silence stale. A timestamp-only write moves it and redraws the
 age silently. Settings open and activation resync. No app-level
-heartbeat timer runs.
+heartbeat timer runs. The first monitor read and explicit refreshes share one
+sequence. A stale constructor snapshot cannot arrive after a newer document.
 
 The watchdog heartbeat carries the effective power state and typed raw
 thermal state/latch. With notifications enabled, the app emits one
@@ -148,20 +150,18 @@ native copy, paste, and find. `Ctrl-V` reaches provider image paste. A Finder
 drop sends shell-safe paths without reading files. Live views move Mac Power to
 metadata. An exited client offers Reconnect.
 
-Cold start reads at most 128 rows and 1 MiB of the last typed snapshot from
-private preferences. These rows grant no health action, ownership proof, PID,
-cleanup right, or power claim; the menu bar and Mac Power count none
-until the first fresh list restores actions. A failed refresh keeps
-them visible, not authoritative. Only a changed presentation is stored.
+Cold start paints at most 128 rows and 1 MiB from private preferences. Cached
+rows grant no action, ownership, PID, cleanup, or power claim until a fresh
+list arrives. A failed refresh keeps them visible but not authoritative. Only
+presentation changes are stored.
 
-A timer-free cache preloads 12 non-live logs, three at once, into free entries
-only; a failed read waits for a new typed revision. Lifecycle changes
-invalidate it. Live or deleted sessions cannot reuse a passive tail. A
-nine-entry cache warms two live 500-line text screens at once; a blank one
-waits for a turn change. A detached live log rereads every 2 s. Both
-caches retain no PTY. Cancellation cannot alter a replacement. A cold attach
-can show one passive SwiftTerm text screen. Live switching uses no raster or
-replacement PTY. tmux holds the complete frame until a synchronized redraw.
+Timer-free caches preload 12 non-live logs, three at once, and nine live
+500-line screens, two at once. They retain no PTY. Empty or failed reads wait
+for a typed revision. The opaque lifecycle ID prevents a reused name from
+inheriting either cache; older rows use creation time and provider identity.
+A detached live log rereads every 2 s. A cold attach can show one passive
+SwiftTerm screen. Live switching uses no raster or replacement PTY. tmux holds
+the frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
 action geometry. A cold passive screen leaves within one second.
 New session accepts an optional printable UTF-8 name up to 100 bytes and

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -59,11 +59,13 @@ registered until the old lifetime lock is released or an exact absent-job
 callback provides the required completion barrier.
 
 An enabled registration with a matching bundled-definition digest is not
-enough to prove liveness. At startup, a missing or released lifetime lock also
-forces the durable replacement flow. This repairs a stale Background Task
-Management parent UUID after an app bundle is replaced with the same version.
-For a legacy watchdog without a lifetime lock, the exact bundled executable
-may prove that the old registration is still live.
+enough to prove liveness. At startup, a missing or released lifetime lock that
+stays unheld after a three-second grace also forces the durable replacement
+flow. The grace covers login, when the app and the service start together.
+This repairs a stale Background Task Management parent UUID after an app
+bundle is replaced with the same version. For a legacy watchdog without a
+lifetime lock, the exact bundled executable may prove that the old
+registration is still live.
 
 Before it creates the listener or changes power state, the helper must pass a
 strict check of its own signature with Security network access enabled. This

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -44,6 +44,27 @@ surface is limited to status, acquire, renew, release, and the typed
 prepare/cancel unregistration lifecycle; it must never execute arbitrary paths,
 shell strings, or provider commands as root.
 
+App updates replace the helper through a durable `SMAppService` handoff. Only
+the complete Developer ID release bundle may register or unregister the helper
+or watchdog. The app, helper, and watchdog must have their exact code
+identifiers and the same valid Team ID. An ad-hoc build or preview stays
+read-only at this boundary.
+
+An enabled registration needs a held root lifetime lock before the app calls
+the helper's prepare method. A missing or released lifetime lock proves that no
+helper process can answer. The app then skips XPC preparation and replays the
+submitted unregister phase under the system and per-user transaction locks.
+Only a busy lifetime lock permits the prepare call. A replacement is not
+registered until the old lifetime lock is released or an exact absent-job
+callback provides the required completion barrier.
+
+An enabled registration with a matching bundled-definition digest is not
+enough to prove liveness. At startup, a missing or released lifetime lock also
+forces the durable replacement flow. This repairs a stale Background Task
+Management parent UUID after an app bundle is replaced with the same version.
+For a legacy watchdog without a lifetime lock, the exact bundled executable
+may prove that the old registration is still live.
+
 Before it creates the listener or changes power state, the helper must pass a
 strict check of its own signature with Security network access enabled. This
 check lets macOS refresh the system trust result that the listener needs for
@@ -83,7 +104,20 @@ failures are retried; an active failure is surfaced rather than silently
 reporting protection. Read-only
 status returns a cached snapshot refreshed at startup, after mutations, and by
 the reconciler. It must never invoke `pmset` or wait behind the root mutation
-lock, so UI, watchdog, and tmux polling remain nonblocking.
+lock, so watchdog and explicit status reads remain nonblocking.
+The combined session list reads the private typed watchdog heartbeat once and
+shares its effective state across both providers. This list-only quick read
+does not open XPC. A missing, unhealthy, malformed, or older-than-three-minutes
+heartbeat reports `unknown` without delaying the session snapshot. Full status,
+start preflight, doctor, acquire, renewal, and mutation keep their live XPC
+contracts and existing deadlines.
+
+The app observes atomic watchdog heartbeat replacements from the nearest
+existing parent directory. It moves the watch closer as missing state
+directories appear. Each document replaces one freshness deadline; the
+deadline publishes `unknown` if the watchdog stops. Menu bar, Settings, and
+temperature notifications share this state and run no repeating heartbeat
+reader.
 
 The default initial acquire carries an eight-second absolute server deadline.
 If protection is not confirmed before it, root rolls back only that request's

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -127,7 +127,8 @@ persisted lease, restores a previous matching lease when applicable, and
 reconciles the owned setting before returning failure. This prevents a timed-out
 caller from activating protection later. The outer XPC timeout remains 30
 seconds so rollback can finish. Root `pmset` invocations have bounded output and
-a two-second timeout. The readable tmux power label refreshes every ten seconds
+a two-second timeout; truncation fails closed. The readable tmux power label
+refreshes every ten seconds
 while working and every 30 seconds while waiting, rather than spawning one root
 status request every two seconds per session.
 

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -4,14 +4,8 @@
 
 Detach.app installs an immutable payload under
 `~/.local/libexec/detach/versions/<semver>-<hash>/`. It switches
-`~/.local/bin/detach` atomically. Order:
-
-1. `detach`
-2. `detach-core`
-3. `detach-install`
-4. `detach-state`
-5. `detach-power`
-6. `tmux`
+`~/.local/bin/detach` atomically. Payload order is `detach`, `detach-core`,
+`detach-install`, `detach-state`, `detach-power`, then `tmux`.
 
 Install and Repair validate a complete payload before CLI activation. Failure
 keeps the active payload. A live or retained managed session blocks
@@ -31,8 +25,8 @@ CLI LaunchAgent stays removed.
 
 - **`bin/detach`** is the only command on PATH. It resolves owned executables as
   immutable siblings and selects `codex` or `claude`. It owns cross-provider
-  `list`, UUID-aware `resume`, storage and reconcile previews, `power status`,
-  config, doctor, repair, and uninstall.
+  `list`, native `watch`, UUID-aware `resume`, storage and reconcile previews,
+  `power status`, config, doctor, repair, and uninstall.
 - **`bin/detach-core`** owns the provider-neutral session lifecycle, inline
   provider adaptations, checkpoint/recovery policy, tmux status, and internal
   self-reinvocation commands. It rejects direct invocation unless the frontend
@@ -45,18 +39,17 @@ remain user-owned and are found through `PATH` or provider-specific test
 overrides. macOS-supplied `sqlite3`, `tar`, `env`, and `lockf` stay explicit,
 injectable platform utilities.
 
-Critical shared-state operations self-reinvoke the core under `lockf`
-(`__checkpoint_once_locked`, `__delete_locked`, `__start_tmux_session_locked`). Start, Resume, Stop, Recover, and Delete also
-share a per-session operation lock so their whole state transitions serialize
-before narrower install/project/checkpoint locks. New shared mutations should
-keep the lock around the whole child process and preserve that lock order.
-The install lock covers the full start readiness wait; its acquisition
-timeout stays above the worst-case hold.
+Critical mutations self-reinvoke core under `lockf`:
+`__checkpoint_once_locked`, `__delete_locked`, and
+`__start_tmux_session_locked`. Start, Resume, Stop, Recover, and Delete also
+serialize through a per-session lock before narrower install, project, and
+checkpoint locks. Keep this order and the lock around the whole child. The
+install lock covers readiness; its timeout exceeds the worst hold.
 
 ### Typed state boundary
 
 `detach-state` is the JSON boundary. Do not edit JSON in shell. It owns typed
-metadata, JSONL, health, reconcile, storage, and emit operations.
+metadata, JSONL, health, reconcile, storage, emit, and event operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
 descriptors, accepts no path stream, rejects unsafe session or checkpoint
 directories, and opens only owned regular files of at most 1 MiB with
@@ -90,6 +83,14 @@ counts. The provider command waits up to 30 seconds for the checkpoint lock,
 then rechecks managed tmux liveness and ownership, rejecting symlinked or
 foreign-owned state/session directories. A partial failure keeps each failed
 session and reports it explicitly.
+
+### Session change events
+
+`watch --json` execs the state helper. Its schema-1 hints are not truth; each
+requires full `list --json`. FSEvents filters the private signal and provider
+JSONL. Bursts yield leading and 150 ms trailing hints; drops or root changes
+yield `resync`. Lifecycle changes replace the signal after owned Start metadata
+or Delete; heartbeats do not. Activation repairs missed delivery.
 
 ### Session lifecycle and tmux
 
@@ -157,23 +158,18 @@ Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
 session. They do not promise survival across logout or reboot; an explicit
 kill of tmux/provider ends the live run. Recovery checkpoints remain available.
-Provider test parts need private state, socket, and artifact roots; their
-parent orders events and requires every part. Small hosts reuse lifecycle
-checkpoints in three Codex and two Claude parts; larger hosts use finer parts.
+Provider test parts use private roots; the parent orders and requires all.
+Small hosts use three Codex and two Claude parts.
 
 Detach status options use session-local `@detach*` keys and never touch a
-foreign tmux server. The strip blends an identity color, uses light text and a
-solid edge, and shows power and time on the right.
-Each managed session sets `Detach · <project basename>` as the terminal title,
-following the active tmux session independent of styling.
-Finished sessions keep a faint hue. Failures use reserved red, which the
-eight-hue identity palette omits. Allocation scans both providers
-under the Start/Resume/Recover install lock. Known terminal history keeps its
-identity but reserves no hue. Unknown state stays conservative. Keep a
-current unique hue; otherwise choose the first free hue from the stable
-provider/project preference, duplicating only after all eight are used.
-Style snapshots save and restore both sides and lengths. An old snapshot without right-side data preserves the
-user's `status-right`. Plain text is the primary power signal: `MAC AWAKE`,
+foreign server. The strip shows identity, power, and time. Sessions set
+`Detach · <project basename>` as the title. Finished sessions fade; failures
+use red outside the eight identity hues. Allocation scans both providers under
+the Start/Resume/Recover install lock. History keeps identity but reserves no
+hue. Unknown is conservative. Keep a unique hue; otherwise use the stable
+provider/project preference and duplicate after all eight.
+Style snapshots restore both sides and lengths; an old one preserves the
+user's `status-right`. Text is the primary power signal: `MAC AWAKE`,
 `MAC CAN SLEEP`, `LOW BATTERY`, `MAC CAN SLEEP: TEMPERATURE`,
 `POWER UNAVAILABLE`, or a transition. App wording is equivalent and icons are
 secondary.
@@ -191,6 +187,7 @@ the original copy tables immediately.
 `list --json` emits JSONL schema 1 with optional `display_name`, power and turn
 state, opaque turn ID, PIDs, health, reconcile, freshness, ownership,
 and cleanup fields. Keep the emitter and Swift `Session` decoder synchronized.
+`watch --json` emits only change hints and never replaces this snapshot.
 Provider lifecycle records, never terminal text, supply turn state
 and the private run-token activity file defined in `power.md`.
 Typed cleanup uses `cleanup_eligible`.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -7,13 +7,11 @@ Detach.app installs an immutable payload under
 `~/.local/bin/detach` atomically. Payload order is `detach`, `detach-core`,
 `detach-install`, `detach-state`, `detach-power`, then `tmux`.
 
-Install and Repair validate a complete payload before CLI activation. Failure
-keeps the active payload. A live or retained managed session blocks
-replacement; retry can succeed later. One PATH entry supports login
-and interactive modes. `--keep-state` preserves checkpoints across reinstall.
-`--purge-state` removes Detach state, not `~/.codex` or `~/.claude`. Uninstall
-restores an unchanged profile, or removes only the Detach entry from a changed
-profile. Source edits require app sync or Repair.
+Install and Repair validate the payload before activation; failure keeps the
+active payload. A live or retained session defers replacement. One PATH entry
+supports all shells. `--keep-state` preserves checkpoints. `--purge-state`
+removes Detach state, not provider data. Uninstall restores an unchanged
+profile or removes only its own entry. Source edits require app sync or Repair.
 
 The app registers its power LaunchDaemon and per-user watchdog with
 `SMAppService`. The root helper needs one administrator approval. The portable
@@ -32,44 +30,49 @@ CLI LaunchAgent stays removed.
   self-reinvocation commands. It rejects direct invocation unless the frontend
   supplies `DETACH_CORE_ENTRYPOINT=1`.
 
-Tests may inject binary and state paths with `DETACH_*` variables. Production
-must default tmux, `detach-state`, and `detach-power` to the immutable sibling
-payload, never Homebrew or another ambient installation. Provider binaries
-remain user-owned and are found through `PATH` or provider-specific test
-overrides. macOS-supplied `sqlite3`, `tar`, `env`, and `lockf` stay explicit,
-injectable platform utilities.
+Tests inject paths through explicit `DETACH_*` environments. An app CLI strips
+them except in isolated UI tests. Production resolves tmux and state/power
+helpers only as immutable siblings. Providers resolve through `PATH`.
 
-Critical mutations self-reinvoke core under `lockf`:
-`__checkpoint_once_locked`, `__delete_locked`, and
-`__start_tmux_session_locked`. Start, Resume, Stop, Recover, and Delete also
-serialize through a per-session lock before narrower install, project, and
-checkpoint locks. Keep this order and the lock around the whole child. The
-install lock covers readiness; its timeout exceeds the worst hold.
+`client switch` targets one exact attached client on the private tmux socket.
+It requires its PID, user ID, expected source, and a live managed target. A
+failed proof causes no mutation. Attach can declare synchronized-output support
+to hold the complete frame until the target redraw.
+
+Critical mutations self-reinvoke core under `lockf`. Start, Resume, Stop,
+Recover, and Delete serialize through a per-session lock before narrower
+install, project, and checkpoint locks. Keep this order and the lock around the
+whole child. The install lock covers readiness; its timeout exceeds the worst
+hold.
 
 ### Typed state boundary
 
 `detach-state` is the JSON boundary. Do not edit JSON in shell. It owns typed
 metadata, JSONL, health, reconcile, storage, emit, and event operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
-descriptors, accepts no path stream, rejects unsafe session or checkpoint
-directories, and opens only owned regular files of at most 1 MiB with
-`O_NOFOLLOW`.
+descriptors. It rejects unsafe directories and opens only owned regular files
+of at most 1 MiB with `O_NOFOLLOW`.
 Integer conversion must not trap. Storage reports allocated and logical bytes,
 excludes provider storage, does not follow symlinks, and authorizes cleanup
 only after a complete scan with explicit `cleanup_eligible: true`.
 
-Per-session `meta.json` uses schema 1, internal `session_name`, optional
-`display_name`, and a `run_token`. Older documents without `display_name`
-remain valid. A stale worker or checkpoint loop must not overwrite replacement
-run metadata. New runs publish `health_schema=1`, exact worker/provider PIDs,
-worker heartbeat time, and checkpoint epoch. Health combines managed tmux/pane
-state, run token, PID ownership and ancestry, valid metadata, heartbeat, and
-checkpoint freshness. Stale data alone cannot classify a proven live provider
-as hung. A recorded live runtime without managed tmux permits no signal,
-replacement, recovery, or deletion. Wait for the exact processes to exit.
-Anything restored into provider storage passes canonical path, symlink,
-session-ID, and JSONL validation, is written to a temporary file, validated
-again, and only then moved into place.
+Per-session `meta.json` schema 1 has internal `session_name`, optional
+`display_name`, and `run_token`. Older documents remain valid. Stale workers
+cannot overwrite a replacement run. New runs publish `health_schema=1`, exact
+worker/provider PIDs, heartbeat, and checkpoint epoch. Health uses tmux, run
+token, PID ownership, metadata, and checkpoint freshness. Stale data cannot
+make a proven live provider hung. A runtime without managed tmux blocks
+mutations until its exact processes exit.
+
+The JSON list reads both providers concurrently and emits Codex before Claude.
+Each captures one all-pane tmux snapshot and one clock sample. `proc_pidinfo`
+reads only recorded worker/provider PIDs and 64 parents. An empty tmux expansion
+is missing; a present wrong identity is a collision. Mutations repeat ownership,
+pane, run-token, and process-group checks.
+
+Typed state caches Codex checkpoint assessment in a receipt bound to provider,
+session ID, and file identity. A change forces a full scan. Restore ignores the
+receipt, validates a temporary copy, then replaces the live file.
 
 State is private (`umask 077`) under
 `~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
@@ -86,11 +89,11 @@ session and reports it explicitly.
 
 ### Session change events
 
-`watch --json` execs the state helper. Its schema-1 hints are not truth; each
-requires full `list --json`. FSEvents filters the private signal and provider
-JSONL. Bursts yield leading and 150 ms trailing hints; drops or root changes
-yield `resync`. Lifecycle changes replace the signal after owned Start metadata
-or Delete; heartbeats do not. Activation repairs missed delivery.
+`watch --json` execs the state helper and exits with its parent or cancellation.
+Lossy hints require `list --json`. FSEvents accepts only exact transcripts from
+usable metadata. Bursts yield leading and 150 ms trailing hints. Drops or root
+changes yield `resync`. Lifecycle signals refresh roots; heartbeats do not.
+Missing provider roots are omitted. Activation repairs loss.
 
 ### Session lifecycle and tmux
 
@@ -206,10 +209,10 @@ unambiguous, and keeps the current binding on a creation-time tie. Subagent
 threads never rebind a session. Wrapper-owned provider flags are rejected;
 policy defaults apply only without an allowed override.
 
-Every 300 seconds by default, a per-session lock protects checkpoint creation.
-A checkpoint contains metadata, validated provider JSONL, pane capture, and a
-repository root from a real `.git` ancestor. Codex adds an integrity-checked
-SQLite backup. Claude archives its matching project session and companions.
+By default, a per-session lock protects a checkpoint every 300 seconds. It has
+metadata, validated provider JSONL, pane capture, and a repository root from a
+real `.git` ancestor. Codex removes temporary sidecars after its checked SQLite
+backup. Claude archives its matching project session and companions.
 Provider-created hard links become independent regular files in staging;
 archives and restore destinations still reject hard links and non-plain
 entries. A provider test override can disable the final `/bin/sync`.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -9,9 +9,9 @@ Detach.app installs an immutable payload under
 
 Install and Repair validate the payload before activation; failure keeps the
 active payload. A live or retained session defers replacement. One PATH entry
-supports all shells. `--keep-state` preserves checkpoints. `--purge-state`
+supports all shells. `--keep-state` keeps checkpoints. `--purge-state`
 removes Detach state, not provider data. Uninstall restores an unchanged
-profile or removes only its own entry. Source edits require app sync or Repair.
+profile or removes only its entry. Source edits require app sync or Repair.
 
 The app registers its power LaunchDaemon and per-user watchdog with
 `SMAppService`. The root helper needs one administrator approval. The portable
@@ -35,7 +35,7 @@ them except in isolated UI tests. Production resolves tmux and state/power
 helpers only as immutable siblings. Providers resolve through `PATH`.
 
 `client switch` targets one exact attached client on the private tmux socket.
-It requires its PID, user ID, expected source, and a live managed target. A
+It needs its PID, user ID, expected source, and a live managed target. A
 failed proof causes no mutation. Attach can declare synchronized-output support
 to hold the complete frame until the target redraw.
 
@@ -63,7 +63,7 @@ token, PID ownership, metadata, and checkpoint freshness. Stale data cannot
 make a proven live provider hung. A runtime without managed tmux blocks
 mutations until its exact processes exit.
 
-The JSON list reads both providers concurrently and emits Codex before Claude.
+The JSON list reads both providers concurrently, Codex before Claude.
 Each captures one all-pane tmux snapshot and one clock sample. `proc_pidinfo`
 reads only recorded worker/provider PIDs and 64 parents. An empty tmux expansion
 is missing; a present wrong identity is a collision. Mutations repeat ownership,
@@ -80,8 +80,8 @@ roots before traversal. The checked Codex SQLite backup is never restored
 automatically.
 
 Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
-Before deletion, the app re-reads and matches the displayed status and byte
-counts. The provider command waits up to 30 seconds for the checkpoint lock,
+Before deletion, the app re-reads and matches the shown status and byte
+counts. The provider command waits up to 30 s for the checkpoint lock,
 then rechecks managed tmux liveness and ownership, rejecting symlinked or
 foreign-owned state/session directories. A partial failure keeps and reports
 each failed session.
@@ -120,7 +120,7 @@ Install migration checks the older default and historical
 from stable install state, then enters the canonical project beneath its
 cleanup trap.
 
-Tmux environment arguments stay in memory; credentials are never scratch data.
+Tmux environment arguments stay in memory; credentials never touch disk.
 
 Default starts form a provider/project history series. A fresh start refuses a
 live member or second writer; otherwise it allocates a successor without
@@ -160,7 +160,7 @@ Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
 session. They do not promise survival across logout or reboot; killing
 tmux or the provider ends the live run. Recovery checkpoints remain.
-Provider test parts use private roots; the parent orders and requires all.
+Provider test parts use private roots; the parent orders and needs all.
 Small hosts use three Codex and two Claude parts.
 
 Detach status options use session-local `@detach*` keys and never touch a
@@ -187,8 +187,8 @@ the original copy tables immediately.
 `*:extkeys` and `*:hyperlinks` once; OSC 8 links stay independent.
 
 `list --json` emits JSONL schema 1 with optional `display_name`, power and turn
-state, opaque turn ID, PIDs, health, reconcile, freshness, ownership,
-and cleanup fields. Keep the emitter and Swift `Session` decoder synchronized.
+state, opaque turn ID, PIDs, health, reconcile, freshness, ownership, cleanup,
+and `stop_requested_at`, which Stop records before it signals. Keep the emitter and the Swift `Session` decoder in sync.
 `watch --json` emits only change hints and never replaces this snapshot.
 Provider lifecycle records, never terminal text, supply turn state
 and the private run-token activity file defined in `power.md`.
@@ -208,7 +208,7 @@ unambiguous, and keeps the current binding on a creation-time tie. Subagent
 threads never rebind a session. Wrapper-owned provider flags are rejected;
 policy defaults apply only without an allowed override.
 
-By default, a per-session lock protects a checkpoint every 300 seconds. It has
+By default, a per-session lock protects a checkpoint every 300 s. It has
 metadata, validated provider JSONL, pane capture, and a repository root from a
 real `.git` ancestor. Codex removes temporary sidecars after its checked SQLite
 backup. Claude archives its matching project session and companions.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -137,10 +137,10 @@ detach-power run --session <name> --run-token <token>
   -- <provider> ...
 ```
 
-The power wrapper must confirm both protection layers, atomically mark the
-ready file before launching the provider, then atomically publish the exact
-spawned provider PID. The starter waits for both handshakes and one forced
-runtime heartbeat and never prints `Started` before they arrive.
+The worker emits `starting` only after metadata and tmux identity match;
+only then may its provider PID be absent. The power wrapper confirms both
+protection layers and publishes its ready file and exact provider PID. The
+starter proves ancestry before `running` and prints `Started` last.
 HUP/INT/TERM forward to the provider while the wrapper stays alive to release
 its lease and assertion; `detach stop` also releases by session/run token. The provider must inherit the
 wrapper's tmux foreground process group; a separate group makes interactive

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -88,12 +88,12 @@ each failed session.
 ### Session change events
 
 `watch --json` execs the state helper and exits with its parent or cancellation.
-Lossy hints require `list --json`. FSEvents accepts only exact transcripts from
-usable metadata in each provider `sessions` root. Bursts yield leading and
-150 ms trailing hints. Drops or root changes yield `resync`. Lifecycle signals
-refresh roots; heartbeats do not. Missing provider roots are omitted. The signal
-publisher accepts a state root and writes only its fixed `session-change`
-member. Activation repairs loss.
+Lossy hints require `list --json`. FSEvents accepts only metadata-named
+transcripts. Exact vnode sources cover 64 live transcripts, including old
+runtimes. Bursts yield leading and 150 ms trailing hints. Drops or root changes
+yield `resync`. Lifecycle signals refresh roots; heartbeats do not. Missing
+provider roots are omitted. The publisher writes only `session-change` under
+the state root. Activation repairs loss.
 
 ### Session lifecycle and tmux
 

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -87,13 +87,12 @@ each failed session.
 
 ### Session change events
 
-`watch --json` execs the state helper and exits with its parent or cancellation.
-Lossy hints require `list --json`. FSEvents accepts only metadata-named
-transcripts. Exact vnode sources cover 64 live transcripts, including old
+`watch --json` execs the helper and follows parent. Hints require
+`list --json`. FSEvents accepts only metadata-named transcripts. Exact vnode
+sources cover 64 live transcripts, including old
 runtimes. Bursts yield leading and 150 ms trailing hints. Drops or root changes
-yield `resync`. Lifecycle signals refresh roots; heartbeats do not. Missing
-provider roots are omitted. The publisher writes only `session-change` under
-the state root. Activation repairs loss.
+yield `resync`. Lifecycle signals refresh roots; heartbeats do not. The
+publisher writes `session-change` under state root. Activation repairs loss.
 
 ### Session lifecycle and tmux
 
@@ -191,8 +190,9 @@ state, opaque turn ID, PIDs, health, reconcile, freshness, ownership, cleanup,
 `stop_requested_at`, and a per-run opaque `lifecycle_id` distinct from the
 mutation token. Keep the emitter and Swift `Session` decoder in sync.
 `watch --json` emits only change hints and never replaces this snapshot.
-Provider lifecycle records, never terminal text, supply turn state
-and the private run-token activity file defined in `power.md`.
+Provider lifecycle records, never terminal text, supply turn state and the
+private activity file in `power.md`. Bounded append caching retains typed turns;
+an unseen oversized gap clears waiting to prevent stale Answer ready.
 Typed cleanup uses `cleanup_eligible`.
 
 ### Provider identity and checkpoints

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -150,8 +150,8 @@ silently, records and publishes status, and retains the pane for logs;
 owned pane and dead provider is finished, not hung.
 
 Stop binds intent and each signal or removal to the exact run token. A failed
-intent write leaves the runtime untouched. During Stop, a live owned worker
-with a gone provider is interrupted, not hung, and grants no action or cleanup.
+intent write leaves the runtime untouched. During Stop, a live worker with no
+provider stays interrupted with no action or cleanup after terminal metadata.
 Delete removes a retained tmux session without a state directory and never
 reports success over leftover state.
 

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -2,10 +2,10 @@
 
 ## Installed distribution
 
-Detach.app installs an immutable payload under
-`~/.local/libexec/detach/versions/<semver>-<hash>/`. It switches
+Detach.app installs an immutable payload below
+`~/.local/libexec/detach/versions/<semver>-<hash>/` and switches
 `~/.local/bin/detach` atomically. Payload order is `detach`, `detach-core`,
-`detach-install`, `detach-state`, `detach-power`, then `tmux`.
+`detach-install`, `detach-state`, `detach-power`, and `tmux`.
 
 Install and Repair validate the payload before activation; failure keeps the
 active payload. A live or retained session defers replacement. One PATH entry
@@ -21,10 +21,8 @@ CLI LaunchAgent stays removed.
 
 ### Shell entry points
 
-- **`bin/detach`** is the only command on PATH. It resolves owned executables as
-  immutable siblings and selects `codex` or `claude`. It owns cross-provider
-  `list`, native `watch`, UUID-aware `resume`, storage and reconcile previews,
-  `power status`, config, doctor, repair, and uninstall.
+- **`bin/detach`** is the only PATH command. It resolves immutable sibling
+  executables, selects the provider, and owns cross-provider commands.
 - **`bin/detach-core`** owns the provider-neutral session lifecycle, inline
   provider adaptations, checkpoint/recovery policy, tmux status, and internal
   self-reinvocation commands. It rejects direct invocation unless the frontend
@@ -34,10 +32,9 @@ Tests inject paths through explicit `DETACH_*` environments. An app CLI strips
 them except in isolated UI tests. Production resolves tmux and state/power
 helpers only as immutable siblings. Providers resolve through `PATH`.
 
-`client switch` targets one exact attached client on the private tmux socket.
-It needs its PID, user ID, expected source, and a live managed target. A
-failed proof causes no mutation. Attach can declare synchronized-output support
-to hold the complete frame until the target redraw.
+`client switch` needs an exact attached-client PID, user ID, source, private
+socket, and live managed target. Failed proof causes no mutation. Attach can
+hold a synchronized frame until the target redraw.
 
 Critical mutations self-reinvoke core under `lockf`. Start, Resume, Stop,
 Recover, and Delete serialize through a per-session lock before narrower
@@ -72,6 +69,8 @@ pane, run-token, and process-group checks.
 Typed state caches Codex checkpoint assessment in a receipt bound to provider,
 session ID, and file identity. A change forces a full scan. Restore ignores the
 receipt, validates a temporary copy, then replaces the live file.
+List summaries use an atomic receipt bound to provider, path, device, inode,
+size, and nanosecond mtime. An unchanged identity skips the 256 KiB tail read.
 
 State is private (`umask 077`) under
 `~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
@@ -93,18 +92,18 @@ Lossy hints require `list --json`. FSEvents accepts only exact transcripts from
 usable metadata in each provider `sessions` root. Bursts yield leading and
 150 ms trailing hints. Drops or root changes yield `resync`. Lifecycle signals
 refresh roots; heartbeats do not. Missing provider roots are omitted. The signal
-path is standardized. Activation repairs loss.
+publisher accepts a state root and writes only its fixed `session-change`
+member. Activation repairs loss.
 
 ### Session lifecycle and tmux
 
 `start` takes one cross-provider project lock, creates a safe identifier, sets
 window `remain-on-exit` off and the provider pane on, then launches `__worker`.
-Splits close on exit; logs and status remain. Without
-`--name`, the identifier is
-`detach-<provider>-<project-slug>-<project-hash>` for the first history;
+Splits close on exit; logs and status remain. Without `--name`, the first
+history is `detach-<provider>-<project-slug>-<project-hash>`;
 successors use a monotonic `-r<12-hex>` suffix and persist the unsuffixed
-`default_session_base`. An explicit human-readable
-name is 1–100 UTF-8 bytes of printable text. Legacy-safe names retain the exact
+`default_session_base`. An explicit name is 1–100 printable UTF-8 bytes.
+Legacy-safe names retain the exact
 `detach-<provider>-<name>` identifier; all other names derive a deterministic
 ASCII slug plus a 12-hex content hash. A full `detach-<provider>-<safe-name>`
 stays reserved as an internal identifier; user input never becomes a tmux name
@@ -152,8 +151,8 @@ silently, records and publishes status, and leaves the pane retained for logs;
 a tmux `pane-died` hook publishes once more. A terminal record with a live
 owned pane and dead provider is finished, not hung.
 
-Stop revalidates the managed run, pane, owned PID, and process group before
-each TERM or KILL. Delete removes a retained tmux session even
+Stop binds durable intent and each signal or removal to the exact run token. A
+failed intent write leaves the runtime untouched. Delete removes a retained tmux session even
 without a state directory and never reports success over leftover state.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
@@ -163,13 +162,13 @@ tmux or the provider ends the live run. Recovery checkpoints remain.
 Provider test parts use private roots; the parent orders and needs all.
 Small hosts use three Codex and two Claude parts.
 
-Detach status options use session-local `@detach*` keys and never touch a
-foreign server. The strip shows identity, power, and time. The title is
-`Detach · <project basename>`. Finished sessions fade; failures
-use red outside the eight identity hues. Allocation scans both providers under
-the Start/Resume/Recover install lock. History keeps identity but reserves no
-hue. Unknown is conservative. Keep a unique hue; otherwise use the stable
-provider/project preference and duplicate after all eight.
+Status uses session-local `@detach*` keys and never changes a foreign server.
+The strip shows identity, power, and time; the title is
+`Detach · <project basename>`. Finished sessions fade and failures use red.
+Hue allocation scans both providers under the Start/Resume/Recover install
+lock. It keeps
+a unique hue, then uses the stable provider/project choice after all eight.
+History reserves no hue; unknown is conservative.
 Style snapshots restore both sides and lengths; an old one preserves the
 user's `status-right`. Text is the primary power signal: `MAC AWAKE`,
 `MAC CAN SLEEP`, `LOW BATTERY`, `MAC CAN SLEEP: TEMPERATURE`,
@@ -188,7 +187,8 @@ the original copy tables immediately.
 
 `list --json` emits JSONL schema 1 with optional `display_name`, power and turn
 state, opaque turn ID, PIDs, health, reconcile, freshness, ownership, cleanup,
-and `stop_requested_at`, which Stop records before it signals. Keep the emitter and the Swift `Session` decoder in sync.
+`stop_requested_at`, and a per-run opaque `lifecycle_id` distinct from the
+mutation token. Keep the emitter and Swift `Session` decoder in sync.
 `watch --json` emits only change hints and never replaces this snapshot.
 Provider lifecycle records, never terminal text, supply turn state
 and the private run-token activity file defined in `power.md`.

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -149,11 +149,11 @@ silently, records and publishes status, and retains the pane for logs;
 `pane-died` publishes again. A terminal record with a live
 owned pane and dead provider is finished, not hung.
 
-Stop binds intent and each signal or removal to the exact run token. A failed
-intent write leaves the runtime untouched. During Stop, a live worker with no
-provider stays interrupted with no action or cleanup after terminal metadata.
-Delete removes a retained tmux session without a state directory and never
-reports success over leftover state.
+Stop binds intent and mutations to the run token. Intent failure leaves
+the run untouched. A live provider keeps its full grace. After exit, the worker
+stays interrupted; actions and cleanup remain blocked for a short checkpoint
+grace, then Stop ends the run. Delete handles retained tmux without state and
+never reports success over leftovers.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -60,11 +60,11 @@ token, PID ownership, metadata, and checkpoint freshness. Stale data cannot
 make a proven live provider hung. A runtime without managed tmux blocks
 mutations until its exact processes exit.
 
-The JSON list reads both providers concurrently, Codex before Claude.
-Each captures one all-pane tmux snapshot and one clock sample. `proc_pidinfo`
-reads only recorded worker/provider PIDs and 64 parents. An empty tmux expansion
-is missing; a present wrong identity is a collision. Mutations repeat ownership,
-pane, run-token, and process-group checks.
+`list --json` reads Codex and Claude concurrently, then emits that order. Each
+uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
+PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
+Mutations recheck ownership, pane, run token, and process group. List jobs
+`exec` cores; cleanup signals the PIDs.
 
 Typed state caches Codex checkpoint assessment in a receipt bound to provider,
 session ID, and file identity. A change forces a full scan. Restore ignores the

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -42,12 +42,11 @@ to hold the complete frame until the target redraw.
 Critical mutations self-reinvoke core under `lockf`. Start, Resume, Stop,
 Recover, and Delete serialize through a per-session lock before narrower
 install, project, and checkpoint locks. Keep this order and the lock around the
-whole child. The install lock covers readiness; its timeout exceeds the worst
-hold.
+whole child. The install lock covers readiness and outlasts the worst hold.
 
 ### Typed state boundary
 
-`detach-state` is the JSON boundary. Do not edit JSON in shell. It owns typed
+`detach-state` is the JSON boundary. Never edit JSON in shell. It owns typed
 metadata, JSONL, health, reconcile, storage, emit, and event operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
 descriptors. It rejects unsafe directories and opens only owned regular files
@@ -77,53 +76,51 @@ receipt, validates a temporary copy, then replaces the live file.
 State is private (`umask 077`) under
 `~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
 conversations. Public operations reject symlinked or foreign-owned mutable
-roots before traversal. Codex's integrity-checked SQLite backup is never
-restored automatically.
+roots before traversal. The checked Codex SQLite backup is never restored
+automatically.
 
 Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
 Before deletion, the app re-reads and matches the displayed status and byte
 counts. The provider command waits up to 30 seconds for the checkpoint lock,
 then rechecks managed tmux liveness and ownership, rejecting symlinked or
-foreign-owned state/session directories. A partial failure keeps each failed
-session and reports it explicitly.
+foreign-owned state/session directories. A partial failure keeps and reports
+each failed session.
 
 ### Session change events
 
 `watch --json` execs the state helper and exits with its parent or cancellation.
 Lossy hints require `list --json`. FSEvents accepts only exact transcripts from
-usable metadata. Bursts yield leading and 150 ms trailing hints. Drops or root
-changes yield `resync`. Lifecycle signals refresh roots; heartbeats do not.
-Missing provider roots are omitted. Activation repairs loss.
+usable metadata in each provider `sessions` root. Bursts yield leading and
+150 ms trailing hints. Drops or root changes yield `resync`. Lifecycle signals
+refresh roots; heartbeats do not. Missing provider roots are omitted. The signal
+path is standardized. Activation repairs loss.
 
 ### Session lifecycle and tmux
 
 `start` takes one cross-provider project lock, creates a safe identifier, sets
 window `remain-on-exit` off and the provider pane on, then launches `__worker`.
-Splits close on exit; provider logs and status remain. Without
+Splits close on exit; logs and status remain. Without
 `--name`, the identifier is
 `detach-<provider>-<project-slug>-<project-hash>` for the first history;
 successors use a monotonic `-r<12-hex>` suffix and persist the unsuffixed
 `default_session_base`. An explicit human-readable
 name is 1–100 UTF-8 bytes of printable text. Legacy-safe names retain the exact
 `detach-<provider>-<name>` identifier; all other names derive a deterministic
-ASCII slug plus a 12-hex content hash. A full
-`detach-<provider>-<safe-name>` stays reserved as an explicit internal
-identifier for backward compatibility; user input never becomes a tmux name or
-state path unless it already satisfies that legacy-safe grammar.
+ASCII slug plus a 12-hex content hash. A full `detach-<provider>-<safe-name>`
+stays reserved as an internal identifier; user input never becomes a tmux name
+or state path unless it satisfies that legacy-safe grammar.
 
 The optional display name is persisted separately, emitted through typed state,
-preserved across resume/recovery, and accepted by later lifecycle commands,
-which resolve it deterministically to the same internal identifier. The
-shared tmux daemon is anchored in persistent install state, not the first
-project directory, and is addressed only through the private
+preserved across resume/recovery, and resolved deterministically by later
+lifecycle commands. The shared tmux daemon is anchored in install state, not
+the first project directory, and is addressed only through the private
 `$DETACH_INSTALL_STATE_ROOT/tmux/tmux.sock`, never ambient `TMUX_TMPDIR`.
-Install migration checks the older default socket and the historical
-`-L dev.tsarev.detach` socket before switching payloads. Each worker starts
+Install migration checks the older default and historical
+`-L dev.tsarev.detach` sockets before switching payloads. Each worker starts
 from stable install state, then enters the canonical project beneath its
 cleanup trap.
 
-Tmux environment arguments stay in memory; provider credentials are never
-session scratch data.
+Tmux environment arguments stay in memory; credentials are never scratch data.
 
 Default starts form a provider/project history series. A fresh start refuses a
 live member or second writer; otherwise it allocates a successor without
@@ -150,8 +147,10 @@ HUP/INT/TERM forward to the provider while the wrapper stays alive to release
 its lease and assertion; explicit `detach stop` also releases idempotently by
 session/run token. The provider must inherit the
 wrapper's tmux foreground process group; a separate group makes interactive
-Codex or Claude stop on terminal I/O. On provider exit, the worker records
-status, attempts a final checkpoint, and leaves the pane retained for logs.
+Codex or Claude stop on terminal I/O. On provider exit the worker checkpoints
+silently, records and publishes status, and leaves the pane retained for logs;
+a tmux `pane-died` hook publishes once more. A terminal record with a live
+owned pane and dead provider is finished, not hung.
 
 Stop revalidates the managed run, pane, owned PID, and process group before
 each TERM or KILL. Delete removes a retained tmux session even
@@ -159,14 +158,14 @@ without a state directory and never reports success over leftover state.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user
-session. They do not promise survival across logout or reboot; an explicit
-kill of tmux/provider ends the live run. Recovery checkpoints remain available.
+session. They do not promise survival across logout or reboot; killing
+tmux or the provider ends the live run. Recovery checkpoints remain.
 Provider test parts use private roots; the parent orders and requires all.
 Small hosts use three Codex and two Claude parts.
 
 Detach status options use session-local `@detach*` keys and never touch a
-foreign server. The strip shows identity, power, and time. Sessions set
-`Detach · <project basename>` as the title. Finished sessions fade; failures
+foreign server. The strip shows identity, power, and time. The title is
+`Detach · <project basename>`. Finished sessions fade; failures
 use red outside the eight identity hues. Allocation scans both providers under
 the Start/Resume/Recover install lock. History keeps identity but reserves no
 hue. Unknown is conservative. Keep a unique hue; otherwise use the stable

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -36,10 +36,10 @@ helpers only as immutable siblings. Providers resolve through `PATH`.
 socket, and live managed target. Failed proof causes no mutation. Attach can
 hold a synchronized frame until the target redraw.
 
-Critical mutations self-reinvoke core under `lockf`. Start, Resume, Stop,
-Recover, and Delete serialize through a per-session lock before narrower
-install, project, and checkpoint locks. Keep this order and the lock around the
-whole child. The install lock covers readiness and outlasts the worst hold.
+Core self-reinvokes critical mutations under `lockf`. Start, Resume, Stop,
+Recover, and Delete hold a session lock before install, project, and checkpoint
+locks. Each lock covers the child; the install lock covers readiness and the
+worst hold.
 
 ### Typed state boundary
 
@@ -52,25 +52,26 @@ Integer conversion must not trap. Storage reports allocated and logical bytes,
 excludes provider storage, does not follow symlinks, and authorizes cleanup
 only after a complete scan with explicit `cleanup_eligible: true`.
 
-Per-session `meta.json` schema 1 has internal `session_name`, optional
-`display_name`, and `run_token`. Older documents remain valid. Stale workers
-cannot overwrite a replacement run. New runs publish `health_schema=1`, exact
-worker/provider PIDs, heartbeat, and checkpoint epoch. Health uses tmux, run
-token, PID ownership, metadata, and checkpoint freshness. Stale data cannot
-make a proven live provider hung. A runtime without managed tmux blocks
-mutations until its exact processes exit.
+Per-session `meta.json` schema 1 stores internal `session_name`, optional
+`display_name`, and `run_token`; older documents remain valid. Each patch locks
+its read-change-atomic-replace transaction, so concurrent writers keep disjoint
+fields. Run tokens stop stale workers from overwriting replacement runs. New
+runs publish `health_schema=1`, exact worker/provider PIDs, heartbeat, and
+checkpoint epoch. Health combines tmux, run token, PID ownership, metadata, and
+checkpoint freshness. Stale data cannot make a proven live provider hung. A
+runtime without managed tmux blocks mutations until its exact processes exit.
 
-`list --json` reads Codex and Claude concurrently, then emits that order. Each
+`list --json` reads Codex and Claude concurrently and emits that order. Each
 uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
 PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
 Mutations recheck ownership, pane, run token, and process group. List jobs
-`exec` cores; cleanup signals the PIDs.
+`exec` cores; cleanup signals PIDs.
 
-Typed state caches Codex checkpoint assessment in a receipt bound to provider,
-session ID, and file identity. A change forces a full scan. Restore ignores the
-receipt, validates a temporary copy, then replaces the live file.
-List summaries use an atomic receipt bound to provider, path, device, inode,
-size, and nanosecond mtime. An unchanged identity skips the 256 KiB tail read.
+Typed state caches Codex checkpoint assessment by provider, session ID, and
+file identity. A change forces a full scan. Restore ignores this receipt,
+validates a temporary copy, then replaces the live file. List summaries use an
+atomic receipt bound to provider, path, device, inode, size, and nanosecond
+mtime. An unchanged identity skips the 256 KiB tail read.
 
 State is private (`umask 077`) under
 `~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
@@ -96,27 +97,23 @@ publisher writes `session-change` under state root. Activation repairs loss.
 
 ### Session lifecycle and tmux
 
-`start` takes one cross-provider project lock, creates a safe identifier, sets
+`start` takes a cross-provider project lock, creates a safe identifier, sets
 window `remain-on-exit` off and the provider pane on, then launches `__worker`.
-Splits close on exit; logs and status remain. Without `--name`, the first
-history is `detach-<provider>-<project-slug>-<project-hash>`;
-successors use a monotonic `-r<12-hex>` suffix and persist the unsuffixed
-`default_session_base`. An explicit name is 1–100 printable UTF-8 bytes.
-Legacy-safe names retain the exact
-`detach-<provider>-<name>` identifier; all other names derive a deterministic
-ASCII slug plus a 12-hex content hash. A full `detach-<provider>-<safe-name>`
-stays reserved as an internal identifier; user input never becomes a tmux name
-or state path unless it satisfies that legacy-safe grammar.
+Splits close on exit; logs and status remain. The first unnamed history is
+`detach-<provider>-<project-slug>-<project-hash>`; successors add a monotonic
+`-r<12-hex>` and store the base as `default_session_base`. Explicit names are
+1–100 printable UTF-8 bytes. Legacy-safe names keep
+`detach-<provider>-<name>`; others use a deterministic ASCII slug plus 12-hex
+content hash. The full internal form stays reserved. User input becomes a tmux
+name or state path only if it matches the legacy-safe grammar.
 
-The optional display name is persisted separately, emitted through typed state,
-preserved across resume/recovery, and resolved deterministically by later
-lifecycle commands. The shared tmux daemon is anchored in install state, not
-the first project directory, and is addressed only through the private
+The optional display name is separate typed state, survives resume/recovery,
+and resolves later lifecycle commands. The shared tmux daemon is anchored in
+install state and uses only the private
 `$DETACH_INSTALL_STATE_ROOT/tmux/tmux.sock`, never ambient `TMUX_TMPDIR`.
-Install migration checks the older default and historical
-`-L dev.tsarev.detach` sockets before switching payloads. Each worker starts
-from stable install state, then enters the canonical project beneath its
-cleanup trap.
+Migration checks older default and `-L dev.tsarev.detach` sockets before a
+payload switch. Each worker starts from stable install state, then enters its
+canonical project beneath the cleanup trap.
 
 Tmux environment arguments stay in memory; credentials never touch disk.
 
@@ -137,23 +134,25 @@ detach-power run --session <name> --run-token <token>
   -- <provider> ...
 ```
 
-The worker emits `starting` only after metadata and tmux identity match;
-only then may its provider PID be absent. The power wrapper confirms both
-protection layers and publishes its ready file and exact provider PID. The
-starter proves ancestry before `running` and prints `Started` last.
-HUP/INT/TERM forward to the provider while the wrapper stays alive to release
-its lease and assertion; `detach stop` also releases by session/run token. The provider must inherit the
-wrapper's tmux foreground process group; a separate group makes interactive
-Codex or Claude stop on terminal I/O. On provider exit the worker checkpoints
-silently, records and publishes status, and retains the pane for logs;
-`pane-died` publishes again. A terminal record with a live
-owned pane and dead provider is finished, not hung.
+Metadata has a typed phase machine: `initializing`, `starting`, `running`,
+`stopping`, `finalizing`, `terminal`. Invalid transitions fail; `status` stores
+outcomes. List hides `initializing`. The worker emits `starting` only after its
+metadata and tmux identity match; only then can provider PID be absent. The
+power wrapper confirms both layers and publishes readiness and exact provider
+PID. The starter proves ancestry before `running` and prints `Started` last.
+HUP/INT/TERM forward while the wrapper releases its lease and assertion;
+`detach stop` also releases by session/run token. The provider inherits the
+wrapper's tmux foreground process group to prevent terminal-I/O stops. On exit,
+the worker publishes actionless `finalizing` with the intended status,
+checkpoints, publishes `terminal`, and retains logs; `pane-died` publishes
+again. A terminal record with an owned live pane and dead provider is finished.
 
-Stop binds intent and mutations to the run token. Intent failure leaves
-the run untouched. A live provider keeps its full grace. After exit, the worker
-stays interrupted; actions and cleanup remain blocked for a short checkpoint
-grace, then Stop ends the run. Delete handles retained tmux without state and
-never reports success over leftovers.
+Stop binds intent and mutations to the run token; intent failure changes
+nothing. Before signaling, it publishes `stopping` and the stopped outcome.
+Stop intent makes it monotonic. Actions and cleanup stay closed while
+teardown is live; dead phases converge. A live provider keeps full grace. Its exact
+worker and Stop publish `terminal` idempotently. Delete handles retained tmux
+without state and never reports success over leftovers.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -141,18 +141,18 @@ metadata and tmux identity match; only then can provider PID be absent. The
 power wrapper confirms both layers and publishes readiness and exact provider
 PID. The starter proves ancestry before `running` and prints `Started` last.
 HUP/INT/TERM forward while the wrapper releases its lease and assertion;
-`detach stop` also releases by session/run token. The provider inherits the
-wrapper's tmux foreground process group to prevent terminal-I/O stops. On exit,
-the worker publishes actionless `finalizing` with the intended status,
+`detach stop` releases by run token. Providers get `COLORTERM=truecolor` and
+the wrapper's tmux process group. Captures keep styles; I/O cannot stop it. The
+worker publishes actionless `finalizing` with the intended status,
 checkpoints, publishes `terminal`, and retains logs; `pane-died` publishes
 again. A terminal record with an owned live pane and dead provider is finished.
 
-Stop binds intent and mutations to the run token; intent failure changes
-nothing. Before signaling, it publishes `stopping` and the stopped outcome.
-Stop intent makes it monotonic. Actions and cleanup stay closed while
-teardown is live; dead phases converge. A live provider keeps full grace. Its exact
-worker and Stop publish `terminal` idempotently. Delete handles retained tmux
-without state and never reports success over leftovers.
+Stop binds intent and mutations to the run token; failure changes nothing. It
+publishes `stopping` and stopped, captures the pane, then signals. Stop intent
+is monotonic. Actions and cleanup stay closed during live teardown; dead phases
+converge. A live provider keeps full grace. Worker and Stop publish `terminal`
+idempotently. Delete handles retained tmux without state and never reports
+success over leftovers.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -143,17 +143,18 @@ ready file before launching the provider, then atomically publish the exact
 spawned provider PID. The starter waits for both handshakes and one forced
 runtime heartbeat and never prints `Started` before they arrive.
 HUP/INT/TERM forward to the provider while the wrapper stays alive to release
-its lease and assertion; explicit `detach stop` also releases idempotently by
-session/run token. The provider must inherit the
+its lease and assertion; `detach stop` also releases by session/run token. The provider must inherit the
 wrapper's tmux foreground process group; a separate group makes interactive
 Codex or Claude stop on terminal I/O. On provider exit the worker checkpoints
-silently, records and publishes status, and leaves the pane retained for logs;
-a tmux `pane-died` hook publishes once more. A terminal record with a live
+silently, records and publishes status, and retains the pane for logs;
+`pane-died` publishes again. A terminal record with a live
 owned pane and dead provider is finished, not hung.
 
-Stop binds durable intent and each signal or removal to the exact run token. A
-failed intent write leaves the runtime untouched. Delete removes a retained tmux session even
-without a state directory and never reports success over leftover state.
+Stop binds intent and each signal or removal to the exact run token. A failed
+intent write leaves the runtime untouched. During Stop, a live owned worker
+with a gone provider is interrupted, not hung, and grants no action or cleanup.
+Delete removes a retained tmux session without a state directory and never
+reports success over leftover state.
 
 Closing Terminal or Detach.app only removes clients. The Detach tmux server,
 worker, provider, checkpoint loop, and power wrapper continue in the macOS user

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -180,6 +180,10 @@
   verify a local app. A normal build must contain only an `arm64` slice for the
   app, watchdog, tmux, state helper, power client, root helper, and embedded
   Sparkle executables. Intel Macs are not supported.
+- `DETACH_SIGNED_APP_FIXTURE=/path/to/Detach.app swift test --filter
+  ServiceManagementMutationAdmission` — runs the real Security framework check
+  of the release-signing gate against a signed bundle. Without the variable the
+  test skips, so run it before a release that changes code signing.
 - `DETACH_ALLOW_REAL_POWER_TEST=1 tests/power-smoke.sh` — deliberately changes
   real system power state through an installed, signed, approved app. Never run
   it as routine verification. Before a release, run it only on supervised

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -260,7 +260,7 @@
     {
       "group": "ui",
       "path": "app/Sources/DetachApp/SessionAttachTerminalView.swift",
-      "region": "swiftterm-metal",
+      "region": "swiftterm-renderer",
       "scenarios": [
         "SC-UI-SESSION-DETAIL"
       ],

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -73,7 +73,7 @@ coverage-region	ui	app/Sources/DetachApp/TerminalPreferencePicker.swift	window-p
 coverage-region	ui	app/Sources/DetachApp/OnboardingView.swift	ui-e2e-instrumentation	SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged onboarding journeys own their semantic locators and safe poller.
 coverage-region	ui	app/Sources/DetachApp/RootView.swift	ui-e2e-instrumentation	SC-UI-DASHBOARD,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL	Packaged journeys cover the test-only semantic bridge and route.
 coverage-region	ui	app/Sources/DetachApp/SessionDetailView.swift	ui-e2e-instrumentation	SC-UI-SESSION-STOP,SC-UI-SESSION-DELETE,SC-UI-SESSION-DETAIL	The packaged journey covers action geometry, UUID copy, and its negative control.
-coverage-region	ui	app/Sources/DetachApp/SessionAttachTerminalView.swift	swiftterm-metal	SC-UI-SESSION-DETAIL	XCTest cannot host LocalProcessTerminalView. HeadlessTerminal owns the process proof.
+coverage-region	ui	app/Sources/DetachApp/SessionAttachTerminalView.swift	swiftterm-renderer	SC-UI-SESSION-DETAIL	XCTest cannot host LocalProcessTerminalView. HeadlessTerminal owns the process proof.
 coverage-region	ui	app/Sources/DetachApp/SessionAttachTerminalView.swift	swiftterm-host	SC-UI-SESSION-DETAIL	XCTest cannot construct the SwiftTerm representable. The packaged journey hosts it.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	ui-e2e-instrumentation	SC-UI-SETTINGS	The packaged Settings journey covers its semantic control.
 coverage-region	ui	app/Sources/DetachApp/SettingsView.swift	system-heartbeat	SC-UI-SETTINGS	XCTest cannot map SwiftUI task modifiers. Unit tests cover the extracted System heartbeat loop.

--- a/tests/fake-codex
+++ b/tests/fake-codex
@@ -18,6 +18,9 @@ sqlite() {
 }
 
 printf '%s\n' "$@" >"$args_file"
+if [ -n "${FAKE_CODEX_COLORTERM_FILE:-}" ]; then
+  printf '%s\n' "${COLORTERM:-}" >"$FAKE_CODEX_COLORTERM_FILE"
+fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -72,6 +75,9 @@ sqlite "$db" "INSERT OR REPLACE INTO threads (id, rollout_path, created_at_ms, u
 
 printf 'fake Codex started in %s\n' "$cwd"
 printf 'mode=%s id=%s\n' "$mode" "$id"
+if [ "$COLORTERM" = truecolor ]; then
+  printf '\033[38;2;12;34;56mtrue-color checkpoint probe\033[0m\n'
+fi
 if [ -n "${FAKE_CODEX_RELEASE_FILE:-}" ]; then
   case "$FAKE_CODEX_RELEASE_FILE" in
     /*) ;;

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -202,7 +202,10 @@ if [ "$#" -eq 5 ] && { [ "$1" = codex ] || [ "$1" = claude ]; } \
   control_loop &
   control_pid=$!
   stty raw -echo
-  /usr/bin/tee -a "$ROOT/fake/control-v.bin"
+  # The real attach client exits 0 when the PTY closes. Falling through to the
+  # unexpected-invocation exit would look like a crashed client to the app.
+  /usr/bin/tee -a "$ROOT/fake/control-v.bin" || true
+  exit 0
 fi
 
 if [ "$#" -eq 3 ] && [ "$1" = codex ] && [ "$2" = attach ] \

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -47,7 +47,7 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
     printf 'The session list is temporarily unavailable; retry from the dashboard.\n' >&2
     exit 75
   fi
-  completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"allowed","health_actions":["resume","delete"]}'
+  completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"allowed","health_reason":"checkpoint_stale","health_actions":["resume","delete"]}'
   if [ -f "$ROOT/fake/resumed" ]; then
     completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"running","created_at":"2026-07-22T07:00:00Z","agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"protected","health_actions":["attach","stop"]}'
   fi
@@ -95,12 +95,128 @@ if [ "$#" -eq 2 ] && [ "$1" = config ] \
 fi
 
 if [ "$#" -eq 4 ] && [ "$2" = logs ] && [ "$3" = --ansi ]; then
+  if [ "$4" = detach-codex-ui-recoverable ]; then
+    if [ -f "$ROOT/fake/recoverable-log-ready" ]; then
+      : >"$ROOT/fake/recoverable-log-refresh-delayed"
+      sleep 0.25
+    fi
+    printf '\033[32mUI fixture log for %s\033[0m\n' "$4"
+    : >"$ROOT/fake/recoverable-log-ready"
+    exit 0
+  fi
   printf '\033[32mUI fixture log for %s\033[0m\n' "$4"
   exit 0
 fi
 
+if [ "$#" -eq 10 ] && [ "$1" = client ] && [ "$2" = switch ] \
+    && [ "$3" = --pid ] && [ "$5" = --from ] && [ "$7" = --to ] \
+    && [ "$9" = --provider ]; then
+  expected_pid="$(<"$ROOT/fake/attach-client-pid")"
+  current_session="$(<"$ROOT/fake/attach-client-current")"
+  [ "$4" = "$expected_pid" ] || {
+    printf 'fake client PID mismatch\n' >&2
+    exit 65
+  }
+  [ "$6" = "$current_session" ] || {
+    printf 'fake client source mismatch\n' >&2
+    exit 65
+  }
+  case "$8" in detach-"${10}"-*) ;; *)
+    printf 'fake client target provider mismatch\n' >&2
+    exit 65
+    ;;
+  esac
+  : >"$ROOT/fake/client-switch-requested"
+  # Keep the old complete terminal frame visible while the command is in
+  # flight. A private FIFO models tmux socket delivery without cross-process
+  # signals that the packaged app sandbox can reject.
+  sleep 0.25
+  [ -p "$ROOT/fake/attach-client-control" ] || {
+    printf 'fake attached client control channel is missing\n' >&2
+    exit 65
+  }
+  printf '%s\n' "$8" >"$ROOT/fake/attach-client-control"
+  attempts=0
+  while [ "$attempts" -lt 50 ] \
+      && [ "$(<"$ROOT/fake/attach-client-current")" != "$8" ]; do
+    attempts=$((attempts + 1))
+    sleep 0.01
+  done
+  [ "$(<"$ROOT/fake/attach-client-current")" = "$8" ]
+  exit 0
+fi
+
+if [ "$#" -eq 5 ] && { [ "$1" = codex ] || [ "$1" = claude ]; } \
+    && [ "$2" = attach ] && [ "$3" = --terminal-features ] \
+    && [ "$4" = sync ]; then
+  attach_session="$5"
+  if [ "$attach_session" = detach-codex-ui-recoverable ] \
+      && [ ! -f "$ROOT/fake/reconnect-ready" ]; then
+    printf 'UI fixture attach for %s\n' "$attach_session"
+    : >"$ROOT/fake/reconnect-ready"
+    exit 0
+  fi
+  [ "$attach_session" != detach-claude-ui-new ] || \
+    : >"$ROOT/fake/new-session-attach-ready"
+
+  render_switched_session() {
+    local target="$1"
+    printf '\033[?2026h\033[2J\033[HUI fixture synchronized repaint for %s\n\033[?2026l' \
+      "$target"
+    printf '%s\n' "$target" >"$ROOT/fake/attach-client-current"
+    case "$target" in
+      detach-codex-ui-running) : >"$ROOT/fake/control-v-ready" ;;
+      detach-claude-ui-new) : >"$ROOT/fake/new-session-attach-ready" ;;
+      detach-codex-ui-quick) : >"$ROOT/fake/quick-session-ready" ;;
+    esac
+  }
+  control_loop() {
+    local target
+    while true; do
+      if IFS= read -r target <"$ROOT/fake/attach-client-control"; then
+        render_switched_session "$target"
+      fi
+    done
+  }
+  cleanup_attach() {
+    [ -z "${control_pid:-}" ] || kill "$control_pid" 2>/dev/null || true
+    if [ -f "$ROOT/fake/attach-client-pid" ] \
+        && [ "$(<"$ROOT/fake/attach-client-pid")" = "$$" ]; then
+      /bin/rm -f "$ROOT/fake/attach-client-pid" \
+        "$ROOT/fake/attach-client-control"
+    fi
+  }
+  trap 'cleanup_attach; exit 0' HUP INT TERM
+  trap cleanup_attach EXIT
+  /bin/rm -f "$ROOT/fake/attach-client-control"
+  mkfifo -m 0600 "$ROOT/fake/attach-client-control"
+  printf '%s\n' "$$" >"$ROOT/fake/attach-client-pid"
+  printf '%s\n' "$attach_session" >"$ROOT/fake/attach-client-current"
+  printf 'UI fixture attach for %s\n' "$attach_session"
+  : >"$ROOT/fake/control-v.bin"
+  case "$attach_session" in
+    detach-codex-ui-running) : >"$ROOT/fake/control-v-ready" ;;
+    detach-claude-ui-new) : >"$ROOT/fake/new-session-attach-ready" ;;
+    detach-codex-ui-quick) : >"$ROOT/fake/quick-session-ready" ;;
+  esac
+  control_loop &
+  control_pid=$!
+  stty raw -echo
+  /usr/bin/tee -a "$ROOT/fake/control-v.bin"
+fi
+
 if [ "$#" -eq 3 ] && [ "$1" = codex ] && [ "$2" = attach ] \
     && [ "$3" = detach-codex-ui-running ]; then
+  if [ -s "$ROOT/fake/control-v.bin" ]; then
+    # Reproduce tmux's attach handoff: clear first, then deliver the new
+    # screen later. The packaged UI journey proves that Detach covers this
+    # gap with its passive retained screen.
+    printf '\033[2J\033[H'
+    : >"$ROOT/fake/running-attach-cleared"
+    sleep 0.25
+    printf 'UI fixture delayed repaint for %s\n' "$3"
+    exec /bin/cat
+  fi
   printf 'UI fixture attach for %s\n' "$3"
   stty raw -echo
   : >"$ROOT/fake/control-v-ready"

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -18,6 +18,27 @@ esac
 
 printf '%s\n' "$*" >>"$INVOCATIONS"
 
+if [ "$#" -eq 2 ] && [ "$1" = watch ] && [ "$2" = --json ]; then
+  fixture_signature() {
+    local marker
+    printf '%s' "$(<"$STATE")"
+    for marker in \
+      recovered resumed stopped-deleted new-session-started quick-chat-started; do
+      [ ! -e "$ROOT/fake/$marker" ] || printf ':%s' "$marker"
+    done
+  }
+  signature="$(fixture_signature)"
+  printf '%s\n' '{"schema":1,"event":"ready"}'
+  trap 'exit 0' HUP INT TERM
+  while sleep 0.05; do
+    next_signature="$(fixture_signature)"
+    [ "$next_signature" = "$signature" ] && continue
+    signature="$next_signature"
+    printf '%s\n' '{"schema":1,"event":"changed"}'
+  done
+  exit 0
+fi
+
 if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   if [ "$(<"$STATE")" = empty ]; then
     exit 0
@@ -46,8 +67,11 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   printf '%s\n' \
     '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-running","name":"UI Running","effective_status":"running","created_at":"2026-07-22T08:00:00Z","model":"gpt-ui-fixture","agent_turn_state":"working","session_color":"#36C5F0","power_protection_state":"protected","health_actions":["attach","stop"]}' \
     "$recoverable" \
-    "$completed" \
-    '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-stopped","name":"UI Stopped","effective_status":"stopped","created_at":"2026-07-22T06:00:00Z","finished_at":"2026-07-22T06:30:00Z","exit_status":143,"session_color":"#1D4ED8","power_protection_state":"allowed","health_actions":["delete"]}'
+    "$completed"
+  if [ ! -f "$ROOT/fake/stopped-deleted" ]; then
+    printf '%s\n' \
+      '{"schema":1,"provider":"codex","session_name":"detach-codex-ui-stopped","name":"UI Stopped","effective_status":"stopped","created_at":"2026-07-22T06:00:00Z","finished_at":"2026-07-22T06:30:00Z","exit_status":143,"session_color":"#1D4ED8","power_protection_state":"allowed","health_actions":["delete"]}'
+  fi
   [ -z "$started" ] || printf '%s\n' "$started"
   [ -z "$quick" ] || printf '%s\n' "$quick"
   exit 0
@@ -162,6 +186,11 @@ fi
 if [ "$#" -eq 4 ] && [ "$1" = codex ] && [ "$2" = delete ] \
     && [ "$3" = --force ] && [ "$4" = detach-codex-ui-stopped ]; then
   printf '%s\n' "$*" >>"$ACTIONS"
+  # Let the UI driver record the accepted action before the event arrives.
+  # This proves that a later typed snapshot, not an earlier refresh, closes
+  # the deletion flow.
+  sleep 0.1
+  : >"$ROOT/fake/stopped-deleted"
   exit 0
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -329,10 +329,12 @@ FAKE_POWER_BIN="$TMP_ROOT/fake-detach-power"
 FAKE_ENV_BIN="$TMP_ROOT/fake-env"
 export FAKE_ENV_ARGS_FILE="$TMP_ROOT/env-args.txt"
 export FAKE_POWER_ARGS_FILE="$TMP_ROOT/power-args.txt"
+export FAKE_POWER_STATUS_FILE="$TMP_ROOT/power-status.txt"
 export FAKE_POWER_RELEASES_FILE="$TMP_ROOT/power-releases.txt"
 printf '%s\n' \
   '#!/bin/bash' \
   'if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then' \
+  '  printf '\''%s\n'\'' "$*" >>"$FAKE_POWER_STATUS_FILE"' \
   '  printf '\''{"schema":1,"state":"%s","helper_reachable":true}\n'\'' "${FAKE_POWER_STATE:-protected}"' \
   '  exit 0' \
   'fi' \
@@ -427,6 +429,71 @@ if codex_part_selected preflight; then
   bash -n "$ROOT/bin/detach-core"
   [ "$($SCRIPT __version)" = "$(<"$ROOT/VERSION")" ]
 
+  : >"$FAKE_POWER_STATUS_FILE"
+  "$DETACH" list --json >/dev/null
+  [ "$(wc -l <"$FAKE_POWER_STATUS_FILE" | tr -d '[:space:]')" = 1 ]
+  grep -Fx 'status --json --quick' "$FAKE_POWER_STATUS_FILE" >/dev/null
+
+  # The public JSON list overlaps independent provider reads but must publish
+  # complete records in Codex-then-Claude order and remove its private files.
+  public_list_tmp="$TMP_ROOT/public-list-tmp"
+  public_codex_root="$TMP_ROOT/public-list-codex"
+  public_claude_root="$TMP_ROOT/public-list-claude"
+  public_list_state_wrapper="$TMP_ROOT/public-list-state"
+  public_list_started="$TMP_ROOT/public-list-started"
+  mkdir -p \
+    "$public_list_tmp" \
+    "$public_codex_root/sessions/detach-codex-public-order" \
+    "$public_claude_root/sessions/detach-claude-public-order"
+  "$STATE_HELPER" meta create \
+    "$public_codex_root/sessions/detach-codex-public-order/meta.json" \
+    --integer schema 1 \
+    --string session_name detach-codex-public-order \
+    --string project_dir "$ROOT" \
+    --string status stopped
+  "$STATE_HELPER" meta create \
+    "$public_claude_root/sessions/detach-claude-public-order/meta.json" \
+    --integer schema 1 \
+    --string session_name detach-claude-public-order \
+    --string project_dir "$ROOT" \
+    --string status stopped
+  printf '%s\n' \
+    '#!/bin/bash' \
+    'set -u' \
+    'if [ "${1:-} ${2:-}" = "meta snapshots" ]; then' \
+    '  printf "started\n" >>"$DETACH_PARALLEL_LIST_STARTED"' \
+    '  attempts=0' \
+    '  while [ "$attempts" -lt 200 ]; do' \
+    '    [ "$(wc -l <"$DETACH_PARALLEL_LIST_STARTED" | tr -d "[:space:]")" -ge 2 ] && break' \
+    '    sleep 0.01' \
+    '    attempts=$((attempts + 1))' \
+    '  done' \
+    '  [ "$attempts" -lt 200 ] || exit 91' \
+    'fi' \
+    'exec "$DETACH_PARALLEL_LIST_STATE_HELPER" "$@"' \
+    >"$public_list_state_wrapper"
+  chmod 0755 "$public_list_state_wrapper"
+  public_list_output="$(
+    TMPDIR="$public_list_tmp" \
+    DETACH_CODEX_STATE_ROOT="$public_codex_root" \
+    DETACH_CLAUDE_STATE_ROOT="$public_claude_root" \
+    DETACH_STATE_BIN="$public_list_state_wrapper" \
+    DETACH_PARALLEL_LIST_STARTED="$public_list_started" \
+    DETACH_PARALLEL_LIST_STATE_HELPER="$STATE_HELPER" \
+    DETACH_POWER_BIN=/usr/bin/false \
+      "$DETACH" list --json
+  )"
+  [ "$(wc -l <"$public_list_started" | tr -d '[:space:]')" = 2 ]
+  [ "$(printf '%s\n' "$public_list_output" | sed -n '1p' | \
+    "$STATE_HELPER" meta get /dev/stdin provider)" = codex ]
+  [ "$(printf '%s\n' "$public_list_output" | sed -n '2p' | \
+    "$STATE_HELPER" meta get /dev/stdin provider)" = claude ]
+  [ "$(printf '%s\n' "$public_list_output" | sed -n '1p' | \
+    "$STATE_HELPER" meta get /dev/stdin effective_status)" = stopped ]
+  [ "$(printf '%s\n' "$public_list_output" | sed -n '1p' | \
+    "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
+  [ -z "$(find "$public_list_tmp" -mindepth 1 -print -quit)" ]
+
   # The app's long-lived source must be the public CLI, backed by one native
   # process. Prove lifecycle and transcript writes produce leading/trailing
   # typed hints on a normal user-data volume (FSEvents excludes some temporary
@@ -441,10 +508,18 @@ if codex_part_selected preflight; then
       rm -rf "$event_root"
     }
     trap cleanup_event_probe EXIT
+    event_session="detach-codex-event"
+    event_managed_transcript="$event_root/codex/sessions/managed.jsonl"
     mkdir -p \
-      "$event_root/state" \
-      "$event_root/codex/sessions" \
-      "$event_root/claude/projects"
+      "$event_root/state/codex/sessions/$event_session" \
+      "$event_root/codex/sessions"
+    touch "$event_managed_transcript"
+    "$STATE_HELPER" meta create \
+      "$event_root/state/codex/sessions/$event_session/meta.json" \
+      --integer schema 1 \
+      --string session_name "$event_session" \
+      --string project_dir "$event_root/project" \
+      --string transcript_path "$event_managed_transcript"
     DETACH_STATE_ROOT="$event_root/state" \
     CODEX_HOME="$event_root/codex" \
     CLAUDE_CONFIG_DIR="$event_root/claude" \
@@ -453,7 +528,10 @@ if codex_part_selected preflight; then
     wait_for_file_text "$event_output" '"event":"ready"'
     "$STATE_HELPER" events publish "$event_root/state/session-change"
     wait_for_file_text "$event_output" '"event":"changed"'
-    touch "$event_root/codex/sessions/turn.jsonl"
+    touch "$event_root/codex/sessions/unmanaged.jsonl"
+    sleep 0.3
+    [ "$(grep -c '"event":"changed"' "$event_output")" -eq 1 ]
+    touch "$event_managed_transcript"
     event_attempts=0
     while [ "$event_attempts" -lt 80 ] && \
           [ "$(grep -c '"event":"changed"' "$event_output" 2>/dev/null || true)" -lt 3 ]; do
@@ -461,6 +539,35 @@ if codex_part_selected preflight; then
       sleep 0.05
     done
     [ "$(grep -c '"event":"changed"' "$event_output")" -ge 3 ]
+
+    claude_event_session="detach-claude-event"
+    claude_event_transcript="$event_root/claude/projects/managed.jsonl"
+    mkdir -p \
+      "$event_root/state/claude/sessions/$claude_event_session" \
+      "$event_root/claude/projects"
+    touch "$claude_event_transcript"
+    "$STATE_HELPER" meta create \
+      "$event_root/state/claude/sessions/$claude_event_session/meta.json" \
+      --integer schema 1 \
+      --string session_name "$claude_event_session" \
+      --string project_dir "$event_root/project" \
+      --string transcript_path "$claude_event_transcript"
+    "$STATE_HELPER" events publish "$event_root/state/session-change"
+    event_attempts=0
+    while [ "$event_attempts" -lt 80 ] && \
+          [ "$(grep -c '"event":"changed"' "$event_output" 2>/dev/null || true)" -lt 4 ]; do
+      event_attempts=$((event_attempts + 1))
+      sleep 0.05
+    done
+    sleep 0.1
+    touch "$claude_event_transcript"
+    event_attempts=0
+    while [ "$event_attempts" -lt 80 ] && \
+          [ "$(grep -c '"event":"changed"' "$event_output" 2>/dev/null || true)" -lt 6 ]; do
+      event_attempts=$((event_attempts + 1))
+      sleep 0.05
+    done
+    [ "$(grep -c '"event":"changed"' "$event_output")" -ge 6 ]
   )
 
   heartbeat_source="$(sed -n \
@@ -699,7 +806,11 @@ bootstrap_codex_checkpoint() {
     sleep 0.1
   done
   [ -s "$checkpoint/rollout.jsonl" ]
+  [ -s "$checkpoint/.detach-jsonl-validation.json" ]
   [ -s "$checkpoint/codex-state.sqlite" ]
+  ! find "$checkpoint" -maxdepth 1 \
+    \( -name 'codex-state.sqlite.tmp.*-shm' -o \
+       -name 'codex-state.sqlite.tmp.*-wal' \) -print -quit | grep -q .
   expected_id="$("$STATE_HELPER" meta get "$meta" codex_session_id)"
   [ -n "$expected_id" ]
   run_codex stop integration
@@ -938,11 +1049,16 @@ tmux -L "$OUTER_SOCKET" send-keys -l -t "$outer_pane" -- \
 tmux -L "$OUTER_SOCKET" send-keys -t "$outer_pane" C-m
 attempts=0
 while ! tmux -L "$SOCKET" list-clients -F '#{client_session}' 2>/dev/null | \
-    grep -Fx "$SESSION" >/dev/null && [ "$attempts" -lt 50 ]; do
+    grep -Fx "$SESSION" >/dev/null && [ "$attempts" -lt 100 ]; do
   attempts=$((attempts + 1))
   sleep 0.1
 done
-tmux -L "$SOCKET" list-clients -F '#{client_session}' | grep -Fx "$SESSION" >/dev/null
+if ! tmux -L "$SOCKET" list-clients -F '#{client_session}' 2>/dev/null | \
+    grep -Fx "$SESSION" >/dev/null; then
+  printf 'nested attach client did not appear within 10 seconds\n' >&2
+  tmux -L "$SOCKET" list-clients -F '#{client_pid} #{client_session}' >&2 || true
+  exit 1
+fi
 tmux -L "$OUTER_SOCKET" send-keys -t "$outer_pane" C-b d
 attempts=0
 while [ ! -f "$nested_returned" ] && [ "$attempts" -lt 50 ]; do
@@ -960,21 +1076,63 @@ tmux -L "$OUTER_SOCKET" kill-server >/dev/null 2>&1 || true
 # public CLI on a real PTY, terminate that client, and prove the managed
 # session, worker, and provider survive.
 TERM=xterm-256color /usr/bin/script -q /dev/null \
-  "$DETACH" codex attach integration >/dev/null 2>&1 &
+  "$DETACH" codex attach --terminal-features sync integration >/dev/null 2>&1 &
 attach_client_wrapper=$!
 attempts=0
 while ! tmux -L "$SOCKET" list-clients -F '#{client_session}' 2>/dev/null | \
-    grep -Fx "$SESSION" >/dev/null && [ "$attempts" -lt 50 ]; do
+    grep -Fx "$SESSION" >/dev/null && [ "$attempts" -lt 100 ]; do
   attempts=$((attempts + 1))
   sleep 0.1
 done
-tmux -L "$SOCKET" list-clients -F '#{client_session}' | grep -Fx "$SESSION" >/dev/null
+if ! tmux -L "$SOCKET" list-clients -F '#{client_session}' 2>/dev/null | \
+    grep -Fx "$SESSION" >/dev/null; then
+  printf 'PTY attach client did not appear within 10 seconds\n' >&2
+  tmux -L "$SOCKET" list-clients -F '#{client_pid} #{client_session}' >&2 || true
+  exit 1
+fi
 attach_client_pid="$(tmux -L "$SOCKET" list-clients \
   -F '#{client_pid} #{client_session}' | \
   awk -v session="$SESSION" '$2 == session { print $1 }')"
 case "$attach_client_pid" in
   ''|*[!0-9]*) printf 'attach client PID is missing\n' >&2; exit 1 ;;
 esac
+client_features="$(tmux -L "$SOCKET" list-clients \
+  -F '#{client_pid}|#{client_termfeatures}' | \
+  awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')"
+case ",$client_features," in *,sync,*) ;; *)
+  printf 'in-app attach client did not advertise synchronized output: %s\n' \
+    "$client_features" >&2
+  exit 1
+  ;;
+esac
+
+# The app keeps this exact visible client and asks the public runtime to move
+# it between live managed sessions. PID and expected source bind the request;
+# a stale source or PID cannot affect another client.
+switch_target="detach-codex-client-switch-target"
+switch_target_pane="$(tmux -L "$SOCKET" new-session -d -P -F '#{pane_id}' \
+  -s "$switch_target" '/bin/sleep 30')"
+tmux -L "$SOCKET" set-option -q -t "=$switch_target:" @detach 1
+tmux -L "$SOCKET" set-option -q -t "=$switch_target:" @detach_provider codex
+tmux -L "$SOCKET" set-option -q -t "=$switch_target:" \
+  @detach_pane_id "$switch_target_pane"
+if "$DETACH" client switch --pid "$attach_client_pid" \
+    --from detach-codex-wrong-source --to "$switch_target" \
+    --provider codex >/dev/null 2>&1; then
+  printf 'client switch accepted a stale source session\n' >&2
+  exit 1
+fi
+[ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
+  awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$SESSION" ]
+"$DETACH" client switch --pid "$attach_client_pid" \
+  --from "$SESSION" --to "$switch_target" --provider codex
+[ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
+  awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$switch_target" ]
+"$DETACH" client switch --pid "$attach_client_pid" \
+  --from "$switch_target" --to "$SESSION" --provider codex
+[ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
+  awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$SESSION" ]
+tmux -L "$SOCKET" kill-session -t "=$switch_target"
 kill -TERM "$attach_client_pid"
 attempts=0
 while tmux -L "$SOCKET" list-clients -F '#{client_session}' 2>/dev/null | \
@@ -1168,6 +1326,7 @@ wait_for_file_text "$FAKE_CODEX_ARGS_FILE" 'start a new thread'
 [ "$(grep -Fxc -- '--ask-for-approval' "$FAKE_CODEX_ARGS_FILE")" = "1" ]
 [ "$(grep -Fxc -- 'never' "$FAKE_CODEX_ARGS_FILE")" = "1" ]
 [ ! -e "$checkpoint/rollout.jsonl" ]
+[ ! -e "$checkpoint/.detach-jsonl-validation.json" ]
 [ ! -e "$checkpoint/meta.json" ]
 fresh_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 if run_codex --name integration --detach -- 'must not replace a running task'; then
@@ -1611,6 +1770,7 @@ while { [ ! -s "$worker_crash_checkpoint" ] || \
   sleep 0.1
 done
 [ -s "$worker_crash_checkpoint" ]
+[ -s "$(dirname "$worker_crash_checkpoint")/.detach-jsonl-validation.json" ]
 worker_crash_pane="$(tmux -L "$SOCKET" show-options -qv \
   -t "=$worker_crash_session:" @detach_pane_id)"
 worker_crash_pid="$("$STATE_HELPER" meta get "$worker_crash_meta" worker_pid)"
@@ -1827,6 +1987,9 @@ list_scale_root="$TMP_ROOT/list-scale-state"
 list_scale_output="$TMP_ROOT/list-scale.jsonl"
 list_scale_invocations="$TMP_ROOT/list-scale-invocations.txt"
 list_scale_wrapper="$TMP_ROOT/list-scale-detach-state"
+list_scale_tmux_invocations="$TMP_ROOT/list-scale-tmux-invocations.txt"
+list_scale_tmux_wrapper="$TMP_ROOT/list-scale-tmux"
+list_scale_live_sessions=()
 mkdir -p "$list_scale_root/sessions"
 list_scale_index=1
 while [ "$list_scale_index" -le 25 ]; do
@@ -1838,6 +2001,12 @@ while [ "$list_scale_index" -le 25 ]; do
     --string session_name "$list_scale_session" \
     --string project_dir "$ROOT" \
     --string status stopped
+  if [ "$list_scale_index" -le 3 ]; then
+    tmux -L "$SOCKET" new-session -d -s "$list_scale_session" /bin/sleep 30
+    tmux -L "$SOCKET" set-option -q -t "=$list_scale_session:" @detach 1
+    tmux -L "$SOCKET" set-option -q -t "=$list_scale_session:" @detach_provider codex
+    list_scale_live_sessions+=( "$list_scale_session" )
+  fi
   list_scale_index=$((list_scale_index + 1))
 done
 printf '%s\n' \
@@ -1845,19 +2014,33 @@ printf '%s\n' \
   'printf x\\n >>"$DETACH_LIST_SCALE_INVOCATIONS"' \
   'exec "$DETACH_LIST_SCALE_STATE_HELPER" "$@"' >"$list_scale_wrapper"
 chmod 0755 "$list_scale_wrapper"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'printf x\\n >>"$DETACH_LIST_SCALE_TMUX_INVOCATIONS"' \
+  'exec "$DETACH_LIST_SCALE_TMUX_HELPER" "$@"' >"$list_scale_tmux_wrapper"
+chmod 0755 "$list_scale_tmux_wrapper"
 SECONDS=0
 DETACH_CODEX_STATE_ROOT="$list_scale_root" \
 DETACH_STATE_BIN="$list_scale_wrapper" \
 DETACH_LIST_SCALE_STATE_HELPER="$STATE_HELPER" \
 DETACH_LIST_SCALE_INVOCATIONS="$list_scale_invocations" \
 DETACH_POWER_BIN=/usr/bin/false \
-DETACH_TMUX_BIN=/usr/bin/false \
-DETACH_TMUX_SOCKET_PATH="$TMUX_SOCKET_ROOT/list-scale.sock" \
+DETACH_TMUX_BIN="$list_scale_tmux_wrapper" \
+DETACH_LIST_SCALE_TMUX_HELPER="$TMUX_TEST_BIN" \
+DETACH_LIST_SCALE_TMUX_INVOCATIONS="$list_scale_tmux_invocations" \
+DETACH_TMUX_SOCKET_PATH="$SOCKET_PATH" \
   "$SCRIPT" codex list --json >"$list_scale_output"
 list_scale_elapsed="$SECONDS"
+for list_scale_session in "${list_scale_live_sessions[@]}"; do
+  tmux -L "$SOCKET" kill-session -t "=$list_scale_session"
+done
 [ "$(wc -l <"$list_scale_output" | tr -d '[:space:]')" = 25 ]
 [ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 5 ] || {
   printf 'list restored per-field state helper fan-out\n' >&2
+  exit 1
+}
+[ "$(wc -l <"$list_scale_tmux_invocations" | tr -d '[:space:]')" = 1 ] || {
+  printf 'list did not use one batched tmux snapshot\n' >&2
   exit 1
 }
 [ "$list_scale_elapsed" -lt 5 ] || {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1297,6 +1297,11 @@ run_codex stop integration
 ! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
 [ "$("$STATE_HELPER" meta get "$meta" status)" = "stopped" ]
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
+# Stop records its intent in typed state before it signals the runtime, and
+# the list carries it, so an `interrupted` window is never read as a crash.
+[ -n "$("$STATE_HELPER" meta get "$meta" stop_requested_at)" ]
+run_codex list --json | grep -F "\"session_name\":\"$SESSION\"" | \
+  grep -F '"stop_requested_at":"' >/dev/null
 grep -Fx "release --session $SESSION --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
 codex_scenario_event pass SC-SESSION-STOP-CODEX
@@ -1325,6 +1330,8 @@ fi
 wait_for_file_text "$FAKE_CODEX_ARGS_FILE" resume
 require_file_line "$FAKE_CODEX_ARGS_FILE" resume
 require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
+# A new run under the same name starts without the previous Stop intent.
+[ -z "$("$STATE_HELPER" meta get "$meta" stop_requested_at)" ]
 pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
 [ -n "$pane_id" ] || { printf 'recovered session is missing its pane ID\n' >&2; exit 1; }
 worker_pid="$(tmux -L "$SOCKET" display-message -p -t "$pane_id" '#{pane_pid}')"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -427,6 +427,63 @@ if codex_part_selected preflight; then
   bash -n "$ROOT/bin/detach-core"
   [ "$($SCRIPT __version)" = "$(<"$ROOT/VERSION")" ]
 
+  # The app's long-lived source must be the public CLI, backed by one native
+  # process. Prove lifecycle and transcript writes produce leading/trailing
+  # typed hints on a normal user-data volume (FSEvents excludes some temporary
+  # filesystem implementations).
+  (
+    event_root="$ROOT/app/build/session-events-$$"
+    event_output="$event_root/events.jsonl"
+    event_pid=""
+    cleanup_event_probe() {
+      [ -z "$event_pid" ] || kill "$event_pid" 2>/dev/null || true
+      [ -z "$event_pid" ] || wait "$event_pid" 2>/dev/null || true
+      rm -rf "$event_root"
+    }
+    trap cleanup_event_probe EXIT
+    mkdir -p \
+      "$event_root/state" \
+      "$event_root/codex/sessions" \
+      "$event_root/claude/projects"
+    DETACH_STATE_ROOT="$event_root/state" \
+    CODEX_HOME="$event_root/codex" \
+    CLAUDE_CONFIG_DIR="$event_root/claude" \
+      "$SCRIPT" watch --json >"$event_output" &
+    event_pid=$!
+    wait_for_file_text "$event_output" '"event":"ready"'
+    "$STATE_HELPER" events publish "$event_root/state/session-change"
+    wait_for_file_text "$event_output" '"event":"changed"'
+    touch "$event_root/codex/sessions/turn.jsonl"
+    event_attempts=0
+    while [ "$event_attempts" -lt 80 ] && \
+          [ "$(grep -c '"event":"changed"' "$event_output" 2>/dev/null || true)" -lt 3 ]; do
+      event_attempts=$((event_attempts + 1))
+      sleep 0.05
+    done
+    [ "$(grep -c '"event":"changed"' "$event_output")" -ge 3 ]
+  )
+
+  heartbeat_source="$(sed -n \
+    '/^runtime_heartbeat_locked() {/,/^runtime_heartbeat_once() {/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$heartbeat_source" | \
+    grep -F 'state_update_meta_for_run_without_event' >/dev/null
+  state_mutation_source="$(sed -n \
+    '/^state_update_meta() {/,/^state_update_meta_without_event() {/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$state_mutation_source" | \
+    grep -F 'publish_session_event' >/dev/null
+  start_source="$(sed -n \
+    '/^start_tmux_session() {/,/^running_session_for_project() {/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$start_source" | sed -n '1,/respawn-pane -k/p' | \
+    grep -F 'publish_session_event' >/dev/null
+  delete_source="$(sed -n \
+    '/^delete_locked() {/,/^restore_rollout_if_needed() {/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$delete_source" | \
+    grep -F 'publish_session_event' >/dev/null
+
 if FAKE_POWER_STATE=unavailable run_codex --name power-preflight --detach -- \
   'must not start without power protection' >/dev/null 2>&1; then
   printf 'start unexpectedly passed an unavailable power preflight\n' >&2

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1428,6 +1428,11 @@ printf '{damaged rollout\n' >"$expected_rollout"
 uppercase_id="$(printf '%s' "$expected_id" | tr '[:lower:]' '[:upper:]')"
 other_cwd="$TMP_ROOT/other-cwd"
 mkdir -p "$other_cwd"
+# Capture the event token before resume. On a fast host, the worker can record
+# `completed`, exit, and run the pane-died hook before the status poll below
+# returns. A baseline taken after that poll would wait for a nonexistent extra
+# event.
+status_hint="$(cat "$DETACH_STATE_ROOT/session-change")"
 (cd "$other_cwd" && "$DETACH" resume --name integration --detach "$uppercase_id")
 wait_for_tmux_option "$SESSION" @detach_status completed
 grep -Fx 'resume' "$FAKE_CODEX_ARGS_FILE" >/dev/null
@@ -1435,10 +1440,6 @@ grep -Fx "$expected_id" "$FAKE_CODEX_ARGS_FILE" >/dev/null
 [ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" = "$expected_id" ]
 completed_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
-# The worker published its final status before it exited. The retained pane
-# dying afterwards writes no state, so a tmux hook must publish one more hint
-# or the app could only learn about the dead pane from window activation.
-status_hint="$(cat "$DETACH_STATE_ROOT/session-change")"
 wait_for_pane_dead "$pane_id"
 hint_attempts=0
 while [ "$hint_attempts" -lt 100 ] && \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1803,6 +1803,51 @@ PATH="$shadow_bin:$PATH" run_codex stop "$shadow_name"
   "$DETACH_CODEX_STATE_ROOT/sessions/$shadow_session/meta.json" status)" = stopped ]
 run_codex delete --force "$shadow_name"
 
+# Freeze the worker after Start, then request Stop. The process-group TERM
+# removes the provider while the stopped worker cannot publish final metadata.
+# This holds the exact UI-visible transition long enough to assert that durable
+# Stop intent keeps it out of Problems without authorizing an early action.
+stop_transition_name=stop-transition
+stop_transition_session=detach-codex-stop-transition
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name "$stop_transition_name" --detach -- 'Stop transition health coverage'
+wait_for_tmux_option "$stop_transition_session" @detach_status running
+stop_transition_meta="$DETACH_CODEX_STATE_ROOT/sessions/$stop_transition_session/meta.json"
+stop_transition_worker="$("$STATE_HELPER" meta get "$stop_transition_meta" worker_pid)"
+kill -STOP "$stop_transition_worker"
+run_codex stop "$stop_transition_name" >"$TMP_ROOT/stop-transition.out" 2>&1 &
+stop_transition_pid=$!
+stop_transition_json=""
+attempts=0
+while [ "$attempts" -lt 80 ]; do
+  candidate_json="$(run_codex list --json | \
+    grep -F "\"session_name\":\"$stop_transition_session\"")"
+  candidate_reason="$(printf '%s' "$candidate_json" | \
+    "$STATE_HELPER" meta get /dev/stdin health_reason)"
+  case "$candidate_reason" in
+    finished|provider_process_lost)
+      stop_transition_json="$candidate_json"
+      break
+      ;;
+  esac
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+kill -CONT "$stop_transition_worker" 2>/dev/null || true
+wait "$stop_transition_pid"
+[ -n "$stop_transition_json" ]
+[ "$(printf '%s' "$stop_transition_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = interrupted ]
+[ "$(printf '%s' "$stop_transition_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
+[ "$(printf '%s' "$stop_transition_json" | \
+  "$STATE_HELPER" meta get /dev/stdin cleanup_eligible)" = false ]
+[ -n "$(printf '%s' "$stop_transition_json" | \
+  "$STATE_HELPER" meta get /dev/stdin stop_requested_at)" ]
+printf '%s' "$stop_transition_json" | grep -F '"health_actions":[]' >/dev/null
+[ "$("$STATE_HELPER" meta get "$stop_transition_meta" status)" = stopped ]
+run_codex delete --force "$stop_transition_name"
+
 # A start holds the install lock through its readiness wait (up to 35
 # seconds). Scale lockf deadlines by 10 for this check so the regression stays
 # discriminating without adding 35 seconds to every Codex test run.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -530,7 +530,7 @@ if codex_part_selected preflight; then
       "$SCRIPT" watch --json >"$event_output" &
     event_pid=$!
     wait_for_file_text "$event_output" '"event":"ready"'
-    "$STATE_HELPER" events publish "$event_root/state/session-change"
+    "$STATE_HELPER" events publish "$event_root/state"
     wait_for_file_text "$event_output" '"event":"changed"'
     touch "$event_root/codex/sessions/unmanaged.jsonl"
     sleep 0.3
@@ -556,7 +556,7 @@ if codex_part_selected preflight; then
       --string session_name "$claude_event_session" \
       --string project_dir "$event_root/project" \
       --string transcript_path "$claude_event_transcript"
-    "$STATE_HELPER" events publish "$event_root/state/session-change"
+    "$STATE_HELPER" events publish "$event_root/state"
     event_attempts=0
     while [ "$event_attempts" -lt 80 ] && \
           [ "$(grep -c '"event":"changed"' "$event_output" 2>/dev/null || true)" -lt 4 ]; do
@@ -593,22 +593,19 @@ if codex_part_selected preflight; then
     grep -F 'install_session_event_hook' >/dev/null
   # The pane-died hook string crosses tmux quoting and `sh -c`. Paths with
   # spaces are common; characters either layer could reinterpret are refused.
-  hook_source="$(sed -n \
-    '/^session_event_hook_command() {/,/^}/p' \
-    "$ROOT/bin/detach-core")"
   hook_command="$(
-    STATE_BIN='/Volumes/User Data/libexec/detach-state'
-    SESSION_EVENT_FILE='/Volumes/User Data/state/session-change'
-    eval "$hook_source"
-    session_event_hook_command
+    DETACH_CORE_ENTRYPOINT=1 \
+    DETACH_PROVIDER=codex \
+    DETACH_STATE_BIN='/Volumes/User Data/libexec/detach-state' \
+    DETACH_STATE_ROOT='/Volumes/User Data/state' \
+      "$ROOT/bin/detach-core" __session_event_hook_command
   )"
-  [ "$hook_command" = "run-shell -b \"'/Volumes/User Data/libexec/detach-state' events publish '/Volumes/User Data/state/session-change' >/dev/null 2>&1 || true\"" ]
-  if (
-    STATE_BIN='/tmp/$HOME/detach-state'
-    SESSION_EVENT_FILE='/tmp/state/session-change'
-    eval "$hook_source"
-    session_event_hook_command >/dev/null
-  ); then
+  [ "$hook_command" = "run-shell -b \"'/Volumes/User Data/libexec/detach-state' events publish '/Volumes/User Data/state' >/dev/null 2>&1 || true\"" ]
+  if DETACH_CORE_ENTRYPOINT=1 \
+     DETACH_PROVIDER=codex \
+     DETACH_STATE_BIN='/tmp/$HOME/detach-state' \
+     DETACH_STATE_ROOT='/tmp/state' \
+       "$ROOT/bin/detach-core" __session_event_hook_command >/dev/null; then
     printf 'hook command accepted an unsafe path\n' >&2
     exit 1
   fi
@@ -885,6 +882,31 @@ TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach)" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_provider)" = "codex" ]
 pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
+meta="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/meta.json"
+# Stop must persist intent for the exact run before its first signal. Inject a
+# state write failure and prove the live pane and metadata remain unchanged.
+stop_state_wrapper="$TMP_ROOT/stop-state-wrapper"
+stop_state_failure="$TMP_ROOT/stop-state-failure"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'if [ -f "$DETACH_STOP_STATE_FAILURE" ] && [ "${1:-}" = meta ] && [ "${2:-}" = patch ]; then' \
+  '  case " $* " in *" stop_requested_at "*) exit 91 ;; esac' \
+  'fi' \
+  'exec "$DETACH_STOP_STATE_DELEGATE" "$@"' \
+  >"$stop_state_wrapper"
+chmod 0755 "$stop_state_wrapper"
+: >"$stop_state_failure"
+if DETACH_STATE_BIN="$stop_state_wrapper" \
+   DETACH_STOP_STATE_FAILURE="$stop_state_failure" \
+   DETACH_STOP_STATE_DELEGATE="$STATE_HELPER" \
+   run_codex stop integration >/dev/null 2>&1; then
+  printf 'Stop unexpectedly signaled a run without durable intent\n' >&2
+  exit 1
+fi
+tmux -L "$SOCKET" has-session -t "=$SESSION"
+[ "$(tmux -L "$SOCKET" display-message -p -t "$pane_id" '#{pane_dead}')" = "0" ]
+[ -z "$("$STATE_HELPER" meta get "$meta" stop_requested_at)" ]
+rm "$stop_state_failure"
 # The creator CLI has already exited. The tmux server and worker must remain
 # alive without an attached client (the same lifecycle as closing Terminal or
 # Detach.app after starting a session).
@@ -1359,6 +1381,8 @@ fi
 
 # A fresh run with the same name must never inherit the previous run's UUID.
 [ -s "$checkpoint/rollout.jsonl" ]
+previous_lifecycle_id="$("$STATE_HELPER" meta get "$meta" lifecycle_id)"
+[ -n "$previous_lifecycle_id" ]
 export FAKE_CODEX_INIT_DELAY=5
 printf '%s\n' 'allowed_approval_policies = ["untrusted", "on-request", "never"]' >"$DETACH_CODEX_REQUIREMENTS_FILE"
 run_codex --name integration --detach -- 'start a new thread'
@@ -1370,6 +1394,10 @@ wait_for_file_text "$FAKE_CODEX_ARGS_FILE" 'start a new thread'
 [ ! -e "$checkpoint/.detach-jsonl-validation.json" ]
 [ ! -e "$checkpoint/meta.json" ]
 fresh_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
+fresh_lifecycle_id="$("$STATE_HELPER" meta get "$meta" lifecycle_id)"
+[ -n "$fresh_lifecycle_id" ]
+[ "$fresh_lifecycle_id" != "$previous_lifecycle_id" ]
+[ "$fresh_lifecycle_id" != "$fresh_run_token" ]
 if run_codex --name integration --detach -- 'must not replace a running task'; then
   printf 'new default start unexpectedly replaced a running task\n' >&2
   exit 1
@@ -1383,7 +1411,9 @@ fi
 fi
 
 if codex_part_selected resume; then
-if [ "$CODEX_TEST_PART" = resume ] || [ "$CODEX_TEST_PART" = resume-identity ]; then
+if [ "$CODEX_TEST_PART" = all ] || \
+   [ "$CODEX_TEST_PART" = resume ] || \
+   [ "$CODEX_TEST_PART" = resume-identity ]; then
   bootstrap_codex_checkpoint
 fi
 
@@ -1451,6 +1481,7 @@ json_line="$(run_codex list --json | grep -F "\"session_name\":\"$SESSION\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin effective_status)" = "running" ]
 [ -n "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin project_dir)" ]
 [ -n "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin created_at)" ]
+[ -n "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin lifecycle_id)" ]
 [ -z "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin exit_status)" ]
 [[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin session_color)" =~ ^#[[:xdigit:]]{6}$ ]]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin power_protection_state)" = "protected" ]
@@ -2032,17 +2063,20 @@ rmdir "$DETACH_CODEX_STATE_ROOT/sessions/$default_session-r000000000001"
 rmdir "$DETACH_CODEX_STATE_ROOT/sessions/$default_session"
 
 # Listing saved histories must remain below the app's five-second deadline as
-# state grows. Count helper launches as a deterministic guard against restoring
-# the former per-field subprocess fan-out, and retain a real wall-clock ceiling
-# on the reference test machine.
+# state grows. The second read uses cached summaries for one 300 KiB transcript
+# per row. Count helper launches as a deterministic guard against restoring the
+# former per-field subprocess fan-out, and retain a wall-clock ceiling.
 list_scale_root="$TMP_ROOT/list-scale-state"
 list_scale_output="$TMP_ROOT/list-scale.jsonl"
 list_scale_invocations="$TMP_ROOT/list-scale-invocations.txt"
 list_scale_wrapper="$TMP_ROOT/list-scale-detach-state"
 list_scale_tmux_invocations="$TMP_ROOT/list-scale-tmux-invocations.txt"
 list_scale_tmux_wrapper="$TMP_ROOT/list-scale-tmux"
+list_scale_transcript="$TMP_ROOT/list-scale-transcript.jsonl"
 list_scale_live_sessions=()
 mkdir -p "$list_scale_root/sessions"
+dd if=/dev/zero of="$list_scale_transcript" bs=1024 count=300 >/dev/null 2>&1
+printf '\n%s\n' '{"payload":{"model":"gpt-scale"}}' >>"$list_scale_transcript"
 list_scale_index=1
 while [ "$list_scale_index" -le 25 ]; do
   list_scale_session="detach-codex-list-scale-$list_scale_index"
@@ -2052,7 +2086,8 @@ while [ "$list_scale_index" -le 25 ]; do
     --integer schema 1 \
     --string session_name "$list_scale_session" \
     --string project_dir "$ROOT" \
-    --string status stopped
+    --string status stopped \
+    --string transcript_path "$list_scale_transcript"
   if [ "$list_scale_index" -le 3 ]; then
     tmux -L "$SOCKET" new-session -d -s "$list_scale_session" /bin/sleep 30
     tmux -L "$SOCKET" set-option -q -t "=$list_scale_session:" @detach 1
@@ -2083,10 +2118,8 @@ DETACH_LIST_SCALE_TMUX_INVOCATIONS="$list_scale_tmux_invocations" \
 DETACH_TMUX_SOCKET_PATH="$SOCKET_PATH" \
   "$SCRIPT" codex list --json >"$list_scale_output"
 list_scale_elapsed="$SECONDS"
-for list_scale_session in "${list_scale_live_sessions[@]}"; do
-  tmux -L "$SOCKET" kill-session -t "=$list_scale_session"
-done
 [ "$(wc -l <"$list_scale_output" | tr -d '[:space:]')" = 25 ]
+[ "$(grep -Fc '"model":"gpt-scale"' "$list_scale_output")" = 25 ]
 [ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 5 ] || {
   printf 'list restored per-field state helper fan-out\n' >&2
   exit 1
@@ -2095,10 +2128,37 @@ done
   printf 'list did not use one batched tmux snapshot\n' >&2
   exit 1
 }
+[ "$(find "$list_scale_root/sessions" -name .transcript-summary-cache.json -type f | \
+  wc -l | tr -d '[:space:]')" = 25 ]
 [ "$list_scale_elapsed" -lt 5 ] || {
-  printf '25-session list exceeded the app deadline: %ss\n' "$list_scale_elapsed" >&2
+  printf 'cold 25-session list exceeded the app deadline: %ss\n' "$list_scale_elapsed" >&2
   exit 1
 }
+: >"$list_scale_invocations"
+: >"$list_scale_tmux_invocations"
+SECONDS=0
+DETACH_CODEX_STATE_ROOT="$list_scale_root" \
+DETACH_STATE_BIN="$list_scale_wrapper" \
+DETACH_LIST_SCALE_STATE_HELPER="$STATE_HELPER" \
+DETACH_LIST_SCALE_INVOCATIONS="$list_scale_invocations" \
+DETACH_POWER_BIN=/usr/bin/false \
+DETACH_TMUX_BIN="$list_scale_tmux_wrapper" \
+DETACH_LIST_SCALE_TMUX_HELPER="$TMUX_TEST_BIN" \
+DETACH_LIST_SCALE_TMUX_INVOCATIONS="$list_scale_tmux_invocations" \
+DETACH_TMUX_SOCKET_PATH="$SOCKET_PATH" \
+  "$SCRIPT" codex list --json >"$list_scale_output"
+list_scale_hot_elapsed="$SECONDS"
+[ "$(wc -l <"$list_scale_output" | tr -d '[:space:]')" = 25 ]
+[ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 5 ]
+[ "$(wc -l <"$list_scale_tmux_invocations" | tr -d '[:space:]')" = 1 ]
+[ "$list_scale_hot_elapsed" -lt 5 ] || {
+  printf 'cached 25-session list exceeded the app deadline: %ss\n' \
+    "$list_scale_hot_elapsed" >&2
+  exit 1
+}
+for list_scale_session in "${list_scale_live_sessions[@]}"; do
+  tmux -L "$SOCKET" kill-session -t "=$list_scale_session"
+done
 
 # Public read paths must reject state-root redirection before creating or
 # traversing sessions in an unrelated directory.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -520,7 +520,11 @@ if codex_part_selected preflight; then
       --string session_name "$event_session" \
       --string project_dir "$event_root/project" \
       --string transcript_path "$event_managed_transcript"
+    # The watcher reads managed metadata from the explicit provider state
+    # roots, so a relocated provider root must be named like the runtime does.
     DETACH_STATE_ROOT="$event_root/state" \
+    DETACH_CODEX_STATE_ROOT="$event_root/state/codex" \
+    DETACH_CLAUDE_STATE_ROOT="$event_root/state/claude" \
     CODEX_HOME="$event_root/codex" \
     CLAUDE_CONFIG_DIR="$event_root/claude" \
       "$SCRIPT" watch --json >"$event_output" &
@@ -585,6 +589,36 @@ if codex_part_selected preflight; then
     "$ROOT/bin/detach-core")"
   printf '%s\n' "$start_source" | sed -n '1,/respawn-pane -k/p' | \
     grep -F 'publish_session_event' >/dev/null
+  printf '%s\n' "$start_source" | sed -n '1,/respawn-pane -k/p' | \
+    grep -F 'install_session_event_hook' >/dev/null
+  # The pane-died hook string crosses tmux quoting and `sh -c`. Paths with
+  # spaces are common; characters either layer could reinterpret are refused.
+  hook_source="$(sed -n \
+    '/^session_event_hook_command() {/,/^}/p' \
+    "$ROOT/bin/detach-core")"
+  hook_command="$(
+    STATE_BIN='/Volumes/User Data/libexec/detach-state'
+    SESSION_EVENT_FILE='/Volumes/User Data/state/session-change'
+    eval "$hook_source"
+    session_event_hook_command
+  )"
+  [ "$hook_command" = "run-shell -b \"'/Volumes/User Data/libexec/detach-state' events publish '/Volumes/User Data/state/session-change' >/dev/null 2>&1 || true\"" ]
+  if (
+    STATE_BIN='/tmp/$HOME/detach-state'
+    SESSION_EVENT_FILE='/tmp/state/session-change'
+    eval "$hook_source"
+    session_event_hook_command >/dev/null
+  ); then
+    printf 'hook command accepted an unsafe path\n' >&2
+    exit 1
+  fi
+  # The cleanup checkpoint must not wake the app while the provider is gone
+  # and the worker is still alive; the status write that follows publishes.
+  worker_cleanup_source="$(sed -n \
+    '/^  worker_cleanup() {/,/^  trap worker_cleanup EXIT/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$worker_cleanup_source" | \
+    grep -F 'DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once' >/dev/null
   delete_source="$(sed -n \
     '/^delete_locked() {/,/^restore_rollout_if_needed() {/p' \
     "$ROOT/bin/detach-core")"
@@ -1364,7 +1398,18 @@ grep -Fx "$expected_id" "$FAKE_CODEX_ARGS_FILE" >/dev/null
 [ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" = "$expected_id" ]
 completed_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
 pane_id="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_pane_id)"
+# The worker published its final status before it exited. The retained pane
+# dying afterwards writes no state, so a tmux hook must publish one more hint
+# or the app could only learn about the dead pane from window activation.
+status_hint="$(cat "$DETACH_STATE_ROOT/session-change")"
 wait_for_pane_dead "$pane_id"
+hint_attempts=0
+while [ "$hint_attempts" -lt 100 ] && \
+      [ "$(cat "$DETACH_STATE_ROOT/session-change")" = "$status_hint" ]; do
+  hint_attempts=$((hint_attempts + 1))
+  sleep 0.05
+done
+[ "$(cat "$DETACH_STATE_ROOT/session-change")" != "$status_hint" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_status)" = "completed" ]
 completed_style="$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" status-style)"
 [ "$completed_style" != "$failed_style" ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1853,6 +1853,50 @@ PATH="$shadow_bin:$PATH" run_codex stop "$shadow_name"
   "$DETACH_CODEX_STATE_ROOT/sessions/$shadow_session/meta.json" status)" = stopped ]
 run_codex delete --force "$shadow_name"
 
+# A legacy worker or a faulty final checkpoint can remain alive after its
+# recorded provider has exited. Stop must keep actions closed until that exact
+# worker is gone, but it must not spend the full live-provider grace on cleanup.
+slow_cleanup_name=stop-slow-final-checkpoint
+slow_cleanup_session=detach-codex-stop-slow-final-checkpoint
+slow_cleanup_marker="$TMP_ROOT/slow-final-checkpoint"
+slow_cleanup_started="$TMP_ROOT/slow-final-checkpoint-started"
+slow_cleanup_sqlite="$TMP_ROOT/slow-final-checkpoint-sqlite"
+sqlite_delegate="$(command -v sqlite3)"
+printf '%s\n' \
+  '#!/bin/bash' \
+  "if [ -f '$slow_cleanup_marker' ]; then" \
+  "  : >'$slow_cleanup_started'" \
+  "  trap '' HUP INT TERM" \
+  '  sleep 30' \
+  'fi' \
+  "exec '$sqlite_delegate' \"\$@\"" \
+  >"$slow_cleanup_sqlite"
+chmod 0755 "$slow_cleanup_sqlite"
+DETACH_SQLITE_BIN="$slow_cleanup_sqlite" \
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name "$slow_cleanup_name" --detach -- \
+    'bounded Stop finalization coverage'
+wait_for_tmux_option "$slow_cleanup_session" @detach_status running
+slow_cleanup_meta="$DETACH_CODEX_STATE_ROOT/sessions/$slow_cleanup_session/meta.json"
+: >"$slow_cleanup_marker"
+slow_cleanup_start_seconds=$SECONDS
+run_codex stop "$slow_cleanup_name"
+slow_cleanup_elapsed=$((SECONDS - slow_cleanup_start_seconds))
+[ -f "$slow_cleanup_started" ]
+if [ "$slow_cleanup_elapsed" -ge 7 ]; then
+  printf 'Stop spent %s seconds waiting after provider exit\n' \
+    "$slow_cleanup_elapsed" >&2
+  exit 1
+fi
+slow_cleanup_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$slow_cleanup_session\"")"
+[ "$(printf '%s' "$slow_cleanup_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = stopped ]
+printf '%s' "$slow_cleanup_json" | \
+  grep -F '"health_actions":["resume","delete"]' >/dev/null
+[ "$("$STATE_HELPER" meta get "$slow_cleanup_meta" status)" = stopped ]
+run_codex delete --force "$slow_cleanup_name"
+
 # Freeze the worker after Start, then request Stop. The process-group TERM
 # removes the provider while the stopped worker cannot publish final metadata.
 # This holds the exact UI-visible transition long enough to assert that durable

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -415,6 +415,7 @@ export CODEX_HOME="$TMP_ROOT/codex-home"
 export CLAUDE_CONFIG_DIR="$TMP_ROOT/claude-home"
 export DETACH_CLAUDE_STATE_ROOT="$TMP_ROOT/claude-state"
 export FAKE_CODEX_ARGS_FILE="$TMP_ROOT/args.txt"
+export FAKE_CODEX_COLORTERM_FILE="$TMP_ROOT/codex-colorterm.txt"
 export FAKE_CODEX_SLEEP=4
 export FAKE_CODEX_EXIT=7
 export FAKE_CODEX_FOREIGN_FIRST=1
@@ -1012,7 +1013,8 @@ if codex_part_selected lifecycle; then
   codex_scenario_event begin SC-SESSION-RECOVER-CODEX
   codex_scenario_event begin SC-SESSION-STOP-CODEX
   codex_scenario_event begin SC-SESSION-DELETE-CODEX
-  LC_ALL=C run_codex --name integration --detach -- "$literal_prompt"
+  COLORTERM=ambient-is-not-a-capability \
+    LC_ALL=C run_codex --name integration --detach -- "$literal_prompt"
 
 wait_for_tmux_option "$SESSION" @detach_status running
 wait_for_tmux_option "$SESSION" set-titles on
@@ -1020,6 +1022,8 @@ LC_ALL=C.UTF-8 wait_for_tmux_option \
   "$SESSION" set-titles-string "Detach · $PROJECT_LABEL"
 wait_for_tmux_option_text "$SESSION" status-left RUNNING
 tmux -L "$SOCKET" has-session -t "=$SESSION"
+wait_for_file_text "$FAKE_CODEX_COLORTERM_FILE" truecolor
+[ "$(<"$FAKE_CODEX_COLORTERM_FILE")" = truecolor ]
 "$DETACH" list | grep -F 'codex' | grep -F "$SESSION" >/dev/null
 codex_scenario_event pass SC-SESSION-CREATE-CODEX
 mkdir -p "$TMP_ROOT/unrelated-tmux-tmpdir"
@@ -1465,6 +1469,10 @@ run_codex stop integration
 ! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
 [ "$("$STATE_HELPER" meta get "$meta" status)" = "stopped" ]
 [ -n "$("$STATE_HELPER" meta get "$meta" stopped_at)" ]
+# The immutable ANSI checkpoint keeps true-color provider styling after tmux
+# is gone, including when the app launched the original provider.
+run_codex logs --ansi integration | LC_ALL=C \
+  grep -F $'\033[38;2;12;34;56mtrue-color checkpoint probe' >/dev/null
 # Stop records its intent in typed state before it signals the runtime, and
 # the list carries it, so an `interrupted` window is never read as a crash.
 [ -n "$("$STATE_HELPER" meta get "$meta" stop_requested_at)" ]
@@ -1974,6 +1982,10 @@ DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
     'bounded Stop finalization coverage'
 wait_for_tmux_option "$slow_cleanup_session" @detach_status running
 slow_cleanup_meta="$DETACH_CODEX_STATE_ROOT/sessions/$slow_cleanup_session/meta.json"
+slow_cleanup_checkpoint="$(dirname "$slow_cleanup_meta")/checkpoint"
+# Only Stop can recreate these snapshots: the final worker checkpoint blocks
+# in SQLite before it reaches pane capture.
+rm -f "$slow_cleanup_checkpoint/pane.txt" "$slow_cleanup_checkpoint/pane-ansi.txt"
 : >"$slow_cleanup_marker"
 slow_cleanup_start_seconds=$SECONDS
 run_codex stop "$slow_cleanup_name"
@@ -1991,6 +2003,9 @@ slow_cleanup_json="$(run_codex list --json | \
 printf '%s' "$slow_cleanup_json" | \
   grep -F '"health_actions":["resume","delete"]' >/dev/null
 [ "$("$STATE_HELPER" meta get "$slow_cleanup_meta" status)" = stopped ]
+[ -s "$slow_cleanup_checkpoint/pane.txt" ]
+run_codex logs --ansi "$slow_cleanup_name" | LC_ALL=C \
+  grep -F $'\033[38;2;12;34;56mtrue-color checkpoint probe' >/dev/null
 run_codex delete --force "$slow_cleanup_name"
 
 # Freeze the worker after Start, then request Stop. The process-group TERM

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -331,6 +331,8 @@ export FAKE_ENV_ARGS_FILE="$TMP_ROOT/env-args.txt"
 export FAKE_POWER_ARGS_FILE="$TMP_ROOT/power-args.txt"
 export FAKE_POWER_STATUS_FILE="$TMP_ROOT/power-status.txt"
 export FAKE_POWER_RELEASES_FILE="$TMP_ROOT/power-releases.txt"
+export FAKE_POWER_DELAY_SESSION="detach-codex-startup-health"
+export FAKE_POWER_DELAY_RELEASE_FILE="$TMP_ROOT/startup-health-release"
 printf '%s\n' \
   '#!/bin/bash' \
   'if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then' \
@@ -346,14 +348,24 @@ printf '%s\n' \
   '  printf '\''%s\n'\'' "$@" >"$FAKE_POWER_ARGS_FILE"' \
   '  ready_file=' \
   '  pid_file=' \
+  '  managed_session=' \
   '  shift' \
   '  while [ "$#" -gt 0 ] && [ "$1" != -- ]; do' \
+  '    if [ "$1" = --session ]; then managed_session="$2"; shift 2; continue; fi' \
   '    if [ "$1" = --ready-file ]; then ready_file="$2"; shift 2; continue; fi' \
   '    if [ "$1" = --pid-file ]; then pid_file="$2"; shift 2; continue; fi' \
   '    shift' \
   '  done' \
   '  [ "${1:-}" = -- ] || exit 2' \
   '  [ "${FAKE_POWER_FAIL_RUN:-0}" != 1 ] || exit 1' \
+  '  if [ "$managed_session" = "${FAKE_POWER_DELAY_SESSION:-}" ]; then' \
+  '    delay_attempts=0' \
+  '    while [ ! -f "$FAKE_POWER_DELAY_RELEASE_FILE" ] && [ "$delay_attempts" -lt 200 ]; do' \
+  '      delay_attempts=$((delay_attempts + 1))' \
+  '      sleep 0.05' \
+  '    done' \
+  '    [ -f "$FAKE_POWER_DELAY_RELEASE_FILE" ] || exit 124' \
+  '  fi' \
   '  [ -z "$ready_file" ] || : >"$ready_file"' \
   '  [ -z "$pid_file" ] || printf '\''%s\n'\'' "$$" >"$pid_file"' \
   '  shift' \
@@ -637,10 +649,20 @@ if codex_part_selected preflight; then
   start_source="$(sed -n \
     '/^start_tmux_session() {/,/^running_session_for_project() {/p' \
     "$ROOT/bin/detach-core")"
-  printf '%s\n' "$start_source" | sed -n '1,/respawn-pane -k/p' | \
-    grep -F 'publish_session_event' >/dev/null
+  if printf '%s\n' "$start_source" | sed -n '1,/respawn-pane -k/p' | \
+     grep -F 'publish_session_event' >/dev/null; then
+    printf 'start published lifecycle state before the worker existed\n' >&2
+    exit 1
+  fi
   printf '%s\n' "$start_source" | sed -n '1,/respawn-pane -k/p' | \
     grep -F 'install_session_event_hook' >/dev/null
+  worker_start_source="$(sed -n \
+    '/^worker_main() {/,/^  if \[ "$PROVIDER" = "claude" \]; then/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$worker_start_source" | \
+    grep -F 'state_update_meta_for_run_without_event' >/dev/null
+  printf '%s\n' "$worker_start_source" | \
+    grep -F 'publish_session_event' >/dev/null
   # The pane-died hook string crosses tmux quoting and `sh -c`. Paths with
   # spaces are common; characters either layer could reinterpret are refused.
   hook_command="$(
@@ -911,6 +933,52 @@ if codex_part_selected lifecycle; then
   export FAKE_CODEX_SLEEP=12
   integration_release="$TMP_ROOT/integration-provider-release"
   export FAKE_CODEX_RELEASE_FILE="$integration_release"
+
+  # Hold the power wrapper between the exact worker handshake and provider
+  # launch. The lifecycle hint observed in this phase must remain `starting`;
+  # it must never flash through Problems as a false missing-provider failure.
+  startup_session="$FAKE_POWER_DELAY_SESSION"
+  startup_meta="$DETACH_CODEX_STATE_ROOT/sessions/$startup_session/meta.json"
+  startup_output="$TMP_ROOT/startup-health-output"
+  rm -f "$FAKE_POWER_DELAY_RELEASE_FILE"
+  run_codex --name startup-health --detach -- 'startup health transition' \
+    >"$startup_output" 2>&1 &
+  startup_command_pid=$!
+  attempts=0
+  startup_worker_pid=""
+  while [ "$attempts" -lt 100 ]; do
+    if [ -f "$startup_meta" ]; then
+      startup_worker_pid="$(
+        "$STATE_HELPER" meta get "$startup_meta" worker_pid 2>/dev/null || true
+      )"
+    fi
+    case "$startup_worker_pid" in ''|*[!0-9]*) ;; *) break ;; esac
+    attempts=$((attempts + 1))
+    sleep 0.05
+  done
+  case "$startup_worker_pid" in
+    ''|*[!0-9]*) printf 'startup worker identity was not published\n' >&2; exit 1 ;;
+  esac
+  [ "$("$STATE_HELPER" meta get "$startup_meta" status)" = starting ]
+  wait_for_tmux_option "$startup_session" @detach_status starting
+  startup_health="$(
+    run_codex list --json | grep -F "\"session_name\":\"$startup_session\""
+  )"
+  [ "$(printf '%s' "$startup_health" | \
+    "$STATE_HELPER" meta get /dev/stdin effective_status)" = starting ]
+  [ "$(printf '%s' "$startup_health" | \
+    "$STATE_HELPER" meta get /dev/stdin health_reason)" = healthy ]
+  : >"$FAKE_POWER_DELAY_RELEASE_FILE"
+  wait "$startup_command_pid"
+  grep -F "Started $startup_session" "$startup_output" >/dev/null
+  startup_health="$(
+    run_codex list --json | grep -F "\"session_name\":\"$startup_session\""
+  )"
+  [ "$(printf '%s' "$startup_health" | \
+    "$STATE_HELPER" meta get /dev/stdin effective_status)" = running ]
+  run_codex stop startup-health >/dev/null
+  run_codex delete --force startup-health >/dev/null
+
   codex_scenario_event begin SC-SESSION-CREATE-CODEX
   codex_scenario_event begin SC-SESSION-PERSIST-CODEX
   codex_scenario_event begin SC-SESSION-RECOVER-CODEX

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -494,6 +494,56 @@ if codex_part_selected preflight; then
     "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
   [ -z "$(find "$public_list_tmp" -mindepth 1 -print -quit)" ]
 
+  # A caller can terminate the public frontend by PID (for example during app
+  # cancellation). Its cleanup must terminate the two exact provider jobs, not
+  # only the background shell functions that launched them.
+  cancel_list_payload="$TMP_ROOT/cancel-list-payload"
+  cancel_list_pids="$TMP_ROOT/cancel-list-pids"
+  mkdir -p "$cancel_list_payload"
+  : >"$cancel_list_pids"
+  install -m 0755 "$ROOT/bin/detach" "$cancel_list_payload/detach"
+  printf '%s\n' \
+    '#!/bin/bash' \
+    '[ "${DETACH_CORE_ENTRYPOINT:-}" = 1 ] || exit 2' \
+    'printf '\''%s\n'\'' "$$" >>"$DETACH_CANCEL_LIST_PIDS"' \
+    'trap '\''exit 0'\'' HUP INT TERM' \
+    'while :; do sleep 0.05; done' \
+    >"$cancel_list_payload/detach-core"
+  chmod 0755 "$cancel_list_payload/detach-core"
+  DETACH_CANCEL_LIST_PIDS="$cancel_list_pids" \
+  DETACH_POWER_BIN=/usr/bin/false \
+    "$cancel_list_payload/detach" list --json >/dev/null 2>&1 &
+  cancel_list_frontend_pid=$!
+  attempts=0
+  while [ "$(wc -l <"$cancel_list_pids" 2>/dev/null || printf 0)" -lt 2 ] && \
+        [ "$attempts" -lt 100 ]; do
+    attempts=$((attempts + 1))
+    sleep 0.01
+  done
+  [ "$attempts" -lt 100 ]
+  kill -TERM "$cancel_list_frontend_pid"
+  wait "$cancel_list_frontend_pid" 2>/dev/null || true
+  cancel_list_survivors=""
+  attempts=0
+  while [ "$attempts" -lt 100 ]; do
+    cancel_list_survivors=""
+    while IFS= read -r cancel_list_pid; do
+      kill -0 "$cancel_list_pid" 2>/dev/null && \
+        cancel_list_survivors="$cancel_list_survivors $cancel_list_pid"
+    done <"$cancel_list_pids"
+    [ -n "$cancel_list_survivors" ] || break
+    attempts=$((attempts + 1))
+    sleep 0.01
+  done
+  if [ -n "$cancel_list_survivors" ]; then
+    for cancel_list_pid in $cancel_list_survivors; do
+      kill -KILL "$cancel_list_pid" 2>/dev/null || true
+    done
+    printf 'public list cancellation left provider jobs alive:%s\n' \
+      "$cancel_list_survivors" >&2
+    exit 1
+  fi
+
   # The app's long-lived source must be the public CLI, backed by one native
   # process. Prove lifecycle and transcript writes produce leading/trailing
   # typed hints on a normal user-data volume (FSEvents excludes some temporary

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -688,6 +688,16 @@ if codex_part_selected preflight; then
     "$ROOT/bin/detach-core")"
   printf '%s\n' "$worker_cleanup_source" | \
     grep -F 'DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once' >/dev/null
+  finalizing_line="$(printf '%s\n' "$worker_cleanup_source" | \
+    grep -n -- '--string lifecycle_phase finalizing' | head -1 | cut -d: -f1)"
+  final_checkpoint_line="$(printf '%s\n' "$worker_cleanup_source" | \
+    grep -n 'checkpoint_once' | tail -1 | cut -d: -f1)"
+  terminal_line="$(printf '%s\n' "$worker_cleanup_source" | \
+    grep -n -- '--string lifecycle_phase terminal' | head -1 | cut -d: -f1)"
+  [ -n "$finalizing_line" ] && [ -n "$final_checkpoint_line" ] && \
+    [ -n "$terminal_line" ]
+  [ "$finalizing_line" -lt "$final_checkpoint_line" ]
+  [ "$final_checkpoint_line" -lt "$terminal_line" ]
   delete_source="$(sed -n \
     '/^delete_locked() {/,/^restore_rollout_if_needed() {/p' \
     "$ROOT/bin/detach-core")"
@@ -934,6 +944,22 @@ if codex_part_selected lifecycle; then
   integration_release="$TMP_ROOT/integration-provider-release"
   export FAKE_CODEX_RELEASE_FILE="$integration_release"
 
+  # Initial metadata is a private handoff document. It must not create a row
+  # before tmux and the worker have published one coherent runtime identity.
+  initializing_session=detach-codex-initializing-fixture
+  initializing_dir="$DETACH_CODEX_STATE_ROOT/sessions/$initializing_session"
+  mkdir -p "$initializing_dir"
+  "$STATE_HELPER" meta create "$initializing_dir/meta.json" \
+    --integer schema 1 \
+    --string session_name "$initializing_session" \
+    --string project_dir "$ROOT" \
+    --string status starting \
+    --string lifecycle_phase initializing \
+    --string run_token initializing-token \
+    --integer health_schema 1
+  ! run_codex list --json | grep -F "\"session_name\":\"$initializing_session\"" >/dev/null
+  rm -rf "$initializing_dir"
+
   # Hold the power wrapper between the exact worker handshake and provider
   # launch. The lifecycle hint observed in this phase must remain `starting`;
   # it must never flash through Problems as a false missing-provider failure.
@@ -960,6 +986,7 @@ if codex_part_selected lifecycle; then
     ''|*[!0-9]*) printf 'startup worker identity was not published\n' >&2; exit 1 ;;
   esac
   [ "$("$STATE_HELPER" meta get "$startup_meta" status)" = starting ]
+  [ "$("$STATE_HELPER" meta get "$startup_meta" lifecycle_phase)" = starting ]
   wait_for_tmux_option "$startup_session" @detach_status starting
   startup_health="$(
     run_codex list --json | grep -F "\"session_name\":\"$startup_session\""
@@ -976,6 +1003,7 @@ if codex_part_selected lifecycle; then
   )"
   [ "$(printf '%s' "$startup_health" | \
     "$STATE_HELPER" meta get /dev/stdin effective_status)" = running ]
+  [ "$("$STATE_HELPER" meta get "$startup_meta" lifecycle_phase)" = running ]
   run_codex stop startup-health >/dev/null
   run_codex delete --force startup-health >/dev/null
 
@@ -1967,8 +1995,9 @@ run_codex delete --force "$slow_cleanup_name"
 
 # Freeze the worker after Start, then request Stop. The process-group TERM
 # removes the provider while the stopped worker cannot publish final metadata.
-# This holds the exact UI-visible transition long enough to assert that durable
-# Stop intent keeps it out of Problems without authorizing an early action.
+# This holds the exact UI-visible transition long enough to assert that the
+# formal stopping phase reports the requested outcome without authorizing an
+# early action.
 stop_transition_name=stop-transition
 stop_transition_session=detach-codex-stop-transition
 DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
@@ -1999,7 +2028,7 @@ kill -CONT "$stop_transition_worker" 2>/dev/null || true
 wait "$stop_transition_pid"
 [ -n "$stop_transition_json" ]
 [ "$(printf '%s' "$stop_transition_json" | \
-  "$STATE_HELPER" meta get /dev/stdin effective_status)" = interrupted ]
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = stopped ]
 [ "$(printf '%s' "$stop_transition_json" | \
   "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
 [ "$(printf '%s' "$stop_transition_json" | \
@@ -2008,6 +2037,7 @@ wait "$stop_transition_pid"
   "$STATE_HELPER" meta get /dev/stdin stop_requested_at)" ]
 printf '%s' "$stop_transition_json" | grep -F '"health_actions":[]' >/dev/null
 [ "$("$STATE_HELPER" meta get "$stop_transition_meta" status)" = stopped ]
+[ "$("$STATE_HELPER" meta get "$stop_transition_meta" lifecycle_phase)" = terminal ]
 run_codex delete --force "$stop_transition_name"
 
 # A start holds the install lock through its readiness wait (up to 35

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -48,15 +48,15 @@ grep -F 'coverage executable has no coverage map' \
 for invocation in \
   'list --json' \
   'codex logs --ansi detach-codex-ui-running' \
-  'codex attach detach-codex-ui-running' \
+  'codex attach --terminal-features sync detach-codex-ui-running' \
   'codex logs --ansi detach-codex-ui-recoverable' \
   'codex recover --detach detach-codex-ui-recoverable' \
-  'codex attach detach-codex-ui-recoverable' \
+  'codex attach --terminal-features sync detach-codex-ui-recoverable' \
   'claude logs --ansi detach-claude-ui-completed' \
   'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9' \
-  'claude attach detach-claude-ui-completed' \
+  'claude attach --terminal-features sync detach-claude-ui-completed' \
   'claude --detach' \
-  'claude attach detach-claude-ui-new' \
+  'claude attach --terminal-features sync detach-claude-ui-new' \
   'codex stop detach-codex-ui-running' \
   'storage --json' \
   'config tmux-style' \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -16,17 +16,22 @@ approved_invocation() {
     'list --json'|\
     'watch --json'|\
     'codex logs --ansi detach-codex-ui-running'|\
-    'codex attach detach-codex-ui-running'|\
+    'codex attach --terminal-features sync detach-codex-ui-running'|\
+    'codex logs --ansi detach-codex-ui-stopped'|\
     'codex logs --ansi detach-codex-ui-recoverable'|\
     'codex recover --detach detach-codex-ui-recoverable'|\
-    'codex attach detach-codex-ui-recoverable'|\
+    'codex attach --terminal-features sync detach-codex-ui-recoverable'|\
     'claude logs --ansi detach-claude-ui-completed'|\
     'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9'|\
-    'claude attach detach-claude-ui-completed'|\
+    'claude attach --terminal-features sync detach-claude-ui-completed'|\
     'claude --detach'|\
     'codex --detach'|\
-    'codex attach detach-codex-ui-quick'|\
-    'claude attach detach-claude-ui-new'|\
+    'codex logs --ansi detach-codex-ui-quick'|\
+    'codex attach --terminal-features sync detach-codex-ui-quick'|\
+    'claude logs --ansi detach-claude-ui-new'|\
+    'claude attach --terminal-features sync detach-claude-ui-new'|\
+    client\ switch\ --pid\ *\ --from\ *\ --to\ *\ --provider\ codex|\
+    client\ switch\ --pid\ *\ --from\ *\ --to\ *\ --provider\ claude|\
     'codex stop detach-codex-ui-running'|\
     'codex delete --force detach-codex-ui-stopped'|\
     'storage --json'|\
@@ -308,8 +313,11 @@ run_app_scenario() {
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
       finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
       live-session-hosts-attach-client|\
+      session-switch-keeps-terminal-layout-stable|\
       live-terminal-renders-on-demand|\
       live-terminal-routes-control-v|\
+      live-session-switch-reuses-synchronized-client|\
+      non-live-session-switch-uses-warm-cache|\
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
       session-shortcut-selects-assigned-session|\
@@ -355,14 +363,17 @@ run_app_scenario main sessions 32 \
   background-app-starts-without-focus \
   dashboard-accessible \
   sidebar-shortcut-guide-visible \
+  non-live-session-switch-uses-warm-cache \
   recover-and-reconnect-run-in-app-with-terminal-fallback \
   sidebar-selects-completed-session \
   session-uuid-copies-from-text-side \
   resume-runs-in-app-with-terminal-fallback \
   session-shortcut-selects-assigned-session \
   live-session-hosts-attach-client \
+  session-switch-keeps-terminal-layout-stable \
   live-terminal-renders-on-demand \
   live-terminal-routes-control-v \
+  live-session-switch-reuses-synchronized-client \
   session-signals-stay-distinct \
   disconnected-stop-blocks-action \
   safe-action-reaches-fake-cli \
@@ -396,15 +407,43 @@ while IFS= read -r invocation; do
   fi
 done <"$FAKE_DIR/invocations.log"
 
-[ "$(grep -Fxc 'codex recover --detach detach-codex-ui-recoverable' \
-  "$FAKE_DIR/invocations.log")" -ge 1 ]
-[ "$(grep -Fxc 'codex attach detach-codex-ui-recoverable' \
-  "$FAKE_DIR/invocations.log")" -ge 2 ]
-[ "$(grep -Fxc 'claude --detach' "$FAKE_DIR/invocations.log")" -eq 1 ]
-[ "$(grep -Fxc 'codex --detach' "$FAKE_DIR/invocations.log")" -eq 1 ]
-[ "$(grep -Fxc 'codex attach detach-codex-ui-quick' \
-  "$FAKE_DIR/invocations.log")" -ge 1 ]
-[ "$(grep -Fxc 'claude attach detach-claude-ui-new' \
-  "$FAKE_DIR/invocations.log")" -ge 1 ]
+recover_count="$(grep -Fxc 'codex recover --detach detach-codex-ui-recoverable' \
+  "$FAKE_DIR/invocations.log" || true)"
+recover_attach_count="$(grep -Fxc \
+  'codex attach --terminal-features sync detach-codex-ui-recoverable' \
+  "$FAKE_DIR/invocations.log" || true)"
+running_attach_count="$(grep -Fxc \
+  'codex attach --terminal-features sync detach-codex-ui-running' \
+  "$FAKE_DIR/invocations.log" || true)"
+switch_count="$(grep -Fc 'client switch --pid ' \
+  "$FAKE_DIR/invocations.log" || true)"
+claude_start_count="$(grep -Fxc 'claude --detach' \
+  "$FAKE_DIR/invocations.log" || true)"
+codex_start_count="$(grep -Fxc 'codex --detach' \
+  "$FAKE_DIR/invocations.log" || true)"
+quick_attach_count="$(grep -Fxc \
+  'codex attach --terminal-features sync detach-codex-ui-quick' \
+  "$FAKE_DIR/invocations.log" || true)"
+new_attach_count="$(grep -Fxc \
+  'claude attach --terminal-features sync detach-claude-ui-new' \
+  "$FAKE_DIR/invocations.log" || true)"
+quick_switch_count="$(grep -Fc \
+  ' --to detach-codex-ui-quick --provider codex' \
+  "$FAKE_DIR/invocations.log" || true)"
+new_switch_count="$(grep -Fc \
+  ' --to detach-claude-ui-new --provider claude' \
+  "$FAKE_DIR/invocations.log" || true)"
+if [ "$recover_count" -lt 1 ] || [ "$recover_attach_count" -lt 2 ] \
+    || [ "$switch_count" -lt 3 ] \
+    || [ "$claude_start_count" -ne 1 ] || [ "$codex_start_count" -ne 1 ] \
+    || [ "$((quick_attach_count + quick_switch_count))" -lt 1 ] \
+    || [ "$((new_attach_count + new_switch_count))" -lt 1 ]; then
+  printf 'UI e2e invocation counts: recover=%s recover_attach=%s running_attach=%s switch=%s claude_start=%s codex_start=%s quick_attach=%s quick_switch=%s new_attach=%s new_switch=%s\n' \
+    "$recover_count" "$recover_attach_count" "$running_attach_count" \
+    "$switch_count" "$claude_start_count" "$codex_start_count" \
+    "$quick_attach_count" "$quick_switch_count" "$new_attach_count" \
+    "$new_switch_count" >&2
+  exit 1
+fi
 
 printf 'Packaged Detach.app UI e2e smoke passed\n'

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -14,6 +14,7 @@ APP_PID=""
 approved_invocation() {
   case "$1" in
     'list --json'|\
+    'watch --json'|\
     'codex logs --ansi detach-codex-ui-running'|\
     'codex attach detach-codex-ui-running'|\
     'codex logs --ansi detach-codex-ui-recoverable'|\


### PR DESCRIPTION
## Contract delta

- Restrict event publication to the fixed session-change member of an owned state root.
- Bind Stop intent and terminal metadata updates to the exact managed run before signaling it.
- Keep the full Stop grace while a provider is alive, but bound legacy worker cleanup after that exact provider exits.
- Add a non-authorizing lifecycle identity so replacement runs cannot inherit notifications, passive logs, or terminal screens.
- Reject incomplete bounded CLI and power output instead of decoding a silent prefix.
- Cache transcript summaries by validated file identity and avoid repeat reads for unchanged histories.
- Keep long turns correct across bounded transcript appends and fall back without preserving a stale Answer ready state.
- Make concurrent process capture independent of the shared utility pool.
- Run exact provider cores as public list jobs so cancellation cannot leave orphan work.
- Invalidate passive-log and terminal-prefetch caches at their lifecycle boundaries.
- Cancel delayed snapshot work when observation stops.
- Advance ordered notification detection without blocking the session event stream on Notification Center.
- Activate a new immutable payload before the app starts its watcher and first fresh list.
- Keep README and runtime, app, power, and coverage-region contracts synchronized.

## Evidence

- 1,060 Swift tests passed, with one expected skip.
- Monolithic and partitioned Codex tests passed, including Stop races, provider-gone finalization, event delivery, long transcript tails, list cancellation, and concurrent capture.
- The provider-gone Stop regression took 19 seconds before the repair. It now reaches durable stopped state and safe Resume/Delete eligibility within the bounded cleanup window while the frozen-worker test keeps actions closed.
- Claude, packaged app, UI E2E, distribution, tmux runtime, quality contracts, release preflight, publication preflight, and the hermetic release workflow passed.
- Static, documentation, generated policy, shell safety, coverage, test inventory, and diff checks passed.
- Hosted run `33732272895` and its authoritative `quality-gates` job passed for commit `c882e46`.
- Local impact-aware evidence `20260903T081140Z-84803` passed every selected stage.
- A local Developer ID build 51 passed strict nested-signature, bundle, and real Security admission verification. Its payload ID is `61e6d2e03e28673511641d1cc3bf30eddcc4290444af9070442c7b65ce96c49a`.
- Watch hint delivery measured 0.08 seconds. Five complete list snapshots measured 0.23 to 0.24 seconds each. These are component measurements, not an end-to-end UI SLO.
- Notarization, upload, publication, and the real closed-lid power gate were not run.
