### PR TITLE
Stabilize Codex client switch fixture

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -941,7 +941,10 @@ bootstrap_codex_checkpoint() {
 if codex_part_selected lifecycle; then
   marker="$TMP_ROOT/must-not-exist"
   literal_prompt="spaces ; \$(touch $marker) * \"quotes\""
-  export FAKE_CODEX_SLEEP=12
+  # Keep the provider alive across the real PTY and nested-client checks. A
+  # cold release gate can legitimately spend more than 12 seconds before the
+  # client-switch assertions, and those assertions require a live source pane.
+  export FAKE_CODEX_SLEEP=60
   integration_release="$TMP_ROOT/integration-provider-release"
   export FAKE_CODEX_RELEASE_FILE="$integration_release"
 


### PR DESCRIPTION
## Contract delta

- Keep the fake Codex provider alive through the real PTY and nested-client checks.
- Remove machine-speed dependence from the ownership-safe client-switch assertions.
- No production behavior changes.

## Evidence

- `scripts/quality-gate --stage codex`
- `scripts/quality-gate`
- Local impact gate PASS: `20260903T105715Z-6320`