### PR TITLE
Fix tmux client inspection in release locale

### DIFF
--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -744,7 +744,12 @@ enum UIE2ETestDriver {
             let collapsedHeight = sheet.frame.height
             let advanced = try await element(identifier: "new-session-advanced")
             try requireSemanticControl(advanced, name: "new session Advanced")
-            try await click(advanced, name: "new session Advanced")
+            try await clickUntil(
+                advanced,
+                name: "new session Advanced",
+                outcome: "new session prompt geometry") {
+                UIE2EGeometryRegistry.frame(for: "new-session-prompt") != nil
+            }
             _ = try await measuredFrame(
                 identifier: "new-session-prompt", name: "new session prompt")
             guard UIE2EGeometryRegistry.frame(for: "new-session-terminal") == nil else {

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -656,6 +656,33 @@ final class DetachStateCommandTests: XCTestCase {
         ])
     }
 
+    func testMetaSnapshotsFailClosedForNonFileTranscripts() throws {
+        let root = temporaryDirectory.appendingPathComponent(
+            "invalid-summary-sessions", isDirectory: true)
+        let name = "detach-codex-directory-summary"
+        let session = root.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: session, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": name,
+            "project_dir": "/tmp/project",
+            "status": "running",
+            "transcript_path": temporaryDirectory.path,
+        ]).write(to: session.appendingPathComponent("meta.json"))
+
+        let output = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let values = output.split(separator: 0, omittingEmptySubsequences: false)
+            .dropLast()
+            .map { String(decoding: $0, as: UTF8.self) }
+
+        XCTAssertEqual(values.count, 27 + 2)
+        XCTAssertEqual(Array(values[22..<27]), Array(repeating: "", count: 5))
+        XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
+    }
+
     func testMetaSnapshotsContinueTurnStateAfterStartLeavesBoundedTail() throws {
         let root = temporaryDirectory.appendingPathComponent(
             "incremental-summary-sessions", isDirectory: true)
@@ -1150,6 +1177,14 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
             "meta", "get", "-", "state",
         ]))
+        XCTAssertEqual(try DetachStateCommand.run(arguments: [
+            "jsonl", "first", "-", "payload.id",
+        ]), Data())
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate", "codex", "-", "session-id",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+        }
         let summary = try DetachStateCommand.run(arguments: [
             "jsonl", "summary", "codex", "-",
         ])

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1769,7 +1769,7 @@ switch_attached_client() {
   [ "$client_pid" -gt 1 ] || die "client PID must be greater than one"
   for session_name in "$source_session" "$target_session"; do
     case "$session_name" in
-      ''|*$'\n'*|*$'\r'*|*$'\t'*) die "client session name is invalid" ;;
+      ''|*'|'*|*$'\n'*|*$'\r'*|*$'\t'*) die "client session name is invalid" ;;
     esac
   done
 
@@ -1784,14 +1784,16 @@ switch_attached_client() {
   tmux_session_running "$target_session" || \
     die "target tmux session '$target_session' has no live pane"
 
-  format=$'#{client_pid}\t#{client_name}\t#{client_session}\t#{client_uid}\tEND'
+  # tmux sanitizes literal control characters in format output when LC_ALL=C.
+  # Use a printable separator and reject it in the caller-controlled names.
+  format='#{client_pid}|#{client_name}|#{client_session}|#{client_uid}|END'
   attempt=0
   while [ "$attempt" -lt 10 ]; do
     attempt=$((attempt + 1))
     matched_name=""
     matches=0
     if client_rows="$("${TMUX_CMD[@]}" list-clients -F "$format" 2>/dev/null)"; then
-      while IFS=$'\t' read -r row_pid client_name client_session client_uid marker extra; do
+      while IFS='|' read -r row_pid client_name client_session client_uid marker extra; do
         [ "$row_pid" = "$client_pid" ] || continue
         matches=$((matches + 1))
         [ "$marker" = END ] && [ -z "$extra" ] || \

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -32,10 +32,9 @@ Tests inject paths through explicit `DETACH_*` environments. An app CLI strips
 them except in isolated UI tests. Production resolves tmux and state/power
 helpers only as immutable siblings. Providers resolve through `PATH`.
 
-`client switch` retries failed or empty reads for 0.5 seconds. PID, UID,
-source, private socket, and managed target must match. Failed
-proof causes no mutation. Attach can hold a synchronized frame until the
-target redraws.
+`client switch` retries reads for 0.5 seconds. PID, UID, source, private socket,
+and managed target must match. Framing must survive `LC_ALL=C`. Failed proof
+causes no mutation. Attach can hold a frame until the target redraws.
 
 Core self-reinvokes critical mutations under `lockf`. Start, Resume, Stop,
 Recover, and Delete hold a session lock before install, project, and checkpoint

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1381,7 +1381,7 @@ printf '%s\n' \
   '  printf '\''attempt\n'\'' >>"$DETACH_CLIENT_SWITCH_INSPECTIONS"' \
   '  [ "$completed" -ge 2 ] || exit 1' \
   '  [ "$completed" -ge 4 ] || exit 0' \
-  '  printf '\''%s\t%s\t%s\t%s\tEND\n'\'' "$DETACH_CLIENT_SWITCH_PID" "$DETACH_CLIENT_SWITCH_NAME" "$DETACH_CLIENT_SWITCH_SESSION" "$DETACH_CLIENT_SWITCH_UID"' \
+  '  printf '\''%s|%s|%s|%s|END\n'\'' "$DETACH_CLIENT_SWITCH_PID" "$DETACH_CLIENT_SWITCH_NAME" "$DETACH_CLIENT_SWITCH_SESSION" "$DETACH_CLIENT_SWITCH_UID"' \
   '  exit 0' \
   'fi' \
   'if [ "$is_switch" = 1 ]; then' \
@@ -1391,7 +1391,7 @@ printf '%s\n' \
   'exec "$DETACH_CLIENT_SWITCH_TMUX_HELPER" "$@"' \
   >"$client_switch_tmux"
 chmod 0755 "$client_switch_tmux"
-DETACH_TMUX_BIN="$client_switch_tmux" \
+LC_ALL=C DETACH_TMUX_BIN="$client_switch_tmux" \
   "$DETACH" client switch --pid "$attach_client_pid" \
   --from "$SESSION" --to "$switch_target" --provider codex
 [ "$(wc -l <"$client_switch_inspections" | tr -d '[:space:]')" = 5 ]
@@ -1401,11 +1401,11 @@ grep -Fx -- 'switch-client' "$client_switch_mutation" >/dev/null
 grep -Fx -- '-c' "$client_switch_mutation" >/dev/null
 grep -Fx -- "$attach_client_name" "$client_switch_mutation" >/dev/null
 grep -Fx -- "=$switch_target" "$client_switch_mutation" >/dev/null
-"$DETACH" client switch --pid "$attach_client_pid" \
+LC_ALL=C "$DETACH" client switch --pid "$attach_client_pid" \
   --from "$SESSION" --to "$switch_target" --provider codex
 [ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
   awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$switch_target" ]
-"$DETACH" client switch --pid "$attach_client_pid" \
+LC_ALL=C "$DETACH" client switch --pid "$attach_client_pid" \
   --from "$switch_target" --to "$SESSION" --provider codex
 [ "$(tmux -L "$SOCKET" list-clients -F '#{client_pid}|#{client_session}' | \
   awk -F '|' -v pid="$attach_client_pid" '$1 == pid { print $2 }')" = "$SESSION" ]


### PR DESCRIPTION
## Contract delta

- Preserve exact tmux client inspection when the release runs with LC_ALL=C.
- Keep PID, UID, source-session, private-socket, and managed-target proof fail closed.
- Exercise both retry control flow and a real attached client in the release locale.
- Make transcript fallback coverage deterministic instead of relying on incidental execution.

## Evidence

- DetachStateCommandTests: 57 passed.
- Codex lifecycle under LC_ALL=C with packaged tmux and detach-state: passed.
- Impact-aware functional stages passed, including Swift, app, UI E2E, Codex, Claude, distribution, tmux runtime, release preflight, publish preflight, and release workflow.
- Business coverage: 95.86% (baseline 95.81%).
- DetachStateCommand coverage: 97.70% (baseline 97.39%).
- Static and gate-contract focused diagnostics: passed.
- git diff --check: passed.

Hosted quality-gates is the readiness authority.
