### PR TITLE
Widen tmux client inspection window

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1785,7 +1785,9 @@ switch_attached_client() {
     die "target tmux session '$target_session' has no live pane"
 
   format=$'#{client_pid}\t#{client_name}\t#{client_session}\t#{client_uid}\tEND'
-  for attempt in 1 2 3; do
+  attempt=0
+  while [ "$attempt" -lt 10 ]; do
+    attempt=$((attempt + 1))
     matched_name=""
     matches=0
     if client_rows="$("${TMUX_CMD[@]}" list-clients -F "$format" 2>/dev/null)"; then
@@ -1806,7 +1808,7 @@ switch_attached_client() {
         break
       fi
     fi
-    [ "$attempt" -lt 3 ] || \
+    [ "$attempt" -lt 10 ] || \
       die "could not identify one exact tmux client for PID $client_pid"
     sleep 0.05
   done

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -32,10 +32,10 @@ Tests inject paths through explicit `DETACH_*` environments. An app CLI strips
 them except in isolated UI tests. Production resolves tmux and state/power
 helpers only as immutable siblings. Providers resolve through `PATH`.
 
-`client switch` retries failed or empty client reads. PID, UID, source,
-private socket, and live managed target must match. Failed proof
-causes no mutation. Attach can hold a synchronized frame until the target
-redraws.
+`client switch` retries failed or empty reads for 0.5 seconds. PID, UID,
+source, private socket, and managed target must match. Failed
+proof causes no mutation. Attach can hold a synchronized frame until the
+target redraws.
 
 Core self-reinvokes critical mutations under `lockf`. Start, Resume, Stop,
 Recover, and Delete hold a session lock before install, project, and checkpoint

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1355,6 +1355,7 @@ printf '%s\n' \
   '  [ ! -f "$DETACH_CLIENT_SWITCH_INSPECTIONS" ] || completed="$(wc -l <"$DETACH_CLIENT_SWITCH_INSPECTIONS" | tr -d "[:space:]")"' \
   '  printf '\''attempt\n'\'' >>"$DETACH_CLIENT_SWITCH_INSPECTIONS"' \
   '  [ "$completed" -ge 2 ] || exit 1' \
+  '  [ "$completed" -ge 4 ] || exit 0' \
   'fi' \
   'exec "$DETACH_CLIENT_SWITCH_TMUX_HELPER" "$@"' \
   >"$client_switch_tmux"
@@ -1362,7 +1363,7 @@ chmod 0755 "$client_switch_tmux"
 DETACH_TMUX_BIN="$client_switch_tmux" \
   "$DETACH" client switch --pid "$attach_client_pid" \
   --from "$SESSION" --to "$switch_target" --provider codex
-[ "$(wc -l <"$client_switch_inspections" | tr -d '[:space:]')" = 3 ]
+[ "$(wc -l <"$client_switch_inspections" | tr -d '[:space:]')" -ge 5 ]
 [ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
   awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$switch_target" ]
 "$DETACH" client switch --pid "$attach_client_pid" \


### PR DESCRIPTION
## Contract delta

- Retry failed or empty tmux client reads for up to about 0.5 seconds.
- Keep exact PID, UID, source session, private socket, and managed live target proof before mutation.
- Cover failed and successful-empty reads before a real client observation.

## Evidence

- Focused Codex lifecycle: PASS
- Parallel Codex quality stage: PASS
- Impact gate: static, app, Codex, Claude, distribution, and tmux-runtime PASS
- Local UI e2e could not acquire foreground because the console frontmost process was loginwindow; the release-run UI e2e passed before the console locked. Hosted quality-gates remain readiness authority.
- bash syntax and git diff --check: PASS