### PR TITLE
Retry transient tmux client inspection

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1758,6 +1758,7 @@ switch_attached_client() {
   local target_session="$3"
   local session_name
   local format row_pid client_name client_session client_uid marker extra
+  local client_rows attempt
   local matched_name=""
   local matches=0
 
@@ -1784,20 +1785,31 @@ switch_attached_client() {
     die "target tmux session '$target_session' has no live pane"
 
   format=$'#{client_pid}\t#{client_name}\t#{client_session}\t#{client_uid}\tEND'
-  while IFS=$'\t' read -r row_pid client_name client_session client_uid marker extra; do
-    [ "$row_pid" = "$client_pid" ] || continue
-    matches=$((matches + 1))
-    [ "$marker" = END ] && [ -z "$extra" ] || \
-      die "tmux returned an invalid client record"
-    [ "$client_uid" = "$UID" ] || \
-      die "refusing to switch a foreign-owned tmux client"
-    [ "$client_session" = "$source_session" ] || \
-      die "tmux client $client_pid is not attached to '$source_session'"
-    matched_name="$client_name"
-  done < <("${TMUX_CMD[@]}" list-clients -F "$format" 2>/dev/null || true)
-
-  [ "$matches" -eq 1 ] && [ -n "$matched_name" ] || \
-    die "could not identify one exact tmux client for PID $client_pid"
+  for attempt in 1 2 3; do
+    matched_name=""
+    matches=0
+    if client_rows="$("${TMUX_CMD[@]}" list-clients -F "$format" 2>/dev/null)"; then
+      while IFS=$'\t' read -r row_pid client_name client_session client_uid marker extra; do
+        [ "$row_pid" = "$client_pid" ] || continue
+        matches=$((matches + 1))
+        [ "$marker" = END ] && [ -z "$extra" ] || \
+          die "tmux returned an invalid client record"
+        [ "$client_uid" = "$UID" ] || \
+          die "refusing to switch a foreign-owned tmux client"
+        [ "$client_session" = "$source_session" ] || \
+          die "tmux client $client_pid is not attached to '$source_session'"
+        matched_name="$client_name"
+      done <<<"$client_rows"
+      [ "$matches" -le 1 ] || \
+        die "could not identify one exact tmux client for PID $client_pid"
+      if [ "$matches" -eq 1 ] && [ -n "$matched_name" ]; then
+        break
+      fi
+    fi
+    [ "$attempt" -lt 3 ] || \
+      die "could not identify one exact tmux client for PID $client_pid"
+    sleep 0.05
+  done
   [ "$source_session" != "$target_session" ] || return 0
   "${TMUX_CMD[@]}" switch-client -c "$matched_name" -t "=$target_session" || \
     die "could not switch tmux client $client_pid to '$target_session'"

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -32,9 +32,10 @@ Tests inject paths through explicit `DETACH_*` environments. An app CLI strips
 them except in isolated UI tests. Production resolves tmux and state/power
 helpers only as immutable siblings. Providers resolve through `PATH`.
 
-`client switch` needs an exact attached-client PID, user ID, source, private
-socket, and live managed target. Failed proof causes no mutation. Attach can
-hold a synchronized frame until the target redraw.
+`client switch` retries failed or empty client reads. PID, UID, source,
+private socket, and live managed target must match. Failed proof
+causes no mutation. Attach can hold a synchronized frame until the target
+redraws.
 
 Core self-reinvokes critical mutations under `lockf`. Start, Resume, Stop,
 Recover, and Delete hold a session lock before install, project, and checkpoint

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1340,8 +1340,29 @@ if "$DETACH" client switch --pid "$attach_client_pid" \
 fi
 [ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
   awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$SESSION" ]
-"$DETACH" client switch --pid "$attach_client_pid" \
+client_switch_tmux="$TMP_ROOT/client-switch-tmux"
+client_switch_inspections="$TMP_ROOT/client-switch-inspections"
+export DETACH_CLIENT_SWITCH_TMUX_HELPER="$TMUX_TEST_BIN"
+export DETACH_CLIENT_SWITCH_INSPECTIONS="$client_switch_inspections"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'is_list=0' \
+  'for argument in "$@"; do' \
+  '  [ "$argument" != list-clients ] || is_list=1' \
+  'done' \
+  'if [ "$is_list" = 1 ]; then' \
+  '  completed=0' \
+  '  [ ! -f "$DETACH_CLIENT_SWITCH_INSPECTIONS" ] || completed="$(wc -l <"$DETACH_CLIENT_SWITCH_INSPECTIONS" | tr -d "[:space:]")"' \
+  '  printf '\''attempt\n'\'' >>"$DETACH_CLIENT_SWITCH_INSPECTIONS"' \
+  '  [ "$completed" -ge 2 ] || exit 1' \
+  'fi' \
+  'exec "$DETACH_CLIENT_SWITCH_TMUX_HELPER" "$@"' \
+  >"$client_switch_tmux"
+chmod 0755 "$client_switch_tmux"
+DETACH_TMUX_BIN="$client_switch_tmux" \
+  "$DETACH" client switch --pid "$attach_client_pid" \
   --from "$SESSION" --to "$switch_target" --provider codex
+[ "$(wc -l <"$client_switch_inspections" | tr -d '[:space:]')" = 3 ]
 [ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
   awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$switch_target" ]
 "$DETACH" client switch --pid "$attach_client_pid" \


### PR DESCRIPTION
## Contract delta

- Retry a failed or empty read-only tmux client inspection up to three times over 100 ms.
- Revalidate the exact client PID, UID, source session, private socket, and live managed target on every successful read.
- Fail immediately for malformed, ambiguous, foreign-owned, or wrong-source records. Do not mutate until proof succeeds.

## Release blocker

Two 0.5.1 pre-release runs stopped in the Codex lifecycle partition. The client PTY was still live, but one `tmux list-clients` inspection returned no usable record under the full concurrent release load. The runtime treated that transient read as final and rejected `client switch`.

## Regression evidence

- The lifecycle test injects two failed `list-clients` calls. The third inspection must prove ownership and switch the same client.
- Focused Codex lifecycle partition: passed.
- Concurrent impact gate: app, Codex, Claude, distribution, and tmux runtime stages passed. Codex passed in 73 seconds.
- `tests/docs-contract.sh`: passed. The routed runtime spec is 12,278 bytes within its 12,288-byte limit.
- Packaged UI scenarios passed on the focused retry. The local diagnostic took 16 seconds against the 15-second reference budget; no timing waiver was used.
- `bash -n` and `git diff --check`: passed.

Hosted `quality-gates` remains readiness authority.
