### PR TITLE
Stabilize finished selection reconciliation

### DIFF
--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -30,6 +30,22 @@ struct SidebarFailurePresentation: Equatable, Identifiable {
     }
 }
 
+struct FinishedSelectionReconciliation: Equatable {
+    let selectedIDs: Set<String>
+    let isSelecting: Bool
+
+    static func resolve(
+        selectedIDs: Set<String>,
+        currentIDs: [String],
+        isSelecting: Bool,
+        isDeleting: Bool
+    ) -> Self {
+        Self(
+            selectedIDs: selectedIDs.intersection(currentIDs),
+            isSelecting: currentIDs.isEmpty && !isDeleting ? false : isSelecting)
+    }
+}
+
 struct SidebarView: View {
     @Environment(\.appFontPointSize) private var fontPointSize
     let store: SessionStore
@@ -182,10 +198,13 @@ struct SidebarView: View {
             startQuickChat()
         }
         .onChange(of: deletableFinishedSessions.map(\.id)) { _, currentIDs in
-            selectedFinishedIDs.formIntersection(currentIDs)
-            if currentIDs.isEmpty && !isDeletingFinished {
-                isSelectingFinished = false
-            }
+            let state = FinishedSelectionReconciliation.resolve(
+                selectedIDs: selectedFinishedIDs,
+                currentIDs: currentIDs,
+                isSelecting: isSelectingFinished,
+                isDeleting: isDeletingFinished)
+            selectedFinishedIDs = state.selectedIDs
+            isSelectingFinished = state.isSelecting
         }
         .navigationSplitViewColumnWidth(
             min: max(230, fontPointSize * 18),

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -714,6 +714,9 @@ enum UIE2ETestDriver {
             try await waitUntil("post-delete session refresh") {
                 store.lastUpdated.map { $0 >= deleteObservedAt } == true
             }
+            try await waitUntil("finished selection closes after delete") {
+                find(identifier: "finished-select-all-button") == nil
+            }
             try await waitUntil("delete confirmation dismissal") {
                 NSApp.windows.allSatisfy(\.sheets.isEmpty)
             }

--- a/app/Tests/DetachAppTests/SidebarViewTests.swift
+++ b/app/Tests/DetachAppTests/SidebarViewTests.swift
@@ -59,4 +59,40 @@ final class SidebarViewTests: XCTestCase {
         XCTAssertEqual(deletion.message, "delete failed")
         XCTAssertEqual(quickChat.message, "start failed")
     }
+
+    func testFinishedSelectionReconciliationRemovesStaleIDs() {
+        XCTAssertEqual(
+            FinishedSelectionReconciliation.resolve(
+                selectedIDs: ["kept", "removed"],
+                currentIDs: ["kept", "new"],
+                isSelecting: true,
+                isDeleting: false),
+            FinishedSelectionReconciliation(
+                selectedIDs: ["kept"],
+                isSelecting: true))
+    }
+
+    func testFinishedSelectionReconciliationClosesEmptyIdleSelection() {
+        XCTAssertEqual(
+            FinishedSelectionReconciliation.resolve(
+                selectedIDs: ["removed"],
+                currentIDs: [],
+                isSelecting: true,
+                isDeleting: false),
+            FinishedSelectionReconciliation(
+                selectedIDs: [],
+                isSelecting: false))
+    }
+
+    func testFinishedSelectionReconciliationPreservesInFlightDeletion() {
+        XCTAssertEqual(
+            FinishedSelectionReconciliation.resolve(
+                selectedIDs: ["removed"],
+                currentIDs: [],
+                isSelecting: true,
+                isDeleting: true),
+            FinishedSelectionReconciliation(
+                selectedIDs: [],
+                isSelecting: true))
+    }
 }


### PR DESCRIPTION
## Contract delta

- Reconcile Finished selection through one typed reducer.
- Preserve selection during an in-flight delete, close it when the final eligible session disappears, and remove stale selected IDs.
- Require the packaged bulk-delete journey to observe the closed selection UI before it continues.

## Evidence

- SidebarViewTests: 6 passed.
- Packaged UI e2e: all four scenarios passed.
- Impact-aware local gate: PASS, run 20260903T214037Z-41962.
- Combined UI coverage: 81.06%; SidebarView: 1026/1141.
- Post-commit changed-line diagnostic: 12/12, 100%.

The user-facing contract is unchanged; this removes a transient presentation race and makes its existing behavior deterministic.