### PR TITLE
[P1] Preserve recovery through replacement startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ not be the weak link.
   fails, or becomes recoverable.
 - **Use actions that match proven state.** Stop is for a live owned process.
   Resume continues a provider conversation. Recover restarts an interrupted
-  managed run from a validated checkpoint. Delete stays blocked until state is
-  safe to remove.
+  managed run from a validated recovery source. Delete stays blocked until
+  state is safe to remove.
 - **Get updates when state changes.** Native filesystem events trigger a
   dashboard refresh for lifecycle and provider turn changes. There is no
   repeating session-list timer while nothing changes.
@@ -134,6 +134,7 @@ The embedded terminal keeps the shortcuts that matter:
 | Switch to a numbered Working or Answer ready session | `Cmd-1` … `Cmd-9` |
 | Paste text | `Cmd-V` |
 | Give Codex or Claude Code an image from the clipboard | `Ctrl-V` |
+| Interrupt a command or close a provider overlay | `Ctrl-C` |
 | Find terminal output | `Cmd-F` |
 | Replace an exited terminal client without restarting the agent | **Reconnect** |
 
@@ -241,7 +242,7 @@ These actions solve different problems:
 |---|---|---|
 | The managed worker is still alive | **Attach** | Open a client for the existing tmux session. Do not start another agent. |
 | The provider conversation exists | **Resume** | Continue the conversation by UUID in its saved project. |
-| A Detach-managed run was interrupted | **Recover** | Validate saved context and a checkpoint, then restart the exact conversation under Detach. |
+| A Detach-managed run was interrupted | **Recover** | Validate saved context and its recovery source, then restart the exact conversation under Detach. |
 
 **Attach = live process. Resume = provider conversation. Recover = interrupted
 managed run.**
@@ -284,14 +285,14 @@ Detach evaluates health from independent facts:
 - the exact worker PID and provider PID, user ownership, and process relation;
 - valid metadata and provider conversation identity;
 - worker heartbeat and checkpoint freshness;
-- a checkpoint that is valid enough for conservative recovery.
+- a provider source that is valid enough for conservative recovery.
 
 | State | Meaning | Safe actions |
 |---|---|---|
 | **Running** | The pane, worker, provider, and run token agree. | Attach, Stop |
 | **Hung** | A required runtime identity is missing or inconsistent, or a recorded process survived tmux. | Attach or Stop only when tmux ownership is proven. Otherwise, no mutation. |
-| **Recoverable** | The live runtime is gone and a matching validated checkpoint exists. | Recover, Delete |
-| **Orphaned** | The live runtime is gone and no safe recovery checkpoint exists. | Delete |
+| **Recoverable** | The live runtime is gone and a matching validated recovery source exists. | Recover, Delete |
+| **Orphaned** | The live runtime is gone and no safe recovery source exists. | Delete |
 | **Finished / stopped** | The worker reached a terminal state. | Resume or Delete, according to provider identity. |
 | **Collision / corrupt** | tmux ownership or metadata cannot be trusted. | Conservative, state-specific actions only. |
 
@@ -324,6 +325,8 @@ then refer to the conversation that is in use.
 - **Codex:** Detach saves the session UUID and rollout JSONL. It keeps a valid
   live rollout when that file is at least as large as the checkpoint. It
   restores only when the matching live rollout is missing, invalid, or smaller.
+  If the backup is absent or belongs to an older generation, List and Recover
+  require the selected live rollout to be valid and match the session UUID.
   A separately validated SQLite backup is an emergency artifact. Detach never
   restores it over the shared Codex database automatically.
 - **Claude Code:** Detach saves the preassigned session UUID, transcript,
@@ -332,6 +335,12 @@ then refer to the conversation that is in use.
   matching checkpoint and its companion artifacts before resume.
 - **Both:** Detach rejects unsafe paths, ambiguous or mismatched UUIDs,
   malformed JSONL, and invalid checkpoint contents.
+
+Resume and Recover keep the last valid checkpoint and saved provider options
+until the replacement run is ready. If the readiness check fails, that recovery
+data stays available. A fresh Start with the same session name clears the prior
+checkpoint. Recover stays unavailable until Detach confirms that the failed
+replacement runtime stopped.
 
 Checkpoint state lives here:
 

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -150,7 +150,7 @@
 "Provider" = "Provider";
 "Provider CLI" = "Provider CLI";
 "Ready — we'll notify you about ready responses, completed sessions, or session problems." = "Ready — we'll notify you about ready responses, completed sessions, or session problems.";
-"Recovery from the latest checkpoint is available" = "Recovery from the latest checkpoint is available";
+"Validated recovery data is available" = "Validated recovery data is available";
 "Recover" = "Recover";
 "Reconnect" = "Reconnect";
 "Recover in %@" = "Recover in %@";
@@ -414,8 +414,9 @@
 "The provider process exited while its worker remained alive." = "The provider process exited while its worker remained alive.";
 "The recorded provider PID is not owned by this worker." = "The recorded provider PID is not owned by this worker.";
 "A recorded runtime process is still alive without its managed tmux session; Detach will not signal it." = "A recorded runtime process is still alive without its managed tmux session; Detach will not signal it.";
-"The live runtime disappeared, but a valid checkpoint can be recovered." = "The live runtime disappeared, but a valid checkpoint can be recovered.";
-"The live runtime disappeared without a valid recovery checkpoint." = "The live runtime disappeared without a valid recovery checkpoint.";
+"Detach could not confirm that the replacement runtime stopped." = "Detach could not confirm that the replacement runtime stopped.";
+"The live runtime disappeared, but validated recovery data is available." = "The live runtime disappeared, but validated recovery data is available.";
+"The live runtime disappeared without validated recovery data." = "The live runtime disappeared without validated recovery data.";
 
 /* Session shortcuts and defaults */
 "Quick chat" = "Quick chat";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -150,7 +150,7 @@
 "Provider" = "Провайдер";
 "Provider CLI" = "CLI провайдера";
 "Ready — we'll notify you about ready responses, completed sessions, or session problems." = "Готово — сообщим о готовом ответе, завершении или проблеме сессии.";
-"Recovery from the latest checkpoint is available" = "Доступно восстановление из последнего чекпойнта";
+"Validated recovery data is available" = "Доступны проверенные данные для восстановления";
 "Recover" = "Восстановить";
 "Reconnect" = "Переподключиться";
 "Recover in %@" = "Восстановить в %@";
@@ -414,8 +414,9 @@
 "The provider process exited while its worker remained alive." = "Процесс провайдера завершился, но его worker остался запущен.";
 "The recorded provider PID is not owned by this worker." = "Сохранённый PID провайдера не принадлежит этому worker-процессу.";
 "A recorded runtime process is still alive without its managed tmux session; Detach will not signal it." = "Сохранённый runtime-процесс ещё работает без управляемой tmux-сессии; Detach не будет посылать ему сигналы.";
-"The live runtime disappeared, but a valid checkpoint can be recovered." = "Живой runtime исчез, но доступна корректная контрольная точка для восстановления.";
-"The live runtime disappeared without a valid recovery checkpoint." = "Живой runtime исчез без корректной контрольной точки для восстановления.";
+"Detach could not confirm that the replacement runtime stopped." = "Detach не удалось подтвердить остановку нового runtime-процесса.";
+"The live runtime disappeared, but validated recovery data is available." = "Живой runtime исчез, но доступны проверенные данные для восстановления.";
+"The live runtime disappeared without validated recovery data." = "Живой runtime исчез без проверенных данных для восстановления.";
 
 /* Session shortcuts and defaults */
 "Quick chat" = "Быстрый чат";

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -483,12 +483,14 @@ enum SessionAttachKeyboard {
     static func providerInput(for event: NSEvent) -> [UInt8]? {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         guard flags.contains(.control),
-              flags.intersection([.command, .option, .shift, .function]).isEmpty,
-              (event.keyCode == 9
-                  || event.charactersIgnoringModifiers?.lowercased() == "v") else {
+              flags.intersection([.command, .option, .shift, .function]).isEmpty else {
             return nil
         }
-        return [0x16]
+        switch event.keyCode {
+        case 8: return [0x03] // Control-C
+        case 9: return [0x16] // Control-V
+        default: return nil
+        }
     }
 
     @discardableResult

--- a/app/Sources/DetachApp/SessionNotificationService.swift
+++ b/app/Sources/DetachApp/SessionNotificationService.swift
@@ -303,7 +303,7 @@ final class SessionNotificationService: ObservableObject {
             }
         case .recoverable:
             title = L10n.string("Session can be recovered")
-            detail = L10n.string("Recovery from the latest checkpoint is available")
+            detail = L10n.string("Validated recovery data is available")
         case .waitingForUser:
             title = L10n.string("Agent response is ready")
             detail = L10n.string("Open the session to continue")

--- a/app/Sources/DetachKit/DetachState.swift
+++ b/app/Sources/DetachKit/DetachState.swift
@@ -101,7 +101,8 @@ public enum SessionMetadataDocument {
 
         try validateLifecycleMutation(from: original, to: object, changes: changes)
 
-        guard JSONSerialization.isValidJSONObject(object) else {
+        guard operationalFieldsAreTyped(object),
+              JSONSerialization.isValidJSONObject(object) else {
             throw DetachStateError.invalidMetadata
         }
         do {
@@ -128,7 +129,8 @@ public enum SessionMetadataDocument {
             }
         }
 
-        guard JSONSerialization.isValidJSONObject(object) else {
+        guard operationalFieldsAreTyped(object),
+              JSONSerialization.isValidJSONObject(object) else {
             throw DetachStateError.invalidMetadata
         }
         do {
@@ -259,6 +261,27 @@ public enum SessionMetadataDocument {
         integer(from: object["schema"]) == 1
             && object["session_name"] as? String == expectedSessionName
             && object["project_dir"] is String
+            && operationalFieldsAreTyped(object)
+    }
+
+    private static func operationalFieldsAreTyped(
+        _ object: [String: Any]
+    ) -> Bool {
+        if let value = object["preserve_recovery_until_ready"],
+           !(value is NSNull) {
+            guard let number = value as? NSNumber,
+                  CFGetTypeID(number) == CFBooleanGetTypeID() else {
+                return false
+            }
+        }
+        for key in ["runtime_ready_at", "runtime_shutdown_observed_at"] {
+            if let value = object[key],
+               !(value is NSNull),
+               !(value is String) {
+                return false
+            }
+        }
+        return true
     }
 
     /// Validates only runtime-owned phase changes. Ordinary scalar patches do
@@ -343,6 +366,7 @@ public struct TranscriptSummary: Equatable, Sendable {
     public var contextWindow: Int?
     public var agentTurnState: AgentTurnState?
     public var agentTurnID: String?
+    var pendingToolUseID: String?
 
     public init(
         model: String? = nil,
@@ -356,6 +380,15 @@ public struct TranscriptSummary: Equatable, Sendable {
         self.contextWindow = contextWindow
         self.agentTurnState = agentTurnState
         self.agentTurnID = agentTurnID
+        self.pendingToolUseID = nil
+    }
+
+    public static func == (lhs: TranscriptSummary, rhs: TranscriptSummary) -> Bool {
+        lhs.model == rhs.model
+            && lhs.contextUsed == rhs.contextUsed
+            && lhs.contextWindow == rhs.contextWindow
+            && lhs.agentTurnState == rhs.agentTurnState
+            && lhs.agentTurnID == rhs.agentTurnID
     }
 }
 
@@ -693,27 +726,81 @@ public enum TranscriptDocument {
             return
         }
 
-        if type == "system", record["subtype"] as? String == "turn_duration" {
+        if type == "assistant",
+           message?["role"] as? String == "assistant",
+           message?["stop_reason"] as? String == "tool_use",
+           let toolUseID = toolUseID(
+            message?["content"], named: "AskUserQuestion") {
             result.agentTurnState = .waiting
-            result.agentTurnID = turnID
+            result.agentTurnID = toolUseID
+            result.pendingToolUseID = toolUseID
+            return
+        }
+
+        if type == "system", record["subtype"] as? String == "turn_duration" {
+            if result.pendingToolUseID == nil {
+                result.agentTurnState = .waiting
+                result.agentTurnID = turnID
+            }
             return
         }
 
         guard type == "user",
               !isJSONTrue(record["isMeta"]),
-              message?["role"] as? String == "user",
-              !containsToolResult(message?["content"]) else {
+              message?["role"] as? String == "user" else {
+            return
+        }
+        let toolResult = toolResultStatus(
+            message?["content"], matching: result.pendingToolUseID)
+        if let pendingToolUseID = result.pendingToolUseID {
+            guard result.agentTurnState == .waiting,
+                  toolResult.present,
+                  toolResult.matches,
+                  pendingToolUseID == result.agentTurnID else {
+                return
+            }
+        } else if toolResult.present {
             return
         }
         result.agentTurnState = .working
         result.agentTurnID = turnID
+        result.pendingToolUseID = nil
     }
 
-    private static func containsToolResult(_ value: Any?) -> Bool {
-        guard let content = value as? [Any] else { return false }
-        return content.contains { item in
-            (item as? [String: Any])?["type"] as? String == "tool_result"
+    private static func toolUseID(_ value: Any?, named name: String) -> String? {
+        guard let content = value as? [Any] else { return nil }
+        return content.compactMap { item -> String? in
+            guard let block = item as? [String: Any],
+                  block["type"] as? String == "tool_use",
+                  block["name"] as? String == name,
+                  let identifier = block["id"] as? String,
+                  !identifier.isEmpty else {
+                return nil
+            }
+            return identifier
+        }.first
+    }
+
+    private static func toolResultStatus(
+        _ value: Any?,
+        matching identifier: String?
+    ) -> (present: Bool, matches: Bool) {
+        guard let content = value as? [Any] else {
+            return (false, false)
         }
+        var present = false
+        for item in content {
+            guard let block = item as? [String: Any],
+                  block["type"] as? String == "tool_result" else {
+                continue
+            }
+            present = true
+            if let identifier,
+               block["tool_use_id"] as? String == identifier {
+                return (true, true)
+            }
+        }
+        return (present, false)
     }
 
     private static func isJSONTrue(_ value: Any?) -> Bool {

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -63,6 +63,10 @@ public enum DetachStateCommand {
             return try metaSnapshot(
                 Array(arguments.dropFirst(2)),
                 standardInput: injectedStandardInput)
+        case ("meta", "recovery-binding"):
+            return try metaRecoveryBinding(
+                Array(arguments.dropFirst(2)),
+                standardInput: injectedStandardInput)
         case ("meta", "snapshots"):
             return try metaSnapshots(
                 Array(arguments.dropFirst(2)),
@@ -109,6 +113,10 @@ public enum DetachStateCommand {
             return try healthSessions(
                 Array(arguments.dropFirst(2)),
                 standardInput: injectedStandardInput)
+        case ("process", "state"):
+            return try processState(Array(arguments.dropFirst(2)))
+        case ("checkpoint", "exchange"):
+            return try checkpointExchange(Array(arguments.dropFirst(2)))
         case ("maintenance", "reconcile"):
             return try maintenanceReconcile(
                 Array(arguments.dropFirst(2)),
@@ -118,6 +126,81 @@ public enum DetachStateCommand {
         default:
             throw DetachStateCommandError.invalidArguments
         }
+    }
+
+    private static func processState(_ arguments: [String]) throws -> Data {
+        guard arguments.count == 1,
+              let rawPID = Int64(arguments[0]),
+              rawPID > 1,
+              rawPID <= Int64(Int32.max) else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let state = ExactProcessStateProbe.state(pid: pid_t(rawPID))
+        return Data((state.rawValue + "\n").utf8)
+    }
+
+    private static func checkpointExchange(_ arguments: [String]) throws -> Data {
+        guard arguments.count == 2 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let sessionPath = arguments[0]
+        let stageName = arguments[1]
+        let pathComponents = sessionPath.split(
+            separator: "/", omittingEmptySubsequences: false)
+        guard sessionPath.hasPrefix("/"),
+              sessionPath != "/",
+              !sessionPath.hasSuffix("/"),
+              !sessionPath.contains("\n"),
+              !sessionPath.contains("\r"),
+              !pathComponents.contains("."),
+              !pathComponents.contains(".."),
+              validSessionIdentifier(fileURL(sessionPath).lastPathComponent),
+              validCheckpointStageName(stageName) else {
+            throw DetachStateCommandError.invalidArguments
+        }
+
+        let session = open(
+            sessionPath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard session >= 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        defer { close(session) }
+        var sessionMetadata = stat()
+        guard fstat(session, &sessionMetadata) == 0,
+              isDirectory(sessionMetadata),
+              sessionMetadata.st_uid == geteuid() else {
+            throw DetachStateCommandError.invalidArguments
+        }
+
+        let stage = try openOwnedDirectory(
+            in: session, name: stageName)
+        defer { close(stage.descriptor) }
+
+        var checkpointMetadata = stat()
+        let checkpointStatus = fstatat(
+            session, "checkpoint", &checkpointMetadata, AT_SYMLINK_NOFOLLOW)
+        if checkpointStatus == 0 {
+            let checkpoint = try openOwnedDirectory(
+                in: session, name: "checkpoint")
+            defer { close(checkpoint.descriptor) }
+            guard namedDirectoryMatches(
+                    stage.metadata, in: session, name: stageName),
+                  namedDirectoryMatches(
+                    checkpoint.metadata, in: session, name: "checkpoint"),
+                  renameatx_np(
+                    session, stageName, session, "checkpoint", UInt32(RENAME_SWAP)) == 0 else {
+                throw DetachStateCommandError.invalidArguments
+            }
+        } else {
+            guard errno == ENOENT,
+                  namedDirectoryMatches(
+                    stage.metadata, in: session, name: stageName),
+                  renameatx_np(
+                    session, stageName, session, "checkpoint", UInt32(RENAME_EXCL)) == 0 else {
+                throw DetachStateCommandError.invalidArguments
+            }
+        }
+        return Data()
     }
 
     private static func eventPublish(_ arguments: [String]) throws -> Data {
@@ -339,7 +422,8 @@ public enum DetachStateCommand {
             "--inspect-processes", "--worker-pid", "--provider-pid", "--pane-pid",
         ])
         let allowed = required.union(processInspection).union([
-            "--stop-requested", "--lifecycle-phase",
+            "--stop-requested", "--lifecycle-phase", "--uncommitted-replacement",
+            "--runtime-quiescent",
         ])
         var values: [String: String] = [:]
         var index = 0
@@ -374,6 +458,10 @@ public enum DetachStateCommand {
             throw DetachStateCommandError.invalidArguments
         }
         let stopRequested = try values["--stop-requested"].map(boolean) ?? false
+        let uncommittedReplacement = try values["--uncommitted-replacement"]
+            .map(boolean) ?? false
+        let runtimeQuiescent = try values["--runtime-quiescent"]
+            .map(boolean) ?? false
         let lifecyclePhase: RuntimeLifecyclePhase?
         if let rawPhase = values["--lifecycle-phase"] {
             guard let parsed = RuntimeLifecyclePhase(rawValue: rawPhase) else {
@@ -413,6 +501,8 @@ public enum DetachStateCommand {
             checkpointFreshness: checkpoint,
             checkpointRecoverable: try boolean(recoverableRaw),
             agentSessionKnown: try boolean(knownRaw),
+            uncommittedReplacement: uncommittedReplacement,
+            runtimeQuiescent: runtimeQuiescent,
             stopRequested: stopRequested,
             lifecyclePhase: lifecyclePhase))
     }
@@ -628,7 +718,65 @@ public enum DetachStateCommand {
         ("health_schema", ["health_schema"]),
         ("stop_requested_at", ["stop_requested_at"]),
         ("lifecycle_phase", ["lifecycle_phase"]),
+        ("preserve_recovery_until_ready", ["preserve_recovery_until_ready"]),
+        ("runtime_ready_at", ["runtime_ready_at"]),
     ]
+
+    private static let recoveryBindingFields: [(String, [String])] = [
+        ("provider", ["provider"]),
+        ("project_dir", ["project_dir"]),
+        ("display_name", ["display_name"]),
+        ("run_token", ["run_token"]),
+        ("lifecycle_id", ["lifecycle_id"]),
+        ("resume_args_file", ["resume_args_file"]),
+        ("agent_session_id", ["agent_session_id", "codex_session_id"]),
+        ("transcript_path", ["transcript_path", "rollout_path"]),
+    ]
+
+    private enum MetadataSnapshotSource: String {
+        case primary
+        case checkpoint
+    }
+
+    private struct MetadataSnapshot {
+        let values: [DetachStateScalar?]
+        let source: MetadataSnapshotSource
+    }
+
+    private static func validatedMetadataSnapshotValues(
+        in data: Data,
+        expectedSessionName: String
+    ) throws -> [DetachStateScalar?]? {
+        guard let values = try SessionMetadataDocument.usableScalars(
+            in: data,
+            expectedSessionName: expectedSessionName,
+            pathGroups: metadataSnapshotFields.map(\.1)) else {
+            return nil
+        }
+        for ((name, _), value) in zip(metadataSnapshotFields, values) {
+            guard metadataSnapshotValueIsTyped(value, for: name) else {
+                throw DetachStateCommandError.unusableMetadata
+            }
+        }
+        return values
+    }
+
+    private static func metadataSnapshotValueIsTyped(
+        _ value: DetachStateScalar?,
+        for name: String
+    ) -> Bool {
+        guard let value else { return true }
+        switch name {
+        case "exit_status", "worker_pid", "provider_pid",
+             "worker_heartbeat_epoch", "last_checkpoint_epoch", "health_schema":
+            if case .integer = value { return true }
+        case "preserve_recovery_until_ready":
+            if case .bool = value { return true }
+        default:
+            if case .string = value { return true }
+        }
+        return false
+    }
 
     /// Emits fixed key/value pairs separated by NUL bytes. The final complete
     /// marker lets a Bash process-substitution consumer detect helper failure
@@ -643,10 +791,8 @@ public enum DetachStateCommand {
         let data = try inputData(
             atPath: arguments[0],
             standardInput: standardInput)
-        guard let values = try SessionMetadataDocument.usableScalars(
-            in: data,
-            expectedSessionName: arguments[1],
-            pathGroups: metadataSnapshotFields.map(\.1)) else {
+        guard let values = try validatedMetadataSnapshotValues(
+            in: data, expectedSessionName: arguments[1]) else {
             throw DetachStateCommandError.unusableMetadata
         }
         var output = Data()
@@ -657,6 +803,39 @@ public enum DetachStateCommand {
         appendNULTerminated("snapshot_complete", to: &output)
         appendNULTerminated("true", to: &output)
         return output
+    }
+
+    /// Emits one canonical, typed recovery binding from one metadata read.
+    /// Volatile lifecycle and heartbeat fields are deliberately excluded so
+    /// callers can compare identity while the same run advances normally.
+    private static func metaRecoveryBinding(
+        _ arguments: [String],
+        standardInput: Data?
+    ) throws -> Data {
+        guard arguments.count == 2 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let data = try inputData(
+            atPath: arguments[0],
+            standardInput: standardInput)
+        guard let values = try SessionMetadataDocument.usableScalars(
+            in: data,
+            expectedSessionName: arguments[1],
+            pathGroups: recoveryBindingFields.map(\.1)) else {
+            throw DetachStateCommandError.unusableMetadata
+        }
+        var object: [String: Any] = [:]
+        for ((name, _), value) in zip(recoveryBindingFields, values) {
+            guard let value else {
+                object[name] = NSNull()
+                continue
+            }
+            guard case .string(let string) = value else {
+                throw DetachStateCommandError.unusableMetadata
+            }
+            object[name] = string
+        }
+        return try encodeJSONObject(object)
     }
 
     /// Enumerates one validated sessions root in one process. Output uses NUL
@@ -672,12 +851,14 @@ public enum DetachStateCommand {
         }
         let includesTranscriptSummary = arguments.count == 2
         var output = Data()
-        try forEachMetadataSnapshot(at: arguments[0]) { session, values, directory in
+        try forEachMetadataSnapshot(at: arguments[0]) {
+            session, values, source, directory in
             appendNULTerminated(session, to: &output)
             appendNULTerminated(values == nil ? "false" : "true", to: &output)
             for value in values ?? Array(repeating: nil, count: metadataSnapshotFields.count) {
                 appendNULTerminated(value.map(render) ?? "", to: &output)
             }
+            appendNULTerminated(source?.rawValue ?? "", to: &output)
             if includesTranscriptSummary {
                 for value in transcriptSummarySnapshotValues(
                     session: session,
@@ -785,7 +966,7 @@ public enum DetachStateCommand {
             summary.agentTurnID ?? "",
         ]
         let receipt = TranscriptSummaryReceipt(
-            schema: 1,
+            schema: TranscriptSummaryReceipt.currentSchema,
             provider: provider.rawValue,
             transcriptPath: transcriptPath,
             identity: after,
@@ -793,7 +974,8 @@ public enum DetachStateCommand {
             contextUsed: summary.contextUsed,
             contextWindow: summary.contextWindow,
             agentTurnState: summary.agentTurnState?.rawValue,
-            agentTurnID: summary.agentTurnID)
+            agentTurnID: summary.agentTurnID,
+            pendingToolUseID: summary.pendingToolUseID)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         if var receiptData = try? encoder.encode(receipt) {
@@ -805,6 +987,7 @@ public enum DetachStateCommand {
     }
 
     private struct TranscriptSummaryReceipt: Codable {
+        static let currentSchema = 3
         private static let overlapByteCount: UInt64 = 64 * 1_024
 
         var schema: Int
@@ -816,19 +999,21 @@ public enum DetachStateCommand {
         var contextWindow: Int?
         var agentTurnState: String?
         var agentTurnID: String?
+        var pendingToolUseID: String?
 
         func snapshotValues(
             provider expectedProvider: Provider,
             transcriptPath expectedPath: String,
             identity expectedIdentity: TranscriptValidationIdentity
         ) -> [String]? {
-            guard schema == 1,
+            guard schema == Self.currentSchema,
                   provider == expectedProvider.rawValue,
                   transcriptPath == expectedPath,
                   identity == expectedIdentity,
                   contextUsed.map({ $0 >= 0 }) ?? true,
                   contextWindow.map({ $0 >= 0 }) ?? true,
-                  agentTurnState.map({ AgentTurnState(rawValue: $0) != nil }) ?? true
+                  agentTurnState.map({ AgentTurnState(rawValue: $0) != nil }) ?? true,
+                  hasValidPendingToolUse
             else { return nil }
             return [
                 model ?? "",
@@ -850,7 +1035,7 @@ public enum DetachStateCommand {
             identity expectedIdentity: TranscriptValidationIdentity,
             maximumByteCount: UInt64
         ) -> (offset: UInt64, summary: TranscriptSummary)? {
-            guard schema == 1,
+            guard schema == Self.currentSchema,
                   provider == expectedProvider.rawValue,
                   transcriptPath == expectedPath,
                   identity.device == expectedIdentity.device,
@@ -859,7 +1044,8 @@ public enum DetachStateCommand {
                   expectedIdentity.size > identity.size,
                   contextUsed.map({ $0 >= 0 }) ?? true,
                   contextWindow.map({ $0 >= 0 }) ?? true,
-                  agentTurnState.map({ AgentTurnState(rawValue: $0) != nil }) ?? true
+                  agentTurnState.map({ AgentTurnState(rawValue: $0) != nil }) ?? true,
+                  hasValidPendingToolUse
             else { return nil }
 
             let previousSize = UInt64(identity.size)
@@ -867,27 +1053,48 @@ public enum DetachStateCommand {
             let overlap = min(previousSize, Self.overlapByteCount)
             let offset = previousSize - overlap
             guard currentSize - offset <= maximumByteCount else { return nil }
-            return (
-                offset,
-                TranscriptSummary(
-                    model: model,
-                    contextUsed: contextUsed,
-                    contextWindow: contextWindow,
-                    agentTurnState: agentTurnState.flatMap(AgentTurnState.init(rawValue:)),
-                    agentTurnID: agentTurnID))
+            var summary = TranscriptSummary(
+                model: model,
+                contextUsed: contextUsed,
+                contextWindow: contextWindow,
+                agentTurnState: agentTurnState.flatMap(AgentTurnState.init(rawValue:)),
+                agentTurnID: agentTurnID)
+            summary.pendingToolUseID = pendingToolUseID
+            return (offset, summary)
+        }
+
+        private var hasValidPendingToolUse: Bool {
+            guard let pendingToolUseID else { return true }
+            return provider == Provider.claude.rawValue
+                && !pendingToolUseID.isEmpty
+                && agentTurnState == AgentTurnState.waiting.rawValue
+                && agentTurnID == pendingToolUseID
         }
     }
 
     private static func metadataSnapshotValues(
         in directory: Int32,
         session: String
-    ) throws -> [DetachStateScalar?]? {
-        if let data = readOwnedMetadataFile(in: directory, name: "meta.json"),
-           let values = try? SessionMetadataDocument.usableScalars(
-            in: data,
-            expectedSessionName: session,
-            pathGroups: metadataSnapshotFields.map(\.1)) {
-            return values
+    ) throws -> MetadataSnapshot? {
+        var primaryMetadata = stat()
+        let primaryStatus = fstatat(
+            directory, "meta.json", &primaryMetadata, AT_SYMLINK_NOFOLLOW)
+        if primaryStatus == 0 {
+            guard isRegularFile(primaryMetadata),
+                  !isSymbolicLink(primaryMetadata),
+                  primaryMetadata.st_uid == geteuid(),
+                  let data = readOwnedMetadataFile(
+                    in: directory, name: "meta.json"),
+                  let values = try? validatedMetadataSnapshotValues(
+                    in: data, expectedSessionName: session) else {
+                // Any present but unusable primary may describe a newer live
+                // generation. Do not conceal it with checkpoint metadata.
+                return nil
+            }
+            return MetadataSnapshot(values: values, source: .primary)
+        }
+        guard errno == ENOENT else {
+            throw DetachStateCommandError.invalidArguments
         }
         var checkpointMetadata = stat()
         let checkpointStatus = fstatat(
@@ -917,11 +1124,9 @@ public enum DetachStateCommand {
             && openedCheckpoint.st_ino == checkpointMetadata.st_ino
         guard checkpointMatches else { throw DetachStateCommandError.invalidArguments }
         if let data = readOwnedMetadataFile(in: checkpoint, name: "meta.json") {
-            if let values = try? SessionMetadataDocument.usableScalars(
-                in: data,
-                expectedSessionName: session,
-                pathGroups: metadataSnapshotFields.map(\.1)) {
-                return values
+            if let values = try? validatedMetadataSnapshotValues(
+                in: data, expectedSessionName: session) {
+                return MetadataSnapshot(values: values, source: .checkpoint)
             }
         }
         return nil
@@ -931,7 +1136,7 @@ public enum DetachStateCommand {
         at root: String
     ) throws -> [(String, [DetachStateScalar?]?)] {
         var snapshots: [(String, [DetachStateScalar?]?)] = []
-        try forEachMetadataSnapshot(at: root) { name, values, _ in
+        try forEachMetadataSnapshot(at: root) { name, values, _, _ in
             snapshots.append((name, values))
         }
         return snapshots
@@ -939,7 +1144,9 @@ public enum DetachStateCommand {
 
     private static func forEachMetadataSnapshot(
         at root: String,
-        visit: (String, [DetachStateScalar?]?, Int32) throws -> Void
+        visit: (
+            String, [DetachStateScalar?]?, MetadataSnapshotSource?, Int32
+        ) throws -> Void
     ) throws {
         let components = root.split(separator: "/", omittingEmptySubsequences: false)
         guard root.hasPrefix("/"),
@@ -1005,10 +1212,10 @@ public enum DetachStateCommand {
             guard sessionMatches else {
                 close(session); throw DetachStateCommandError.invalidArguments
             }
-            let values: [DetachStateScalar?]?
+            let snapshot: MetadataSnapshot?
             do {
-                values = try metadataSnapshotValues(in: session, session: name)
-                try visit(name, values, session)
+                snapshot = try metadataSnapshotValues(in: session, session: name)
+                try visit(name, snapshot?.values, snapshot?.source, session)
             } catch {
                 close(session)
                 throw error
@@ -1124,6 +1331,58 @@ public enum DetachStateCommand {
 
     private static func isSymbolicLink(_ item: stat) -> Bool {
         item.st_mode & S_IFMT == S_IFLNK
+    }
+
+    private static func validCheckpointStageName(_ value: String) -> Bool {
+        let prefix = ".checkpoint-stage-"
+        guard value.hasPrefix(prefix),
+              value.utf8.count > prefix.utf8.count,
+              value.utf8.count <= Int(NAME_MAX) else { return false }
+        return value.utf8.allSatisfy {
+            asciiAlphanumeric($0) || $0 == 0x2E || $0 == 0x5F || $0 == 0x2D
+        }
+    }
+
+    private static func openOwnedDirectory(
+        in parent: Int32,
+        name: String
+    ) throws -> (descriptor: Int32, metadata: stat) {
+        var namedMetadata = stat()
+        guard fstatat(parent, name, &namedMetadata, AT_SYMLINK_NOFOLLOW) == 0,
+              isDirectory(namedMetadata),
+              !isSymbolicLink(namedMetadata),
+              namedMetadata.st_uid == geteuid() else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let descriptor = openat(
+            parent, name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        var openedMetadata = stat()
+        guard fstat(descriptor, &openedMetadata) == 0,
+              isDirectory(openedMetadata),
+              openedMetadata.st_uid == geteuid(),
+              openedMetadata.st_dev == namedMetadata.st_dev,
+              openedMetadata.st_ino == namedMetadata.st_ino else {
+            close(descriptor)
+            throw DetachStateCommandError.invalidArguments
+        }
+        return (descriptor, openedMetadata)
+    }
+
+    private static func namedDirectoryMatches(
+        _ expected: stat,
+        in parent: Int32,
+        name: String
+    ) -> Bool {
+        var current = stat()
+        return fstatat(parent, name, &current, AT_SYMLINK_NOFOLLOW) == 0
+            && isDirectory(current)
+            && !isSymbolicLink(current)
+            && current.st_uid == geteuid()
+            && current.st_dev == expected.st_dev
+            && current.st_ino == expected.st_ino
     }
 
     private static func validSessionIdentifier(_ value: String) -> Bool {

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -77,6 +77,74 @@ struct SessionProcessIdentity: Equatable, Sendable {
     var userID: uid_t
 }
 
+enum ExactProcessState: String, Equatable, Sendable {
+    case alive
+    case dead
+    case unknown
+}
+
+enum ExactProcessStateProbe {
+    enum Existence: Equatable, Sendable {
+        case exists
+        case missing
+        case unknown
+    }
+
+    typealias ExistenceLookup = (pid_t) -> Existence
+    typealias IdentityLookup = (pid_t) -> SessionProcessIdentity?
+
+    static func state(
+        pid: pid_t,
+        userID: uid_t = geteuid(),
+        existence: ExistenceLookup = liveExistence,
+        identity: IdentityLookup = liveProcessIdentity
+    ) -> ExactProcessState {
+        guard pid > 1 else { return .unknown }
+        switch existence(pid) {
+        case .missing:
+            return .dead
+        case .unknown:
+            return .unknown
+        case .exists:
+            break
+        }
+        if let process = identity(pid) {
+            // A different user now owning this PID proves that the recorded
+            // process exited. Reuse by the same user stays conservatively live.
+            return process.userID == userID ? .alive : .dead
+        }
+        // The process can exit between kill(2) and proc_pidinfo(2). Confirm
+        // ESRCH once more; every other lookup failure remains unknown.
+        return existence(pid) == .missing ? .dead : .unknown
+    }
+
+    private static func liveExistence(_ pid: pid_t) -> Existence {
+        if Darwin.kill(pid, 0) == 0 { return .exists }
+        switch errno {
+        case ESRCH:
+            return .missing
+        case EPERM:
+            return .exists
+        default:
+            return .unknown
+        }
+    }
+}
+
+private func liveProcessIdentity(_ pid: pid_t) -> SessionProcessIdentity? {
+    var information = proc_bsdinfo()
+    let expected = Int32(MemoryLayout<proc_bsdinfo>.size)
+    guard proc_pidinfo(
+        pid,
+        PROC_PIDTBSDINFO,
+        0,
+        &information,
+        expected) == expected else { return nil }
+    return SessionProcessIdentity(
+        parentPID: pid_t(information.pbi_ppid),
+        userID: uid_t(information.pbi_uid))
+}
+
 /// Reads only the process identities named by one health record. The result is
 /// presentation evidence. Runtime mutations repeat their established live
 /// ownership and tmux-token checks immediately before they act.
@@ -89,7 +157,7 @@ enum SessionProcessHealthInspector {
         providerPID rawProviderPID: String,
         panePID rawPanePID: String,
         userID: uid_t = geteuid(),
-        lookup: Lookup = liveIdentity
+        lookup: Lookup = liveProcessIdentity
     ) -> SessionProcessHealth {
         let workerPID = validPID(rawWorkerPID)
         let providerPID = validPID(rawProviderPID)
@@ -158,19 +226,6 @@ enum SessionProcessHealthInspector {
         return false
     }
 
-    private static func liveIdentity(_ pid: pid_t) -> SessionProcessIdentity? {
-        var information = proc_bsdinfo()
-        let expected = Int32(MemoryLayout<proc_bsdinfo>.size)
-        guard proc_pidinfo(
-            pid,
-            PROC_PIDTBSDINFO,
-            0,
-            &information,
-            expected) == expected else { return nil }
-        return SessionProcessIdentity(
-            parentPID: pid_t(information.pbi_ppid),
-            userID: uid_t(information.pbi_uid))
-    }
 }
 
 public enum SessionHealthReason: String, Codable, Sendable {
@@ -192,6 +247,7 @@ public enum SessionHealthReason: String, Codable, Sendable {
     case providerProcessLost = "provider_process_lost"
     case providerPIDNotDescendant = "provider_pid_not_descendant"
     case runtimeProcessWithoutTmux = "runtime_process_without_tmux"
+    case runtimeQuiescenceUnproven = "runtime_quiescence_unproven"
     case recoverableCheckpoint = "recoverable_checkpoint"
     case noRecoveryCheckpoint = "no_recovery_checkpoint"
 }
@@ -217,6 +273,8 @@ public struct SessionHealthEvidence: Equatable, Sendable {
     public var checkpointFreshness: FreshnessState
     public var checkpointRecoverable: Bool
     public var agentSessionKnown: Bool
+    public var uncommittedReplacement: Bool
+    public var runtimeQuiescent: Bool
     public var stopRequested: Bool
     public var lifecyclePhase: RuntimeLifecyclePhase
 
@@ -232,6 +290,8 @@ public struct SessionHealthEvidence: Equatable, Sendable {
         checkpointFreshness: FreshnessState,
         checkpointRecoverable: Bool,
         agentSessionKnown: Bool,
+        uncommittedReplacement: Bool = false,
+        runtimeQuiescent: Bool = false,
         stopRequested: Bool = false,
         lifecyclePhase: RuntimeLifecyclePhase? = nil
     ) {
@@ -246,6 +306,8 @@ public struct SessionHealthEvidence: Equatable, Sendable {
         self.checkpointFreshness = checkpointFreshness
         self.checkpointRecoverable = checkpointRecoverable
         self.agentSessionKnown = agentSessionKnown
+        self.uncommittedReplacement = uncommittedReplacement
+        self.runtimeQuiescent = runtimeQuiescent
         self.stopRequested = stopRequested
         self.lifecyclePhase = lifecyclePhase
             ?? RuntimeLifecyclePhase.inferred(fromMetadataStatus: metaStatus.rawValue)
@@ -284,15 +346,85 @@ public enum SessionHealthEvaluator {
                 evidence: evidence)
         }
 
+        // A missing or retained dead tmux pane does not prove that the
+        // recorded runtime exited. Keep every mutation closed while either
+        // exact process can still be alive, independent of saved metadata.
+        if (evidence.tmuxState == .missing || evidence.tmuxState == .dead),
+           runtimeProcessMayStillBeAlive(evidence) {
+            return assessment(
+                status: .hung,
+                reason: .runtimeProcessWithoutTmux,
+                actions: [],
+                evidence: evidence)
+        }
+
         if !evidence.metadataValid {
-            let actions: [SessionAction] = evidence.tmuxState == .live
-                ? [.attach, .stop] : [.delete]
+            let actions: [SessionAction]
+            switch evidence.tmuxState {
+            case .live:
+                actions = [.attach, .stop]
+            case .missing:
+                // A present but unreadable operational record can hide a
+                // newer runtime generation. Typed cleanup must not infer
+                // ownership from absence of tmux alone.
+                actions = []
+            case .dead, .foreign:
+                // A retained pane needs a valid primary run token before any
+                // mutation. Foreign tmux was handled above.
+                actions = []
+            }
             return assessment(
                 status: .corrupt,
                 reason: .malformedMetadata,
                 actions: actions,
-                ownershipProven: evidence.tmuxState == .live || evidence.tmuxState == .dead,
+                ownershipProven: evidence.tmuxState == .live,
                 evidence: evidence)
+        }
+
+        // A retained dead pane is safe to remove only when it belongs to the
+        // exact operational generation in primary metadata. A mismatch can
+        // be a newer tmux run, so it authorizes no recovery or deletion.
+        if evidence.tmuxState == .dead,
+           evidence.runTokenState != .match {
+            return assessment(
+                status: .corrupt,
+                reason: evidence.runTokenState == .missing
+                    ? .runTokenMissing : .runTokenMismatch,
+                actions: [],
+                evidence: evidence)
+        }
+
+        if evidence.tmuxState == .missing || evidence.tmuxState == .dead {
+            if evidence.uncommittedReplacement,
+               !evidence.runtimeQuiescent {
+                return assessment(
+                    status: .hung,
+                    reason: .runtimeQuiescenceUnproven,
+                    actions: [],
+                    evidence: evidence)
+            }
+            if evidence.uncommittedReplacement,
+               evidence.runtimeQuiescent,
+               evidence.checkpointRecoverable {
+                var result = assessment(
+                    status: .recoverable,
+                    reason: .recoverableCheckpoint,
+                    actions: [.recover, .delete],
+                    evidence: evidence)
+                // Removing a retained dead pane is safe. Do not rewrite the
+                // primary replacement metadata that selects the checkpoint.
+                if evidence.tmuxState == .dead {
+                    result.reconcileAction = .removeDeadTmux
+                }
+                result.cleanupEligible = false
+                return result
+            }
+            if evidence.uncommittedReplacement,
+               evidence.runtimeQuiescent {
+                return interruptedAssessment(
+                    evidence,
+                    deadTmux: evidence.tmuxState == .dead)
+            }
         }
 
         // Active transition phases close user actions while an exact runtime
@@ -581,9 +713,8 @@ public enum SessionHealthEvaluator {
     }
 
     private static func runtimeProcessMayStillBeAlive(_ evidence: SessionHealthEvidence) -> Bool {
-        evidence.runtimeIdentityExpected && (
-            evidence.workerState == .alive
-                || evidence.providerState == .alive
-                || evidence.providerState == .mismatch)
+        evidence.workerState == .alive
+            || evidence.providerState == .alive
+            || evidence.providerState == .mismatch
     }
 }

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -118,9 +118,12 @@ enum ExactProcessStateProbe {
         return existence(pid) == .missing ? .dead : .unknown
     }
 
-    private static func liveExistence(_ pid: pid_t) -> Existence {
-        if Darwin.kill(pid, 0) == 0 { return .exists }
-        switch errno {
+    static func classifyExistence(
+        killResult: Int32,
+        errorNumber: Int32
+    ) -> Existence {
+        if killResult == 0 { return .exists }
+        switch errorNumber {
         case ESRCH:
             return .missing
         case EPERM:
@@ -128,6 +131,11 @@ enum ExactProcessStateProbe {
         default:
             return .unknown
         }
+    }
+
+    private static func liveExistence(_ pid: pid_t) -> Existence {
+        let result = Darwin.kill(pid, 0)
+        return classifyExistence(killResult: result, errorNumber: errno)
     }
 }
 
@@ -476,13 +484,6 @@ public enum SessionHealthEvaluator {
             guard isActive(evidence.metaStatus) else {
                 return finishedAssessment(evidence, reason: .finished)
             }
-            if runtimeProcessMayStillBeAlive(evidence) {
-                return assessment(
-                    status: .hung,
-                    reason: .runtimeProcessWithoutTmux,
-                    actions: [],
-                    evidence: evidence)
-            }
             return interruptedAssessment(evidence, deadTmux: false)
 
         case .dead:
@@ -490,13 +491,6 @@ public enum SessionHealthEvaluator {
                 var result = finishedAssessment(evidence, reason: .paneExited)
                 result.reconcileAction = .removeDeadTmux
                 return result
-            }
-            if runtimeProcessMayStillBeAlive(evidence) {
-                return assessment(
-                    status: .hung,
-                    reason: .runtimeProcessWithoutTmux,
-                    actions: [],
-                    evidence: evidence)
             }
             return interruptedAssessment(evidence, deadTmux: true)
 

--- a/app/Sources/DetachKit/SessionPresentation.swift
+++ b/app/Sources/DetachKit/SessionPresentation.swift
@@ -136,10 +136,12 @@ public extension Session {
             L10n.string("The recorded provider PID is not owned by this worker.")
         case .runtimeProcessWithoutTmux:
             L10n.string("A recorded runtime process is still alive without its managed tmux session; Detach will not signal it.")
+        case .runtimeQuiescenceUnproven:
+            L10n.string("Detach could not confirm that the replacement runtime stopped.")
         case .recoverableCheckpoint:
-            L10n.string("The live runtime disappeared, but a valid checkpoint can be recovered.")
+            L10n.string("The live runtime disappeared, but validated recovery data is available.")
         case .noRecoveryCheckpoint:
-            L10n.string("The live runtime disappeared without a valid recovery checkpoint.")
+            L10n.string("The live runtime disappeared without validated recovery data.")
         }
     }
 

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -933,10 +933,10 @@ final class SessionAttachTerminalTests: XCTestCase {
     }
 
     @MainActor
-    func testControlVReachesTheProviderAsTheRawClipboardImageShortcut() throws {
+    func testControlShortcutsReachTheProviderAsRawBytes() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(
-                "detach-attach-control-v-\(UUID().uuidString)",
+                "detach-attach-control-shortcuts-\(UUID().uuidString)",
                 isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -949,7 +949,7 @@ final class SessionAttachTerminalTests: XCTestCase {
             args: [
                 "-c",
                 "stty raw -echo; : > '\(ready.path)'; "
-                    + "dd bs=1 count=1 of='\(received.path)' 2>/dev/null",
+                    + "dd bs=1 count=2 of='\(received.path)' 2>/dev/null",
             ],
             environment: ["PATH=/bin:/usr/bin"])
         defer { SessionAttachController.terminate(process: terminal.process) }
@@ -958,7 +958,18 @@ final class SessionAttachTerminalTests: XCTestCase {
             FileManager.default.fileExists(atPath: ready.path)
                 && terminal.process.running
         }
-        let event = try XCTUnwrap(NSEvent.keyEvent(
+        let controlC = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .control,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{03}",
+            charactersIgnoringModifiers: "c",
+            isARepeat: false,
+            keyCode: 8))
+        let controlV = try XCTUnwrap(NSEvent.keyEvent(
             with: .keyDown,
             location: .zero,
             modifierFlags: .control,
@@ -971,13 +982,16 @@ final class SessionAttachTerminalTests: XCTestCase {
             keyCode: 9))
 
         XCTAssertTrue(SessionAttachKeyboard.routeProviderShortcut(
-            from: event,
+            from: controlC,
+            send: terminal.send))
+        XCTAssertTrue(SessionAttachKeyboard.routeProviderShortcut(
+            from: controlV,
             send: terminal.send))
 
         try waitUntil {
-            (try? Data(contentsOf: received).count) == 1
+            (try? Data(contentsOf: received).count) == 2
         }
-        XCTAssertEqual(try Data(contentsOf: received), Data([0x16]))
+        XCTAssertEqual(try Data(contentsOf: received), Data([0x03, 0x16]))
     }
 
     func testProviderClipboardShortcutRequiresUnmodifiedControlV() throws {

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -933,7 +933,7 @@ final class SessionAttachTerminalTests: XCTestCase {
     }
 
     @MainActor
-    func testControlShortcutsReachTheProviderAsRawBytes() throws {
+    func testControlVReachesTheProviderAsTheRawClipboardImageShortcut() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "detach-attach-control-shortcuts-\(UUID().uuidString)",

--- a/app/Tests/DetachAppTests/SessionNotificationServiceTests.swift
+++ b/app/Tests/DetachAppTests/SessionNotificationServiceTests.swift
@@ -284,7 +284,7 @@ final class SessionNotificationServiceTests: XCTestCase {
             (
                 .recoverable,
                 "Session can be recovered",
-                "Recovery from the latest checkpoint is available"
+                "Validated recovery data is available"
             ),
         ]
 

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -418,6 +418,25 @@ final class DetachStateCommandTests: XCTestCase {
         }
         XCTAssertTrue(FileManager.default.fileExists(atPath: linkedStage.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: linkedCheckpoint.path))
+
+        let unreadableSession = temporaryDirectory.appendingPathComponent(
+            "detach-codex-unreadable-stage", isDirectory: true)
+        let unreadableStageName = ".checkpoint-stage-unreadable"
+        let unreadableStage = unreadableSession.appendingPathComponent(
+            unreadableStageName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: unreadableStage, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000], ofItemAtPath: unreadableStage.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: unreadableStage.path)
+        }
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "checkpoint", "exchange", unreadableSession.path, unreadableStageName,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
     }
 
     func testMetaGetUsesFallbackPaths() throws {
@@ -556,6 +575,7 @@ final class DetachStateCommandTests: XCTestCase {
     func testMetaRecoveryBindingNormalizesAliasesAndRejectsWrongTypes() throws {
         let current = temporaryDirectory.appendingPathComponent("current-meta.json")
         let legacy = temporaryDirectory.appendingPathComponent("legacy-meta.json")
+        let sparse = temporaryDirectory.appendingPathComponent("sparse-meta.json")
         let invalid = temporaryDirectory.appendingPathComponent("invalid-meta.json")
         let common: [String: Any] = [
             "schema": 1,
@@ -584,6 +604,25 @@ final class DetachStateCommandTests: XCTestCase {
         ])
         XCTAssertEqual(currentBinding, legacyBinding)
 
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-codex-project",
+            "project_dir": "/tmp/project",
+        ]).write(to: sparse)
+        let sparseBinding = try DetachStateCommand.run(arguments: [
+            "meta", "recovery-binding", sparse.path, "detach-codex-project",
+        ])
+        let sparseObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: sparseBinding) as? [String: Any])
+        XCTAssertEqual(sparseObject["project_dir"] as? String, "/tmp/project")
+        XCTAssertTrue(sparseObject["provider"] is NSNull)
+
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "recovery-binding", current.path, "detach-codex-other",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .unusableMetadata)
+        }
+
         var invalidObject = currentObject
         invalidObject["resume_args_file"] = 7
         try JSONSerialization.data(withJSONObject: invalidObject).write(to: invalid)
@@ -594,11 +633,12 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
-    func testMetaSnapshotsBatchesAbsentPrimaryFallbacksAndRejectsIncompleteInput() throws {
+    func testMetaSnapshotsBatchesFallbacksAndRejectsIncompleteInput() throws {
         let root = temporaryDirectory.appendingPathComponent("sessions", isDirectory: true)
         let first = root.appendingPathComponent("detach-codex-one", isDirectory: true)
         let second = root.appendingPathComponent("detach-codex-two", isDirectory: true)
         let third = root.appendingPathComponent("detach-claude-three", isDirectory: true)
+        let empty = root.appendingPathComponent("detach-codex-zempty", isDirectory: true)
         let checkpointDirectory = first.appendingPathComponent("checkpoint", isDirectory: true)
         let checkpoint = checkpointDirectory.appendingPathComponent("meta.json")
         try FileManager.default.createDirectory(
@@ -607,6 +647,8 @@ final class DetachStateCommandTests: XCTestCase {
             at: second, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(
             at: third, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: empty, withIntermediateDirectories: true)
         try Data(count: 1_048_577).write(to: second.appendingPathComponent("meta.json"))
         let project = "/tmp/project\twith\ncontrols"
         try JSONSerialization.data(withJSONObject: [
@@ -632,7 +674,7 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
         let recordSize = 25
-        XCTAssertEqual(values.count, recordSize * 3 + 2)
+        XCTAssertEqual(values.count, recordSize * 4 + 2)
         XCTAssertEqual(values[0], "detach-claude-three")
         XCTAssertEqual(values[1], "true")
         XCTAssertEqual(values[2], "running")
@@ -649,6 +691,9 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(values[recordSize * 2 + 1], "false")
         XCTAssertEqual(values[recordSize * 2 + 24], "")
         XCTAssertTrue(values[(recordSize * 2 + 2)..<(recordSize * 3)].allSatisfy(\.isEmpty))
+        XCTAssertEqual(values[recordSize * 3], "detach-codex-zempty")
+        XCTAssertEqual(values[recordSize * 3 + 1], "false")
+        XCTAssertTrue(values[(recordSize * 3 + 2)..<(recordSize * 4)].allSatisfy(\.isEmpty))
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
         let repeatedSeparatorRoot = root.path.replacingOccurrences(
             of: "/sessions", with: "//sessions")
@@ -796,15 +841,18 @@ final class DetachStateCommandTests: XCTestCase {
             ("preserve_recovery_until_ready", "false"),
             ("runtime_ready_at", false),
             ("runtime_shutdown_observed_at", 0),
+            ("exit_status", "not-an-integer"),
+            ("status", 7),
         ]
         for (field, value) in malformedValues {
-            try JSONSerialization.data(withJSONObject: [
+            var object: [String: Any] = [
                 "schema": 1,
                 "session_name": "detach-codex-typed",
                 "project_dir": "/tmp/project",
                 "status": "starting",
-                field: value,
-            ]).write(to: primary)
+            ]
+            object[field] = value
+            try JSONSerialization.data(withJSONObject: object).write(to: primary)
 
             XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
                 "meta", "snapshot", primary.path, "detach-codex-typed",

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -214,10 +214,16 @@ final class DetachStateCommandTests: XCTestCase {
             ["emit", "session", "codex", "session", "running", "--unknown", "value"],
             ["meta", "get", "only-path"],
             ["meta", "snapshot", "only-path"],
+            ["meta", "recovery-binding", "only-path"],
             ["meta", "snapshots"],
             ["health", "session", "--"],
             ["health", "session", "no-separator"],
             ["health", "sessions"],
+            ["process", "state"],
+            ["process", "state", "0"],
+            ["process", "state", "not-a-pid"],
+            ["checkpoint", "exchange"],
+            ["checkpoint", "exchange", "/tmp/detach-codex-session"],
             ["events", "publish"],
             ["events", "publish", "/tmp/one", "/tmp/two"],
             ["meta", "usable", "only-path"],
@@ -237,6 +243,181 @@ final class DetachStateCommandTests: XCTestCase {
         ])) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidInteger("not-a-pid"))
         }
+    }
+
+    func testProcessStateReportsTheCurrentOwnedProcess() throws {
+        let data = try DetachStateCommand.run(arguments: [
+            "process", "state", String(getpid()),
+        ])
+
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "alive\n")
+    }
+
+    func testCheckpointExchangeSwapsACompleteExistingGeneration() throws {
+        let session = temporaryDirectory.appendingPathComponent(
+            "detach-codex-exchange", isDirectory: true)
+        let checkpoint = session.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        let stageName = ".checkpoint-stage-run-123"
+        let stage = session.appendingPathComponent(stageName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: checkpoint, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: stage, withIntermediateDirectories: false)
+        try Data("generation A\n".utf8).write(
+            to: checkpoint.appendingPathComponent("meta.json"))
+        try Data("payload A\n".utf8).write(
+            to: checkpoint.appendingPathComponent("rollout.jsonl"))
+        try Data("generation B\n".utf8).write(
+            to: stage.appendingPathComponent("meta.json"))
+        try Data("payload B\n".utf8).write(
+            to: stage.appendingPathComponent("rollout.jsonl"))
+        let checkpointIdentifier = try directoryIdentifier(checkpoint)
+        let stageIdentifier = try directoryIdentifier(stage)
+
+        let output = try DetachStateCommand.run(arguments: [
+            "checkpoint", "exchange", session.path, stageName,
+        ])
+
+        XCTAssertTrue(output.isEmpty)
+        XCTAssertEqual(try directoryIdentifier(checkpoint), stageIdentifier)
+        XCTAssertEqual(try directoryIdentifier(stage), checkpointIdentifier)
+        XCTAssertEqual(
+            try String(
+                contentsOf: checkpoint.appendingPathComponent("meta.json"),
+                encoding: .utf8),
+            "generation B\n")
+        XCTAssertEqual(
+            try String(
+                contentsOf: checkpoint.appendingPathComponent("rollout.jsonl"),
+                encoding: .utf8),
+            "payload B\n")
+        XCTAssertEqual(
+            try String(
+                contentsOf: stage.appendingPathComponent("meta.json"),
+                encoding: .utf8),
+            "generation A\n")
+        XCTAssertEqual(
+            try String(
+                contentsOf: stage.appendingPathComponent("rollout.jsonl"),
+                encoding: .utf8),
+            "payload A\n")
+    }
+
+    func testCheckpointExchangeRenamesTheFirstGenerationIntoPlace() throws {
+        let session = temporaryDirectory.appendingPathComponent(
+            "detach-claude-first-checkpoint", isDirectory: true)
+        let stageName = ".checkpoint-stage-first"
+        let stage = session.appendingPathComponent(stageName, isDirectory: true)
+        let checkpoint = session.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: stage, withIntermediateDirectories: true)
+        try Data("first generation\n".utf8).write(
+            to: stage.appendingPathComponent("meta.json"))
+        let stageIdentifier = try directoryIdentifier(stage)
+
+        let redundantSeparatorPath = session.deletingLastPathComponent().path
+            + "//" + session.lastPathComponent
+        XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+            "checkpoint", "exchange", redundantSeparatorPath, stageName,
+        ]))
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stage.path))
+        XCTAssertEqual(try directoryIdentifier(checkpoint), stageIdentifier)
+        XCTAssertEqual(
+            try String(
+                contentsOf: checkpoint.appendingPathComponent("meta.json"),
+                encoding: .utf8),
+            "first generation\n")
+    }
+
+    func testCheckpointExchangeRejectsUnsafeNamesAndSymlinkedDirectories() throws {
+        let session = temporaryDirectory.appendingPathComponent(
+            "detach-codex-safe-session", isDirectory: true)
+        let checkpoint = session.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        let stageName = ".checkpoint-stage-safe"
+        let stage = session.appendingPathComponent(stageName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: checkpoint, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: stage, withIntermediateDirectories: false)
+        try Data("generation A\n".utf8).write(
+            to: checkpoint.appendingPathComponent("sentinel"))
+        try Data("generation B\n".utf8).write(
+            to: stage.appendingPathComponent("sentinel"))
+
+        let longName = ".checkpoint-stage-" + String(
+            repeating: "a", count: Int(NAME_MAX))
+        for unsafeName in [
+            "", ".", "..", "checkpoint", ".checkpoint-stage-",
+            ".checkpoint-stage-child/name", ".checkpoint-stage-line\nbreak",
+            longName,
+        ] {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "checkpoint", "exchange", session.path, unsafeName,
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+            }
+        }
+        XCTAssertEqual(
+            try String(
+                contentsOf: checkpoint.appendingPathComponent("sentinel"),
+                encoding: .utf8),
+            "generation A\n")
+        XCTAssertEqual(
+            try String(
+                contentsOf: stage.appendingPathComponent("sentinel"),
+                encoding: .utf8),
+            "generation B\n")
+
+        let externalStage = temporaryDirectory.appendingPathComponent(
+            "external-stage", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: externalStage, withIntermediateDirectories: false)
+        try FileManager.default.removeItem(at: stage)
+        try FileManager.default.createSymbolicLink(
+            at: stage, withDestinationURL: externalStage)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "checkpoint", "exchange", session.path, stageName,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stage.path))
+        XCTAssertEqual(
+            try String(
+                contentsOf: checkpoint.appendingPathComponent("sentinel"),
+                encoding: .utf8),
+            "generation A\n")
+
+        let linkedSession = temporaryDirectory.appendingPathComponent(
+            "detach-codex-linked-session", isDirectory: true)
+        try FileManager.default.createSymbolicLink(
+            at: linkedSession, withDestinationURL: session)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "checkpoint", "exchange", linkedSession.path, stageName,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+
+        let checkpointLinkSession = temporaryDirectory.appendingPathComponent(
+            "detach-codex-checkpoint-link", isDirectory: true)
+        let linkedCheckpoint = checkpointLinkSession.appendingPathComponent("checkpoint")
+        let linkedStageName = ".checkpoint-stage-linked-checkpoint"
+        let linkedStage = checkpointLinkSession.appendingPathComponent(
+            linkedStageName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: linkedStage, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: linkedCheckpoint, withDestinationURL: checkpoint)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "checkpoint", "exchange", checkpointLinkSession.path, linkedStageName,
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: linkedStage.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: linkedCheckpoint.path))
     }
 
     func testMetaGetUsesFallbackPaths() throws {
@@ -372,13 +553,53 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
-    func testMetaSnapshotsBatchesFallbacksAndRejectsIncompleteInput() throws {
+    func testMetaRecoveryBindingNormalizesAliasesAndRejectsWrongTypes() throws {
+        let current = temporaryDirectory.appendingPathComponent("current-meta.json")
+        let legacy = temporaryDirectory.appendingPathComponent("legacy-meta.json")
+        let invalid = temporaryDirectory.appendingPathComponent("invalid-meta.json")
+        let common: [String: Any] = [
+            "schema": 1,
+            "session_name": "detach-codex-project",
+            "project_dir": "/tmp/project",
+            "provider": "codex",
+            "display_name": "Project",
+            "run_token": "run-1",
+            "lifecycle_id": "lifecycle-1",
+            "resume_args_file": "resume-args-run-1.bin",
+        ]
+        var currentObject = common
+        currentObject["agent_session_id"] = "thread-1"
+        currentObject["transcript_path"] = "/tmp/rollout.jsonl"
+        var legacyObject = common
+        legacyObject["codex_session_id"] = "thread-1"
+        legacyObject["rollout_path"] = "/tmp/rollout.jsonl"
+        try JSONSerialization.data(withJSONObject: currentObject).write(to: current)
+        try JSONSerialization.data(withJSONObject: legacyObject).write(to: legacy)
+
+        let currentBinding = try DetachStateCommand.run(arguments: [
+            "meta", "recovery-binding", current.path, "detach-codex-project",
+        ])
+        let legacyBinding = try DetachStateCommand.run(arguments: [
+            "meta", "recovery-binding", legacy.path, "detach-codex-project",
+        ])
+        XCTAssertEqual(currentBinding, legacyBinding)
+
+        var invalidObject = currentObject
+        invalidObject["resume_args_file"] = 7
+        try JSONSerialization.data(withJSONObject: invalidObject).write(to: invalid)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "recovery-binding", invalid.path, "detach-codex-project",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .unusableMetadata)
+        }
+    }
+
+    func testMetaSnapshotsBatchesAbsentPrimaryFallbacksAndRejectsIncompleteInput() throws {
         let root = temporaryDirectory.appendingPathComponent("sessions", isDirectory: true)
         let first = root.appendingPathComponent("detach-codex-one", isDirectory: true)
         let second = root.appendingPathComponent("detach-codex-two", isDirectory: true)
         let third = root.appendingPathComponent("detach-claude-three", isDirectory: true)
         let checkpointDirectory = first.appendingPathComponent("checkpoint", isDirectory: true)
-        let invalid = first.appendingPathComponent("meta.json")
         let checkpoint = checkpointDirectory.appendingPathComponent("meta.json")
         try FileManager.default.createDirectory(
             at: checkpointDirectory, withIntermediateDirectories: true)
@@ -386,7 +607,6 @@ final class DetachStateCommandTests: XCTestCase {
             at: second, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(
             at: third, withIntermediateDirectories: true)
-        try Data("not-json".utf8).write(to: invalid)
         try Data(count: 1_048_577).write(to: second.appendingPathComponent("meta.json"))
         let project = "/tmp/project\twith\ncontrols"
         try JSONSerialization.data(withJSONObject: [
@@ -400,6 +620,8 @@ final class DetachStateCommandTests: XCTestCase {
             "session_name": "detach-claude-three",
             "project_dir": "/tmp/primary",
             "status": "running",
+            "preserve_recovery_until_ready": true,
+            "runtime_ready_at": "2026-09-04T12:00:00Z",
         ]).write(to: third.appendingPathComponent("meta.json"))
         try Data("ignored".utf8).write(to: root.appendingPathComponent("regular-file"))
 
@@ -409,18 +631,23 @@ final class DetachStateCommandTests: XCTestCase {
         let values = output.split(separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        let recordSize = 22
+        let recordSize = 25
         XCTAssertEqual(values.count, recordSize * 3 + 2)
         XCTAssertEqual(values[0], "detach-claude-three")
         XCTAssertEqual(values[1], "true")
         XCTAssertEqual(values[2], "running")
         XCTAssertEqual(values[4], "/tmp/primary")
+        XCTAssertEqual(values[22], "true")
+        XCTAssertEqual(values[23], "2026-09-04T12:00:00Z")
+        XCTAssertEqual(values[24], "primary")
         XCTAssertEqual(values[recordSize], "detach-codex-one")
         XCTAssertEqual(values[recordSize + 1], "true")
         XCTAssertEqual(values[recordSize + 2], "stopped")
         XCTAssertEqual(values[recordSize + 4], project)
+        XCTAssertEqual(values[recordSize + 24], "checkpoint")
         XCTAssertEqual(values[recordSize * 2], "detach-codex-two")
         XCTAssertEqual(values[recordSize * 2 + 1], "false")
+        XCTAssertEqual(values[recordSize * 2 + 24], "")
         XCTAssertTrue(values[(recordSize * 2 + 2)..<(recordSize * 3)].allSatisfy(\.isEmpty))
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
         let repeatedSeparatorRoot = root.path.replacingOccurrences(
@@ -465,8 +692,6 @@ final class DetachStateCommandTests: XCTestCase {
             "detach-codex-checkpoint", isDirectory: true)
         try FileManager.default.createDirectory(
             at: checkpointSession, withIntermediateDirectories: true)
-        try Data("not-json".utf8).write(
-            to: checkpointSession.appendingPathComponent("meta.json"))
         try FileManager.default.createSymbolicLink(
             at: checkpointSession.appendingPathComponent("checkpoint"),
             withDestinationURL: external)
@@ -550,6 +775,54 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testMetadataSnapshotsRejectMistypedOperationalFieldsWithoutFallback() throws {
+        let root = temporaryDirectory.appendingPathComponent(
+            "typed-sessions", isDirectory: true)
+        let session = root.appendingPathComponent(
+            "detach-codex-typed", isDirectory: true)
+        let checkpoint = session.appendingPathComponent(
+            "checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: checkpoint, withIntermediateDirectories: true)
+        let primary = session.appendingPathComponent("meta.json")
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1,
+            "session_name": "detach-codex-typed",
+            "project_dir": "/tmp/project",
+            "status": "running",
+        ]).write(to: checkpoint.appendingPathComponent("meta.json"))
+
+        let malformedValues: [(String, Any)] = [
+            ("preserve_recovery_until_ready", "false"),
+            ("runtime_ready_at", false),
+            ("runtime_shutdown_observed_at", 0),
+        ]
+        for (field, value) in malformedValues {
+            try JSONSerialization.data(withJSONObject: [
+                "schema": 1,
+                "session_name": "detach-codex-typed",
+                "project_dir": "/tmp/project",
+                "status": "starting",
+                field: value,
+            ]).write(to: primary)
+
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "meta", "snapshot", primary.path, "detach-codex-typed",
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .unusableMetadata)
+            }
+            let output = try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", root.path,
+            ])
+            let values = output.split(
+                separator: 0, omittingEmptySubsequences: false
+            ).dropLast().map { String(decoding: $0, as: UTF8.self) }
+            XCTAssertEqual(values[0], "detach-codex-typed")
+            XCTAssertEqual(values[1], "false")
+            XCTAssertEqual(values[24], "")
+        }
+    }
+
     func testMetaSnapshotsCanBatchBoundedTranscriptSummaries() throws {
         let root = temporaryDirectory.appendingPathComponent(
             "summary-sessions", isDirectory: true)
@@ -579,10 +852,11 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(values.count, 27 + 2)
+        XCTAssertEqual(values.count, 30 + 2)
         XCTAssertEqual(values[0], "detach-codex-summary")
         XCTAssertEqual(values[1], "true")
-        XCTAssertEqual(Array(values[22..<27]), [
+        XCTAssertEqual(values[24], "primary")
+        XCTAssertEqual(Array(values[25..<30]), [
             "gpt-batched", "", "", "working", "turn-batched",
         ])
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
@@ -601,7 +875,7 @@ final class DetachStateCommandTests: XCTestCase {
             separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        XCTAssertEqual(cachedValues[22], "cached-proof")
+        XCTAssertEqual(cachedValues[25], "cached-proof")
 
         try Data("""
         {"payload":{"model":"gpt-updated"}}
@@ -614,7 +888,7 @@ final class DetachStateCommandTests: XCTestCase {
             separator: 0, omittingEmptySubsequences: false)
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
-        XCTAssertEqual(changedValues[22], "gpt-updated")
+        XCTAssertEqual(changedValues[25], "gpt-updated")
 
         XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
             "meta", "snapshots", root.path, "--unknown",
@@ -651,9 +925,101 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(Array(values[22..<27]), [
+        XCTAssertEqual(values[24], "primary")
+        XCTAssertEqual(Array(values[25..<30]), [
             "claude-test", "10", "", "working", "turn-claude",
         ])
+
+        let askUserQuestion = Data("""
+
+        {"type":"assistant","isSidechain":false,"uuid":"ask-user","message":{"role":"assistant","model":"claude-test","stop_reason":"tool_use","content":[{"type":"tool_use","name":"AskUserQuestion","id":"tool-1"}]}}
+        """.utf8)
+        let transcriptHandle = try FileHandle(forWritingTo: transcript)
+        try transcriptHandle.seekToEnd()
+        try transcriptHandle.write(contentsOf: askUserQuestion)
+        try transcriptHandle.close()
+
+        let waitingOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let waitingValues = waitingOutput.split(
+            separator: 0, omittingEmptySubsequences: false
+        ).dropLast().map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(Array(waitingValues[28..<30]), ["waiting", "tool-1"])
+
+        let receipt = session.appendingPathComponent(
+            ".transcript-summary-cache.json")
+        var legacyReceipt = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: receipt))
+                as? [String: Any])
+        legacyReceipt["schema"] = 1
+        legacyReceipt["agentTurnState"] = NSNull()
+        legacyReceipt["agentTurnID"] = NSNull()
+        try JSONSerialization.data(withJSONObject: legacyReceipt).write(to: receipt)
+
+        let migratedOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let migratedValues = migratedOutput.split(
+            separator: 0, omittingEmptySubsequences: false
+        ).dropLast().map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(Array(migratedValues[28..<30]), ["waiting", "tool-1"])
+        let migratedReceipt = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: receipt))
+                as? [String: Any])
+        XCTAssertEqual(migratedReceipt["schema"] as? Int, 3)
+
+        let unrelatedToolResult = Data("""
+
+        {"type":"user","isSidechain":false,"isMeta":false,"uuid":"other-tool-result","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"other-tool"}]}}
+        """.utf8)
+        let unrelatedHandle = try FileHandle(forWritingTo: transcript)
+        try unrelatedHandle.seekToEnd()
+        try unrelatedHandle.write(contentsOf: unrelatedToolResult)
+        try unrelatedHandle.close()
+
+        let stillWaitingOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let stillWaitingValues = stillWaitingOutput.split(
+            separator: 0, omittingEmptySubsequences: false
+        ).dropLast().map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(
+            Array(stillWaitingValues[28..<30]), ["waiting", "tool-1"])
+
+        let plainUser = Data("""
+
+        {"type":"user","isSidechain":false,"isMeta":false,"uuid":"plain-user","message":{"role":"user","content":"not a matching tool result"}}
+        """.utf8)
+        let plainUserHandle = try FileHandle(forWritingTo: transcript)
+        try plainUserHandle.seekToEnd()
+        try plainUserHandle.write(contentsOf: plainUser)
+        try plainUserHandle.close()
+
+        let latchedOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let latchedValues = latchedOutput.split(
+            separator: 0, omittingEmptySubsequences: false
+        ).dropLast().map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(Array(latchedValues[28..<30]), ["waiting", "tool-1"])
+
+        let toolResult = Data("""
+
+        {"type":"user","isSidechain":false,"isMeta":false,"uuid":"answer-user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"First option"}]}}
+        """.utf8)
+        let answerHandle = try FileHandle(forWritingTo: transcript)
+        try answerHandle.seekToEnd()
+        try answerHandle.write(contentsOf: toolResult)
+        try answerHandle.close()
+
+        let workingOutput = try DetachStateCommand.run(arguments: [
+            "meta", "snapshots", root.path, "--with-transcript-summary",
+        ])
+        let workingValues = workingOutput.split(
+            separator: 0, omittingEmptySubsequences: false
+        ).dropLast().map { String(decoding: $0, as: UTF8.self) }
+        XCTAssertEqual(Array(workingValues[28..<30]), ["working", "answer-user"])
     }
 
     func testMetaSnapshotsFailClosedForNonFileTranscripts() throws {
@@ -678,8 +1044,9 @@ final class DetachStateCommandTests: XCTestCase {
             .dropLast()
             .map { String(decoding: $0, as: UTF8.self) }
 
-        XCTAssertEqual(values.count, 27 + 2)
-        XCTAssertEqual(Array(values[22..<27]), Array(repeating: "", count: 5))
+        XCTAssertEqual(values.count, 30 + 2)
+        XCTAssertEqual(values[24], "primary")
+        XCTAssertEqual(Array(values[25..<30]), Array(repeating: "", count: 5))
         XCTAssertEqual(Array(values.suffix(2)), ["", "true"])
     }
 
@@ -712,7 +1079,7 @@ final class DetachStateCommandTests: XCTestCase {
                 separator: 0, omittingEmptySubsequences: false)
                 .dropLast()
                 .map { String(decoding: $0, as: UTF8.self) }
-            return Array(values[25..<27])
+            return Array(values[28..<30])
         }
 
         XCTAssertEqual(try turnFields(), ["working", "turn-long"])
@@ -766,7 +1133,7 @@ final class DetachStateCommandTests: XCTestCase {
                 separator: 0, omittingEmptySubsequences: false)
                 .dropLast()
                 .map { String(decoding: $0, as: UTF8.self) }
-            return Array(values[25..<27])
+            return Array(values[28..<30])
         }
 
         XCTAssertEqual(try turnFields(), ["waiting", "turn-old"])
@@ -1292,6 +1659,13 @@ final class DetachStateCommandTests: XCTestCase {
         )) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidBoolean("yes"))
         }
+        for option in ["--uncommitted-replacement", "--runtime-quiescent"] {
+            XCTAssertThrowsError(try DetachStateCommand.run(
+                arguments: valid + [option, "yes"]
+            )) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .invalidBoolean("yes"))
+            }
+        }
     }
 
     func testHealthEvaluateEnvelopeCarriesStatusAndTypedJSONTogether() throws {
@@ -1317,6 +1691,67 @@ final class DetachStateCommandTests: XCTestCase {
             from: output[output.index(after: newline)...])
         XCTAssertEqual(assessment.effectiveStatus, .running)
         XCTAssertEqual(assessment.reason, .healthy)
+    }
+
+    func testHealthEvaluateRequiresQuiescenceForUncommittedRecovery() throws {
+        let pid = String(ProcessInfo.processInfo.processIdentifier)
+        let common = [
+            "health", "evaluate",
+            "--metadata-valid", "true",
+            "--runtime-identity-expected", "true",
+            "--meta-status", "failed",
+            "--run-token", "match",
+            "--heartbeat", "missing",
+            "--checkpoint", "fresh",
+            "--checkpoint-recoverable", "true",
+            "--agent-session-known", "true",
+            "--uncommitted-replacement", "true",
+            "--lifecycle-phase", "terminal",
+        ]
+        let unknownOutput = try DetachStateCommand.run(arguments: common + [
+            "--tmux", "missing",
+            "--worker", "dead",
+            "--provider-process", "dead",
+        ])
+        let unknown = try JSONDecoder().decode(
+            SessionHealthAssessment.self,
+            from: unknownOutput)
+        XCTAssertEqual(unknown.effectiveStatus, .hung)
+        XCTAssertEqual(unknown.reason, .runtimeQuiescenceUnproven)
+        XCTAssertTrue(unknown.actions.isEmpty)
+
+        let liveOutput = try DetachStateCommand.run(arguments: common + [
+            "--runtime-quiescent", "true",
+            "--tmux", "missing",
+            "--worker", "unknown",
+            "--provider-process", "unknown",
+            "--inspect-processes", "true",
+            "--worker-pid", pid,
+            "--provider-pid", "-",
+            "--pane-pid", "-",
+        ])
+        let live = try JSONDecoder().decode(
+            SessionHealthAssessment.self,
+            from: liveOutput)
+        XCTAssertEqual(live.effectiveStatus, .hung)
+        XCTAssertEqual(live.reason, .runtimeProcessWithoutTmux)
+        XCTAssertTrue(live.actions.isEmpty)
+        XCTAssertEqual(live.reconcileAction, .none)
+
+        let deadOutput = try DetachStateCommand.run(arguments: common + [
+            "--runtime-quiescent", "true",
+            "--tmux", "dead",
+            "--worker", "dead",
+            "--provider-process", "dead",
+        ])
+        let dead = try JSONDecoder().decode(
+            SessionHealthAssessment.self,
+            from: deadOutput)
+        XCTAssertEqual(dead.effectiveStatus, .recoverable)
+        XCTAssertEqual(dead.reason, .recoverableCheckpoint)
+        XCTAssertEqual(dead.actions, [.recover, .delete])
+        XCTAssertEqual(dead.reconcileAction, .removeDeadTmux)
+        XCTAssertFalse(dead.cleanupEligible)
     }
 
     func testHealthEvaluateKeepsExactStopTransitionStopped() throws {
@@ -1829,6 +2264,13 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertEqual(first, second)
         XCTAssertTrue(try XCTUnwrap(first.sessions.first).deletable)
         XCTAssertGreaterThan(first.allocatedBytes, 0)
+    }
+
+    private func directoryIdentifier(_ directory: URL) throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: directory.path)
+        return try XCTUnwrap(
+            attributes[.systemFileNumber] as? NSNumber).uint64Value
     }
 
     private func makeStorageSession(

--- a/app/Tests/DetachKitTests/DetachStateTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateTests.swift
@@ -23,6 +23,68 @@ final class DetachStateTests: XCTestCase {
             expectedSessionName: "detach-codex-project"))
     }
 
+    func testRecoveryHandoffMetadataFieldsKeepTheirJSONTypes() throws {
+        let base: [String: Any] = [
+            "schema": 1,
+            "session_name": "detach-codex-project",
+            "project_dir": "/tmp/project",
+        ]
+        let validFields: [[String: Any]] = [
+            [:],
+            [
+                "preserve_recovery_until_ready": NSNull(),
+                "runtime_ready_at": NSNull(),
+                "runtime_shutdown_observed_at": NSNull(),
+            ],
+            [
+                "preserve_recovery_until_ready": true,
+                "runtime_ready_at": "2026-09-04T12:00:00Z",
+                "runtime_shutdown_observed_at": "2026-09-04T13:00:00Z",
+            ],
+        ]
+        for fields in validFields {
+            let data = try JSONSerialization.data(
+                withJSONObject: base.merging(fields) { _, new in new })
+            XCTAssertTrue(SessionMetadataDocument.isUsable(
+                data, expectedSessionName: "detach-codex-project"))
+        }
+
+        let invalidFields: [(String, Any)] = [
+            ("preserve_recovery_until_ready", "false"),
+            ("preserve_recovery_until_ready", 0),
+            ("runtime_ready_at", false),
+            ("runtime_ready_at", ["timestamp"]),
+            ("runtime_shutdown_observed_at", 0),
+            ("runtime_shutdown_observed_at", ["value": "timestamp"]),
+        ]
+        for (field, value) in invalidFields {
+            let data = try JSONSerialization.data(
+                withJSONObject: base.merging([field: value]) { _, new in new })
+            XCTAssertFalse(SessionMetadataDocument.isUsable(
+                data, expectedSessionName: "detach-codex-project"))
+        }
+
+        XCTAssertThrowsError(try SessionMetadataDocument.create(changes: [
+            .init(
+                key: "preserve_recovery_until_ready",
+                value: .string("false")),
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidMetadata)
+        }
+        let corrupt = try JSONSerialization.data(withJSONObject: base.merging([
+            "runtime_ready_at": false,
+        ]) { _, new in new })
+        XCTAssertThrowsError(try SessionMetadataDocument.patch(
+            corrupt,
+            changes: [.init(key: "status", value: .string("running"))]
+        )) { error in
+            XCTAssertEqual(error as? DetachStateError, .invalidMetadata)
+        }
+        XCTAssertNoThrow(try SessionMetadataDocument.patch(
+            corrupt,
+            changes: [.init(key: "runtime_ready_at", value: .null)]))
+    }
+
     func testMetadataCreateRoundTripsEverySupportedScalar() throws {
         let data = try SessionMetadataDocument.create(changes: [
             .init(key: "text", value: .string("value")),
@@ -483,5 +545,49 @@ final class DetachStateTests: XCTestCase {
                 contextWindow: nil,
                 agentTurnState: .waiting,
                 agentTurnID: "real-user"))
+    }
+
+    func testClaudeSummaryTracksAskUserQuestionUntilItsMatchingResult() {
+        let contradictoryTail = Data("""
+        {"type":"user","uuid":"real-user","message":{"role":"user","content":"go"}}
+        {"type":"assistant","uuid":"missing-stop","message":{"role":"assistant","content":[{"type":"tool_use","name":"AskUserQuestion","id":"ask-without-stop"}]}}
+        {"type":"assistant","uuid":"wrong-stop","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"tool_use","name":"AskUserQuestion","id":"ask-after-end"}]}}
+        """.utf8)
+
+        XCTAssertEqual(
+            TranscriptDocument.summary(ofTail: contradictoryTail, provider: .claude),
+            TranscriptSummary(
+                contextUsed: 0,
+                agentTurnState: .working,
+                agentTurnID: "real-user"))
+
+        let waitingTail = Data("""
+        {"type":"user","uuid":"real-user","message":{"role":"user","content":"go"}}
+        {"type":"assistant","uuid":"ordinary-tool","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"bash-1"}]}}
+        {"type":"assistant","uuid":"sidechain-ask","isSidechain":true,"message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"AskUserQuestion","id":"sidechain-1"}]}}
+        {"type":"assistant","uuid":"malformed-ask","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"AskUserQuestion"}]}}
+        {"type":"assistant","uuid":"ask-record","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"AskUserQuestion","id":"ask-1"}]}}
+        {"type":"user","uuid":"unrelated-result","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"bash-1"}]}}
+        {"type":"user","uuid":"plain-user","message":{"role":"user","content":"this must not clear a pending tool result"}}
+        """.utf8)
+
+        XCTAssertEqual(
+            TranscriptDocument.summary(ofTail: waitingTail, provider: .claude),
+            TranscriptSummary(
+                contextUsed: 0,
+                agentTurnState: .waiting,
+                agentTurnID: "ask-1"))
+
+        var answeredTail = waitingTail
+        answeredTail.append(Data("""
+
+        {"type":"user","uuid":"answer-record","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"ask-1"}]}}
+        """.utf8))
+        XCTAssertEqual(
+            TranscriptDocument.summary(ofTail: answeredTail, provider: .claude),
+            TranscriptSummary(
+                contextUsed: 0,
+                agentTurnState: .working,
+                agentTurnID: "answer-record"))
     }
 }

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -173,6 +173,76 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertFalse(result.ownershipProven)
     }
 
+    func testTerminalFailureWithLiveRecordedProcessBlocksUncommittedRecovery() {
+        let result = evaluate(
+            status: .failed,
+            tmux: .missing,
+            worker: .alive,
+            provider: .dead,
+            recoverable: true,
+            uncommittedReplacement: true,
+            runtimeQuiescent: true,
+            lifecyclePhase: .terminal)
+
+        XCTAssertEqual(result.effectiveStatus, .hung)
+        XCTAssertEqual(result.reason, .runtimeProcessWithoutTmux)
+        XCTAssertTrue(result.actions.isEmpty)
+        XCTAssertEqual(result.reconcileAction, .none)
+        XCTAssertFalse(result.cleanupEligible)
+    }
+
+    func testQuiescentUncommittedReplacementUsesCheckpointWithoutStateRewrite() {
+        for (tmux, reconcile) in [
+            (TmuxHealthState.missing, SessionReconcileAction.none),
+            (.dead, .removeDeadTmux),
+        ] {
+            let result = evaluate(
+                status: .failed,
+                tmux: tmux,
+                worker: .dead,
+                provider: .dead,
+                recoverable: true,
+                uncommittedReplacement: true,
+                runtimeQuiescent: true,
+                lifecyclePhase: .terminal)
+
+            XCTAssertEqual(result.effectiveStatus, .recoverable, "tmux=\(tmux)")
+            XCTAssertEqual(result.reason, .recoverableCheckpoint, "tmux=\(tmux)")
+            XCTAssertEqual(result.actions, [.recover, .delete], "tmux=\(tmux)")
+            XCTAssertEqual(result.reconcileAction, reconcile, "tmux=\(tmux)")
+            XCTAssertFalse(result.cleanupEligible, "tmux=\(tmux)")
+        }
+    }
+
+    func testUncommittedReplacementSeparatesUnknownRuntimeFromInvalidCheckpoint() {
+        let unknown = evaluate(
+            status: .failed,
+            tmux: .missing,
+            worker: .dead,
+            provider: .dead,
+            recoverable: true,
+            uncommittedReplacement: true,
+            runtimeQuiescent: false,
+            lifecyclePhase: .terminal)
+        XCTAssertEqual(unknown.effectiveStatus, .hung)
+        XCTAssertEqual(unknown.reason, .runtimeQuiescenceUnproven)
+        XCTAssertTrue(unknown.actions.isEmpty)
+
+        let invalidCheckpoint = evaluate(
+            status: .failed,
+            tmux: .missing,
+            worker: .dead,
+            provider: .dead,
+            recoverable: false,
+            uncommittedReplacement: true,
+            runtimeQuiescent: true,
+            lifecyclePhase: .terminal)
+        XCTAssertEqual(invalidCheckpoint.effectiveStatus, .orphaned)
+        XCTAssertEqual(invalidCheckpoint.reason, .noRecoveryCheckpoint)
+        XCTAssertEqual(invalidCheckpoint.actions, [.delete])
+        XCTAssertEqual(invalidCheckpoint.reconcileAction, .markOrphaned)
+    }
+
     func testFinishingWorkerWithTerminalMetadataIsNotHung() {
         // After Ctrl+C the worker writes `interrupted`, publishes the hint,
         // and only then exits. The list that follows sees a live owned pane
@@ -235,6 +305,31 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertFalse(result.cleanupEligible)
     }
 
+    func testDeadTmuxRunTokenConflictCannotExposePreservedRecovery() {
+        for (token, reason) in [
+            (RunTokenHealthState.missing, SessionHealthReason.runTokenMissing),
+            (.mismatch, .runTokenMismatch),
+        ] {
+            let result = evaluate(
+                status: .failed,
+                tmux: .dead,
+                token: token,
+                worker: .dead,
+                provider: .dead,
+                recoverable: true,
+                uncommittedReplacement: true,
+                runtimeQuiescent: true,
+                lifecyclePhase: .terminal)
+
+            XCTAssertEqual(result.effectiveStatus, .corrupt, "token=\(token)")
+            XCTAssertEqual(result.reason, reason, "token=\(token)")
+            XCTAssertTrue(result.actions.isEmpty, "token=\(token)")
+            XCTAssertEqual(result.reconcileAction, .none, "token=\(token)")
+            XCTAssertFalse(result.ownershipProven, "token=\(token)")
+            XCTAssertFalse(result.cleanupEligible, "token=\(token)")
+        }
+    }
+
     func testMalformedMetadataNeverAuthorizesCleanupOfALivePane() {
         let result = evaluate(metadataValid: false)
 
@@ -244,20 +339,45 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertFalse(result.cleanupEligible)
     }
 
-    func testMalformedMetadataWithoutALivePaneOnlyOffersDelete() {
-        let result = evaluate(metadataValid: false, tmux: .missing)
+    func testMalformedMetadataWithoutALivePaneOffersNoMutation() {
+        let result = evaluate(
+            metadataValid: false,
+            tmux: .missing,
+            worker: .dead,
+            provider: .dead)
 
         XCTAssertEqual(result.effectiveStatus, .corrupt)
         XCTAssertEqual(result.reason, .malformedMetadata)
-        XCTAssertEqual(result.actions, [.delete])
+        XCTAssertTrue(result.actions.isEmpty)
         XCTAssertFalse(result.ownershipProven)
     }
 
-    func testMalformedMetadataWithADeadManagedPaneProvesOwnership() {
-        let result = evaluate(metadataValid: false, tmux: .dead)
+    func testMalformedMetadataWithADeadManagedPaneCannotAuthorizeMutation() {
+        let result = evaluate(
+            metadataValid: false,
+            tmux: .dead,
+            worker: .dead,
+            provider: .dead)
 
-        XCTAssertEqual(result.actions, [.delete])
-        XCTAssertTrue(result.ownershipProven)
+        XCTAssertTrue(result.actions.isEmpty)
+        XCTAssertFalse(result.ownershipProven)
+        XCTAssertFalse(result.cleanupEligible)
+    }
+
+    func testMalformedMetadataCannotAuthorizeActionsWhileARecordedRuntimeLives() {
+        for tmux in [TmuxHealthState.missing, .dead] {
+            let result = evaluate(
+                metadataValid: false,
+                tmux: tmux,
+                worker: .alive,
+                provider: .dead)
+
+            XCTAssertEqual(result.effectiveStatus, .hung, "tmux=\(tmux)")
+            XCTAssertEqual(result.reason, .runtimeProcessWithoutTmux, "tmux=\(tmux)")
+            XCTAssertTrue(result.actions.isEmpty, "tmux=\(tmux)")
+            XCTAssertEqual(result.reconcileAction, .none, "tmux=\(tmux)")
+            XCTAssertFalse(result.cleanupEligible, "tmux=\(tmux)")
+        }
     }
 
     func testMissingRunTokenIsCorruptButManagedPaneRemainsControllable() {
@@ -289,22 +409,30 @@ final class SessionHealthTests: XCTestCase {
     }
 
     func testStoppingPhaseStaysActionlessWhileRuntimeTeardownRemains() {
-        let inProgress: [(TmuxHealthState, ProcessHealthState)] = [
-            (.live, .dead),
-            (.dead, .alive),
-            (.missing, .alive),
-        ]
-        for (tmux, worker) in inProgress {
+        let managed = evaluate(
+            status: .stopped,
+            tmux: .live,
+            worker: .dead,
+            provider: .dead,
+            stopRequested: true,
+            lifecyclePhase: .stopping)
+        XCTAssertEqual(managed.effectiveStatus, .stopped)
+        XCTAssertEqual(managed.reason, .finished)
+        XCTAssertTrue(managed.actions.isEmpty)
+        XCTAssertEqual(managed.reconcileAction, .none)
+        XCTAssertFalse(managed.cleanupEligible)
+
+        for tmux in [TmuxHealthState.dead, .missing] {
             let result = evaluate(
                 status: .stopped,
                 tmux: tmux,
-                worker: worker,
+                worker: .alive,
                 provider: .dead,
                 stopRequested: true,
                 lifecyclePhase: .stopping)
 
-            XCTAssertEqual(result.effectiveStatus, .stopped, "tmux=\(tmux)")
-            XCTAssertEqual(result.reason, .finished, "tmux=\(tmux)")
+            XCTAssertEqual(result.effectiveStatus, .hung, "tmux=\(tmux)")
+            XCTAssertEqual(result.reason, .runtimeProcessWithoutTmux, "tmux=\(tmux)")
             XCTAssertTrue(result.actions.isEmpty, "tmux=\(tmux)")
             XCTAssertEqual(result.reconcileAction, .none, "tmux=\(tmux)")
             XCTAssertFalse(result.cleanupEligible, "tmux=\(tmux)")
@@ -623,6 +751,54 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertLessThanOrEqual(reads, 3, "cycle identities must stay cached")
     }
 
+    func testExactProcessProbeRequiresPositiveDeathEvidence() {
+        let owned = SessionProcessIdentity(parentPID: 1, userID: 501)
+        let foreign = SessionProcessIdentity(parentPID: 1, userID: 502)
+
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
+                pid: 20,
+                userID: 501,
+                existence: { _ in .missing },
+                identity: { _ in XCTFail("missing PID must not be inspected"); return nil }),
+            .dead)
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
+                pid: 20,
+                userID: 501,
+                existence: { _ in .exists },
+                identity: { _ in owned }),
+            .alive)
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
+                pid: 20,
+                userID: 501,
+                existence: { _ in .exists },
+                identity: { _ in foreign }),
+            .dead)
+
+        var confirmedExitReads = 0
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
+                pid: 20,
+                existence: { _ in
+                    confirmedExitReads += 1
+                    return confirmedExitReads == 1 ? .exists : .missing
+                },
+                identity: { _ in nil }),
+            .dead)
+        var unknownReads = 0
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
+                pid: 20,
+                existence: { _ in
+                    unknownReads += 1
+                    return unknownReads == 1 ? .exists : .unknown
+                },
+                identity: { _ in nil }),
+            .unknown)
+    }
+
     private func evaluate(
         metadataValid: Bool = true,
         runtimeIdentityExpected: Bool = true,
@@ -635,6 +811,8 @@ final class SessionHealthTests: XCTestCase {
         checkpoint: FreshnessState = .fresh,
         recoverable: Bool = true,
         agentSessionKnown: Bool = true,
+        uncommittedReplacement: Bool = false,
+        runtimeQuiescent: Bool = false,
         stopRequested: Bool = false,
         lifecyclePhase: RuntimeLifecyclePhase? = nil
     ) -> SessionHealthAssessment {
@@ -650,6 +828,8 @@ final class SessionHealthTests: XCTestCase {
             checkpointFreshness: checkpoint,
             checkpointRecoverable: recoverable,
             agentSessionKnown: agentSessionKnown,
+            uncommittedReplacement: uncommittedReplacement,
+            runtimeQuiescent: runtimeQuiescent,
             stopRequested: stopRequested,
             lifecyclePhase: lifecyclePhase))
     }

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -352,6 +352,12 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertFalse(result.ownershipProven)
     }
 
+    // Preserve the baseline test ID. The corrected contract now rejects the
+    // delete action that this regression test originally expected.
+    func testMalformedMetadataWithoutALivePaneOnlyOffersDelete() {
+        testMalformedMetadataWithoutALivePaneOffersNoMutation()
+    }
+
     func testMalformedMetadataWithADeadManagedPaneCannotAuthorizeMutation() {
         let result = evaluate(
             metadataValid: false,
@@ -362,6 +368,12 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertTrue(result.actions.isEmpty)
         XCTAssertFalse(result.ownershipProven)
         XCTAssertFalse(result.cleanupEligible)
+    }
+
+    // Preserve the baseline test ID. A dead pane no longer proves ownership;
+    // this anchor executes the replacement fail-closed assertion.
+    func testMalformedMetadataWithADeadManagedPaneProvesOwnership() {
+        testMalformedMetadataWithADeadManagedPaneCannotAuthorizeMutation()
     }
 
     func testMalformedMetadataCannotAuthorizeActionsWhileARecordedRuntimeLives() {
@@ -757,6 +769,18 @@ final class SessionHealthTests: XCTestCase {
 
         XCTAssertEqual(
             ExactProcessStateProbe.state(
+                pid: 1,
+                existence: { _ in XCTFail("invalid PID must not be inspected"); return .exists },
+                identity: { _ in XCTFail("invalid PID must not be inspected"); return nil }),
+            .unknown)
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
+                pid: 20,
+                existence: { _ in .unknown },
+                identity: { _ in XCTFail("unknown PID must not be inspected"); return nil }),
+            .unknown)
+        XCTAssertEqual(
+            ExactProcessStateProbe.state(
                 pid: 20,
                 userID: 501,
                 existence: { _ in .missing },
@@ -796,6 +820,19 @@ final class SessionHealthTests: XCTestCase {
                     return unknownReads == 1 ? .exists : .unknown
                 },
                 identity: { _ in nil }),
+            .unknown)
+
+        XCTAssertEqual(
+            ExactProcessStateProbe.classifyExistence(killResult: 0, errorNumber: 0),
+            .exists)
+        XCTAssertEqual(
+            ExactProcessStateProbe.classifyExistence(killResult: -1, errorNumber: ESRCH),
+            .missing)
+        XCTAssertEqual(
+            ExactProcessStateProbe.classifyExistence(killResult: -1, errorNumber: EPERM),
+            .exists)
+        XCTAssertEqual(
+            ExactProcessStateProbe.classifyExistence(killResult: -1, errorNumber: EINVAL),
             .unknown)
     }
 

--- a/app/Tests/DetachKitTests/SessionPresentationTests.swift
+++ b/app/Tests/DetachKitTests/SessionPresentationTests.swift
@@ -110,7 +110,7 @@ final class SessionPresentationTests: XCTestCase {
             .runTokenMissing, .runTokenMismatch, .workerPIDMissing, .workerProcessLost,
             .workerPIDMismatch, .providerPIDMissing, .providerProcessLost,
             .providerPIDNotDescendant, .runtimeProcessWithoutTmux,
-            .recoverableCheckpoint, .noRecoveryCheckpoint,
+            .runtimeQuiescenceUnproven, .recoverableCheckpoint, .noRecoveryCheckpoint,
         ]
 
         for reason in reasons {
@@ -123,6 +123,15 @@ final class SessionPresentationTests: XCTestCase {
             }
         }
         XCTAssertNil(make(.running).healthReasonLabel)
+    }
+
+    func testUnprovenRuntimeQuiescenceHasAnAccurateDiagnosticLabel() {
+        var session = make(.hung)
+        session.healthReason = .runtimeQuiescenceUnproven
+
+        XCTAssertEqual(
+            session.healthReasonLabel,
+            L10n.string("Detach could not confirm that the replacement runtime stopped."))
     }
 
     func testContextUsageHandlesMissingInvalidAndSaturatedWindows() {

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -648,22 +648,133 @@ session_meta() {
   printf '%s/meta.json\n' "$(session_dir "$1")"
 }
 
+session_file_is_safe_or_absent() {
+  local path="$1"
+  local parent
+
+  parent="$(dirname "$path")"
+  [ -d "$parent" ] && [ ! -L "$parent" ] && \
+    [ "$(stat -f '%u' "$parent" 2>/dev/null)" = "$UID" ] || return 1
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    safe_owned_plain_file "$path"
+  fi
+}
+
+replace_session_file_with_empty() {
+  local path="$1"
+  local parent
+  local tmp
+
+  session_file_is_safe_or_absent "$path" || return 1
+  parent="$(dirname "$path")"
+  tmp="$(/usr/bin/mktemp "$parent/.detach-session-file.XXXXXX")" || return 1
+  : >"$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  safe_owned_plain_file "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$path"
+}
+
+replace_session_file_with_line() {
+  local path="$1"
+  local value="$2"
+  local parent
+  local tmp
+
+  session_file_is_safe_or_absent "$path" || return 1
+  parent="$(dirname "$path")"
+  tmp="$(/usr/bin/mktemp "$parent/.detach-session-file.XXXXXX")" || return 1
+  printf '%s\n' "$value" >"$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  safe_owned_plain_file "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$path"
+}
+
 usable_meta_path() {
   local session="$1"
   local primary
   local checkpoint
-  local candidate
 
   primary="$(session_meta "$session")"
   checkpoint="$(session_dir "$session")/checkpoint/meta.json"
-  for candidate in "$primary" "$checkpoint"; do
-    [ -f "$candidate" ] || continue
-    if "$STATE_BIN" meta usable "$candidate" "$session" >/dev/null 2>&1; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done
-  return 1
+
+  if [ -e "$primary" ] || [ -L "$primary" ]; then
+    [ -f "$primary" ] && [ ! -L "$primary" ] || return 1
+    "$STATE_BIN" meta snapshot "$primary" "$session" >/dev/null 2>&1 || \
+      return 1
+    printf '%s\n' "$primary"
+    return 0
+  fi
+  [ -e "$checkpoint" ] || [ -L "$checkpoint" ] || return 1
+  [ -f "$checkpoint" ] && [ ! -L "$checkpoint" ] || return 1
+  "$STATE_BIN" meta snapshot "$checkpoint" "$session" >/dev/null 2>&1 || \
+    return 1
+  printf '%s\n' "$checkpoint"
+  return 0
+}
+
+uncommitted_recovery_meta_path() {
+  local session="$1"
+  local primary
+  local checkpoint
+  local preserve_until_ready
+  local runtime_ready_at
+
+  primary="$(session_meta "$session")"
+  checkpoint="$(session_dir "$session")/checkpoint/meta.json"
+  [ -f "$primary" ] && [ ! -L "$primary" ] && \
+    "$STATE_BIN" meta usable "$primary" "$session" >/dev/null 2>&1 || return 1
+  load_meta_snapshot_path "$primary" "$session" || return 2
+  preserve_until_ready="$META_PRESERVE_RECOVERY_UNTIL_READY"
+  runtime_ready_at="$META_RUNTIME_READY_AT"
+  [ "$preserve_until_ready" = "true" ] && [ -z "$runtime_ready_at" ] || return 1
+  [ -f "$checkpoint" ] && [ ! -L "$checkpoint" ] && \
+    "$STATE_BIN" meta snapshot "$checkpoint" "$session" \
+      >/dev/null 2>&1 || return 2
+  printf '%s\n' "$checkpoint"
+}
+
+SELECTED_RECOVERY_META=""
+SELECTED_RECOVERY_IS_UNCOMMITTED=0
+
+select_recovery_meta_for_mutation() {
+  local session="$1"
+  local allow_missing="${2:-0}"
+  local selection_status=0
+  local selected=""
+  local primary
+  local checkpoint
+
+  SELECTED_RECOVERY_META=""
+  SELECTED_RECOVERY_IS_UNCOMMITTED=0
+  selected="$(uncommitted_recovery_meta_path "$session" 2>/dev/null)" || \
+    selection_status=$?
+  case "$selection_status" in
+    0) SELECTED_RECOVERY_IS_UNCOMMITTED=1 ;;
+    1)
+      if ! selected="$(usable_meta_path "$session" 2>/dev/null)"; then
+        primary="$(session_meta "$session")"
+        checkpoint="$(session_dir "$session")/checkpoint/meta.json"
+        if [ "$allow_missing" = "1" ] && \
+           [ ! -e "$primary" ] && [ ! -L "$primary" ] && \
+           [ ! -e "$checkpoint" ] && [ ! -L "$checkpoint" ]; then
+          return 0
+        fi
+        return 1
+      fi
+      ;;
+    *) return 1 ;;
+  esac
+  SELECTED_RECOVERY_META="$selected"
 }
 
 reset_meta_snapshot() {
@@ -689,6 +800,8 @@ reset_meta_snapshot() {
   META_HEALTH_SCHEMA=""
   META_STOP_REQUESTED_AT=""
   META_LIFECYCLE_PHASE=""
+  META_PRESERVE_RECOVERY_UNTIL_READY=""
+  META_RUNTIME_READY_AT=""
   TRANSCRIPT_MODEL=""
   TRANSCRIPT_CTX_USED=""
   TRANSCRIPT_CTX_WINDOW=""
@@ -725,6 +838,8 @@ load_meta_snapshot_path() {
       health_schema) META_HEALTH_SCHEMA="$value" ;;
       stop_requested_at) META_STOP_REQUESTED_AT="$value" ;;
       lifecycle_phase) META_LIFECYCLE_PHASE="$value" ;;
+      preserve_recovery_until_ready) META_PRESERVE_RECOVERY_UNTIL_READY="$value" ;;
+      runtime_ready_at) META_RUNTIME_READY_AT="$value" ;;
       snapshot_complete) [ "$value" = true ] && META_SNAPSHOT_COMPLETE=1 ;;
       *) return 1 ;;
     esac
@@ -740,10 +855,19 @@ load_usable_meta_snapshot() {
 
   primary="$(session_meta "$session")"
   checkpoint="$(session_dir "$session")/checkpoint/meta.json"
-  if [ -f "$primary" ] && load_meta_snapshot_path "$primary" "$session"; then
-    return 0
+  if [ -e "$primary" ] || [ -L "$primary" ]; then
+    [ -f "$primary" ] && [ ! -L "$primary" ] || {
+      reset_meta_snapshot
+      return 1
+    }
+    if load_meta_snapshot_path "$primary" "$session"; then
+      return 0
+    fi
+    reset_meta_snapshot
+    return 1
   fi
-  if [ -f "$checkpoint" ] && load_meta_snapshot_path "$checkpoint" "$session"; then
+  if [ -f "$checkpoint" ] && [ ! -L "$checkpoint" ] && \
+     load_meta_snapshot_path "$checkpoint" "$session"; then
     return 0
   fi
   reset_meta_snapshot
@@ -1899,6 +2023,487 @@ state_update_meta_for_run() {
   state_update_meta "$session" --run-token "$run_token" "$@"
 }
 
+metadata_snapshots_have_same_recovery_binding() {
+  local session="$1"
+  local left="$2"
+  local right="$3"
+  local left_value
+  local right_value
+
+  if [ ! -e "$left" ] && [ ! -L "$left" ]; then
+    return 1
+  fi
+  [ -f "$left" ] && [ ! -L "$left" ] && \
+    left_value="$(
+      "$STATE_BIN" meta recovery-binding "$left" "$session" 2>/dev/null
+    )" || return 2
+  [ -f "$right" ] && [ ! -L "$right" ] && \
+    right_value="$(
+      "$STATE_BIN" meta recovery-binding "$right" "$session" 2>/dev/null
+    )" || return 2
+  [ "$left_value" = "$right_value" ]
+}
+
+strict_checkpoint_recovery_generation_is_valid() {
+  local session="$1"
+  local meta="$2"
+  local checkpoint_dir
+  local id
+  local transcript
+  local backup
+  local db
+  local id_sql
+  local stored_provider
+  local inferred_id=0
+  local source
+
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ "$meta" = "$checkpoint_dir/meta.json" ] || return 1
+  owned_plain_checkpoint_directory "$checkpoint_dir" || return 1
+  [ -f "$meta" ] && [ ! -L "$meta" ] && \
+    "$STATE_BIN" meta snapshot "$meta" "$session" >/dev/null 2>&1 || \
+      return 1
+  saved_resume_args_path "$session" "$meta" >/dev/null || return 1
+  recovery_request_is_valid "$session" "$meta" direct || return 1
+  id="$(
+    "$STATE_BIN" meta get "$meta" agent_session_id codex_session_id \
+      2>/dev/null
+  )" || return 1
+  transcript="$(
+    "$STATE_BIN" meta get "$meta" transcript_path rollout_path 2>/dev/null
+  )" || return 1
+  stored_provider="$(
+    "$STATE_BIN" meta get "$meta" provider 2>/dev/null
+  )" || return 1
+  case "$PROVIDER:$stored_provider" in
+    codex:|codex:codex|claude:claude) ;;
+    *) return 1 ;;
+  esac
+  if [ -z "$id" ] || [ "$id" = "-" ]; then
+    inferred_id=1
+    if [ "$PROVIDER" = "claude" ]; then
+      backup="$checkpoint_dir/transcript.jsonl"
+      safe_owned_plain_file "$backup" || return 1
+      id="$(
+        "$STATE_BIN" jsonl first "$backup" sessionId 2>/dev/null
+      )" || return 1
+      if [ -z "$transcript" ]; then
+        transcript="$(claude_transcript_for_id "$id" 2>/dev/null)" || return 1
+      fi
+    else
+      backup="$checkpoint_dir/rollout.jsonl"
+      safe_owned_plain_file "$backup" || return 1
+      id="$(
+        "$STATE_BIN" jsonl first \
+          "$backup" payload.id payload.session_id 2>/dev/null
+      )" || return 1
+      if [ -z "$transcript" ]; then
+        db="$(codex_state_db)"
+        [ -n "$db" ] && [ -f "$db" ] || return 1
+        id_sql="$(sql_escape "$id")"
+        transcript="$($SQLITE_BIN -noheader -cmd '.timeout 5000' "$db" \
+          "SELECT rollout_path FROM threads WHERE id = '$id_sql' LIMIT 1;" \
+          2>/dev/null)" || return 1
+      fi
+    fi
+  fi
+  [ -n "$id" ] && [ "$id" != "-" ] || return 1
+  if [ "$inferred_id" -eq 0 ]; then
+    "$STATE_BIN" meta matches "$meta" "$PROVIDER" "$id" \
+      >/dev/null 2>&1 || return 1
+  fi
+
+  if [ "$PROVIDER" = "codex" ]; then
+    [ -n "$transcript" ] && \
+      safe_codex_rollout_path "$transcript" || return 1
+    safe_owned_plain_file "$checkpoint_dir/rollout.jsonl" && \
+      valid_jsonl "$checkpoint_dir/rollout.jsonl" "$id"
+    return
+  fi
+  [ "$PROVIDER" = "claude" ] || return 1
+  if [ -z "$transcript" ]; then
+    for source in \
+      "$checkpoint_dir/claude-session.tar" \
+      "$checkpoint_dir/transcript.jsonl" \
+      "$checkpoint_dir/claude-session" \
+      "$checkpoint_dir/claude-file-history" \
+      "$checkpoint_dir/claude-session-env"; do
+      [ ! -e "$source" ] && [ ! -L "$source" ] || return 1
+    done
+    claude_metadata_only_recovery_source_is_valid \
+      "$session" "$meta" "$id"
+    return
+  fi
+  if [ ! -e "$checkpoint_dir/claude-session.tar" ] && \
+     [ ! -L "$checkpoint_dir/claude-session.tar" ] && \
+     [ ! -e "$checkpoint_dir/transcript.jsonl" ] && \
+     [ ! -L "$checkpoint_dir/transcript.jsonl" ]; then
+    return 1
+  fi
+  claude_recovery_payload_is_valid "$session" "$id" "$transcript"
+}
+
+selected_live_payload_matches_checkpoint() {
+  local session="$1"
+  local id="$2"
+  local transcript="$3"
+  local checkpoint_dir
+  local backup
+
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  if [ "$PROVIDER" = "codex" ]; then
+    backup="$checkpoint_dir/rollout.jsonl"
+    safe_codex_rollout_path "$transcript" && \
+      valid_jsonl "$transcript" "$id" && \
+      safe_owned_plain_file "$backup" && \
+      cmp -s "$transcript" "$backup"
+    return
+  fi
+  [ "$PROVIDER" = "claude" ] || return 1
+  if [ -z "$transcript" ]; then
+    claude_metadata_only_recovery_source_is_valid \
+      "$session" "$(session_meta "$session")" "$id"
+    return
+  fi
+  # The transcript is only one part of a Claude recovery bundle. Defer this
+  # comparison until the complete live bundle has been staged.
+  return 1
+}
+
+plain_directory_trees_match() {
+  local left="$1"
+  local right="$2"
+  local entry
+  local relative
+  local peer
+  local left_mode
+  local right_mode
+
+  safe_plain_directory_tree "$left" && \
+    safe_plain_directory_tree "$right" || return 1
+  while IFS= read -r -d '' entry; do
+    relative="${entry#"$left"/}"
+    peer="$right/$relative"
+    if [ -d "$entry" ] && [ ! -L "$entry" ]; then
+      [ -d "$peer" ] && [ ! -L "$peer" ] || return 1
+    elif safe_plain_file "$entry"; then
+      safe_plain_file "$peer" && cmp -s "$entry" "$peer" || return 1
+    else
+      return 1
+    fi
+    left_mode="$(stat -f '%HT:%Lp' "$entry" 2>/dev/null)" || return 1
+    right_mode="$(stat -f '%HT:%Lp' "$peer" 2>/dev/null)" || return 1
+    [ "$left_mode" = "$right_mode" ] || return 1
+  done < <(find "$left" -mindepth 1 -print0 2>/dev/null)
+  while IFS= read -r -d '' entry; do
+    relative="${entry#"$right"/}"
+    peer="$left/$relative"
+    [ -e "$peer" ] && [ ! -L "$peer" ] || return 1
+  done < <(find "$right" -mindepth 1 -print0 2>/dev/null)
+}
+
+claude_checkpoint_archives_have_same_payload() (
+  local left="$1"
+  local right="$2"
+  local id="$3"
+  local comparison_root
+  local cleanup_command
+  local left_tree
+  local right_tree
+
+  valid_claude_checkpoint_archive "$left" "$id" && \
+    valid_claude_checkpoint_archive "$right" "$id" || exit 1
+  comparison_root="$(/usr/bin/mktemp -d \
+    "${TMPDIR:-/tmp}/detach-claude-comparison.XXXXXX")" || exit 1
+  printf -v cleanup_command 'rm -rf -- %q' "$comparison_root"
+  trap "$cleanup_command" EXIT
+  left_tree="$comparison_root/left"
+  right_tree="$comparison_root/right"
+  mkdir -m 0700 "$left_tree" "$right_tree" || exit 1
+  "$TAR_BIN" -xf "$left" -C "$left_tree" >/dev/null 2>&1 || exit 1
+  "$TAR_BIN" -xf "$right" -C "$right_tree" >/dev/null 2>&1 || exit 1
+  plain_directory_trees_match "$left_tree" "$right_tree"
+)
+
+materialize_selected_recovery_checkpoint() (
+  local session="$1"
+  local source_meta="$2"
+  local stage_token="$3"
+  local session_path
+  local checkpoint_dir
+  local checkpoint_meta
+  local checkpoint_id
+  local comparison_status=0
+  local source_binding
+  local current_binding
+  local id
+  local transcript
+  local backup
+  local db
+  local id_sql
+  local resolved_transcript
+  local restore_transcript
+  local resolved_status=0
+  local metadata_only=0
+  local stage_name
+  local stage
+  local stage_meta
+  local stage_cleanup_armed=0
+  local rollback_status=0
+  local source
+  local -a stage_binding_patch=()
+
+  session_path="$(session_dir "$session")"
+  checkpoint_dir="$session_path/checkpoint"
+  checkpoint_meta="$checkpoint_dir/meta.json"
+  [ -f "$source_meta" ] && [ ! -L "$source_meta" ] && \
+    "$STATE_BIN" meta snapshot "$source_meta" "$session" \
+      >/dev/null 2>&1 || return 1
+  owned_plain_checkpoint_directory "$checkpoint_dir" || return 1
+  saved_resume_args_path "$session" "$source_meta" >/dev/null || return 1
+  recovery_request_is_valid "$session" "$source_meta" direct || return 1
+
+  if metadata_snapshots_have_same_recovery_binding \
+       "$session" "$checkpoint_meta" "$source_meta"; then
+    if strict_checkpoint_recovery_generation_is_valid \
+         "$session" "$checkpoint_meta"; then
+      checkpoint_id="$(
+        "$STATE_BIN" meta get \
+          "$checkpoint_meta" agent_session_id codex_session_id 2>/dev/null
+      )" || return 1
+      if [ -n "$checkpoint_id" ] && [ "$checkpoint_id" != "-" ]; then
+        if [ "$source_meta" = "$checkpoint_meta" ] || \
+           selected_live_payload_matches_checkpoint \
+             "$session" "$checkpoint_id" "$(
+               "$STATE_BIN" meta get \
+                 "$source_meta" transcript_path rollout_path 2>/dev/null
+             )"; then
+          return 0
+        fi
+      fi
+    fi
+  else
+    comparison_status=$?
+    [ "$comparison_status" -eq 1 ] || return 1
+  fi
+
+  source_binding="$(
+    "$STATE_BIN" meta recovery-binding "$source_meta" "$session" 2>/dev/null
+  )" || return 1
+  id="$(
+    "$STATE_BIN" meta get "$source_meta" agent_session_id codex_session_id \
+      2>/dev/null
+  )" || return 1
+  transcript="$(
+    "$STATE_BIN" meta get "$source_meta" transcript_path rollout_path \
+      2>/dev/null
+  )" || return 1
+  if [ -z "$id" ] || [ "$id" = "-" ]; then
+    if [ "$PROVIDER" = "claude" ]; then
+      backup="$checkpoint_dir/transcript.jsonl"
+      [ -f "$backup" ] && [ ! -L "$backup" ] || return 1
+      id="$(
+        "$STATE_BIN" jsonl first "$backup" sessionId 2>/dev/null
+      )" || return 1
+    elif [ "$PROVIDER" = "codex" ]; then
+      backup="$checkpoint_dir/rollout.jsonl"
+      [ -f "$backup" ] && [ ! -L "$backup" ] || return 1
+      id="$(
+        "$STATE_BIN" jsonl first \
+          "$backup" payload.id payload.session_id 2>/dev/null
+      )" || return 1
+      db="$(codex_state_db)"
+      [ -n "$db" ] && [ -f "$db" ] || return 1
+      id_sql="$(sql_escape "$id")"
+      transcript="$($SQLITE_BIN -noheader -cmd '.timeout 5000' "$db" \
+        "SELECT rollout_path FROM threads WHERE id = '$id_sql' LIMIT 1;" \
+        2>/dev/null)" || return 1
+    fi
+  fi
+  [ -n "$id" ] && [ "$id" != "-" ] || return 1
+
+  if [ "$PROVIDER" = "claude" ] && [ -z "$transcript" ]; then
+    resolved_transcript="$(claude_transcript_for_id "$id" 2>/dev/null)" || \
+      resolved_status=$?
+    case "$resolved_status" in
+      0) transcript="$resolved_transcript" ;;
+      1)
+        claude_metadata_only_recovery_source_is_valid \
+          "$session" "$source_meta" "$id" || return 1
+        metadata_only=1
+        ;;
+      *) return 1 ;;
+    esac
+  fi
+
+  scavenge_checkpoint_stages "$session" "$session_path" || return 1
+  stage_name=".checkpoint-stage-preserve-$stage_token-$$"
+  checkpoint_stage_name_is_safe "$stage_name" || return 1
+  stage="$session_path/$stage_name"
+  [ ! -e "$stage" ] && [ ! -L "$stage" ] || return 1
+  mkdir -m 0700 "$stage" || return 1
+  stage_cleanup_armed=1
+  trap checkpoint_stage_cleanup_on_exit EXIT
+  trap 'exit 1' HUP INT TERM
+
+  if [ "$PROVIDER" = "codex" ]; then
+    [ -n "$transcript" ] && \
+      checkpoint_rollout "$session" "$transcript" "$id" "$stage" || \
+        return 1
+  elif [ "$PROVIDER" = "claude" ]; then
+    if [ "$metadata_only" -eq 0 ]; then
+      checkpoint_claude_artifacts \
+        "$session" "$transcript" "$id" "$stage" || return 1
+    fi
+  else
+    return 1
+  fi
+
+  stage_meta="$stage/meta.json"
+  cp -p "$source_meta" "$stage_meta" || return 1
+  stage_binding_patch=( --string agent_session_id "$id" )
+  if [ -n "$transcript" ]; then
+    stage_binding_patch+=( --string transcript_path "$transcript" )
+  else
+    stage_binding_patch+=( --null transcript_path )
+  fi
+  if [ "$PROVIDER" = "codex" ]; then
+    stage_binding_patch+=(
+      --string codex_session_id "$id"
+      --string rollout_path "$transcript"
+    )
+  fi
+  "$STATE_BIN" meta patch "$stage_meta" \
+    "${stage_binding_patch[@]}" || return 1
+  if [ -e "$stage/.meta-patch.lock" ] || [ -L "$stage/.meta-patch.lock" ]; then
+    [ -f "$stage/.meta-patch.lock" ] && [ ! -L "$stage/.meta-patch.lock" ] && \
+      rm -f -- "$stage/.meta-patch.lock" || return 1
+  fi
+  "$STATE_BIN" meta snapshot "$stage_meta" "$session" >/dev/null 2>&1 || \
+    return 1
+  "$STATE_BIN" meta matches "$stage_meta" "$PROVIDER" "$id" \
+    >/dev/null 2>&1 || return 1
+  [ "$("$STATE_BIN" meta get "$stage_meta" transcript_path rollout_path \
+      2>/dev/null)" = "$transcript" ] || return 1
+  saved_resume_args_path "$session" "$stage_meta" >/dev/null || return 1
+  if [ "$PROVIDER" = "codex" ]; then
+    safe_owned_plain_file "$stage/rollout.jsonl" && \
+      valid_jsonl_cached "$stage/rollout.jsonl" "$id" || return 1
+  elif [ "$metadata_only" -eq 0 ]; then
+    restore_transcript="$(
+      canonical_claude_transcript_path "$transcript" "$id"
+    )" || return 1
+    valid_claude_checkpoint_archive "$stage/claude-session.tar" "$id" && \
+      preflight_claude_archive_restore \
+        "$stage/claude-session.tar" "$id" "$restore_transcript" \
+        "$(canonical_claude_home)" || return 1
+  else
+    for source in \
+      "$stage/claude-session.tar" \
+      "$stage/transcript.jsonl" \
+      "$stage/claude-session" \
+      "$stage/claude-file-history" \
+      "$stage/claude-session-env"; do
+      [ ! -e "$source" ] && [ ! -L "$source" ] || return 1
+    done
+  fi
+
+  current_binding="$(
+    "$STATE_BIN" meta recovery-binding "$source_meta" "$session" 2>/dev/null
+  )" || return 1
+  [ "$current_binding" = "$source_binding" ] || return 1
+  saved_resume_args_path "$session" "$source_meta" >/dev/null || return 1
+  recovery_request_is_valid "$session" "$source_meta" direct || return 1
+
+  # A transcript-bound Claude session can reuse canonical A only when its
+  # complete provider bundle is unchanged. Comparing the validated staged
+  # trees catches project, history, environment, task, and team changes that
+  # do not append a transcript record.
+  if [ "$PROVIDER" = "claude" ] && [ "$metadata_only" -eq 0 ]; then
+    if metadata_snapshots_have_same_recovery_binding \
+         "$session" "$checkpoint_meta" "$source_meta"; then
+      if strict_checkpoint_recovery_generation_is_valid \
+           "$session" "$checkpoint_meta" && \
+         [ -f "$checkpoint_dir/claude-session.tar" ] && \
+         [ ! -L "$checkpoint_dir/claude-session.tar" ] && \
+         claude_checkpoint_archives_have_same_payload \
+           "$checkpoint_dir/claude-session.tar" \
+           "$stage/claude-session.tar" "$id"; then
+        return 0
+      fi
+    else
+      comparison_status=$?
+      [ "$comparison_status" -eq 1 ] || return 1
+    fi
+  fi
+
+  # Once exchange starts, either directory name can hold the previous durable
+  # generation. The EXIT trap must not guess which one is disposable.
+  stage_cleanup_armed=0
+  "$STATE_BIN" checkpoint exchange "$session_path" "$stage_name" || return 1
+  checkpoint_test_barrier \
+    "${DETACH_TEST_CHECKPOINT_POSTEXCHANGE_READY:-}" \
+    "${DETACH_TEST_CHECKPOINT_POSTEXCHANGE_RELEASE:-}" || return 1
+  if [ "$SYNC_ENABLED" != "0" ] && ! checkpoint_publish_sync; then
+    restore_checkpoint_after_failed_publish_sync \
+      "$session_path" "$stage_name" || rollback_status=$?
+    if [ "$rollback_status" -eq 0 ]; then
+      remove_checkpoint_stage "$session_path" "$stage" && \
+        /bin/sync 2>/dev/null || true
+    fi
+    return 1
+  fi
+  remove_checkpoint_stage "$session_path" "$stage" || return 1
+  [ "$SYNC_ENABLED" = "0" ] || /bin/sync
+)
+
+reset_checkpoint_generation() (
+  local session="$1"
+  local stage_token="$2"
+  local session_path
+  local stage_name
+  local stage
+  local reset_marker_name=.detach-checkpoint-reset
+  local stage_cleanup_armed=0
+  local rollback_status=0
+
+  session_path="$(session_dir "$session")"
+  owned_plain_checkpoint_directory "$session_path/checkpoint" || return 1
+  scavenge_checkpoint_stages "$session" "$session_path" || return 1
+  stage_name=".checkpoint-stage-reset-$stage_token-$$"
+  checkpoint_stage_name_is_safe "$stage_name" || return 1
+  stage="$session_path/$stage_name"
+  [ ! -e "$stage" ] && [ ! -L "$stage" ] || return 1
+  mkdir -m 0700 "$stage" || return 1
+  printf '%s\n' "$stage_name" >"$stage/$reset_marker_name" || return 1
+  safe_owned_plain_file "$stage/$reset_marker_name" || return 1
+  stage_cleanup_armed=1
+  trap checkpoint_stage_cleanup_on_exit EXIT
+  trap 'exit 1' HUP INT TERM
+
+  # From this point onward, retain both names on interruption or uncertainty.
+  stage_cleanup_armed=0
+  "$STATE_BIN" checkpoint exchange "$session_path" "$stage_name" || return 1
+  checkpoint_test_barrier \
+    "${DETACH_TEST_CHECKPOINT_POSTEXCHANGE_READY:-}" \
+    "${DETACH_TEST_CHECKPOINT_POSTEXCHANGE_RELEASE:-}" || return 1
+  if [ "$SYNC_ENABLED" != "0" ] && ! checkpoint_publish_sync; then
+    restore_checkpoint_after_failed_publish_sync \
+      "$session_path" "$stage_name" || rollback_status=$?
+    if [ "$rollback_status" -eq 0 ]; then
+      remove_checkpoint_stage "$session_path" "$stage" && \
+        /bin/sync 2>/dev/null || true
+    fi
+    return 1
+  fi
+  remove_checkpoint_stage "$session_path" "$stage" || return 1
+  [ ! -e "$stage" ] && [ ! -L "$stage" ] || return 1
+  [ "$SYNC_ENABLED" = "0" ] || /bin/sync || return 1
+  remove_checkpoint_reset_marker \
+    "$session_path/checkpoint" "$stage_name" || return 1
+  [ "$SYNC_ENABLED" = "0" ] || /bin/sync
+)
+
 write_initial_meta() {
   local session="$1"
   local cwd="$2"
@@ -1917,33 +2522,56 @@ write_initial_meta() {
   local lifecycle_id
   local create_args
   local default_base
+  local previous_meta
+  local preserve_until_ready=false
+  local stale_resume_args
 
   dir="$(session_dir "$session")"
   meta="$dir/meta.json"
-  tmp="$meta.tmp.$$"
-  mkdir -p "$dir/checkpoint"
-  if [ "$preserve_checkpoint" != "1" ]; then
-    rm -f \
-      "$dir/checkpoint/meta.json" \
-      "$dir/checkpoint/rollout.jsonl" \
-      "$dir/checkpoint/transcript.jsonl" \
-      "$dir/checkpoint/.detach-jsonl-validation.json" \
-      "$dir/checkpoint/claude-session.tar" \
-      "$dir/checkpoint/codex-state.sqlite" \
-      "$dir/checkpoint/pane.txt" \
-      "$dir/checkpoint/pane-ansi.txt" \
-      "$dir/checkpoint/worktree-status.txt" \
-      "$dir/exit-status"
-    rm -rf \
-      "$dir/checkpoint/claude-session" \
-      "$dir/checkpoint/claude-file-history" \
-      "$dir/checkpoint/claude-session-env"
-    : >"$dir/checkpoint.log"
+  ensure_owned_checkpoint_directory "$dir" || return 1
+  lifecycle_id="$(new_run_token)" || return 1
+  tmp="$dir/.meta-$lifecycle_id.tmp"
+  session_file_is_safe_or_absent "$meta" || return 1
+  [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || return 1
+  session_file_is_safe_or_absent "$dir/checkpoint.log" || return 1
+  session_file_is_safe_or_absent "$dir/known-thread-ids.txt" || return 1
+  session_file_is_safe_or_absent "$dir/exit-status" || return 1
+  if [ "$preserve_checkpoint" = "1" ]; then
+    preserve_until_ready=true
+    select_recovery_meta_for_mutation "$session" 1 || return 1
+    previous_meta="$SELECTED_RECOVERY_META"
+    if [ -n "$previous_meta" ]; then
+      # A selected generation includes its saved provider options. Validate
+      # that binding before staging its immutable provider payload.
+      saved_resume_args_path "$session" "$previous_meta" >/dev/null || return 1
+      materialize_selected_recovery_checkpoint \
+        "$session" "$previous_meta" "$run_token" || return 1
+    fi
+  else
+    for stale_resume_args in \
+      "$dir/resume-args.bin" "$dir"/resume-args-*.bin; do
+      if [ -e "$stale_resume_args" ] || [ -L "$stale_resume_args" ]; then
+        [ -f "$stale_resume_args" ] && [ ! -L "$stale_resume_args" ] || return 1
+      fi
+    done
+    reset_checkpoint_generation "$session" "$run_token" || return 1
+    rm -f -- "$dir/exit-status" || return 1
+    for stale_resume_args in \
+      "$dir/resume-args.bin" "$dir"/resume-args-*.bin; do
+      if [ -e "$stale_resume_args" ] || [ -L "$stale_resume_args" ]; then
+        [ -f "$stale_resume_args" ] && [ ! -L "$stale_resume_args" ] || return 1
+        rm -f -- "$stale_resume_args" || return 1
+      fi
+    done
+    replace_session_file_with_empty "$dir/checkpoint.log" || return 1
+  fi
+  if [ "$preserve_checkpoint" = "1" ] && [ "$SYNC_ENABLED" != "0" ]; then
+    # Request writeback for the complete A recovery bundle before primary
+    # metadata can identify replacement B.
+    /bin/sync
   fi
   agent_version="$("$agent_bin" --version 2>/dev/null || printf 'unknown')"
   session_color="$(allocate_session_color "$PROVIDER" "$cwd" "$session")" || return 1
-  lifecycle_id="$(new_run_token)" || return 1
-
   create_args=(
     --integer schema 1
     --string session_name "$session"
@@ -1953,6 +2581,9 @@ write_initial_meta() {
     --string status starting
     --string lifecycle_phase initializing
     --string run_token "$run_token"
+    --bool preserve_recovery_until_ready "$preserve_until_ready"
+    --null runtime_ready_at
+    --null resume_args_file
     --string lifecycle_id "$lifecycle_id"
     --string provider "$PROVIDER"
     --string session_color "$session_color"
@@ -1964,6 +2595,7 @@ write_initial_meta() {
     --null last_checkpoint_epoch
     --null worker_pid
     --null provider_pid
+    --null runtime_shutdown_observed_at
     --null worker_heartbeat_at
     --null worker_heartbeat_epoch
     --null exit_status
@@ -2005,9 +2637,22 @@ write_initial_meta() {
   else
     create_args+=( --null codex_bin --null codex_version --null codex_session_id --null rollout_path )
   fi
-  rm -f "$tmp"
   "$STATE_BIN" meta create "$tmp" "${create_args[@]}" || return 1
-  mv -f "$tmp" "$meta"
+  safe_owned_plain_file "$tmp" && \
+    "$STATE_BIN" meta snapshot "$tmp" "$session" >/dev/null 2>&1 || {
+      rm -f -- "$tmp"
+      return 1
+    }
+  session_file_is_safe_or_absent "$meta" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$meta" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  safe_owned_plain_file "$meta" && \
+    "$STATE_BIN" meta snapshot "$meta" "$session" >/dev/null 2>&1
 }
 
 claude_home() {
@@ -2094,6 +2739,74 @@ safe_plain_directory_tree() {
   safe_plain_source_tree "$root" || return 1
   unsafe="$(find "$root" -type f -links +1 -print -quit 2>/dev/null)" || return 1
   [ -z "$unsafe" ]
+}
+
+claude_archive_identity_is_valid() {
+  local root="$1"
+  local id="$2"
+  local short_id="${id:0:8}"
+  local entry
+  local name
+  local lead_id
+
+  safe_plain_directory_tree "$root" || return 1
+  while IFS= read -r -d '' entry; do
+    name="${entry##*/}"
+    case "$name" in
+      transcript.jsonl)
+        safe_plain_file "$entry" || return 1
+        ;;
+      project-session|file-history|session-env|tasks|teams)
+        [ -d "$entry" ] && [ ! -L "$entry" ] || return 1
+        ;;
+      *) return 1 ;;
+    esac
+  done < <(find "$root" -mindepth 1 -maxdepth 1 -print0 2>/dev/null)
+
+  if [ -d "$root/tasks" ]; then
+    while IFS= read -r -d '' entry; do
+      [ -d "$entry" ] && [ ! -L "$entry" ] || return 1
+      name="${entry##*/}"
+      case "$name" in
+        "$id"|"session-$short_id") ;;
+        *) return 1 ;;
+      esac
+    done < <(find "$root/tasks" -mindepth 1 -maxdepth 1 -print0 2>/dev/null)
+  fi
+
+  if [ -d "$root/teams" ]; then
+    while IFS= read -r -d '' entry; do
+      [ -d "$entry" ] && [ ! -L "$entry" ] || return 1
+      safe_plain_file "$entry/config.json" || return 1
+      lead_id="$($STATE_BIN meta get \
+        "$entry/config.json" leadSessionId 2>/dev/null)" || return 1
+      [ "$(printf '%s' "$lead_id" | tr '[:upper:]' '[:lower:]')" = \
+        "$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')" ] || return 1
+    done < <(find "$root/teams" -mindepth 1 -maxdepth 1 -print0 2>/dev/null)
+  fi
+}
+
+claude_team_destination_matches_id() {
+  local destination="$1"
+  local id="$2"
+  local config="$destination/config.json"
+  local lead_id
+  local entry
+
+  if [ ! -e "$destination" ] && [ ! -L "$destination" ]; then
+    return 0
+  fi
+  [ -d "$destination" ] && [ ! -L "$destination" ] || return 1
+  if [ ! -e "$config" ] && [ ! -L "$config" ]; then
+    entry="$(find "$destination" -mindepth 1 -print -quit 2>/dev/null)" || \
+      return 1
+    [ -z "$entry" ]
+    return
+  fi
+  safe_plain_file "$config" || return 1
+  lead_id="$($STATE_BIN meta get "$config" leadSessionId 2>/dev/null)" || return 1
+  [ "$(printf '%s' "$lead_id" | tr '[:upper:]' '[:lower:]')" = \
+    "$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')" ]
 }
 
 safe_plain_file() {
@@ -2196,9 +2909,245 @@ valid_claude_checkpoint_archive() {
   local archive="$1"
   local expected_id="$2"
 
-  [ -s "$archive" ] || return 1
+  safe_plain_file "$archive" || return 1
+  "$TAR_BIN" -tf "$archive" 2>/dev/null | \
+    awk '
+      /^\// { unsafe = 1 }
+      /(^|\/)\.\.($|\/)/ { unsafe = 1 }
+      /\\/ { unsafe = 1 }
+      END { exit(unsafe ? 1 : 0) }
+    ' || return 1
+  "$TAR_BIN" -tvf "$archive" 2>/dev/null | \
+    awk '
+      NF && substr($0, 1, 1) != "-" && substr($0, 1, 1) != "d" { unsafe = 1 }
+      END { exit(unsafe ? 1 : 0) }
+    ' || return 1
   "$TAR_BIN" -xOf "$archive" ./transcript.jsonl 2>/dev/null | \
     valid_claude_transcript_stream "$expected_id"
+}
+
+claude_recovery_source_is_valid() {
+  local session="$1"
+  local id="$2"
+  local transcript="$3"
+
+  claude_recovery_preflight "$session" "$id" "$transcript"
+}
+
+preflight_claude_archive_restore() (
+  local archive="$1"
+  local id="$2"
+  local transcript="$3"
+  local home="$4"
+  local validate_destinations="${5:-1}"
+  local stage
+  local cleanup_command
+  local source
+  local destination
+  local index
+  local -a restore_sources=()
+  local -a restore_destinations=()
+
+  stage="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/detach-claude-recovery.XXXXXX")" || \
+    exit 1
+  printf -v cleanup_command 'rm -rf -- %q' "$stage"
+  trap "$cleanup_command" EXIT
+  "$TAR_BIN" -xf "$archive" -C "$stage" >/dev/null 2>&1 || exit 1
+  safe_plain_directory_tree "$stage" && \
+    claude_archive_identity_is_valid "$stage" "$id" || exit 1
+  safe_plain_file "$stage/transcript.jsonl" && \
+    valid_claude_transcript "$stage/transcript.jsonl" "$id" || exit 1
+  [ "$validate_destinations" = "1" ] || exit 0
+
+  for source in \
+    "$stage/project-session" \
+    "$stage/file-history" \
+    "$stage/session-env"; do
+    case "$source" in
+      "$stage/project-session") destination="${transcript%.jsonl}" ;;
+      "$stage/file-history") destination="$home/file-history/$id" ;;
+      *) destination="$home/session-env/$id" ;;
+    esac
+    [ -d "$source" ] || continue
+    restore_sources+=( "$source" )
+    restore_destinations+=( "$destination" )
+  done
+  for source in "$stage"/tasks/*; do
+    [ -d "$source" ] || continue
+    restore_sources+=( "$source" )
+    restore_destinations+=( "$home/tasks/$(basename "$source")" )
+  done
+  for source in "$stage"/teams/*; do
+    [ -d "$source" ] || continue
+    restore_sources+=( "$source" )
+    restore_destinations+=( "$home/teams/$(basename "$source")" )
+  done
+  if [ "${#restore_sources[@]}" -gt 0 ]; then
+    for ((index = 0; index < ${#restore_sources[@]}; index++)); do
+      safe_plain_directory_tree "${restore_sources[$index]}" && \
+        preflight_claude_restore_publish_state \
+          "${restore_destinations[$index]}" "$home" || exit 1
+      case "${restore_sources[$index]}" in
+        "$stage"/teams/*)
+          claude_team_destination_matches_id \
+            "${restore_destinations[$index]}" "$id" || exit 1
+          ;;
+      esac
+    done
+  fi
+)
+
+claude_recovery_preflight() {
+  local session="$1"
+  local id="$2"
+  local transcript="$3"
+  local checkpoint_dir
+  local checkpoint_meta
+  local live_valid=0
+
+  safe_claude_transcript_path "$transcript" "$id" || return 1
+  if valid_claude_transcript "$transcript" "$id"; then
+    live_valid=1
+  fi
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  checkpoint_meta="$checkpoint_dir/meta.json"
+  if [ -e "$checkpoint_meta" ] || [ -L "$checkpoint_meta" ]; then
+    [ -f "$checkpoint_meta" ] && [ ! -L "$checkpoint_meta" ] && \
+      "$STATE_BIN" meta usable "$checkpoint_meta" "$session" \
+        >/dev/null 2>&1 || return 1
+    if ! "$STATE_BIN" meta matches "$checkpoint_meta" "$PROVIDER" "$id" \
+         >/dev/null 2>&1; then
+      [ "$live_valid" -eq 1 ]
+      return
+    fi
+  fi
+  claude_recovery_payload_is_valid "$session" "$id" "$transcript"
+}
+
+claude_recovery_payload_source_is_valid() {
+  local session="$1"
+  local id="$2"
+  local transcript="$3"
+  local checkpoint_dir
+  local archive
+  local backup
+  local candidate
+  local source
+  local live_valid=0
+
+  safe_claude_transcript_path "$transcript" "$id" || return 1
+  if valid_claude_transcript "$transcript" "$id"; then
+    live_valid=1
+  fi
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  archive="$checkpoint_dir/claude-session.tar"
+  if [ -e "$archive" ] || [ -L "$archive" ]; then
+    valid_claude_checkpoint_archive "$archive" "$id" && \
+      preflight_claude_archive_restore "$archive" "$id" "" "" 0
+    return
+  fi
+
+  backup="$checkpoint_dir/transcript.jsonl"
+  if [ -e "$backup" ] || [ -L "$backup" ]; then
+    safe_plain_file "$backup" && \
+      valid_claude_transcript "$backup" "$id" || return 1
+  else
+    [ "$live_valid" -eq 1 ]
+    return
+  fi
+
+  for candidate in claude-session claude-file-history claude-session-env; do
+    source="$checkpoint_dir/$candidate"
+    if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+      continue
+    fi
+    [ -d "$source" ] && [ ! -L "$source" ] || return 1
+    safe_plain_directory_tree "$source" || return 1
+  done
+}
+
+claude_transcript_restore_destination_is_valid() {
+  local id="$1"
+  local transcript="$2"
+  local home
+  local tmp
+
+  safe_claude_transcript_path "$transcript" "$id" || return 1
+  home="$(canonical_claude_home)" || return 1
+  transcript="$(canonical_claude_transcript_path "$transcript" "$id")" || \
+    return 1
+  [ ! -L "$transcript" ] && \
+    { [ ! -e "$transcript" ] || safe_plain_file "$transcript"; } || return 1
+  tmp="$transcript.detach.tmp"
+  if [ -e "$tmp" ] || [ -L "$tmp" ]; then
+    safe_plain_file "$tmp" || return 1
+  fi
+  [ -n "$home" ]
+}
+
+claude_recovery_payload_is_valid() {
+  local session="$1"
+  local id="$2"
+  local transcript="$3"
+  local checkpoint_dir
+  local archive
+  local backup
+  local home
+  local tmp
+  local candidate
+  local destination
+  local source
+  local live_valid=0
+  local -a restore_destinations=()
+
+  safe_claude_transcript_path "$transcript" "$id" || return 1
+  if valid_claude_transcript "$transcript" "$id"; then
+    live_valid=1
+  fi
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  archive="$checkpoint_dir/claude-session.tar"
+  backup="$checkpoint_dir/transcript.jsonl"
+  if [ -e "$archive" ] || [ -L "$archive" ]; then
+    valid_claude_checkpoint_archive "$archive" "$id" || return 1
+  elif [ -e "$backup" ] || [ -L "$backup" ]; then
+    safe_plain_file "$backup" && \
+      valid_claude_transcript "$backup" "$id" || return 1
+  else
+    [ "$live_valid" -eq 1 ]
+    return
+  fi
+
+  home="$(canonical_claude_home)" || return 1
+  transcript="$(canonical_claude_transcript_path "$transcript" "$id")" || return 1
+  [ ! -L "$transcript" ] && \
+    { [ ! -e "$transcript" ] || safe_plain_file "$transcript"; } || return 1
+  tmp="$transcript.detach.tmp"
+  if [ -e "$tmp" ] || [ -L "$tmp" ]; then
+    safe_plain_file "$tmp" || return 1
+  fi
+
+  if [ -e "$archive" ] || [ -L "$archive" ]; then
+    preflight_claude_archive_restore "$archive" "$id" "$transcript" "$home"
+    return
+  else
+    for candidate in \
+      "claude-session|${transcript%.jsonl}" \
+      "claude-file-history|$home/file-history/$id" \
+      "claude-session-env|$home/session-env/$id"; do
+      source="$checkpoint_dir/${candidate%%|*}"
+      if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+        continue
+      fi
+      [ -d "$source" ] && [ ! -L "$source" ] || return 1
+      safe_plain_directory_tree "$source" || return 1
+      restore_destinations+=( "${candidate#*|}" )
+    done
+  fi
+  if [ "${#restore_destinations[@]}" -gt 0 ]; then
+    for destination in "${restore_destinations[@]}"; do
+      preflight_claude_restore_publish_state "$destination" "$home" || return 1
+    done
+  fi
 }
 
 claude_matching_checkpoint_exists() {
@@ -2217,6 +3166,115 @@ claude_matching_checkpoint_exists() {
   return 1
 }
 
+claude_provider_entry_for_id_exists() {
+  local id="$1"
+  local configured_home
+  local home
+  local projects
+  local short_id
+  local candidate
+  local config
+
+  configured_home="$(claude_home)"
+  if [ ! -e "$configured_home" ] && [ ! -L "$configured_home" ]; then
+    return 1
+  fi
+  home="$(canonical_claude_home)" || return 2
+  projects="$home/projects"
+  if [ -e "$projects" ] || [ -L "$projects" ]; then
+    [ -d "$projects" ] && [ ! -L "$projects" ] || return 2
+  fi
+  short_id="${id:0:8}"
+  for candidate in \
+    "$projects"/*/"$id.jsonl" \
+    "$projects"/*/"$id" \
+    "$home/file-history/$id" \
+    "$home/session-env/$id" \
+    "$home/tasks/$id" \
+    "$home/tasks/session-$short_id" \
+    "$home/teams/session-$short_id"; do
+    if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+      return 0
+    fi
+  done
+  for config in "$home"/teams/*/config.json; do
+    if [ ! -e "$config" ] && [ ! -L "$config" ]; then
+      continue
+    fi
+    [ -f "$config" ] && [ ! -L "$config" ] || return 2
+    [ "$("$STATE_BIN" meta get "$config" leadSessionId 2>/dev/null || true)" = \
+      "$id" ] && return 0
+  done
+  return 1
+}
+
+claude_metadata_only_recovery_source_is_valid() {
+  local session="$1"
+  local meta="$2"
+  local id="$3"
+  local transcript
+  local source
+  local entry_status=0
+  local checkpoint_dir
+  local checkpoint_meta
+  local checkpoint_id
+  local checkpoint_transcript
+  local payload_present=0
+
+  [[ "$id" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]] || \
+    return 1
+  "$STATE_BIN" meta matches "$meta" claude "$id" >/dev/null 2>&1 || \
+    return 1
+  transcript="$(
+    "$STATE_BIN" meta get "$meta" transcript_path 2>/dev/null
+  )" || return 1
+  [ -z "$transcript" ] || return 1
+  claude_provider_entry_for_id_exists "$id" || entry_status=$?
+  [ "$entry_status" -eq 1 ] || return 1
+
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  if [ -e "$checkpoint_dir" ] || [ -L "$checkpoint_dir" ]; then
+    owned_plain_checkpoint_directory "$checkpoint_dir" || return 1
+  else
+    return 0
+  fi
+  # A metadata-only checkpoint represents the interval before Claude creates
+  # its first transcript. It cannot carry a partial provider bundle for the
+  # same UUID. A complete older generation may still be canonical while a
+  # ready primary generation awaits materialization into its own checkpoint.
+  for source in \
+    "$checkpoint_dir/claude-session.tar" \
+    "$checkpoint_dir/transcript.jsonl" \
+    "$checkpoint_dir/claude-session" \
+    "$checkpoint_dir/claude-file-history" \
+    "$checkpoint_dir/claude-session-env"; do
+    if [ -e "$source" ] || [ -L "$source" ]; then
+      payload_present=1
+      break
+    fi
+  done
+  [ "$payload_present" -eq 1 ] || return 0
+
+  checkpoint_meta="$checkpoint_dir/meta.json"
+  [ "$meta" != "$checkpoint_meta" ] || return 1
+  [ -f "$checkpoint_meta" ] && [ ! -L "$checkpoint_meta" ] && \
+    "$STATE_BIN" meta usable "$checkpoint_meta" "$session" \
+      >/dev/null 2>&1 || return 1
+  if "$STATE_BIN" meta matches "$checkpoint_meta" claude "$id" \
+       >/dev/null 2>&1; then
+    return 1
+  fi
+  checkpoint_id="$(
+    "$STATE_BIN" meta get "$checkpoint_meta" agent_session_id 2>/dev/null
+  )" || return 1
+  checkpoint_transcript="$(
+    "$STATE_BIN" meta get "$checkpoint_meta" transcript_path 2>/dev/null
+  )" || return 1
+  [ -n "$checkpoint_id" ] && [ -n "$checkpoint_transcript" ] || return 1
+  claude_recovery_payload_source_is_valid \
+    "$session" "$checkpoint_id" "$checkpoint_transcript"
+}
+
 codex_home() {
   printf '%s\n' "${CODEX_HOME:-$HOME/.codex}"
 }
@@ -2228,9 +3286,16 @@ safe_codex_rollout_path() {
   local parent_real
   local relative
   local ancestor
+  local parent_relative
+  local remaining
+  local component
+  local current
 
   sessions="$(codex_home)/sessions"
-  [ -d "$sessions" ] && [ ! -L "$path" ] || return 1
+  [ -d "$sessions" ] && [ ! -L "$sessions" ] && [ ! -L "$path" ] || return 1
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    safe_owned_plain_file "$path" || return 1
+  fi
   case "$path" in
     "$sessions"/*) ;;
     *) return 1 ;;
@@ -2239,6 +3304,26 @@ safe_codex_rollout_path() {
   case "/$relative/" in
     */../*|*/./*) return 1 ;;
   esac
+  parent_relative="${relative%/*}"
+  [ "$parent_relative" != "$relative" ] || parent_relative=""
+  remaining="$parent_relative"
+  current="$sessions"
+  while [ -n "$remaining" ]; do
+    component="${remaining%%/*}"
+    if [ "$remaining" = "$component" ]; then
+      remaining=""
+    else
+      remaining="${remaining#*/}"
+    fi
+    case "$component" in ''|.|..) return 1 ;; esac
+    current="$current/$component"
+    [ ! -L "$current" ] || return 1
+    if [ -e "$current" ]; then
+      [ -d "$current" ] || return 1
+    else
+      break
+    fi
+  done
   sessions_real="$(cd -P "$sessions" >/dev/null 2>&1 && pwd)" || return 1
   ancestor="$(dirname "$path")"
   while [ ! -e "$ancestor" ]; do
@@ -2282,36 +3367,46 @@ snapshot_known_threads() {
   local db
   local cwd_sql
   local output
+  local tmp
 
   output="$(session_dir "$session")/known-thread-ids.txt"
+  session_file_is_safe_or_absent "$output" || return 1
   if [ "$PROVIDER" = "claude" ]; then
-    : >"$output"
-    return 0
+    replace_session_file_with_empty "$output"
+    return
   fi
   db="$(codex_state_db)"
   if [ -z "$db" ] || [ ! -f "$db" ]; then
-    : >"$output"
-    return 0
+    replace_session_file_with_empty "$output"
+    return
   fi
+  tmp="$output.tmp.$$"
+  [ ! -e "$tmp" ] && [ ! -L "$tmp" ] || return 1
   cwd_sql="$(sql_escape "$cwd")"
-  "$SQLITE_BIN" -noheader -cmd '.timeout 5000' "$db" \
+  if ! "$SQLITE_BIN" -noheader -cmd '.timeout 5000' "$db" \
     "SELECT id FROM threads
      WHERE source = 'cli'
        AND COALESCE(thread_source, 'user') = 'user'
        AND cwd = '$cwd_sql'
-     ORDER BY id;" >"$output"
+     ORDER BY id;" >"$tmp"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  safe_owned_plain_file "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$output"
 }
 
 write_resume_args() {
-  local session="$1"
+  local output="$1"
   shift
-  local output
   local tmp
   local arg
 
-  output="$(session_dir "$session")/resume-args.bin"
   tmp="$output.tmp.$$"
-  : >"$tmp"
+  : >"$tmp" || { rm -f "$tmp"; return 1; }
   if [ "$PROVIDER" = "claude" ]; then
     while [ "$#" -gt 0 ]; do
       arg="$1"
@@ -2324,10 +3419,10 @@ write_resume_args() {
           ;;
         --allowedTools|--allowed-tools|--betas|--disallowedTools|--disallowed-tools|\
         --file|--mcp-config|--tools|--add-dir)
-          printf '%s\0' "$arg" >>"$tmp"
+          printf '%s\0' "$arg" >>"$tmp" || { rm -f "$tmp"; return 1; }
           while [ "$#" -gt 0 ]; do
             case "$1" in -*) break ;; esac
-            printf '%s\0' "$1" >>"$tmp"
+            printf '%s\0' "$1" >>"$tmp" || { rm -f "$tmp"; return 1; }
             shift
           done
           ;;
@@ -2336,7 +3431,7 @@ write_resume_args() {
         --plugin-url|--remote-control-session-name-prefix|--setting-sources|\
         --settings|--system-prompt)
           [ "$#" -gt 0 ] || continue
-          printf '%s\0%s\0' "$arg" "$1" >>"$tmp"
+          printf '%s\0%s\0' "$arg" "$1" >>"$tmp" || { rm -f "$tmp"; return 1; }
           shift
           ;;
         --agent=*|--agents=*|--allowedTools=*|--allowed-tools=*|--betas=*|\
@@ -2346,17 +3441,17 @@ write_resume_args() {
         --plugin-dir=*|--plugin-url=*|--prompt-suggestions=*|--remote-control=*|\
         --remote-control-session-name-prefix=*|--setting-sources=*|--settings=*|\
         --system-prompt=*|--tools=*|--add-dir=*)
-          printf '%s\0' "$arg" >>"$tmp"
+          printf '%s\0' "$arg" >>"$tmp" || { rm -f "$tmp"; return 1; }
           ;;
         --allow-dangerously-skip-permissions|--dangerously-skip-permissions|\
         --bare|--brief|--chrome|--no-chrome|--disable-slash-commands|\
         --exclude-dynamic-system-prompt-sections|--ide|--safe-mode|\
         --strict-mcp-config|--verbose)
-          printf '%s\0' "$arg" >>"$tmp"
+          printf '%s\0' "$arg" >>"$tmp" || { rm -f "$tmp"; return 1; }
           ;;
       esac
     done
-    mv -f "$tmp" "$output"
+    mv -f "$tmp" "$output" || { rm -f "$tmp"; return 1; }
     return
   fi
   while [ "$#" -gt 0 ]; do
@@ -2367,21 +3462,84 @@ write_resume_args() {
       --add-dir|--enable|--disable|--local-provider|--remote|--remote-auth-token-env|\
       -i|--image)
         [ "$#" -gt 0 ] || continue
-        printf '%s\0%s\0' "$arg" "$1" >>"$tmp"
+        printf '%s\0%s\0' "$arg" "$1" >>"$tmp" || { rm -f "$tmp"; return 1; }
         shift
         ;;
       --config=*|--model=*|--profile=*|--sandbox=*|--ask-for-approval=*|\
       --add-dir=*|--enable=*|--disable=*|--local-provider=*|--remote=*|\
       --remote-auth-token-env=*|--image=*)
-        printf '%s\0' "$arg" >>"$tmp"
+        printf '%s\0' "$arg" >>"$tmp" || { rm -f "$tmp"; return 1; }
         ;;
       --search|--oss|--strict-config|--no-alt-screen|\
       --dangerously-bypass-approvals-and-sandbox|--dangerously-bypass-hook-trust)
-        printf '%s\0' "$arg" >>"$tmp"
+        printf '%s\0' "$arg" >>"$tmp" || { rm -f "$tmp"; return 1; }
         ;;
     esac
   done
-  mv -f "$tmp" "$output"
+  mv -f "$tmp" "$output" || { rm -f "$tmp"; return 1; }
+}
+
+valid_resume_args_file() {
+  local path="$1"
+  local final_byte
+
+  safe_owned_plain_file "$path" || return 1
+  [ ! -s "$path" ] && return 0
+  final_byte="$(
+    LC_ALL=C /usr/bin/tail -c 1 "$path" 2>/dev/null | \
+      /usr/bin/od -An -t u1 2>/dev/null | tr -d '[:space:]'
+  )"
+  [ "$final_byte" = "0" ]
+}
+
+saved_resume_args_path() {
+  local session="$1"
+  local meta="$2"
+  local name
+  local token
+  local expected_token
+  local path
+
+  name="$("$STATE_BIN" meta get "$meta" resume_args_file 2>/dev/null)" || return 1
+  if [ -n "$name" ]; then
+    case "$name" in *[!A-Za-z0-9._-]*) return 1 ;; esac
+    case "$name" in resume-args-*.bin) ;; *) return 1 ;; esac
+    token="${name#resume-args-}"
+    token="${token%.bin}"
+    [ -n "$token" ] || return 1
+    expected_token="$("$STATE_BIN" meta get "$meta" run_token 2>/dev/null)" || return 1
+    [ -n "$expected_token" ] && [ "$token" = "$expected_token" ] || return 1
+    path="$(session_dir "$session")/$name"
+    valid_resume_args_file "$path" || return 1
+    printf '%s\n' "$path"
+    return 0
+  fi
+
+  path="$(session_dir "$session")/resume-args.bin"
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    valid_resume_args_file "$path" || return 1
+    printf '%s\n' "$path"
+  fi
+}
+
+prune_superseded_resume_args() {
+  local session="$1"
+  local meta="$2"
+  local keep
+  local candidate
+
+  keep="$(saved_resume_args_path "$session" "$meta")" || return 1
+  [ -n "$keep" ] || return 0
+  [ "$keep" != "$(session_dir "$session")/resume-args.bin" ] || return 0
+  for candidate in \
+    "$(session_dir "$session")/resume-args.bin" \
+    "$(session_dir "$session")"/resume-args-*.bin; do
+    [ "$candidate" != "$keep" ] || continue
+    if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+      [ -f "$candidate" ] && [ ! -L "$candidate" ] || continue
+      rm -f -- "$candidate" || return 1
+    fi
+  done
 }
 
 codex_thread_created_ms() {
@@ -2540,7 +3698,7 @@ valid_jsonl() {
   local path="$1"
   local expected_id="$2"
 
-  [ -s "$path" ] && \
+  [ -f "$path" ] && [ ! -L "$path" ] && [ -s "$path" ] && \
     "$STATE_BIN" jsonl validate codex "$path" "$expected_id" >/dev/null 2>&1
 }
 
@@ -2548,8 +3706,94 @@ valid_jsonl_cached() {
   local path="$1"
   local expected_id="$2"
 
-  [ -s "$path" ] && \
+  [ -f "$path" ] && [ ! -L "$path" ] && [ -s "$path" ] && \
     "$STATE_BIN" jsonl validate-cached codex "$path" "$expected_id" >/dev/null 2>&1
+}
+
+codex_rollout_destination_matches_id() {
+  local path="$1"
+  local expected_id="$2"
+  local db
+  local id_sql
+  local path_sql
+  local conflicting_id
+  local selected_path
+  local embedded_id
+  local db_present=0
+  local db_matches=0
+
+  safe_codex_rollout_path "$path" || return 1
+  [ -n "$expected_id" ] || return 1
+
+  # Prefer Codex's own thread index when it is available. A recovery for one
+  # thread must never overwrite a path already assigned to another thread,
+  # even when the destination JSONL is damaged and cannot identify itself.
+  db="$(codex_state_db)"
+  if [ -n "$db" ]; then
+    db_present=1
+    safe_owned_plain_file "$db" || return 1
+    id_sql="$(sql_escape "$expected_id")"
+    path_sql="$(sql_escape "$path")"
+    conflicting_id="$($SQLITE_BIN -noheader -cmd '.timeout 5000' "$db" \
+      "SELECT id FROM threads
+         WHERE rollout_path = '$path_sql'
+           AND lower(id) <> lower('$id_sql')
+         LIMIT 1;" 2>/dev/null)" || return 1
+    [ -z "$conflicting_id" ] || return 1
+    selected_path="$($SQLITE_BIN -noheader -cmd '.timeout 5000' "$db" \
+      "SELECT rollout_path FROM threads
+         WHERE lower(id) = lower('$id_sql')
+         LIMIT 1;" 2>/dev/null)" || return 1
+    if [ -n "$selected_path" ]; then
+      [ "$selected_path" = "$path" ] || return 1
+      db_matches=1
+    fi
+  fi
+
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    embedded_id="$($STATE_BIN jsonl first \
+      "$path" payload.id payload.session_id 2>/dev/null)" || embedded_id=""
+    if [ -n "$embedded_id" ]; then
+      [ "$(printf '%s' "$embedded_id" | tr '[:upper:]' '[:lower:]')" = \
+        "$(printf '%s' "$expected_id" | tr '[:upper:]' '[:lower:]')" ] || \
+        return 1
+      return 0
+    fi
+    [ "$db_matches" -eq 1 ] || return 1
+  elif [ "$db_present" -eq 1 ]; then
+    [ "$db_matches" -eq 1 ] || return 1
+  fi
+}
+
+publish_codex_rollout_checkpoint() {
+  local backup="$1"
+  local rollout="$2"
+  local id="$3"
+  local parent
+  local tmp
+
+  safe_owned_plain_file "$backup" || return 1
+  codex_rollout_destination_matches_id "$rollout" "$id" || return 1
+  parent="$(dirname "$rollout")"
+  mkdir -p "$parent" || return 1
+  codex_rollout_destination_matches_id "$rollout" "$id" || return 1
+  tmp="$(/usr/bin/mktemp "$parent/.detach-rollout.XXXXXX")" || return 1
+  safe_owned_plain_file "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  cp -p -- "$backup" "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  safe_owned_plain_file "$tmp" && valid_jsonl "$tmp" "$id" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$rollout" || {
+    rm -f -- "$tmp"
+    return 1
+  }
 }
 
 restore_matching_rollout_checkpoint() {
@@ -2557,12 +3801,14 @@ restore_matching_rollout_checkpoint() {
   local id="$2"
   local rollout="$3"
   local backup
-  local tmp
   local restore=0
 
-  safe_codex_rollout_path "$rollout" || return 1
+  codex_rollout_destination_matches_id "$rollout" "$id" || return 1
   backup="$(session_dir "$session")/checkpoint/rollout.jsonl"
-  [ -f "$backup" ] || return 0
+  if [ ! -e "$backup" ] && [ ! -L "$backup" ]; then
+    return 0
+  fi
+  [ -f "$backup" ] && [ ! -L "$backup" ] || return 1
   valid_jsonl "$backup" "$id" || return 0
   if ! valid_jsonl "$rollout" "$id"; then
     restore=1
@@ -2571,14 +3817,7 @@ restore_matching_rollout_checkpoint() {
   fi
   [ "$restore" -eq 1 ] || return 0
 
-  mkdir -p "$(dirname "$rollout")"
-  tmp="$rollout.detach.tmp.$$"
-  cp -p "$backup" "$tmp" || return 1
-  valid_jsonl "$tmp" "$id" || {
-    rm -f "$tmp"
-    return 1
-  }
-  mv -f "$tmp" "$rollout" || return 1
+  publish_codex_rollout_checkpoint "$backup" "$rollout" "$id" || return 1
   [ "$SYNC_ENABLED" = "0" ] || /bin/sync
   error "restored Codex rollout from the matching checkpoint before resume"
 }
@@ -2640,6 +3879,7 @@ restore_missing_checkpoint_files() {
   local source
   local relative
   local target
+  local tmp
 
   RESTORE_MISSING_CHANGED=0
   [ -d "$backup" ] || return 0
@@ -2663,7 +3903,17 @@ restore_missing_checkpoint_files() {
       else
         mkdir -p "$(dirname "$target")" || return 1
         [ ! -L "$(dirname "$target")" ] || return 1
-        cp -p "$source" "$target" || return 1
+        tmp="$target.detach.tmp"
+        if [ -e "$tmp" ] || [ -L "$tmp" ]; then
+          safe_plain_file "$tmp" || return 1
+          rm -f "$tmp" || return 1
+        fi
+        cp -p "$source" "$tmp" || {
+          [ ! -L "$tmp" ] && rm -f "$tmp"
+          return 1
+        }
+        safe_plain_file "$tmp" || return 1
+        mv -f "$tmp" "$target" || return 1
         RESTORE_MISSING_CHANGED=1
       fi
     fi
@@ -2677,6 +3927,7 @@ restore_matching_claude_checkpoint() {
   local transcript="$3"
   local force_checkpoint="${4:-0}"
   local checkpoint_dir
+  local checkpoint_meta
   local backup
   local tmp
   local restore=0
@@ -2698,9 +3949,22 @@ restore_matching_claude_checkpoint() {
   if [ -n "$transcript" ] && valid_claude_transcript "$transcript" "$id"; then
     live_valid=1
   fi
+  checkpoint_meta="$checkpoint_dir/meta.json"
+  if [ -e "$checkpoint_meta" ] || [ -L "$checkpoint_meta" ]; then
+    [ -f "$checkpoint_meta" ] && [ ! -L "$checkpoint_meta" ] && \
+      "$STATE_BIN" meta usable "$checkpoint_meta" "$session" \
+        >/dev/null 2>&1 || return 1
+    if ! "$STATE_BIN" meta matches "$checkpoint_meta" "$PROVIDER" "$id" \
+         >/dev/null 2>&1; then
+      [ "$live_valid" -eq 1 ] || return 1
+      checkpoint_log "$session" \
+        "ignored stale Claude checkpoint for valid live session $id"
+      return 0
+    fi
+  fi
   archive="$checkpoint_dir/claude-session.tar"
   if [ -e "$archive" ] || [ -L "$archive" ]; then
-    safe_plain_file "$archive" || return 1
+    valid_claude_checkpoint_archive "$archive" "$id" || return 1
     stage="$checkpoint_dir/claude-restore.$$"
     rm -rf "$stage"
     mkdir -p "$stage" || return 1
@@ -2723,13 +3987,10 @@ restore_matching_claude_checkpoint() {
       }
     "$TAR_BIN" -xf "$archive" -C "$stage" >/dev/null 2>&1 || {
       rm -rf "$stage"
-      if [ "$live_valid" -eq 1 ]; then
-        checkpoint_log "$session" "ignored unreadable Claude checkpoint for valid live session $id"
-        return 0
-      fi
       return 1
     }
-    if ! safe_plain_directory_tree "$stage"; then
+    if ! safe_plain_directory_tree "$stage" || \
+       ! claude_archive_identity_is_valid "$stage" "$id"; then
       rm -rf "$stage"
       return 1
     fi
@@ -2748,10 +4009,6 @@ restore_matching_claude_checkpoint() {
   }
   valid_claude_transcript "$backup" "$id" || {
     [ -z "$stage" ] || rm -rf "$stage"
-    if [ "$live_valid" -eq 1 ]; then
-      checkpoint_log "$session" "ignored stale or mismatched Claude checkpoint for valid live session $id"
-      return 0
-    fi
     return 1
   }
   [ -n "$transcript" ] || {
@@ -2806,7 +4063,13 @@ restore_matching_claude_checkpoint() {
       "claude-file-history|$home/file-history/$id" \
       "claude-session-env|$home/session-env/$id"; do
       source="$checkpoint_dir/${item%%|*}"
-      [ -d "$source" ] || continue
+      if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+        continue
+      fi
+      [ -d "$source" ] && [ ! -L "$source" ] || {
+        [ -z "$stage" ] || rm -rf "$stage"
+        return 1
+      }
       restore_sources+=( "$source" )
       restore_destinations+=( "${item#*|}" )
     done
@@ -2818,6 +4081,15 @@ restore_matching_claude_checkpoint() {
         [ -z "$stage" ] || rm -rf "$stage"
         return 1
       }
+    case "${restore_sources[$index]}" in
+      "$stage"/teams/*)
+        claude_team_destination_matches_id \
+          "${restore_destinations[$index]}" "$id" || {
+            [ -z "$stage" ] || rm -rf "$stage"
+            return 1
+          }
+        ;;
+    esac
   done
 
   if ! valid_claude_transcript "$transcript" "$id"; then
@@ -2908,7 +4180,12 @@ restore_matching_claude_checkpoint() {
     for source in "$stage"/teams/*; do
       [ -d "$source" ] || continue
       destination="$home/teams/$(basename "$source")"
-      if [ "$force_directories" -eq 1 ] || [ ! -d "$destination" ] || [ -L "$destination" ]; then
+      claude_team_destination_matches_id "$destination" "$id" || {
+        rm -rf "$stage"
+        return 1
+      }
+      if [ "$force_directories" -eq 1 ] || [ ! -d "$destination" ] || \
+         [ -L "$destination" ] || [ ! -f "$destination/config.json" ]; then
         restore_directory_checkpoint "$source" "$destination" "$home" || {
           rm -rf "$stage"
           return 1
@@ -2929,7 +4206,10 @@ restore_matching_claude_checkpoint() {
       "claude-session-env|$home/session-env/$id"; do
       source="$checkpoint_dir/${item%%|*}"
       destination="${item#*|}"
-      [ -d "$source" ] || continue
+      if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+        continue
+      fi
+      [ -d "$source" ] && [ ! -L "$source" ] || return 1
       if [ "$force_directories" -eq 1 ] || [ ! -d "$destination" ] || [ -L "$destination" ]; then
         restore_directory_checkpoint "$source" "$destination" "$home" || return 1
         changed=1
@@ -2946,22 +4226,101 @@ restore_matching_claude_checkpoint() {
   fi
 }
 
+resume_runtime_is_quiescent_locked() {
+  local session="$1"
+
+  if tmux_has_session "$session"; then
+    tmux_is_managed "$session" || return 1
+    tmux_session_running "$session" && return 1
+    require_dead_tmux_primary_run_match "$session" || return 1
+  fi
+  refuse_runtime_without_managed_tmux "$session"
+}
+
+prepare_codex_resume_locked() {
+  local session="$1"
+  local id="$2"
+  local rollout="$3"
+
+  resume_runtime_is_quiescent_locked "$session" || return 1
+  restore_matching_rollout_checkpoint "$session" "$id" "$rollout" || return 1
+  valid_jsonl "$rollout" "$id"
+}
+
+prepare_claude_resume_locked() {
+  local session="$1"
+  local id="$2"
+  local transcript="$3"
+  local mode="$4"
+  local meta
+  local saved_id
+  local saved_transcript
+
+  resume_runtime_is_quiescent_locked "$session" || return 1
+  case "$mode" in
+    transcript)
+      restore_matching_claude_checkpoint "$session" "$id" "$transcript" || \
+        return 1
+      valid_claude_transcript "$transcript" "$id"
+      ;;
+    metadata-only)
+      meta="$(usable_meta_path "$session" 2>/dev/null)" || return 1
+      saved_id="$(
+        "$STATE_BIN" meta get "$meta" agent_session_id 2>/dev/null
+      )" || return 1
+      [ "$(printf '%s' "$saved_id" | tr '[:upper:]' '[:lower:]')" = "$id" ] || \
+        return 1
+      saved_transcript="$(
+        "$STATE_BIN" meta get "$meta" transcript_path 2>/dev/null
+      )" || return 1
+      [ -z "$saved_transcript" ] || return 1
+      claude_metadata_only_recovery_source_is_valid \
+        "$session" "$meta" "$id"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 checkpoint_log() {
   local session="$1"
   shift
-  printf '%s %s\n' "$(now_iso)" "$*" >>"$(session_dir "$session")/checkpoint.log"
+  local path="$(session_dir "$session")/checkpoint.log"
+  local parent
+  local tmp
+
+  session_file_is_safe_or_absent "$path" || return 1
+  parent="$(dirname "$path")"
+  tmp="$(/usr/bin/mktemp "$parent/.detach-checkpoint-log.XXXXXX")" || return 1
+  if [ -e "$path" ]; then
+    cp -p -- "$path" "$tmp" || {
+      rm -f -- "$tmp"
+      return 1
+    }
+  else
+    : >"$tmp" || return 1
+  fi
+  printf '%s %s\n' "$(now_iso)" "$*" >>"$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  safe_owned_plain_file "$tmp" || {
+    rm -f -- "$tmp"
+    return 1
+  }
+  mv -f -- "$tmp" "$path"
 }
 
 checkpoint_rollout() {
   local session="$1"
   local rollout="$2"
   local expected_id="$3"
-  local checkpoint_dir
+  local checkpoint_dir="${4:-}"
   local tmp
   local attempt
 
   [ -f "$rollout" ] && safe_codex_rollout_path "$rollout" || return 1
-  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -n "$checkpoint_dir" ] || checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -d "$checkpoint_dir" ] && [ ! -L "$checkpoint_dir" ] || return 1
   tmp="$checkpoint_dir/rollout.jsonl.tmp.$$"
 
   for attempt in 1 2 3; do
@@ -2982,7 +4341,10 @@ copy_checkpoint_directory() {
   local source="$1"
   local destination="$2"
 
-  [ -d "$source" ] || return 0
+  if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+    return 0
+  fi
+  [ -d "$source" ] && [ ! -L "$source" ] || return 1
   # Claude can hard-link tool results into a session companion directory.
   # The private staging copy must contain independent regular files so the
   # checkpoint archive and every later restore keep rejecting hard links.
@@ -2996,7 +4358,7 @@ checkpoint_claude_artifacts() {
   local session="$1"
   local transcript="$2"
   local id="$3"
-  local checkpoint_dir
+  local checkpoint_dir="${4:-}"
   local tmp
   local home
   local stage
@@ -3007,7 +4369,8 @@ checkpoint_claude_artifacts() {
   local short_id
 
   [ -f "$transcript" ] && safe_claude_transcript_path "$transcript" "$id" || return 1
-  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -n "$checkpoint_dir" ] || checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -d "$checkpoint_dir" ] && [ ! -L "$checkpoint_dir" ] || return 1
   stage="$checkpoint_dir/claude-stage.$$"
   archive_tmp="$checkpoint_dir/claude-session.tar.tmp.$$"
   rm -rf "$stage"
@@ -3045,7 +4408,9 @@ checkpoint_claude_artifacts() {
     return 1
   }
   for task in "$home/tasks/$id" "$home/tasks/session-$short_id"; do
-    [ -d "$task" ] || continue
+    if [ ! -e "$task" ] && [ ! -L "$task" ]; then
+      continue
+    fi
     copy_checkpoint_directory "$task" "$stage/tasks/$(basename "$task")" || {
       rm -rf "$stage"
       checkpoint_log "$session" "Claude checkpoint skipped because task artifacts could not be copied safely"
@@ -3053,7 +4418,15 @@ checkpoint_claude_artifacts() {
     }
   done
   for config in "$home"/teams/*/config.json; do
-    [ -f "$config" ] || continue
+    if [ ! -e "$config" ] && [ ! -L "$config" ]; then
+      continue
+    fi
+    if [ ! -f "$config" ] || [ -L "$config" ]; then
+      rm -rf "$stage"
+      checkpoint_log "$session" \
+        "Claude checkpoint skipped because a team config is unsafe"
+      return 1
+    fi
     [ "$("$STATE_BIN" meta get "$config" leadSessionId 2>/dev/null || true)" = "$id" ] || continue
     team="$(dirname "$config")"
     copy_checkpoint_directory "$team" "$stage/teams/$(basename "$team")" || {
@@ -3074,11 +4447,15 @@ checkpoint_claude_artifacts() {
     rm -f "$archive_tmp"
     return 1
   }
-  "$TAR_BIN" -tf "$archive_tmp" >/dev/null 2>&1 || {
+  if ! valid_claude_checkpoint_archive "$archive_tmp" "$id" || \
+     ! preflight_claude_archive_restore \
+         "$archive_tmp" "$id" "$transcript" "$home" 0; then
     rm -rf "$stage"
     rm -f "$archive_tmp"
+    checkpoint_log "$session" \
+      "Claude checkpoint skipped because the archive is not safely recoverable"
     return 1
-  }
+  fi
   mv -f "$archive_tmp" "$checkpoint_dir/claude-session.tar" || {
     rm -rf "$stage"
     return 1
@@ -3099,8 +4476,8 @@ checkpoint_claude_artifacts() {
 
 checkpoint_database() {
   local session="$1"
+  local checkpoint_dir="${2:-}"
   local db
-  local checkpoint_dir
   local tmp
   local tmp_shm
   local tmp_wal
@@ -3109,7 +4486,8 @@ checkpoint_database() {
   [ "$PROVIDER" = "codex" ] || return 0
   db="$(codex_state_db)"
   [ -n "$db" ] && [ -f "$db" ] || return 1
-  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -n "$checkpoint_dir" ] || checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -d "$checkpoint_dir" ] && [ ! -L "$checkpoint_dir" ] || return 1
   for stale_sidecar in \
     "$checkpoint_dir"/codex-state.sqlite.tmp.*-shm \
     "$checkpoint_dir"/codex-state.sqlite.tmp.*-wal; do
@@ -3143,43 +4521,53 @@ checkpoint_database() {
 
 checkpoint_pane() {
   local session="$1"
-  local checkpoint_dir
+  local checkpoint_dir="${2:-}"
   local tmp
   local pane
 
   tmux_has_session "$session" || return 1
+  [ -n "$checkpoint_dir" ] || checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -d "$checkpoint_dir" ] && [ ! -L "$checkpoint_dir" ] || return 1
   pane="$(tmux_pane_id "$session" 2>/dev/null || true)"
   [ -n "$pane" ] || {
     checkpoint_log "$session" "pane snapshot failed: pane id is unavailable (socket=$TMUX_SOCKET_PATH)"
-    "${TMUX_CMD[@]}" list-sessions -F 'tmux session: #{session_name}' >>"$(session_dir "$session")/checkpoint.log" 2>&1 || true
     return 1
   }
-  checkpoint_dir="$(session_dir "$session")/checkpoint"
-  tmp="$checkpoint_dir/pane.txt.tmp.$$"
-  "${TMUX_CMD[@]}" capture-pane -p -J -S "-$HISTORY_LIMIT" -t "$pane" >"$tmp" 2>>"$(session_dir "$session")/checkpoint.log" || {
+  tmp="$(/usr/bin/mktemp "$checkpoint_dir/.pane.XXXXXX")" || return 1
+  "${TMUX_CMD[@]}" capture-pane -p -J -S "-$HISTORY_LIMIT" -t "$pane" \
+    >"$tmp" 2>/dev/null || {
     checkpoint_log "$session" "pane snapshot failed for $pane"
-    rm -f "$tmp"
+    rm -f -- "$tmp"
     return 1
   }
-  mv -f "$tmp" "$checkpoint_dir/pane.txt"
+  safe_owned_plain_file "$tmp" && \
+    mv -f -- "$tmp" "$checkpoint_dir/pane.txt" || {
+      rm -f -- "$tmp"
+      return 1
+    }
 
-  tmp="$checkpoint_dir/pane-ansi.txt.tmp.$$"
+  tmp="$(/usr/bin/mktemp "$checkpoint_dir/.pane-ansi.XXXXXX")" || return 1
   if "${TMUX_CMD[@]}" capture-pane -p -e -J -S "-$HISTORY_LIMIT" -t "$pane" >"$tmp" 2>/dev/null; then
-    mv -f "$tmp" "$checkpoint_dir/pane-ansi.txt"
+    safe_owned_plain_file "$tmp" && \
+      mv -f -- "$tmp" "$checkpoint_dir/pane-ansi.txt" || {
+        rm -f -- "$tmp"
+        return 1
+      }
   else
-    rm -f "$tmp"
+    rm -f -- "$tmp"
   fi
 }
 
 checkpoint_worktree() {
   local session="$1"
   local cwd="$2"
-  local checkpoint_dir
+  local checkpoint_dir="${3:-}"
   local tmp
   local repository_root
   local marker_type="absent"
 
-  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -n "$checkpoint_dir" ] || checkpoint_dir="$(session_dir "$session")/checkpoint"
+  [ -d "$checkpoint_dir" ] && [ ! -L "$checkpoint_dir" ] || return 1
   tmp="$checkpoint_dir/worktree-status.txt.tmp.$$"
   repository_root="$(canonical_project_dir_for "$cwd")" || repository_root="$cwd"
   [ ! -d "$repository_root/.git" ] || marker_type="directory"
@@ -3187,6 +4575,227 @@ checkpoint_worktree() {
   printf 'repository-root: %s\nrepository-marker: %s\n' \
     "$repository_root" "$marker_type" >"$tmp"
   mv -f "$tmp" "$checkpoint_dir/worktree-status.txt"
+}
+
+checkpoint_test_barrier() {
+  local ready_file="${1:-}"
+  local release_file="${2:-}"
+  local pid_file="${DETACH_TEST_CHECKPOINT_BARRIER_PID_FILE:-}"
+  local attempts=0
+
+  [ -z "$ready_file" ] && [ -z "$release_file" ] && return 0
+  [ -n "$ready_file" ] && [ -n "$release_file" ] || return 1
+  [ ! -e "$ready_file" ] && [ ! -L "$ready_file" ] || return 1
+  if [ -n "$pid_file" ]; then
+    [ ! -e "$pid_file" ] && [ ! -L "$pid_file" ] || return 1
+    printf '%s\n' "${BASHPID:-$$}" >"$pid_file" || return 1
+  fi
+  printf 'ready\n' >"$ready_file" || return 1
+  while [ "$attempts" -lt 300 ]; do
+    [ -f "$release_file" ] && [ ! -L "$release_file" ] && return 0
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
+  return 1
+}
+
+checkpoint_stage_name_is_safe() {
+  local name="$1"
+
+  [ "${#name}" -le 255 ] && \
+    [[ "$name" =~ ^\.checkpoint-stage-[A-Za-z0-9._-]+$ ]]
+}
+
+owned_plain_checkpoint_directory() {
+  local path="$1"
+  local foreign
+
+  [ -d "$path" ] && [ ! -L "$path" ] && \
+    [ "$(stat -f '%u' "$path" 2>/dev/null)" = "$UID" ] || return 1
+  safe_plain_source_tree "$path" || return 1
+  foreign="$(find "$path" -mindepth 1 ! -user "$UID" -print -quit 2>/dev/null)" || \
+    return 1
+  [ -z "$foreign" ]
+}
+
+ensure_owned_checkpoint_directory() {
+  local session_path="$1"
+  local checkpoint_path="$session_path/checkpoint"
+
+  if [ ! -e "$session_path" ] && [ ! -L "$session_path" ]; then
+    mkdir -m 0700 -- "$session_path" || return 1
+  fi
+  [ -d "$session_path" ] && [ ! -L "$session_path" ] && \
+    [ "$(stat -f '%u' "$session_path" 2>/dev/null)" = "$UID" ] || return 1
+  if [ ! -e "$checkpoint_path" ] && [ ! -L "$checkpoint_path" ]; then
+    mkdir -m 0700 -- "$checkpoint_path" || return 1
+  fi
+  owned_plain_checkpoint_directory "$checkpoint_path"
+}
+
+remove_checkpoint_stage() {
+  local session_path="$1"
+  local stage="$2"
+  local stage_name="${stage##*/}"
+
+  [ "$stage" = "$session_path/$stage_name" ] && \
+    checkpoint_stage_name_is_safe "$stage_name" || return 1
+  if [ -e "$stage" ] || [ -L "$stage" ]; then
+    owned_plain_checkpoint_directory "$stage" || return 1
+    rm -rf -- "$stage"
+  fi
+}
+
+checkpoint_reset_stage_name() {
+  local checkpoint_dir="$1"
+  local marker_name=.detach-checkpoint-reset
+  local marker="$checkpoint_dir/$marker_name"
+  local recorded_stage
+  local marker_size
+  local extra_entry
+
+  owned_plain_checkpoint_directory "$checkpoint_dir" || return 1
+  safe_owned_plain_file "$marker" || return 1
+  IFS= read -r recorded_stage <"$marker" || return 1
+  marker_size="$(stat -f '%z' "$marker" 2>/dev/null)" || return 1
+  [ "$marker_size" = "$(( ${#recorded_stage} + 1 ))" ] || return 1
+  checkpoint_stage_name_is_safe "$recorded_stage" || return 1
+  case "$recorded_stage" in .checkpoint-stage-reset-*) ;; *) return 1 ;; esac
+  extra_entry="$(find "$checkpoint_dir" -mindepth 1 -maxdepth 1 \
+    ! -name "$marker_name" -print -quit 2>/dev/null)" || return 1
+  [ -z "$extra_entry" ] || return 1
+  printf '%s\n' "$recorded_stage"
+}
+
+remove_checkpoint_reset_marker() {
+  local checkpoint_dir="$1"
+  local expected_stage="$2"
+  local recorded_stage
+  local marker="$checkpoint_dir/.detach-checkpoint-reset"
+
+  recorded_stage="$(checkpoint_reset_stage_name "$checkpoint_dir")" || return 1
+  [ "$recorded_stage" = "$expected_stage" ] || return 1
+  rm -f -- "$marker"
+}
+
+scavenge_checkpoint_stages() {
+  local session="$1"
+  local session_path="$2"
+  local stale_stage
+  local found=0
+  local canonical_mode=""
+  local reset_stage=""
+
+  for stale_stage in "$session_path"/.checkpoint-stage-*; do
+    [ -e "$stale_stage" ] || [ -L "$stale_stage" ] || continue
+    if [ "$found" -eq 0 ]; then
+      if strict_checkpoint_recovery_generation_is_valid \
+           "$session" "$session_path/checkpoint/meta.json"; then
+        canonical_mode=recovery
+      elif reset_stage="$(
+        checkpoint_reset_stage_name "$session_path/checkpoint"
+      )"; then
+        canonical_mode=reset
+      else
+        checkpoint_log "$session" \
+          "stale checkpoint stage retained because canonical recovery is invalid"
+        return 1
+      fi
+      found=1
+    fi
+    owned_plain_checkpoint_directory "$stale_stage" || {
+      checkpoint_log "$session" \
+        "unsafe stale checkpoint stage requires manual inspection: ${stale_stage##*/}"
+      return 1
+    }
+    if [ "$canonical_mode" = reset ]; then
+      [ "${stale_stage##*/}" = "$reset_stage" ] || {
+        checkpoint_log "$session" \
+          "unrelated checkpoint stage retained beside a reset generation"
+        return 1
+      }
+    fi
+  done
+  if [ "$found" -eq 1 ] && [ "$SYNC_ENABLED" != "0" ]; then
+    /bin/sync || return 1
+  fi
+  for stale_stage in "$session_path"/.checkpoint-stage-*; do
+    [ -e "$stale_stage" ] || [ -L "$stale_stage" ] || continue
+    if ! remove_checkpoint_stage "$session_path" "$stale_stage"; then
+      checkpoint_log "$session" \
+        "unsafe stale checkpoint stage requires manual inspection: ${stale_stage##*/}"
+      return 1
+    fi
+  done
+  if [ "$found" -eq 1 ] && [ "$SYNC_ENABLED" != "0" ]; then
+    /bin/sync || return 1
+  fi
+  if [ "$canonical_mode" = reset ]; then
+    remove_checkpoint_reset_marker \
+      "$session_path/checkpoint" "$reset_stage" || return 1
+    [ "$SYNC_ENABLED" = "0" ] || /bin/sync || return 1
+  fi
+}
+
+safe_owned_plain_file() {
+  local path="$1"
+
+  safe_plain_file "$path" && \
+    [ "$(stat -f '%u' "$path" 2>/dev/null)" = "$UID" ]
+}
+
+copy_checkpoint_optional_file() {
+  local source="$1"
+  local destination="$2"
+
+  if [ ! -e "$source" ] && [ ! -L "$source" ]; then
+    return 0
+  fi
+  safe_owned_plain_file "$source" || return 1
+  [ ! -e "$destination" ] && [ ! -L "$destination" ] || return 1
+  cp -p "$source" "$destination" || return 1
+  safe_owned_plain_file "$destination" && cmp -s "$source" "$destination"
+}
+
+seed_checkpoint_optional_artifacts() {
+  local checkpoint_dir="$1"
+  local stage="$2"
+  local name
+  local database
+  local sidecar
+
+  if [ ! -e "$checkpoint_dir" ] && [ ! -L "$checkpoint_dir" ]; then
+    return 0
+  fi
+  owned_plain_checkpoint_directory "$checkpoint_dir" || return 1
+  for name in pane.txt pane-ansi.txt worktree-status.txt; do
+    copy_checkpoint_optional_file \
+      "$checkpoint_dir/$name" "$stage/$name" || return 1
+  done
+  [ "$PROVIDER" = "codex" ] || return 0
+
+  database="$stage/codex-state.sqlite"
+  copy_checkpoint_optional_file \
+    "$checkpoint_dir/codex-state.sqlite" "$database" || return 1
+  [ -e "$database" ] || return 0
+  [ -n "$SQLITE_BIN" ] && \
+    [ "$("$SQLITE_BIN" "$database" 'PRAGMA quick_check;' 2>/dev/null)" = "ok" ] || \
+      return 1
+  for sidecar in "$database-shm" "$database-wal"; do
+    if [ -e "$sidecar" ] || [ -L "$sidecar" ]; then
+      safe_owned_plain_file "$sidecar" || return 1
+      rm -f -- "$sidecar" || return 1
+    fi
+  done
+}
+
+checkpoint_stage_cleanup_on_exit() {
+  [ "${stage_cleanup_armed:-0}" = "1" ] || return 0
+  stage_cleanup_armed=0
+  remove_checkpoint_stage "$session_path" "$stage" || {
+    checkpoint_log "$session" "checkpoint stage cleanup deferred: ${stage##*/}" \
+      2>/dev/null || true
+  }
 }
 
 checkpoint_lock_path() {
@@ -3221,6 +4830,38 @@ session_operation_locked() {
   esac
 }
 
+runtime_writer_matches_live_worker() {
+  local session="$1"
+  local run_token="$2"
+  local worker_pid="$3"
+  local meta
+  local recorded_worker_pid
+  local pane
+  local pane_pid
+
+  case "$worker_pid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$worker_pid" -gt 1 ] 2>/dev/null || return 1
+  meta="$(session_meta "$session")"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  "$STATE_BIN" meta usable "$meta" "$session" >/dev/null 2>&1 || return 1
+  [ "$("$STATE_BIN" meta get "$meta" run_token 2>/dev/null || true)" = "$run_token" ] || \
+    return 1
+  recorded_worker_pid="$(
+    "$STATE_BIN" meta get "$meta" worker_pid 2>/dev/null || true
+  )"
+  [ "$recorded_worker_pid" = "$worker_pid" ] || return 1
+  tmux_has_session "$session" && tmux_is_managed "$session" || return 1
+  [ "$(tmux_option "$session" '@detach_run_token')" = "$run_token" ] || return 1
+  [ "$(tmux_pane_dead "$session")" = "0" ] || return 1
+  pane="$(tmux_pane_id "$session" 2>/dev/null || true)"
+  [ -n "$pane" ] || return 1
+  pane_pid="$(
+    "${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' \
+      2>/dev/null || true
+  )"
+  [ "$pane_pid" = "$worker_pid" ] && process_is_owned_alive "$worker_pid"
+}
+
 checkpoint_once() {
   local session="$1"
 
@@ -3229,63 +4870,267 @@ checkpoint_once() {
     "$SELF" __checkpoint_once_locked "$@"
 }
 
-checkpoint_once_locked() {
+checkpoint_stop_edge_locked() {
+  local session="$1"
+  local run_token="$2"
+  local worker_pid="$3"
+
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
+  checkpoint_run_may_publish "$session" "$run_token" || return 1
+  checkpoint_pane "$session"
+}
+
+checkpoint_publish_sync() {
+  [ "${DETACH_TEST_CHECKPOINT_SYNC_FAIL:-0}" != "1" ] || return 1
+  /bin/sync
+}
+
+checkpoint_rollback_sync() {
+  [ "${DETACH_TEST_CHECKPOINT_ROLLBACK_SYNC_FAIL:-0}" != "1" ] || return 1
+  /bin/sync
+}
+
+restore_checkpoint_after_failed_publish_sync() {
+  local session_path="$1"
+  local stage_name="$2"
+
+  "$STATE_BIN" checkpoint exchange "$session_path" "$stage_name" || \
+    return 2
+  checkpoint_rollback_sync || return 1
+}
+
+checkpoint_once_locked() (
   local session="$1"
   local run_token="${2:-}"
+  local worker_pid="${3:-}"
+  local session_path
   local meta
   local cwd
   local id
   local rollout
   local checkpoint_dir
+  local stage_name
+  local stage
+  local stage_meta
+  local staged_id
+  local staged_rollout
   local checkpoint_time
   local checkpoint_epoch
-  local tmp
   local publish=0
+  local stage_cleanup_armed=0
+  local rollback_status=0
 
+  [ -n "$run_token" ] && [ -n "$worker_pid" ] || return 1
   meta="$(session_meta "$session")"
-  [ -f "$meta" ] || return 1
-  if [ -n "$run_token" ] && [ "$("$STATE_BIN" meta get "$meta" run_token)" != "$run_token" ]; then
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
     return 1
-  fi
-  mkdir -p "$(session_dir "$session")/checkpoint"
+  checkpoint_run_may_publish "$session" "$run_token" || return 1
+
+  session_path="$(session_dir "$session")"
+  [ -d "$session_path" ] && [ ! -L "$session_path" ] && \
+    [ "$(stat -f '%u' "$session_path" 2>/dev/null)" = "$UID" ] || return 1
+  checkpoint_dir="$session_path/checkpoint"
+  scavenge_checkpoint_stages "$session" "$session_path" || return 1
+  stage_name=".checkpoint-stage-$run_token-$$"
+  stage="$session_path/$stage_name"
+  [ ! -e "$stage" ] && [ ! -L "$stage" ] || return 1
+  mkdir -m 0700 "$stage" || return 1
+  stage_cleanup_armed=1
+  trap checkpoint_stage_cleanup_on_exit EXIT
+  trap 'exit 1' HUP INT TERM
+  seed_checkpoint_optional_artifacts "$checkpoint_dir" "$stage" || return 1
 
   discover_codex_session "$session" "$run_token" >/dev/null 2>&1 || true
-  cwd="$("$STATE_BIN" meta get "$meta" project_dir)"
-  id="$("$STATE_BIN" meta get "$meta" agent_session_id codex_session_id)"
-  rollout="$("$STATE_BIN" meta get "$meta" transcript_path rollout_path)"
+  cwd="$("$STATE_BIN" meta get "$meta" project_dir 2>/dev/null)" || {
+    return 1
+  }
+  id="$(
+    "$STATE_BIN" meta get "$meta" agent_session_id codex_session_id 2>/dev/null
+  )" || {
+    return 1
+  }
+  rollout="$(
+    "$STATE_BIN" meta get "$meta" transcript_path rollout_path 2>/dev/null
+  )" || {
+    return 1
+  }
 
   if [ -n "$id" ] && [ -n "$rollout" ]; then
     if [ "$PROVIDER" = "claude" ]; then
-      checkpoint_claude_artifacts "$session" "$rollout" "$id" && publish=1
-    elif checkpoint_rollout "$session" "$rollout" "$id"; then
+      checkpoint_claude_artifacts "$session" "$rollout" "$id" "$stage" && \
+        publish=1
+    elif checkpoint_rollout "$session" "$rollout" "$id" "$stage"; then
       publish=1
     fi
   fi
-  checkpoint_database "$session" || true
-  checkpoint_pane "$session" || true
-  checkpoint_worktree "$session" "$cwd"
+  [ "$publish" -eq 1 ] || {
+    return 1
+  }
+  checkpoint_database "$session" "$stage" || true
+  checkpoint_pane "$session" "$stage" || true
+  checkpoint_worktree "$session" "$cwd" "$stage" || true
 
-  if [ "$publish" -eq 1 ]; then
-    checkpoint_time="$(now_iso)"
-    checkpoint_epoch="$(date '+%s')"
-    if [ -n "$run_token" ]; then
-      state_update_meta_for_run "$session" "$run_token" \
-        --string last_checkpoint_at "$checkpoint_time" \
-        --integer last_checkpoint_epoch "$checkpoint_epoch" || true
-    else
-      state_update_meta "$session" \
-        --string last_checkpoint_at "$checkpoint_time" \
-        --integer last_checkpoint_epoch "$checkpoint_epoch" || true
-    fi
-    checkpoint_dir="$(session_dir "$session")/checkpoint"
-    tmp="$checkpoint_dir/meta.json.tmp.$$"
-    cp -p "$meta" "$tmp" && mv -f "$tmp" "$checkpoint_dir/meta.json"
-    rm -f "$tmp"
+  checkpoint_time="$(now_iso)"
+  checkpoint_epoch="$(date '+%s')"
+  stage_meta="$stage/meta.json"
+  cp -p "$meta" "$stage_meta" || {
+    return 1
+  }
+  "$STATE_BIN" meta patch "$stage_meta" --run-token "$run_token" \
+    --string last_checkpoint_at "$checkpoint_time" \
+    --integer last_checkpoint_epoch "$checkpoint_epoch" || {
+      return 1
+    }
+  if [ -e "$stage/.meta-patch.lock" ] || [ -L "$stage/.meta-patch.lock" ]; then
+    [ -f "$stage/.meta-patch.lock" ] && [ ! -L "$stage/.meta-patch.lock" ] && \
+      rm -f -- "$stage/.meta-patch.lock" || {
+        return 1
+      }
+  fi
+  "$STATE_BIN" meta snapshot "$stage_meta" "$session" >/dev/null 2>&1 || {
+    return 1
+  }
+  staged_id="$(
+    "$STATE_BIN" meta get "$stage_meta" agent_session_id codex_session_id \
+      2>/dev/null
+  )" || {
+    return 1
+  }
+  staged_rollout="$(
+    "$STATE_BIN" meta get "$stage_meta" transcript_path rollout_path \
+      2>/dev/null
+  )" || {
+    return 1
+  }
+  [ "$staged_id" = "$id" ] && [ "$staged_rollout" = "$rollout" ] || {
+    return 1
+  }
+  "$STATE_BIN" meta matches "$stage_meta" "$PROVIDER" "$id" \
+    >/dev/null 2>&1 || {
+      return 1
+    }
+  if [ "$PROVIDER" = "claude" ]; then
+    valid_claude_checkpoint_archive "$stage/claude-session.tar" "$id" || {
+      return 1
+    }
+  else
+    valid_jsonl_cached "$stage/rollout.jsonl" "$id" || {
+      return 1
+    }
   fi
 
+  checkpoint_test_barrier \
+    "${DETACH_TEST_CHECKPOINT_PREPUBLISH_READY:-}" \
+    "${DETACH_TEST_CHECKPOINT_PREPUBLISH_RELEASE:-}" || {
+      return 1
+    }
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || {
+    return 1
+  }
+  checkpoint_run_may_publish "$session" "$run_token" || {
+    return 1
+  }
+  metadata_snapshots_have_same_recovery_binding \
+    "$session" "$stage_meta" "$meta" || {
+      return 1
+    }
+  saved_resume_args_path "$session" "$stage_meta" >/dev/null || {
+    return 1
+  }
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || {
+    return 1
+  }
+  checkpoint_test_barrier \
+    "${DETACH_TEST_CHECKPOINT_PREEXCHANGE_READY:-}" \
+    "${DETACH_TEST_CHECKPOINT_PREEXCHANGE_RELEASE:-}" || {
+      return 1
+    }
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || {
+    return 1
+  }
+
+  # Exchange transfers the old canonical generation to $stage. Disarm the
+  # pre-exchange cleanup before the atomic operation so a signal can never
+  # delete a generation whose durability is still uncertain.
+  stage_cleanup_armed=0
+  "$STATE_BIN" checkpoint exchange "$session_path" "$stage_name" || {
+    return 1
+  }
+  checkpoint_test_barrier \
+    "${DETACH_TEST_CHECKPOINT_POSTEXCHANGE_READY:-}" \
+    "${DETACH_TEST_CHECKPOINT_POSTEXCHANGE_RELEASE:-}" || {
+      return 1
+    }
+  if [ "$SYNC_ENABLED" != "0" ]; then
+    if ! checkpoint_publish_sync; then
+      restore_checkpoint_after_failed_publish_sync \
+        "$session_path" "$stage_name" || rollback_status=$?
+      if [ "$rollback_status" -eq 0 ]; then
+        # The rollback sync made canonical A durable. Removing alternate B is
+        # now optional cleanup and cannot destroy the last durable recovery.
+        remove_checkpoint_stage "$session_path" "$stage" && \
+          /bin/sync 2>/dev/null || true
+      else
+        # Keep both directory entries when either the swap-back or its sync
+        # is uncertain. A later operator or validated scavenger can choose a
+        # generation without guessing what reached durable storage.
+        :
+      fi
+      checkpoint_test_barrier \
+        "${DETACH_TEST_CHECKPOINT_ROLLBACK_READY:-}" \
+        "${DETACH_TEST_CHECKPOINT_ROLLBACK_RELEASE:-}" || true
+      return 1
+    fi
+  fi
+  state_update_meta_for_run "$session" "$run_token" \
+    --string last_checkpoint_at "$checkpoint_time" \
+    --integer last_checkpoint_epoch "$checkpoint_epoch" || \
+      checkpoint_log "$session" "primary checkpoint timestamp update failed"
+  prune_superseded_resume_args "$session" "$checkpoint_dir/meta.json" || true
+  remove_checkpoint_stage "$session_path" "$stage" || return 1
   if [ "$SYNC_ENABLED" != "0" ]; then
     /bin/sync
   fi
+)
+
+runtime_readiness_is_committed() {
+  local session="$1"
+  local run_token="$2"
+  local meta
+  local primary_run_token
+  local ready_at
+
+  meta="$(session_meta "$session")"
+
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 2
+  load_meta_snapshot_path "$meta" "$session" || return 2
+  primary_run_token="$META_RUN_TOKEN"
+  [ "$primary_run_token" = "$run_token" ] || return 2
+  ready_at="$META_RUNTIME_READY_AT"
+  [ -n "$ready_at" ] && return 0
+  return 1
+}
+
+checkpoint_run_may_publish() {
+  local session="$1"
+  local requested_run_token="${2:-}"
+  local meta
+  local primary_run_token
+  local preserve_until_ready
+
+  meta="$(session_meta "$session")"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  load_meta_snapshot_path "$meta" "$session" || return 1
+  primary_run_token="$META_RUN_TOKEN"
+  if [ -n "$requested_run_token" ]; then
+    [ "$primary_run_token" = "$requested_run_token" ] || return 1
+  fi
+  preserve_until_ready="$META_PRESERVE_RECOVERY_UNTIL_READY"
+  [ "$preserve_until_ready" != "true" ] || \
+    { [ -n "$primary_run_token" ] && \
+      runtime_readiness_is_committed "$session" "$primary_run_token"; }
 }
 
 checkpoint_loop() {
@@ -3304,22 +5149,36 @@ checkpoint_loop() {
   trap checkpoint_loop_cleanup EXIT
   trap 'exit 0' HUP INT TERM
 
+  # A replacement run must not publish over the last recovery point until the
+  # command-side starter commits both readiness proofs. If that starter exits,
+  # keeping the previous checkpoint is safer than inferring readiness here.
+  while kill -0 "$worker_pid" 2>/dev/null && \
+        ! checkpoint_run_may_publish "$session" "$run_token"; do
+    sleep 1 &
+    sleep_pid=$!
+    wait "$sleep_pid" || exit 0
+    sleep_pid=""
+  done
+  checkpoint_run_may_publish "$session" "$run_token" || return 0
+
   while kill -0 "$worker_pid" 2>/dev/null && [ "$attempts" -lt 60 ]; do
-    if discover_codex_session "$session" "$run_token" >/dev/null 2>&1; then
+    if "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+         "$SELF" __discover_live_worker_locked \
+           "$session" "$run_token" "$worker_pid" >/dev/null 2>&1; then
       break
     fi
     attempts=$((attempts + 1))
     sleep 1
   done
 
-  checkpoint_once "$session" "$run_token" || true
+  checkpoint_once "$session" "$run_token" "$worker_pid" || true
   while kill -0 "$worker_pid" 2>/dev/null; do
     sleep "$CHECKPOINT_INTERVAL" &
     sleep_pid=$!
     wait "$sleep_pid" || exit 0
     sleep_pid=""
     kill -0 "$worker_pid" 2>/dev/null || break
-    checkpoint_once "$session" "$run_token" || true
+    checkpoint_once "$session" "$run_token" "$worker_pid" || true
   done
 }
 
@@ -3336,18 +5195,58 @@ runtime_heartbeat_locked() {
     --string worker_heartbeat_at "$heartbeat_time"
   )
 
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
+  checkpoint_test_barrier \
+    "${DETACH_TEST_HEARTBEAT_POSTGUARD_READY:-}" \
+    "${DETACH_TEST_HEARTBEAT_POSTGUARD_RELEASE:-}" || return 1
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
+
+  "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
+    @detach_worker_pid "$worker_pid" 2>/dev/null || return 1
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
+  "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
+    @detach_heartbeat_epoch "$heartbeat_epoch" 2>/dev/null || return 1
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
   if [ -n "$provider_pid" ]; then
     update_args+=( --integer provider_pid "$provider_pid" )
+    "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
+      @detach_provider_pid "$provider_pid" 2>/dev/null || return 1
   else
     update_args+=( --null provider_pid )
+    "${TMUX_CMD[@]}" set-option -qu -t "=$session:" \
+      @detach_provider_pid 2>/dev/null || return 1
   fi
   # A provider thread switch (for example /clear) should surface in list
   # output within one heartbeat, not only on the next checkpoint tick.
   if [ "$PROVIDER" = "codex" ]; then
+    runtime_writer_matches_live_worker \
+      "$session" "$run_token" "$worker_pid" || return 1
     discover_codex_session "$session" "$run_token" >/dev/null 2>&1 || true
   fi
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
   state_update_meta_for_run_without_event \
-    "$session" "$run_token" "${update_args[@]}"
+    "$session" "$run_token" "${update_args[@]}" || return 1
+  # Keep session-wide tmux presentation behind the same exact-worker proof.
+  # An orphan status loop must not restyle a same-name replacement after a
+  # Recover barrier rejects its heartbeat.
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
+  power_refresh_session_status "$session" 2>/dev/null || true
+}
+
+discover_live_worker_locked() {
+  local session="$1"
+  local run_token="$2"
+  local worker_pid="$3"
+
+  runtime_writer_matches_live_worker "$session" "$run_token" "$worker_pid" || \
+    return 1
+  discover_codex_session "$session" "$run_token"
 }
 
 runtime_heartbeat_once() {
@@ -3355,6 +5254,7 @@ runtime_heartbeat_once() {
   local run_token="$2"
   local worker_pid="$3"
   local provider_pid_file="$4"
+  local lock_timeout="${5:-2}"
   local provider_pid=""
   local heartbeat_epoch
   local heartbeat_time
@@ -3366,24 +5266,12 @@ runtime_heartbeat_once() {
   heartbeat_epoch="$(date '+%s')"
   heartbeat_time="$(now_iso)"
 
-  if [ "$(tmux_option "$session" '@detach_run_token')" = "$run_token" ]; then
-    "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
-      @detach_worker_pid "$worker_pid" 2>/dev/null || true
-    "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
-      @detach_heartbeat_epoch "$heartbeat_epoch" 2>/dev/null || true
-    if [ -n "$provider_pid" ]; then
-      "${TMUX_CMD[@]}" set-option -q -t "=$session:" \
-        @detach_provider_pid "$provider_pid" 2>/dev/null || true
-    else
-      "${TMUX_CMD[@]}" set-option -qu -t "=$session:" \
-        @detach_provider_pid 2>/dev/null || true
-    fi
-  fi
-
-  "$LOCKF_BIN" -k -t 2 "$(checkpoint_lock_path "$session")" \
+  case "$lock_timeout" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$lock_timeout" -gt 0 ] || return 1
+  "$LOCKF_BIN" -k -t "$lock_timeout" "$(checkpoint_lock_path "$session")" \
     "$SELF" __runtime_heartbeat_locked \
       "$session" "$run_token" "$worker_pid" "$provider_pid" \
-      "$heartbeat_epoch" "$heartbeat_time" >/dev/null 2>&1 || true
+      "$heartbeat_epoch" "$heartbeat_time" >/dev/null 2>&1
 }
 
 power_protection_state() {
@@ -3591,12 +5479,12 @@ runtime_status_loop() {
   trap 'exit 0' HUP INT TERM
   while kill -0 "$worker_pid" 2>/dev/null && \
         [ "$(tmux_option "$session" '@detach_run_token')" = "$run_token" ]; do
-    runtime_heartbeat_once \
-      "$session" "$run_token" "$worker_pid" "$provider_pid_file"
-    refresh_power_activity_state \
-      "$session" "$activity_file" "$activity_source_file" 2>/dev/null || \
-      write_power_activity_state "$activity_file" working 2>/dev/null || true
-    power_refresh_session_status "$session" 2>/dev/null || true
+    if runtime_heartbeat_once \
+         "$session" "$run_token" "$worker_pid" "$provider_pid_file"; then
+      refresh_power_activity_state \
+        "$session" "$activity_file" "$activity_source_file" 2>/dev/null || \
+        write_power_activity_state "$activity_file" working 2>/dev/null || true
+    fi
     sleep_interval="$HEALTH_HEARTBEAT_INTERVAL"
     [ "$POWER_ACTIVITY_STATE" != "waiting" ] || \
       sleep_interval="$IDLE_HEALTH_HEARTBEAT_INTERVAL"
@@ -3633,14 +5521,29 @@ worker_main() {
   local provider_pid_file
   local power_activity_file
   local power_activity_source_file
+  local run_resume_args_file
+  local stop_requested_at
 
   power_ready_file="$(session_dir "$session")/power-ready-$run_token"
   provider_pid_file="$(session_dir "$session")/provider-pid-$run_token"
   power_activity_file="$(session_dir "$session")/power-activity-$run_token"
   power_activity_source_file="$(session_dir "$session")/power-activity-source-$run_token"
+  run_resume_args_file="$(session_dir "$session")/resume-args-$run_token.bin"
 
   worker_cleanup() {
     local cleanup_status=$?
+    local cleanup_provider_pid=""
+    local file_provider_pid=""
+    local metadata_provider_pid=""
+    local closing_committed=0
+    local finished_at
+    local provider_artifact_present=0
+    local provider_identity_conflict=0
+    local provider_identity_safe=1
+    local provider_identity_recorded=0
+    local runtime_readiness_status=0
+    local shutdown_observed=0
+    local closing_args=()
     [ "$cleanup_done" -eq 0 ] || return 0
     cleanup_done=1
     trap - EXIT HUP INT TERM
@@ -3660,36 +5563,144 @@ worker_main() {
       exit_status="$cleanup_status"
     fi
 
+    metadata_provider_pid="$(
+      "$STATE_BIN" meta get "$(session_meta "$session")" provider_pid \
+        2>/dev/null || true
+    )"
+    case "$metadata_provider_pid" in
+      ''|*[!0-9]*) metadata_provider_pid="" ;;
+      *)
+        [ "$metadata_provider_pid" -gt 1 ] 2>/dev/null || metadata_provider_pid=""
+        ;;
+    esac
+    cleanup_provider_pid="$metadata_provider_pid"
+    if [ -e "$provider_pid_file" ] || [ -L "$provider_pid_file" ]; then
+      provider_artifact_present=1
+      if [ -f "$provider_pid_file" ] && [ ! -L "$provider_pid_file" ]; then
+        IFS= read -r file_provider_pid <"$provider_pid_file" || file_provider_pid=""
+        case "$file_provider_pid" in
+          ''|*[!0-9]*) file_provider_pid=""; provider_identity_safe=0 ;;
+          *)
+            [ "$file_provider_pid" -gt 1 ] 2>/dev/null || {
+              file_provider_pid=""
+              provider_identity_safe=0
+            }
+            ;;
+        esac
+      else
+        provider_identity_safe=0
+      fi
+      if [ -n "$metadata_provider_pid" ] && [ -n "$file_provider_pid" ] && \
+         [ "$metadata_provider_pid" != "$file_provider_pid" ]; then
+        provider_identity_conflict=1
+      elif [ -n "$file_provider_pid" ]; then
+        cleanup_provider_pid="$file_provider_pid"
+      fi
+    fi
+    if [ "$provider_identity_safe" -eq 1 ] && \
+       [ "$provider_identity_conflict" -eq 0 ] && \
+       [ -n "$cleanup_provider_pid" ]; then
+      provider_identity_recorded=1
+      process_is_confirmed_dead "$cleanup_provider_pid" && shutdown_observed=1
+    elif [ "$provider_identity_safe" -eq 1 ] && \
+         [ "$provider_identity_conflict" -eq 0 ] && \
+         [ "$provider_artifact_present" -eq 0 ]; then
+      if [ ! -e "$power_ready_file" ] && [ ! -L "$power_ready_file" ]; then
+        # detach-power publishes the ready marker before it attempts to launch
+        # the provider. Its completed foreground command and an absent marker
+        # therefore prove that no provider process existed for this run.
+        shutdown_observed=1
+      elif [ "$exit_status" -lt 128 ]; then
+        # A normal detach-power return after readiness but before PID-file
+        # publication means its launcher killed and waited for the child. A
+        # signal exit remains unknown because it can orphan that child.
+        shutdown_observed=1
+      fi
+    fi
+
     # Stop owns its terminal outcome from the moment its exact-run intent is
     # recorded. Other exits first publish their intended outcome as finalizing.
     # Health keeps both phases actionless while the final checkpoint completes.
-    if [ -n "$(read_meta_field "$session" stop_requested_at 2>/dev/null || true)" ]; then
+    stop_requested_at="$(
+      "$STATE_BIN" meta get "$(session_meta "$session")" stop_requested_at \
+        2>/dev/null || true
+    )"
+    if [ -n "$stop_requested_at" ]; then
       status_label="stopped"
-      state_update_meta_for_run_without_event "$session" "$run_token" \
+    fi
+    finished_at="$(now_iso)"
+    closing_args=(
+      --string status "$status_label"
+      --integer exit_status "$exit_status"
+      --string finished_at "$finished_at"
+    )
+    if [ "$provider_identity_recorded" -eq 1 ]; then
+      closing_args+=( --integer provider_pid "$cleanup_provider_pid" )
+    fi
+    if [ "$shutdown_observed" -eq 1 ]; then
+      closing_args+=( --string runtime_shutdown_observed_at "$finished_at" )
+    fi
+    if [ -n "$stop_requested_at" ]; then
+      if state_update_meta_for_run_without_event "$session" "$run_token" \
         --string lifecycle_phase stopping \
-        --string status "$status_label" \
-        --integer exit_status "$exit_status" \
-        --string finished_at "$(now_iso)" || true
+        "${closing_args[@]}"; then
+        closing_committed=1
+      fi
     else
-      state_update_meta_for_run "$session" "$run_token" \
+      if state_update_meta_for_run "$session" "$run_token" \
         --string lifecycle_phase finalizing \
-        --string status "$status_label" \
-        --integer exit_status "$exit_status" \
-        --string finished_at "$(now_iso)" || true
+        "${closing_args[@]}"; then
+        closing_committed=1
+      fi
+    fi
+    if [ "$closing_committed" -eq 0 ] && \
+       state_update_meta_for_run "$session" "$run_token" \
+         --string lifecycle_phase terminal \
+         "${closing_args[@]}"; then
+      # The starter can close an unready run before the worker observes its
+      # signal. A terminal-to-terminal patch still preserves the worker's
+      # provider identity or its safe pre-launch shutdown proof.
+      closing_committed=1
     fi
 
     # The phase write above is the lifecycle hint. The checkpoint itself does
     # not need to wake the app before the terminal phase is committed.
-    DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once "$session" "$run_token" || true
-    rm -f "$provider_pid_file" "$power_activity_file" \
-      "$power_activity_source_file"
+    if checkpoint_run_may_publish "$session" "$run_token"; then
+      DETACH_SUPPRESS_SESSION_EVENT=1 \
+        checkpoint_once "$session" "$run_token" "$$" || true
+    else
+      # Close the lifecycle before discarding staged options. A concurrent
+      # readiness patch can otherwise win after the check above.
+      if [ "$closing_committed" -eq 1 ] && \
+         state_update_meta_for_run "$session" "$run_token" \
+           --string lifecycle_phase terminal \
+           --string status "$status_label" \
+           --integer exit_status "$exit_status" \
+           --string finished_at "$finished_at"; then
+        runtime_readiness_status=0
+        runtime_readiness_is_committed "$session" "$run_token" || \
+          runtime_readiness_status=$?
+        if [ "$runtime_readiness_status" -eq 1 ]; then
+          rm -f "$run_resume_args_file"
+        fi
+      fi
+    fi
+    if [ "$closing_committed" -eq 1 ] && \
+       [ "$provider_identity_safe" -eq 1 ] && \
+       [ "$provider_identity_conflict" -eq 0 ] && \
+       { [ "$provider_identity_recorded" -eq 1 ] || [ "$shutdown_observed" -eq 1 ]; }; then
+      rm -f "$power_ready_file" "$provider_pid_file"
+    fi
+    rm -f "$power_activity_file" "$power_activity_source_file"
 
     state_update_meta_for_run "$session" "$run_token" \
       --string lifecycle_phase terminal \
       --string status "$status_label" \
       --integer exit_status "$exit_status" \
       --string finished_at "$(now_iso)" || true
-    printf '%s\n' "$exit_status" >"$(session_dir "$session")/exit-status"
+    replace_session_file_with_line \
+      "$(session_dir "$session")/exit-status" "$exit_status" || \
+      checkpoint_log "$session" "exit status publication failed" || true
     if [ "$(tmux_option "$session" '@detach_run_token')" = "$run_token" ]; then
       "${TMUX_CMD[@]}" set-option -q -t "=$session:" @detach_running 0 2>/dev/null || true
       power_refresh_session_status "$session" 2>/dev/null || true
@@ -3869,9 +5880,13 @@ start_tmux_session() {
   local provider_pid_file
   local power_activity_file
   local power_activity_source_file
+  local resume_args_name
+  local run_resume_args_file
+  local runtime_ready_at
   local worker_pid
   local provider_pid
   local readiness_attempts=0
+  local worker_launch_attempted=0
 
   start_ms="$(now_ms)"
   run_token="$(new_run_token)"
@@ -3879,6 +5894,8 @@ start_tmux_session() {
   provider_pid_file="$(session_dir "$session")/provider-pid-$run_token"
   power_activity_file="$(session_dir "$session")/power-activity-$run_token"
   power_activity_source_file="$(session_dir "$session")/power-activity-source-$run_token"
+  resume_args_name="resume-args-$run_token.bin"
+  run_resume_args_file="$(session_dir "$session")/$resume_args_name"
   if [ "$PROVIDER" = "claude" ] && [ -z "$recovery_id" ]; then
     recovery_id="$(new_run_token)"
   fi
@@ -3894,16 +5911,98 @@ start_tmux_session() {
 
   partial_cleanup() {
     local cleanup_status=$?
+    local cleanup_worker_pid=""
+    local cleanup_provider_pid=""
+    local file_provider_pid=""
+    local metadata_provider_pid=""
+    local cleanup_attempts=0
+    local runtime_readiness_status=0
+    local terminal_committed=0
+    local close_args=()
     trap - EXIT HUP INT TERM
     if [ "$started" -eq 0 ]; then
+      cleanup_worker_pid="$(
+        "$STATE_BIN" meta get "$(session_meta "$session")" worker_pid \
+          2>/dev/null || true
+      )"
+      case "$cleanup_worker_pid" in
+        ''|*[!0-9]*) cleanup_worker_pid="$(tmux_option "$session" '@detach_worker_pid')" ;;
+      esac
+      metadata_provider_pid="$(
+        "$STATE_BIN" meta get "$(session_meta "$session")" provider_pid \
+          2>/dev/null || true
+      )"
+      case "$metadata_provider_pid" in
+        ''|*[!0-9]*) metadata_provider_pid="" ;;
+        *)
+          [ "$metadata_provider_pid" -gt 1 ] 2>/dev/null || metadata_provider_pid=""
+          ;;
+      esac
+      cleanup_provider_pid="$metadata_provider_pid"
+      if [ -f "$provider_pid_file" ] && [ ! -L "$provider_pid_file" ]; then
+        IFS= read -r file_provider_pid <"$provider_pid_file" || file_provider_pid=""
+        case "$file_provider_pid" in
+          ''|*[!0-9]*) file_provider_pid="" ;;
+          *)
+            [ "$file_provider_pid" -gt 1 ] 2>/dev/null || file_provider_pid=""
+            ;;
+        esac
+        if [ -z "$metadata_provider_pid" ] || \
+           [ "$metadata_provider_pid" = "$file_provider_pid" ]; then
+          cleanup_provider_pid="$file_provider_pid"
+        fi
+      fi
+      close_args=(
+        --string lifecycle_phase terminal
+        --string status start_failed
+        --string finished_at "$(now_iso)"
+      )
+      case "$cleanup_worker_pid" in
+        ''|*[!0-9]*) ;;
+        *) close_args+=( --integer worker_pid "$cleanup_worker_pid" ) ;;
+      esac
+      case "$cleanup_provider_pid" in
+        ''|*[!0-9]*) ;;
+        *) close_args+=( --integer provider_pid "$cleanup_provider_pid" ) ;;
+      esac
+      if state_update_meta_for_run \
+           "$session" "$run_token" "${close_args[@]}"; then
+        terminal_committed=1
+      fi
       [ "$created" -eq 0 ] || "${TMUX_CMD[@]}" kill-session -t "=$session" 2>/dev/null || true
       "$POWER_BIN" release --session "$session" --run-token "$run_token" \
         >/dev/null 2>&1 || true
-      rm -f "$power_ready_file" "$provider_pid_file" "$power_activity_file" \
-        "$power_activity_source_file" "$legacy_env_file"
-      state_update_meta_for_run "$session" "$run_token" \
-        --string lifecycle_phase terminal \
-        --string status start_failed --string finished_at "$(now_iso)" || true
+      rm -f "$power_activity_file" "$power_activity_source_file" "$legacy_env_file"
+      if [ "$worker_launch_attempted" -eq 0 ] && \
+         [ "$terminal_committed" -eq 1 ] && \
+         ! tmux_has_session "$session"; then
+        # respawn-pane was never invoked, and the placeholder pane is gone.
+        # No replacement worker or provider can exist, so this starter owns a
+        # complete local shutdown observation for B.
+        state_update_meta_for_run "$session" "$run_token" \
+          --string runtime_shutdown_observed_at "$(now_iso)" || true
+      fi
+      while [ "$terminal_committed" -eq 1 ] && \
+            [ "$cleanup_attempts" -lt 40 ] && \
+            ! replacement_runtime_is_quiescent "$session"; do
+        cleanup_attempts=$((cleanup_attempts + 1))
+        sleep 0.05
+      done
+      if [ "$terminal_committed" -eq 1 ] && \
+         replacement_runtime_is_quiescent "$session"; then
+        state_update_meta_for_run "$session" "$run_token" \
+          --string runtime_shutdown_observed_at "$(now_iso)" || true
+        rm -f "$power_ready_file" "$provider_pid_file"
+      fi
+      if [ "$preserve_checkpoint" = "1" ] && \
+         [ "$terminal_committed" -eq 1 ]; then
+        runtime_readiness_status=0
+        runtime_readiness_is_committed "$session" "$run_token" || \
+          runtime_readiness_status=$?
+        if [ "$runtime_readiness_status" -eq 1 ]; then
+          rm -f "$run_resume_args_file"
+        fi
+      fi
     fi
     exit "$cleanup_status"
   }
@@ -3923,7 +6022,16 @@ start_tmux_session() {
       "$recovery_id" "$recovery_rollout" "$run_token" "$preserve_checkpoint" || \
     die "could not initialize session metadata"
   snapshot_known_threads "$session" "$cwd" || die "could not snapshot existing $PROVIDER_LABEL sessions"
-  write_resume_args "$session" "$@" || die "could not save $PROVIDER_LABEL resume options"
+  write_resume_args "$run_resume_args_file" "$@" || \
+    die "could not stage $PROVIDER_LABEL resume options"
+  # The readiness commit publishes this run-token-bound file by name. Request
+  # writeback before any metadata can make that pointer authoritative.
+  [ "$SYNC_ENABLED" = "0" ] || /bin/sync
+  if [ "$preserve_checkpoint" != "1" ]; then
+    state_update_meta_for_run_without_event "$session" "$run_token" \
+      --string resume_args_file "$resume_args_name" || \
+        die "could not save $PROVIDER_LABEL resume options"
+  fi
   rm -f "$power_ready_file" "$provider_pid_file" "$power_activity_file" \
     "$power_activity_source_file"
   session_color="$(read_meta_field "$session" session_color)"
@@ -3965,6 +6073,9 @@ start_tmux_session() {
     env_args+=( "$arg" )
   done < <(tmux_environment_args)
 
+  # Once respawn is attempted, a nonzero tmux result cannot prove that no
+  # child appeared. Every later failure needs process or wrapper evidence.
+  worker_launch_attempted=1
   "${TMUX_CMD[@]}" respawn-pane -k \
     -t "$pane_id" \
     -c "$cwd" \
@@ -3992,19 +6103,22 @@ start_tmux_session() {
     process_is_descendant "$provider_pid" "$worker_pid" || \
       die "$PROVIDER_LABEL exited before its managed runtime was confirmed"
   runtime_heartbeat_once "$session" "$run_token" "$worker_pid" "$provider_pid_file"
+  runtime_ready_at="$(now_iso)"
   state_update_meta_for_run "$session" "$run_token" \
     --string lifecycle_phase running \
     --string status running \
+    --string runtime_ready_at "$runtime_ready_at" \
+    --string resume_args_file "$resume_args_name" \
     --integer worker_pid "$worker_pid" \
     --integer provider_pid "$provider_pid" \
     --string worker_heartbeat_at "$(now_iso)" \
     --integer worker_heartbeat_epoch "$(date '+%s')" || \
       die "could not publish confirmed runtime readiness"
+  started=1
   tmux_update_session_status "$session" running || \
     error "warning: could not publish confirmed runtime style"
   rm -f "$power_ready_file"
 
-  started=1
   trap - EXIT HUP INT TERM
   printf 'Started %s in %s\n' "$session" "$cwd"
   printf 'Checkpoint interval: %s seconds\n' "$CHECKPOINT_INTERVAL"
@@ -4058,6 +6172,7 @@ start_tmux_session_locked() {
     die "default history '$session' was allocated by another start; retry to create the next history"
   fi
   if tmux_has_session "$session"; then
+    require_dead_tmux_primary_run_match "$session"
     "${TMUX_CMD[@]}" kill-session -t "=$session" || die "could not remove completed tmux session '$session'"
   fi
   existing="$(running_session_for_project "$cwd" "$session" || true)"
@@ -4135,6 +6250,7 @@ provider_session_context() {
   local id="$1"
   local dir
   local meta
+  local recovery_meta
   local session=""
   local project=""
   local live=false
@@ -4156,7 +6272,16 @@ provider_session_context() {
     session="$(basename "$dir")"
     meta="$(usable_meta_path "$session" 2>/dev/null || true)"
     [ -n "$meta" ] || continue
-    "$STATE_BIN" meta matches "$meta" "$PROVIDER" "$id" >/dev/null 2>&1 || continue
+    if ! "$STATE_BIN" meta matches "$meta" "$PROVIDER" "$id" >/dev/null 2>&1; then
+      recovery_meta="$(
+        uncommitted_recovery_meta_path "$session" 2>/dev/null || true
+      )"
+      [ -n "$recovery_meta" ] && \
+        replacement_runtime_is_quiescent "$session" && \
+        "$STATE_BIN" meta matches "$recovery_meta" "$PROVIDER" "$id" \
+          >/dev/null 2>&1 || continue
+      meta="$recovery_meta"
+    fi
     project="$("$STATE_BIN" meta get "$meta" project_dir)"
     live=false
     if tmux_has_session "$session" && tmux_is_managed "$session" && tmux_session_running "$session"; then
@@ -4205,17 +6330,62 @@ resume_agent_session() {
   local session="$1"
   local cwd="$2"
   local detach="$3"
-  local id="$4"
-  local display_name="$5"
-  shift 5
+  shift 3
+
+  mkdir -p "$INSTALL_STATE_ROOT" || \
+    die "cannot create install lock directory"
+  "$LOCKF_BIN" -k -t "$INSTALL_LOCK_TIMEOUT" "$INSTALL_LOCK" \
+    "$SELF" __resume_under_install_lock "$session" "$cwd" "$@" || \
+      return 1
+  [ "$detach" -eq 1 ] || attach_session "$session"
+}
+
+resume_under_install_lock() {
+  local session="$1"
+  local cwd="$2"
+  shift 2
+  local lock
+
+  lock="$(project_lock_path "$cwd")"
+  "$LOCKF_BIN" -k -t 30 "$lock" \
+    "$SELF" __resume_under_project_lock "$session" "$cwd" "$@"
+}
+
+resume_under_project_lock() {
+  local session="$1"
+  local cwd="$2"
+  shift 2
+  local existing
+
+  existing="$(running_session_for_project "$cwd" "$session" || true)"
+  [ -z "$existing" ] || \
+    die "project already has a running detached session: $existing"
+  resume_agent_session_locked "$session" "$cwd" "$@"
+}
+
+resume_agent_session_locked() {
+  local session="$1"
+  local cwd="$2"
+  local id="$3"
+  local display_name="$4"
+  shift 4
   local db
   local id_sql
   local rows
   local rollout
+  local preserve_checkpoint=1
 
   [[ "$id" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]] || \
     die "resume requires an exact session UUID"
   id="$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')"
+  refuse_runtime_without_managed_tmux "$session"
+  if tmux_has_session "$session"; then
+    tmux_is_managed "$session" || \
+      die "refusing to resume over unmanaged tmux session '$session'"
+    tmux_session_running "$session" && \
+      die "a detached task is already running; use '$PROGRAM attach $session' or '$PROGRAM stop $session' first"
+    require_dead_tmux_primary_run_match "$session"
+  fi
   if [ "$PROVIDER" = "claude" ]; then
     local saved_id
     local resolved_status
@@ -4225,17 +6395,14 @@ resume_agent_session() {
     if [ "$saved_id" = "$id" ]; then
       rollout="$(read_meta_field "$session" transcript_path 2>/dev/null || true)"
     fi
-    if [ -z "$rollout" ] || \
-       ! safe_claude_transcript_path "$rollout" "$id" || \
-       ! valid_claude_transcript "$rollout" "$id"; then
-      local saved_rollout="$rollout"
+    if [ -z "$rollout" ]; then
       rollout="$(claude_transcript_for_id "$id" 2>/dev/null)"
       resolved_status=$?
       if [ "$resolved_status" -eq 2 ]; then
         die "multiple valid Claude transcripts were found for session '$id'"
       fi
       if [ "$resolved_status" -ne 0 ]; then
-        rollout="$saved_rollout"
+        rollout=""
       fi
     fi
     transcript_present=0
@@ -4247,31 +6414,36 @@ resume_agent_session() {
         die "Claude transcript for '$id' is missing or invalid"
       valid_claude_transcript "$rollout" "$id" || \
         die "Claude transcript for '$id' is missing or invalid"
-      restore_matching_claude_checkpoint "$session" "$id" "$rollout" || \
+      "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+        "$SELF" __prepare_claude_resume_locked \
+          "$session" "$id" "$rollout" transcript || \
         die "could not restore the matching Claude checkpoint"
-      start_under_project_lock "$session" "$cwd" "$display_name" \
-        "$id" "$rollout" 0 resume "$id" "$@" || \
+      start_tmux_session_locked "$session" "$cwd" "$display_name" \
+        "$id" "$rollout" "$preserve_checkpoint" resume "$id" "$@" || \
         die "could not start Claude resume session"
     elif claude_matching_checkpoint_exists "$session" "$id"; then
       [ -n "$rollout" ] && safe_claude_transcript_path "$rollout" "$id" || \
         die "Claude session '$id' was not found"
-      restore_matching_claude_checkpoint "$session" "$id" "$rollout" || \
+      "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+        "$SELF" __prepare_claude_resume_locked \
+          "$session" "$id" "$rollout" transcript || \
         die "could not restore the matching Claude checkpoint"
-      valid_claude_transcript "$rollout" "$id" || \
-        die "Claude transcript for '$id' is missing or invalid"
-      start_under_project_lock "$session" "$cwd" "$display_name" \
-        "$id" "$rollout" 0 resume "$id" "$@" || \
+      start_tmux_session_locked "$session" "$cwd" "$display_name" \
+        "$id" "$rollout" "$preserve_checkpoint" resume "$id" "$@" || \
         die "could not start Claude resume session"
     elif [ "$saved_id" = "$id" ]; then
       # Detach owns this UUID. Claude never wrote a transcript, and no
       # matching checkpoint can recreate one, so --resume would fail.
-      start_under_project_lock "$session" "$cwd" "$display_name" \
-        "$id" "" 0 "$@" || \
+      "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+        "$SELF" __prepare_claude_resume_locked \
+          "$session" "$id" "" metadata-only || \
+        die "Claude session '$id' changed while preparing resume"
+      start_tmux_session_locked "$session" "$cwd" "$display_name" \
+        "$id" "" "$preserve_checkpoint" "$@" || \
         die "could not start Claude resume session"
     else
       die "Claude session '$id' was not found"
     fi
-    [ "$detach" -eq 1 ] || attach_session "$session"
     return
   fi
   db="$(codex_state_db)"
@@ -4283,14 +6455,13 @@ resume_agent_session() {
   [ -n "$rows" ] || die "Codex session '$id' was not found"
   rollout="$rows"
   [ -n "$rollout" ] || die "Codex session '$id' has no rollout path"
-  restore_matching_rollout_checkpoint "$session" "$id" "$rollout" || \
+  "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+    "$SELF" __prepare_codex_resume_locked "$session" "$id" "$rollout" || \
     die "could not restore the matching rollout checkpoint"
-  valid_jsonl "$rollout" "$id" || die "Codex rollout for '$id' is missing or invalid"
 
-  start_under_project_lock "$session" "$cwd" "$display_name" \
-    "$id" "$rollout" 0 resume "$id" "$@" || \
+  start_tmux_session_locked "$session" "$cwd" "$display_name" \
+    "$id" "$rollout" "$preserve_checkpoint" resume "$id" "$@" || \
     die "could not start Codex resume session"
-  [ "$detach" -eq 1 ] || attach_session "$session"
 }
 
 transcript_model_context() {
@@ -4334,6 +6505,16 @@ process_is_owned_alive() {
   [ "$process_uid" = "$owner_uid" ]
 }
 
+process_is_confirmed_dead() {
+  local pid="$1"
+  local state
+
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$pid" -gt 1 ] 2>/dev/null || return 1
+  state="$("$STATE_BIN" process state "$pid" 2>/dev/null || true)"
+  [ "$state" = "dead" ]
+}
+
 process_is_descendant() {
   local child="$1"
   local ancestor="$2"
@@ -4352,6 +6533,67 @@ process_is_descendant() {
     depth=$((depth + 1))
   done
   return 1
+}
+
+replacement_runtime_is_quiescent() {
+  local session="$1"
+  local meta
+  local run_token
+  local worker_pid
+  local provider_pid
+  local provider_pid_file
+  local provider_pid_from_file=""
+  local runtime_shutdown_observed_at
+  local provider_identity_known=0
+
+  meta="$(session_meta "$session")"
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 1
+  tmux_session_running "$session" && return 1
+  "$STATE_BIN" meta usable "$meta" "$session" >/dev/null 2>&1 || return 1
+  run_token="$("$STATE_BIN" meta get "$meta" run_token 2>/dev/null)" || return 1
+  [[ "$run_token" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]] || \
+    return 1
+  worker_pid="$("$STATE_BIN" meta get "$meta" worker_pid 2>/dev/null)" || return 1
+  provider_pid="$("$STATE_BIN" meta get "$meta" provider_pid 2>/dev/null)" || return 1
+  runtime_shutdown_observed_at="$(
+    "$STATE_BIN" meta get "$meta" runtime_shutdown_observed_at 2>/dev/null
+  )" || return 1
+
+  case "$worker_pid" in
+    '')
+      [ -n "$runtime_shutdown_observed_at" ] || return 1
+      ;;
+    *[!0-9]*) return 1 ;;
+    *)
+      [ "$worker_pid" -gt 1 ] 2>/dev/null || return 1
+      process_is_confirmed_dead "$worker_pid" || return 1
+      ;;
+  esac
+
+  case "$provider_pid" in
+    '') ;;
+    *[!0-9]*) return 1 ;;
+    *)
+      [ "$provider_pid" -gt 1 ] 2>/dev/null || return 1
+      provider_identity_known=1
+      process_is_confirmed_dead "$provider_pid" || return 1
+      ;;
+  esac
+  provider_pid_file="$(session_dir "$session")/provider-pid-$run_token"
+  if [ -e "$provider_pid_file" ] || [ -L "$provider_pid_file" ]; then
+    [ -f "$provider_pid_file" ] && [ ! -L "$provider_pid_file" ] || return 1
+    IFS= read -r provider_pid_from_file <"$provider_pid_file" || \
+      provider_pid_from_file=""
+    case "$provider_pid_from_file" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$provider_pid_from_file" -gt 1 ] 2>/dev/null || return 1
+    provider_identity_known=1
+    process_is_confirmed_dead "$provider_pid_from_file" || return 1
+  fi
+  if [ "$provider_identity_known" -eq 0 ] && \
+     [ -z "$runtime_shutdown_observed_at" ]; then
+    return 1
+  fi
+  return 0
 }
 
 signal_managed_pane_group() {
@@ -4385,25 +6627,128 @@ signal_managed_pane_group() {
   kill "-$signal" -- "-$pgid"
 }
 
-checkpoint_is_recoverable() {
+codex_recovery_source_is_valid() {
   local session="$1"
-  local id="$2"
-  local transcript_path
+  local meta="$2"
+  local id="$3"
+  local transcript_path="$4"
+  local validation_mode="${5:-cached}"
   local dir
+  local backup
+  local checkpoint_meta
 
-  [ -n "$id" ] && [ "$id" != "-" ] || return 1
   dir="$(session_dir "$session")"
-  transcript_path="$(read_meta_field "$session" transcript_path rollout_path 2>/dev/null || true)"
-  if [ "$PROVIDER" = "claude" ] && \
-     safe_claude_transcript_path "$transcript_path" "$id"; then
-    valid_claude_checkpoint_archive "$dir/checkpoint/claude-session.tar" "$id" || \
-      valid_claude_transcript "$dir/checkpoint/transcript.jsonl" "$id"
-  elif [ "$PROVIDER" = "codex" ] && \
-       safe_codex_rollout_path "$transcript_path"; then
-    valid_jsonl_cached "$dir/checkpoint/rollout.jsonl" "$id"
+  codex_rollout_destination_matches_id "$transcript_path" "$id" || return 1
+  backup="$dir/checkpoint/rollout.jsonl"
+  if [ -e "$backup" ] || [ -L "$backup" ]; then
+    [ -f "$backup" ] && [ ! -L "$backup" ] || return 1
+    case "$validation_mode" in
+      cached) valid_jsonl_cached "$backup" "$id" && return 0 ;;
+      direct) valid_jsonl "$backup" "$id" && return 0 ;;
+      *) return 1 ;;
+    esac
+    checkpoint_meta="$dir/checkpoint/meta.json"
+    if [ -e "$checkpoint_meta" ] || [ -L "$checkpoint_meta" ]; then
+      [ -f "$checkpoint_meta" ] && [ ! -L "$checkpoint_meta" ] || return 1
+      if "$STATE_BIN" meta matches "$checkpoint_meta" "$PROVIDER" "$id" \
+           >/dev/null 2>&1; then
+        return 1
+      fi
+    fi
+    valid_jsonl "$transcript_path" "$id"
+  else
+    valid_jsonl "$transcript_path" "$id"
+  fi
+}
+
+recovery_request_is_valid() {
+  local session="$1"
+  local meta="$2"
+  local validation_mode="${3:-cached}"
+  local id
+  local transcript_path
+  local backup
+  local db
+  local id_sql
+  local resolved_status
+  local resolved_transcript
+  local checkpoint_dir
+
+  checkpoint_dir="$(session_dir "$session")/checkpoint"
+  if [ -e "$checkpoint_dir" ] || [ -L "$checkpoint_dir" ]; then
+    owned_plain_checkpoint_directory "$checkpoint_dir" || return 1
+  fi
+
+  id="$(
+    "$STATE_BIN" meta get "$meta" agent_session_id codex_session_id \
+      2>/dev/null
+  )" || return 1
+  transcript_path="$(
+    "$STATE_BIN" meta get "$meta" transcript_path rollout_path \
+      2>/dev/null
+  )" || return 1
+  if [ -z "$id" ]; then
+    if [ "$PROVIDER" = "claude" ]; then
+      backup="$(session_dir "$session")/checkpoint/transcript.jsonl"
+    else
+      backup="$(session_dir "$session")/checkpoint/rollout.jsonl"
+    fi
+    if [ -f "$backup" ] && [ ! -L "$backup" ]; then
+      if [ "$PROVIDER" = "claude" ]; then
+        id="$("$STATE_BIN" jsonl first "$backup" sessionId 2>/dev/null || true)"
+      else
+        id="$(
+          "$STATE_BIN" jsonl first "$backup" payload.id payload.session_id \
+            2>/dev/null || true
+        )"
+        db="$(codex_state_db)"
+        if [ -n "$id" ] && [ -n "$db" ] && [ -f "$db" ]; then
+          id_sql="$(sql_escape "$id")"
+          transcript_path="$($SQLITE_BIN -noheader -cmd '.timeout 5000' "$db" \
+            "SELECT rollout_path FROM threads WHERE id = '$id_sql' LIMIT 1;" \
+            2>/dev/null || true)"
+        fi
+      fi
+    fi
+  fi
+  [ -n "$id" ] && [ "$id" != "-" ] || return 1
+  saved_resume_args_path "$session" "$meta" >/dev/null || return 1
+  if [ "$PROVIDER" = "claude" ]; then
+    if [ -z "$transcript_path" ]; then
+      resolved_transcript="$(claude_transcript_for_id "$id" 2>/dev/null)"
+      resolved_status=$?
+      case "$resolved_status" in
+        0)
+          claude_recovery_source_is_valid \
+            "$session" "$id" "$resolved_transcript"
+          ;;
+        1)
+          claude_metadata_only_recovery_source_is_valid \
+            "$session" "$meta" "$id"
+          ;;
+        *) return 1 ;;
+      esac
+      return
+    fi
+    claude_recovery_source_is_valid "$session" "$id" "$transcript_path"
+  elif [ "$PROVIDER" = "codex" ]; then
+    [ -n "$transcript_path" ] || return 1
+    codex_recovery_source_is_valid \
+      "$session" "$meta" "$id" "$transcript_path" "$validation_mode"
   else
     return 1
   fi
+}
+
+checkpoint_is_recoverable() {
+  local session="$1"
+  local meta="${2:-}"
+
+  if [ -z "$meta" ]; then
+    meta="$(usable_meta_path "$session" 2>/dev/null || true)"
+  fi
+  [ -n "$meta" ] || return 1
+  recovery_request_is_valid "$session" "$meta"
 }
 
 freshness_for_epoch() {
@@ -4445,12 +6790,18 @@ session_health_envelope() {
   local output_mode="${11:-assessment}"
   local stop_requested_at="${12:-}"
   local lifecycle_phase="${13:-}"
+  local preserve_recovery_until_ready="${14:-}"
+  local runtime_ready_at="${15:-}"
   local stop_requested=false
+  local uncommitted_replacement=false
+  local runtime_quiescent=false
+  local recovery_meta=""
+  local active_meta=""
   local now
   local checkpoint_threshold
 
-  if [ "$#" -ge 13 ]; then
-    shift 13
+  if [ "$#" -ge 15 ]; then
+    shift 15
   else
     set --
   fi
@@ -4475,6 +6826,10 @@ session_health_envelope() {
     [ "$health_schema" = "1" ] && runtime_identity_expected=true
     [ -n "$id" ] && [ "$id" != "-" ] && agent_session_known=true
     [ -z "$stop_requested_at" ] || stop_requested=true
+    if [ "$preserve_recovery_until_ready" = "true" ] && \
+       [ -z "$runtime_ready_at" ]; then
+      uncommitted_replacement=true
+    fi
   fi
 
   tmux_health_snapshot "$session"
@@ -4483,13 +6838,33 @@ session_health_envelope() {
   tmux_heartbeat_epoch="$TMUX_HEALTH_HEARTBEAT_EPOCH"
   pane_pid="$TMUX_HEALTH_PANE_PID"
 
-  # Full provider checkpoint validation can be expensive. It affects the
-  # transition only after an active runtime disappears, never a healthy live
-  # poll or a session whose terminal status is already recorded.
-  case "$tmux_state:$meta_status" in
-    missing:starting|missing:running|missing:recovering|missing:hung|\
-    dead:starting|dead:running|dead:recovering|dead:hung)
-      checkpoint_is_recoverable "$session" "$id" && checkpoint_recoverable=true
+  # Full provider checkpoint validation can be expensive. It affects only a
+  # disappeared runtime. An uncommitted replacement validates the preserved
+  # checkpoint generation, never its operational primary metadata.
+  case "$tmux_state" in
+    missing|dead)
+      if [ "$uncommitted_replacement" = "true" ]; then
+        if replacement_runtime_is_quiescent "$session"; then
+          runtime_quiescent=true
+          recovery_meta="$(
+            uncommitted_recovery_meta_path "$session" 2>/dev/null || true
+          )"
+          if [ -n "$recovery_meta" ] && \
+             checkpoint_is_recoverable "$session" "$recovery_meta"; then
+            checkpoint_recoverable=true
+          fi
+        fi
+      else
+        case "$meta_status" in
+          starting|running|recovering|hung)
+            active_meta="$(usable_meta_path "$session" 2>/dev/null || true)"
+            if [ -n "$active_meta" ] && \
+               checkpoint_is_recoverable "$session" "$active_meta"; then
+              checkpoint_recoverable=true
+            fi
+            ;;
+        esac
+      fi
       ;;
   esac
 
@@ -4572,6 +6947,8 @@ session_health_envelope() {
     --checkpoint "$checkpoint_freshness" \
     --checkpoint-recoverable "$checkpoint_recoverable" \
     --agent-session-known "$agent_session_known" \
+    --uncommitted-replacement "$uncommitted_replacement" \
+    --runtime-quiescent "$runtime_quiescent" \
     --stop-requested "$stop_requested"
     --lifecycle-phase "$lifecycle_phase"
   )
@@ -4605,8 +6982,18 @@ refuse_runtime_without_managed_tmux() {
   local health_output
   local health_json
   local reason
+  local primary
+  local checkpoint
 
-  load_usable_meta_snapshot "$session" || return 0
+  if ! load_usable_meta_snapshot "$session"; then
+    primary="$(session_meta "$session")"
+    checkpoint="$(session_dir "$session")/checkpoint/meta.json"
+    if [ ! -e "$primary" ] && [ ! -L "$primary" ] && \
+       [ ! -e "$checkpoint" ] && [ ! -L "$checkpoint" ]; then
+      return 0
+    fi
+    die "no valid operational metadata for '$session'; refusing to change saved state"
+  fi
   status="$META_STATUS"
   id="$META_AGENT_SESSION_ID"
   [ -n "$status" ] || status="unknown"
@@ -4615,15 +7002,62 @@ refuse_runtime_without_managed_tmux() {
     "$session" true "$status" "$id" "$META_RUN_TOKEN" \
     "$META_WORKER_PID" "$META_PROVIDER_PID" "$META_WORKER_HEARTBEAT_EPOCH" \
     "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" assessment \
-    "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE")" || \
+    "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE" \
+    "$META_PRESERVE_RECOVERY_UNTIL_READY" "$META_RUNTIME_READY_AT")" || \
     die "could not safely evaluate runtime ownership for '$session'"
   health_json="${health_output#*$'\n'}"
   [ "$health_json" != "$health_output" ] || \
     die "could not decode runtime ownership for '$session'"
   reason="$(printf '%s' "$health_json" | \
     "$STATE_BIN" meta get /dev/stdin reason 2>/dev/null || true)"
-  [ "$reason" != "runtime_process_without_tmux" ] || \
-    die "recorded runtime process for '$session' is still alive without managed tmux; refusing to signal it or change saved state"
+  case "$reason" in
+    runtime_process_without_tmux)
+      die "recorded runtime process for '$session' is still alive without managed tmux; refusing to signal it or change saved state"
+      ;;
+    runtime_quiescence_unproven)
+      die "replacement runtime shutdown for '$session' is not proven; refusing to signal it or change saved state"
+      ;;
+  esac
+}
+
+require_dead_tmux_primary_run_match() {
+  local session="$1"
+  local expected_tmux_run_token="${2:-}"
+  local require_primary="${3:-0}"
+  local primary
+  local primary_run_token
+  local tmux_run_token
+
+  tmux_has_session "$session" || return 0
+  tmux_is_managed "$session" || \
+    die "refusing to remove unmanaged tmux session '$session'"
+  [ "$(tmux_pane_dead "$session")" = "1" ] || \
+    die "refusing to remove live tmux session '$session'"
+  tmux_run_token="$(tmux_option "$session" '@detach_run_token')"
+  if [ -n "$expected_tmux_run_token" ] && \
+     [ "$tmux_run_token" != "$expected_tmux_run_token" ]; then
+    die "refusing to remove a replacement tmux run for '$session'"
+  fi
+
+  primary="$(session_meta "$session")"
+  if [ ! -e "$primary" ] && [ ! -L "$primary" ]; then
+    if [ "$require_primary" -eq 0 ] && \
+       [ ! -e "$(session_dir "$session")" ] && \
+       [ ! -L "$(session_dir "$session")" ]; then
+      return 0
+    fi
+    die "no valid operational metadata for retained tmux session '$session'"
+  fi
+  [ -f "$primary" ] && [ ! -L "$primary" ] && \
+    "$STATE_BIN" meta usable "$primary" "$session" >/dev/null 2>&1 || \
+      die "no valid operational metadata for retained tmux session '$session'"
+  primary_run_token="$(
+    "$STATE_BIN" meta get "$primary" run_token 2>/dev/null || true
+  )"
+  if [ -z "$primary_run_token" ] || [ -z "$tmux_run_token" ] || \
+     [ "$primary_run_token" != "$tmux_run_token" ]; then
+    die "retained tmux run does not match operational metadata for '$session'"
+  fi
 }
 
 prepare_list_json_args() {
@@ -4678,6 +7112,7 @@ list_session_records() {
   local json_mode="${1:-0}"
   local session
   local metadata_valid
+  local metadata_source
   local snapshots_complete=0
   local completion_marker
   local status
@@ -4698,6 +7133,20 @@ list_session_records() {
   local worker_pid
   local provider_pid
   local worker_heartbeat_at
+  local health_status
+  local health_id
+  local health_run_token
+  local health_worker_pid
+  local health_provider_pid
+  local health_worker_heartbeat_at
+  local health_worker_heartbeat_epoch
+  local health_last_checkpoint_epoch
+  local health_schema
+  local health_stop_requested_at
+  local health_lifecycle_phase
+  local health_preserve_recovery_until_ready
+  local health_runtime_ready_at
+  local recovery_meta
   local LIST_HEALTH_NOW
 
   ensure_state_dirs
@@ -4755,6 +7204,9 @@ list_session_records() {
       IFS= read -r -d '' META_HEALTH_SCHEMA && \
       IFS= read -r -d '' META_STOP_REQUESTED_AT && \
       IFS= read -r -d '' META_LIFECYCLE_PHASE && \
+      IFS= read -r -d '' META_PRESERVE_RECOVERY_UNTIL_READY && \
+      IFS= read -r -d '' META_RUNTIME_READY_AT && \
+      IFS= read -r -d '' metadata_source && \
       IFS= read -r -d '' TRANSCRIPT_MODEL && \
       IFS= read -r -d '' TRANSCRIPT_CTX_USED && \
       IFS= read -r -d '' TRANSCRIPT_CTX_WINDOW && \
@@ -4778,12 +7230,12 @@ list_session_records() {
           "" "" "" "" "" ""
         session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
-          request "" "" "${LIST_JSON_ARGS[@]}" || \
+          request "" "" "" "" "${LIST_JSON_ARGS[@]}" || \
           die "could not evaluate health for '$session'"
       else
         health_output="$(session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
-          assessment "" "")" || \
+          assessment "" "" "" "")" || \
           die "could not evaluate health for '$session'"
       fi
       if [ "$json_mode" = "1" ]; then
@@ -4801,7 +7253,46 @@ list_session_records() {
     # `initializing` metadata exists only so the worker and starter can share
     # one typed document. It is not a coherent list record until the worker has
     # published its exact PID against the configured tmux run token.
-    [ "$META_LIFECYCLE_PHASE" != "initializing" ] || continue
+    if [ "$META_LIFECYCLE_PHASE" = "initializing" ] && \
+       [ "$META_PRESERVE_RECOVERY_UNTIL_READY" != "true" ]; then
+      continue
+    fi
+    health_status="$META_STATUS"
+    health_id="$META_AGENT_SESSION_ID"
+    health_run_token="$META_RUN_TOKEN"
+    # Checkpoint metadata is a recovery source, not operational authority for
+    # a retained tmux pane. Without a usable primary generation, health must
+    # keep a dead pane actionless instead of treating A's token as ownership
+    # proof for an unknown operational run.
+    [ "$metadata_source" = "primary" ] || health_run_token=""
+    health_worker_pid="$META_WORKER_PID"
+    health_provider_pid="$META_PROVIDER_PID"
+    health_worker_heartbeat_at="$META_WORKER_HEARTBEAT_AT"
+    health_worker_heartbeat_epoch="$META_WORKER_HEARTBEAT_EPOCH"
+    health_last_checkpoint_epoch="$META_LAST_CHECKPOINT_EPOCH"
+    health_schema="$META_HEALTH_SCHEMA"
+    health_stop_requested_at="$META_STOP_REQUESTED_AT"
+    health_lifecycle_phase="$META_LIFECYCLE_PHASE"
+    health_preserve_recovery_until_ready="$META_PRESERVE_RECOVERY_UNTIL_READY"
+    health_runtime_ready_at="$META_RUNTIME_READY_AT"
+
+    # Once the replacement runtime is positively quiescent, present the
+    # recovery generation while retaining its replacement PID/token evidence
+    # for the typed health decision below.
+    recovery_meta=""
+    if [ "$health_preserve_recovery_until_ready" = "true" ] && \
+       [ -z "$health_runtime_ready_at" ] && \
+       replacement_runtime_is_quiescent "$session"; then
+      recovery_meta="$(
+        uncommitted_recovery_meta_path "$session" 2>/dev/null || true
+      )"
+      if [ -n "$recovery_meta" ] && \
+         checkpoint_is_recoverable "$session" "$recovery_meta"; then
+        load_meta_snapshot_path "$recovery_meta" "$session" || \
+          die "could not decode recovery metadata for '$session'"
+        transcript_model_context "$META_TRANSCRIPT_PATH"
+      fi
+    fi
     status="$META_STATUS"
     display_name="$META_DISPLAY_NAME"
     cwd="$META_PROJECT_DIR"
@@ -4814,9 +7305,9 @@ list_session_records() {
     created="$META_CREATED_AT"
     finished="$META_FINISHED_AT"
     exit_json="$META_EXIT_STATUS"
-    worker_pid="$META_WORKER_PID"
-    provider_pid="$META_PROVIDER_PID"
-    worker_heartbeat_at="$META_WORKER_HEARTBEAT_AT"
+    worker_pid="$health_worker_pid"
+    provider_pid="$health_provider_pid"
+    worker_heartbeat_at="$health_worker_heartbeat_at"
     session_color="$META_SESSION_COLOR"
     if [ -z "$session_color" ] && [ -n "$cwd" ] && [ "$cwd" != "?" ]; then
       session_color="$(session_color_for "$PROVIDER" "$cwd")" || session_color=''
@@ -4835,18 +7326,20 @@ list_session_records() {
         "$worker_pid" "$provider_pid" "$worker_heartbeat_at" "$display_name" \
         "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_ID"
       session_health_envelope \
-        "$session" true "$status" "$id" "$META_RUN_TOKEN" \
-        "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
-        "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" \
-        request "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE" \
+        "$session" true "$health_status" "$health_id" "$health_run_token" \
+        "$worker_pid" "$provider_pid" "$health_worker_heartbeat_epoch" \
+        "$health_last_checkpoint_epoch" "$health_schema" \
+        request "$health_stop_requested_at" "$health_lifecycle_phase" \
+        "$health_preserve_recovery_until_ready" "$health_runtime_ready_at" \
         "${LIST_JSON_ARGS[@]}" || \
         die "could not evaluate health for '$session'"
     else
       health_output="$(session_health_envelope \
-        "$session" true "$status" "$id" "$META_RUN_TOKEN" \
-        "$worker_pid" "$provider_pid" "$META_WORKER_HEARTBEAT_EPOCH" \
-        "$META_LAST_CHECKPOINT_EPOCH" "$META_HEALTH_SCHEMA" assessment \
-        "$META_STOP_REQUESTED_AT" "$META_LIFECYCLE_PHASE")" || \
+        "$session" true "$health_status" "$health_id" "$health_run_token" \
+        "$worker_pid" "$provider_pid" "$health_worker_heartbeat_epoch" \
+        "$health_last_checkpoint_epoch" "$health_schema" assessment \
+        "$health_stop_requested_at" "$health_lifecycle_phase" \
+        "$health_preserve_recovery_until_ready" "$health_runtime_ready_at")" || \
         die "could not evaluate health for '$session'"
     fi
     if [ "$json_mode" = "1" ]; then
@@ -4978,6 +7471,7 @@ stop_session() {
     if [ -n "$pane" ] && [ "$(tmux_pane_dead "$session")" = "0" ]; then
       [ "$tmux_run_token_proven" -eq 1 ] || \
         die "refusing to stop a live session without an exact run token"
+      pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
       # Record intent only for the exact managed run immediately before its
       # first signal. A failed write aborts Stop; a fresh start clears intent.
       stop_requested_at="$(now_iso)"
@@ -4988,9 +7482,14 @@ stop_session() {
           die "could not record Stop intent for the exact managed run"
       stop_intent_recorded=1
       # Preserve the stop-edge screen before the first signal. A bounded Stop
-      # may later terminate a worker stuck in a slow database checkpoint.
-      checkpoint_pane "$session" || true
-      pane_pid="$("${TMUX_CMD[@]}" display-message -p -t "$pane" '#{pane_pid}' 2>/dev/null || true)"
+      # may later terminate a worker stuck in a slow database checkpoint. A
+      # replacement that has not committed readiness must leave the previous
+      # generation's pane checkpoint unchanged.
+      if checkpoint_run_may_publish "$session" "$run_token"; then
+        "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+          "$SELF" __checkpoint_stop_edge_locked \
+            "$session" "$run_token" "$pane_pid" || true
+      fi
       provider_pid="$(read_meta_field "$session" provider_pid 2>/dev/null || true)"
       case "$provider_pid" in ''|*[!0-9]*) provider_pid="" ;; esac
       if [ -n "$pane_pid" ]; then
@@ -5101,6 +7600,7 @@ delete_session() {
     if [ "$(tmux_pane_dead "$session")" = "0" ]; then
       die "session '$session' is still running; stop it first"
     fi
+    require_dead_tmux_primary_run_match "$session"
   fi
   if [ "$force" -ne 1 ]; then
     [ -t 0 ] || die "refusing to delete without --force when stdin is not a terminal"
@@ -5142,6 +7642,7 @@ delete_locked() {
     if [ "$(tmux_pane_dead "$session")" = "0" ]; then
       die "session '$session' is running again; aborting delete"
     fi
+    require_dead_tmux_primary_run_match "$session"
   fi
   if tmux_has_session "$session"; then
     "${TMUX_CMD[@]}" kill-session -t "=$session" || die "could not remove tmux session '$session'"
@@ -5153,16 +7654,24 @@ delete_locked() {
 
 restore_rollout_if_needed() {
   local session="$1"
-  local meta
+  local meta="${2:-}"
+  local selected_id="${3:-}"
+  local selected_rollout="${4:-}"
   local rollout
   local backup
   local id
+  local checkpoint_meta
   local restore=0
-  local tmp
 
-  meta="$(usable_meta_path "$session")" || die "no valid saved state for '$session'"
-  rollout="$("$STATE_BIN" meta get "$meta" transcript_path rollout_path)"
-  id="$("$STATE_BIN" meta get "$meta" agent_session_id codex_session_id)"
+  if [ -z "$meta" ]; then
+    meta="$(usable_meta_path "$session")" || die "no valid saved state for '$session'"
+  fi
+  rollout="$selected_rollout"
+  [ -n "$rollout" ] || \
+    rollout="$("$STATE_BIN" meta get "$meta" transcript_path rollout_path)"
+  id="$selected_id"
+  [ -n "$id" ] || \
+    id="$("$STATE_BIN" meta get "$meta" agent_session_id codex_session_id)"
   if [ "$PROVIDER" = "claude" ]; then
     [ -n "$id" ] || die "no Claude session UUID was checkpointed"
     if [ -z "$rollout" ]; then
@@ -5175,9 +7684,32 @@ restore_rollout_if_needed() {
     return
   fi
   backup="$(session_dir "$session")/checkpoint/rollout.jsonl"
-  safe_codex_rollout_path "$rollout" || die "refusing unsafe Codex rollout path"
-  [ -n "$rollout" ] && [ -n "$id" ] && [ -f "$backup" ] || return 0
-  valid_jsonl "$backup" "$id" || die "saved rollout checkpoint is invalid"
+  codex_rollout_destination_matches_id "$rollout" "$id" || \
+    die "refusing Codex rollout path owned by another session"
+  [ -n "$rollout" ] && [ -n "$id" ] || return 0
+  if [ ! -e "$backup" ] && [ ! -L "$backup" ]; then
+    valid_jsonl "$rollout" "$id" || \
+      die "Codex rollout is missing or invalid and no checkpoint is available"
+    return 0
+  fi
+  [ -f "$backup" ] && [ ! -L "$backup" ] || \
+    die "saved rollout checkpoint is not a safe regular file"
+  if ! valid_jsonl "$backup" "$id"; then
+    checkpoint_meta="$(session_dir "$session")/checkpoint/meta.json"
+    if [ -e "$checkpoint_meta" ] || [ -L "$checkpoint_meta" ]; then
+      [ -f "$checkpoint_meta" ] && [ ! -L "$checkpoint_meta" ] || \
+        die "saved checkpoint metadata is not a safe regular file"
+      if "$STATE_BIN" meta matches "$checkpoint_meta" "$PROVIDER" "$id" \
+           >/dev/null 2>&1; then
+        die "saved rollout checkpoint is invalid"
+      fi
+    fi
+    valid_jsonl "$rollout" "$id" || \
+      die "Codex rollout and its saved checkpoint do not match the selected session"
+    checkpoint_log "$session" \
+      "ignored stale Codex checkpoint for valid live session $id" || true
+    return 0
+  fi
 
   if ! valid_jsonl "$rollout" "$id"; then
     restore=1
@@ -5186,57 +7718,84 @@ restore_rollout_if_needed() {
   fi
 
   if [ "$restore" -eq 1 ]; then
-    mkdir -p "$(dirname "$rollout")"
-    tmp="$rollout.detach.tmp.$$"
-    cp -p "$backup" "$tmp" || die "could not copy rollout checkpoint"
-    valid_jsonl "$tmp" "$id" || {
-      rm -f "$tmp"
-      die "copied rollout checkpoint failed validation"
-    }
-    mv -f "$tmp" "$rollout" || die "could not restore rollout from checkpoint"
+    publish_codex_rollout_checkpoint "$backup" "$rollout" "$id" || \
+      die "could not safely restore rollout from checkpoint"
     [ "$SYNC_ENABLED" = "0" ] || /bin/sync
     error "restored damaged Codex rollout from the last checkpoint"
   fi
 }
 
-recover_session() {
+recover_session_prepare_locked() {
   local session="$1"
-  local detach="$2"
+  local locked_cwd="$2"
   local meta
-  local cwd
-  local display_name
   local id
   local rollout
   local backup
   local db
   local id_sql
-  local primary
-  local tmp
-  local resume_args=()
-  local arg
-
-  refuse_runtime_without_managed_tmux "$session"
-  meta="$(usable_meta_path "$session")" || die "no valid saved state for '$session'"
-  primary="$(session_meta "$session")"
-  if [ "$meta" != "$primary" ]; then
-    tmp="$primary.recover.tmp.$$"
-    cp -p "$meta" "$tmp" && mv -f "$tmp" "$primary" || die "could not restore checkpoint metadata"
-    meta="$primary"
-  fi
+  local preflight_meta
+  local retained_dead_tmux=0
+  local retained_run_token=""
+  local resolved_status
+  local selected_cwd
 
   if tmux_has_session "$session"; then
     tmux_is_managed "$session" || die "refusing to recover over unmanaged tmux session '$session'"
-    if tmux_session_running "$session"; then
-      [ "$detach" -eq 1 ] && return 0
-      attach_session "$session"
-    fi
-    "${TMUX_CMD[@]}" kill-session -t "=$session" >/dev/null 2>&1 || true
+    tmux_session_running "$session" && \
+      die "session '$session' is running again; refusing recovery"
+    retained_dead_tmux=1
+    retained_run_token="$(tmux_option "$session" '@detach_run_token')"
+  fi
+  refuse_runtime_without_managed_tmux "$session"
+  if [ "$retained_dead_tmux" -eq 1 ]; then
+    require_dead_tmux_primary_run_match "$session" "$retained_run_token" 1
+  fi
+  select_recovery_meta_for_mutation "$session" || \
+    die "no valid saved state for '$session'"
+  preflight_meta="$SELECTED_RECOVERY_META"
+  selected_cwd="$(
+    "$STATE_BIN" meta get "$preflight_meta" project_dir 2>/dev/null
+  )" || die "could not read saved project directory"
+  [ "$selected_cwd" = "$locked_cwd" ] || \
+    die "saved project changed while recovery locks were acquired"
+  if [ "$SELECTED_RECOVERY_IS_UNCOMMITTED" -eq 1 ]; then
+    replacement_runtime_is_quiescent "$session" || \
+      die "replacement runtime shutdown is not proven; refusing to recover over it"
+  fi
+  # Validate the selected generation, saved arguments, and every provider
+  # restore destination before removing a retained pane. A deterministic
+  # recovery refusal must leave that evidence intact.
+  recovery_request_is_valid "$session" "$preflight_meta" direct || \
+    die "saved $PROVIDER_LABEL recovery data is missing, unsafe, or invalid"
+  if [ "$retained_dead_tmux" -eq 1 ] && tmux_has_session "$session"; then
+    require_dead_tmux_primary_run_match "$session" "$retained_run_token" 1
+    "${TMUX_CMD[@]}" kill-session -t "=$session" >/dev/null 2>&1 || \
+      die "could not remove retained tmux session '$session'"
   fi
 
-  cwd="$("$STATE_BIN" meta get "$meta" project_dir)"
-  display_name="$("$STATE_BIN" meta get "$meta" display_name 2>/dev/null || true)"
-  id="$("$STATE_BIN" meta get "$meta" agent_session_id codex_session_id)"
-  rollout="$("$STATE_BIN" meta get "$meta" transcript_path rollout_path)"
+  # Removing a retained pane changes the health evidence. Repeat the exact
+  # process proof and generation selection before restoring provider data.
+  refuse_runtime_without_managed_tmux "$session"
+  select_recovery_meta_for_mutation "$session" || \
+    die "no valid saved state for '$session'"
+  meta="$SELECTED_RECOVERY_META"
+  selected_cwd="$(
+    "$STATE_BIN" meta get "$meta" project_dir 2>/dev/null
+  )" || die "could not read saved project directory"
+  [ "$selected_cwd" = "$locked_cwd" ] || \
+    die "saved project changed while recovery locks were acquired"
+  if [ "$SELECTED_RECOVERY_IS_UNCOMMITTED" -eq 1 ]; then
+    replacement_runtime_is_quiescent "$session" || \
+      die "replacement runtime shutdown is not proven; refusing to recover over it"
+  fi
+
+  id="$(
+    "$STATE_BIN" meta get "$meta" agent_session_id codex_session_id
+  )" || die "could not read saved $PROVIDER_LABEL session identity"
+  rollout="$(
+    "$STATE_BIN" meta get "$meta" transcript_path rollout_path
+  )" || die "could not read saved $PROVIDER_LABEL transcript path"
 
   if [ -z "$id" ]; then
     if [ "$PROVIDER" = "claude" ]; then
@@ -5258,34 +7817,199 @@ recover_session() {
       fi
     fi
   fi
-  [ -n "$id" ] && [ -n "$rollout" ] || die "no unambiguous $PROVIDER_LABEL session UUID was checkpointed"
-  if [ "$PROVIDER" = "claude" ]; then
-    state_update_meta "$session" \
-      --string agent_session_id "$id" --string transcript_path "$rollout" || \
-      die "could not repair recovery metadata"
-  else
-    state_update_meta "$session" \
-      --string agent_session_id "$id" --string transcript_path "$rollout" \
-      --string codex_session_id "$id" --string rollout_path "$rollout" || \
-      die "could not repair recovery metadata"
+  [ -n "$id" ] || \
+    die "no unambiguous $PROVIDER_LABEL session UUID was checkpointed"
+  if [ "$PROVIDER" = "claude" ] && [ -z "$rollout" ]; then
+    rollout="$(claude_transcript_for_id "$id" 2>/dev/null)"
+    resolved_status=$?
+    case "$resolved_status" in
+      0) ;;
+      1)
+        claude_metadata_only_recovery_source_is_valid \
+          "$session" "$meta" "$id" || \
+            die "saved Claude metadata-only recovery data is invalid"
+        return 0
+        ;;
+      *) die "multiple valid Claude transcripts were found for session '$id'" ;;
+    esac
   fi
-  restore_rollout_if_needed "$session"
-  if [ -f "$(session_dir "$session")/resume-args.bin" ]; then
+  [ -n "$rollout" ] || \
+    die "no unambiguous $PROVIDER_LABEL transcript was checkpointed"
+  restore_rollout_if_needed "$session" "$meta" "$id" "$rollout"
+}
+
+recover_session() {
+  local session="$1"
+  local detach="$2"
+  local meta
+  local cwd
+
+  if tmux_has_session "$session"; then
+    tmux_is_managed "$session" || \
+      die "refusing to recover over unmanaged tmux session '$session'"
+    if tmux_session_running "$session"; then
+      [ "$detach" -eq 1 ] && return 0
+      attach_session "$session"
+      return 0
+    fi
+  fi
+  select_recovery_meta_for_mutation "$session" || \
+    die "no valid saved state for '$session'"
+  meta="$SELECTED_RECOVERY_META"
+  cwd="$("$STATE_BIN" meta get "$meta" project_dir 2>/dev/null)" || \
+    die "could not read saved project directory"
+  [ -n "$cwd" ] || die "saved project directory is missing"
+
+  mkdir -p "$INSTALL_STATE_ROOT" || \
+    die "cannot create install lock directory"
+  "$LOCKF_BIN" -k -t "$INSTALL_LOCK_TIMEOUT" "$INSTALL_LOCK" \
+    "$SELF" __recover_under_install_lock "$session" "$cwd" || return 1
+  [ "$detach" -eq 1 ] || attach_session "$session"
+}
+
+recover_under_install_lock() {
+  local session="$1"
+  local cwd="$2"
+  local lock
+
+  lock="$(project_lock_path "$cwd")"
+  "$LOCKF_BIN" -k -t 30 "$lock" \
+    "$SELF" __recover_under_project_lock "$session" "$cwd"
+}
+
+recover_under_project_lock() {
+  local session="$1"
+  local cwd="$2"
+  local existing
+
+  existing="$(running_session_for_project "$cwd" "$session" || true)"
+  [ -z "$existing" ] || \
+    die "project already has a running detached session: $existing"
+  recover_session_project_locked "$session" "$cwd"
+}
+
+recover_session_project_locked() {
+  local session="$1"
+  local locked_cwd="$2"
+  local meta
+  local cwd
+  local display_name
+  local id
+  local rollout
+  local backup
+  local db
+  local id_sql
+  local resume_args=()
+  local resume_args_file
+  local arg
+  local resolved_status
+  local metadata_only=0
+
+  if tmux_has_session "$session"; then
+    tmux_is_managed "$session" || \
+      die "refusing to recover over unmanaged tmux session '$session'"
+    tmux_session_running "$session" && \
+      die "session '$session' is running again; refusing recovery"
+  fi
+
+  # Checkpoint and heartbeat children can outlive a killed worker. Serialize
+  # generation selection, retained-pane removal, and provider restore against
+  # every writer. Their locked handlers recheck the exact live worker, so a
+  # queued orphan cannot mutate the selected generation after this barrier.
+  "$LOCKF_BIN" -k -t 30 "$(checkpoint_lock_path "$session")" \
+    "$SELF" __recover_session_prepare_locked \
+      "$session" "$locked_cwd" || return 1
+
+  refuse_runtime_without_managed_tmux "$session"
+  select_recovery_meta_for_mutation "$session" || \
+    die "no valid saved state for '$session'"
+  meta="$SELECTED_RECOVERY_META"
+  if [ "$SELECTED_RECOVERY_IS_UNCOMMITTED" -eq 1 ]; then
+    replacement_runtime_is_quiescent "$session" || \
+      die "replacement runtime shutdown is not proven; refusing to recover over it"
+  fi
+  recovery_request_is_valid "$session" "$meta" direct || \
+    die "saved $PROVIDER_LABEL recovery data is missing, unsafe, or invalid"
+
+  cwd="$("$STATE_BIN" meta get "$meta" project_dir)" || \
+    die "could not read saved project directory"
+  [ "$cwd" = "$locked_cwd" ] || \
+    die "saved project changed while recovery locks were acquired"
+  display_name="$("$STATE_BIN" meta get "$meta" display_name 2>/dev/null)" || \
+    die "could not read saved display name"
+  id="$(
+    "$STATE_BIN" meta get "$meta" agent_session_id codex_session_id
+  )" || die "could not read saved $PROVIDER_LABEL session identity"
+  rollout="$(
+    "$STATE_BIN" meta get "$meta" transcript_path rollout_path
+  )" || die "could not read saved $PROVIDER_LABEL transcript path"
+
+  if [ -z "$id" ]; then
+    if [ "$PROVIDER" = "claude" ]; then
+      backup="$(session_dir "$session")/checkpoint/transcript.jsonl"
+    else
+      backup="$(session_dir "$session")/checkpoint/rollout.jsonl"
+    fi
+    if [ -f "$backup" ]; then
+      if [ "$PROVIDER" = "claude" ]; then
+        id="$("$STATE_BIN" jsonl first "$backup" sessionId 2>/dev/null || true)"
+      else
+        id="$("$STATE_BIN" jsonl first "$backup" payload.id payload.session_id 2>/dev/null || true)"
+        db="$(codex_state_db)"
+        if [ -n "$id" ] && [ -n "$db" ] && [ -f "$db" ]; then
+          id_sql="$(sql_escape "$id")"
+          rollout="$($SQLITE_BIN -noheader -cmd '.timeout 5000' "$db" \
+            "SELECT rollout_path FROM threads WHERE id = '$id_sql' LIMIT 1;" 2>/dev/null || true)"
+        fi
+      fi
+    fi
+  fi
+  [ -n "$id" ] || \
+    die "no unambiguous $PROVIDER_LABEL session UUID was checkpointed"
+  if [ "$PROVIDER" = "claude" ] && [ -z "$rollout" ]; then
+    rollout="$(claude_transcript_for_id "$id" 2>/dev/null)"
+    resolved_status=$?
+    case "$resolved_status" in
+      0) ;;
+      1)
+        claude_metadata_only_recovery_source_is_valid \
+          "$session" "$meta" "$id" || \
+            die "saved Claude metadata-only recovery data is invalid"
+        metadata_only=1
+        ;;
+      *) die "multiple valid Claude transcripts were found for session '$id'" ;;
+    esac
+  fi
+  if [ "$metadata_only" -eq 0 ]; then
+    [ -n "$rollout" ] || \
+      die "no unambiguous $PROVIDER_LABEL transcript was checkpointed"
+  fi
+  resume_args_file="$(saved_resume_args_path "$session" "$meta")" || \
+    die "saved $PROVIDER_LABEL resume options are missing or invalid"
+  if [ -n "$resume_args_file" ]; then
     while IFS= read -r -d '' arg; do
       resume_args+=( "$arg" )
-    done <"$(session_dir "$session")/resume-args.bin"
+    done <"$resume_args_file"
   fi
-  if [ "${#resume_args[@]}" -gt 0 ]; then
-    start_under_project_lock "$session" "$cwd" "$display_name" \
+  if [ "$metadata_only" -eq 1 ]; then
+    if [ "${#resume_args[@]}" -gt 0 ]; then
+      start_tmux_session_locked "$session" "$cwd" "$display_name" \
+        "$id" "" 1 "${resume_args[@]}" || \
+        die "could not start metadata-only checkpoint recovery"
+    else
+      start_tmux_session_locked "$session" "$cwd" "$display_name" \
+        "$id" "" 1 || \
+        die "could not start metadata-only checkpoint recovery"
+    fi
+  elif [ "${#resume_args[@]}" -gt 0 ]; then
+    start_tmux_session_locked "$session" "$cwd" "$display_name" \
       "$id" "$rollout" 1 resume "$id" "${resume_args[@]}" || \
       die "could not start checkpoint recovery"
   else
-    start_under_project_lock "$session" "$cwd" "$display_name" \
+    start_tmux_session_locked "$session" "$cwd" "$display_name" \
       "$id" "$rollout" 1 resume "$id" || \
       die "could not start checkpoint recovery"
   fi
-  [ "$detach" -eq 1 ] || attach_session "$session"
-  return 0
 }
 
 main() {
@@ -5496,10 +8220,35 @@ case "${1:-}" in
     shift
     checkpoint_once_locked "$@"
     ;;
+  __checkpoint_stop_edge_locked)
+    shift
+    [ "$#" -eq 3 ] || exit 1
+    checkpoint_stop_edge_locked "$@"
+    ;;
   __runtime_heartbeat_locked)
     shift
     [ "$#" -eq 6 ] || exit 1
     runtime_heartbeat_locked "$@"
+    ;;
+  __runtime_heartbeat_once)
+    shift
+    [ "$#" -eq 4 ] || [ "$#" -eq 5 ] || exit 1
+    runtime_heartbeat_once "$@"
+    ;;
+  __prepare_codex_resume_locked)
+    shift
+    [ "$#" -eq 3 ] || exit 1
+    prepare_codex_resume_locked "$@"
+    ;;
+  __prepare_claude_resume_locked)
+    shift
+    [ "$#" -eq 4 ] || exit 1
+    prepare_claude_resume_locked "$@"
+    ;;
+  __discover_live_worker_locked)
+    shift
+    [ "$#" -eq 3 ] || exit 1
+    discover_live_worker_locked "$@"
     ;;
   __delete_locked)
     shift
@@ -5508,6 +8257,31 @@ case "${1:-}" in
   __session_operation_locked)
     shift
     session_operation_locked "$@"
+    ;;
+  __recover_session_prepare_locked)
+    shift
+    [ "$#" -eq 2 ] || exit 1
+    recover_session_prepare_locked "$@"
+    ;;
+  __resume_under_install_lock)
+    shift
+    [ "$#" -ge 4 ] || exit 1
+    resume_under_install_lock "$@"
+    ;;
+  __resume_under_project_lock)
+    shift
+    [ "$#" -ge 4 ] || exit 1
+    resume_under_project_lock "$@"
+    ;;
+  __recover_under_install_lock)
+    shift
+    [ "$#" -eq 2 ] || exit 1
+    recover_under_install_lock "$@"
+    ;;
+  __recover_under_project_lock)
+    shift
+    [ "$#" -eq 2 ] || exit 1
+    recover_under_project_lock "$@"
     ;;
   __write_initial_meta)
     shift

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -51,10 +51,12 @@ replace it for a temporarily stale heartbeat.
 The menu bar is display-only. Its prompt mark is filled for protected, dim for
 sleep allowed, badged for attention, and outlined for unknown. Starting,
 running, and recovering sessions are active; hung sessions are not. Green means
-working and orange means waiting. Waiting outranks working. A badge hides both
-tints so power warnings stay visible. Monochrome states remain template; tints
-resolve from label or system colors. VoiceOver names
-the session state. The first menu line is `state · reason · freshness`.
+working and orange means waiting. Claude `AskUserQuestion` records with a
+`tool_use` stop reason enter waiting; their matching user tool-result records
+return to working. Waiting outranks working. A badge hides both tints so power
+warnings stay visible. Monochrome states remain template; tints resolve from
+label or system colors. VoiceOver names the session state. The first menu line
+is `state · reason · freshness`.
 Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. Typed heartbeat and
 `detach watch --json` sources supply them. A schema-1 hint, activation, or
@@ -144,9 +146,10 @@ tmux client. Closing the view ends the client.
 
 Terminal I/O is event-driven. CoreGraphics repaints on changes and uses a
 steady cursor. No terminal poller or frame loop runs. `Command-C/V/F` provide
-native copy, paste, and find. `Ctrl-V` reaches provider image paste. A Finder
-drop sends shell-safe paths without reading files. Live views move Mac Power to
-metadata. An exited client offers Reconnect.
+native copy, paste, and find. `Ctrl-C` and `Ctrl-V` reach providers as
+conventional control bytes. A Finder drop sends shell-safe paths without
+reading files. Live views move Mac Power to metadata. An exited client offers
+Reconnect.
 
 Cold start paints at most 128 rows and 1 MiB from private preferences. Cached
 rows grant no action, ownership, PID, cleanup, or power claim until a fresh

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -22,7 +22,23 @@ it does not wait for the idle runtime heartbeat. A transcript event belongs to
 the watch generation that delivered it: an event from a cancelled watch must
 not cancel its replacement or change the reported state. Missing, changed, or
 malformed handoff state stays `working`. Transition failures are surfaced and
-must not claim that sleep is safe. The provider continues while waiting.
+must not claim that sleep is safe. A Claude `AskUserQuestion` record with a
+`tool_use` stop reason and its matching user tool-result response provide the
+structured waiting and working transitions. The provider continues while
+waiting.
+
+When requested, the wrapper writes the run-token ready marker after both power
+layers are active and before provider launch. It writes the provider PID
+atomically after a successful spawn. A ready marker without a provider PID is
+an unknown launch state while wrapper completion is not known. Runtime recovery
+must not treat the marker as proof that the provider stopped. A dead worker
+with neither file is also unknown because the foreground wrapper can outlive
+that worker. Exact provider death proves shutdown. A normal wrapper error after
+spawn or PID publication failure also proves shutdown because the launcher
+kills and waits for the child. Before the starter invokes `respawn-pane`, it can
+record that no wrapper or provider exists after it removes the placeholder tmux
+session. A `respawn-pane` attempt ends this local proof. A signal exit does not
+provide shutdown proof.
 
 Each working session owns a separate helper lease. Outside the low-battery and
 thermal fail-safe states, the helper keeps the machine-wide closed-lid setting

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -60,12 +60,20 @@ runs publish `health_schema=1`, exact worker/provider PIDs, heartbeat, and
 checkpoint epoch. Health combines tmux, run token, PID ownership, metadata, and
 checkpoint freshness. Stale data cannot make a proven live provider hung. A
 runtime without managed tmux blocks mutations until its exact processes exit.
+`preserve_recovery_until_ready` is Boolean; `runtime_ready_at` and
+`runtime_shutdown_observed_at` are strings. A mistyped primary is unusable.
+Checkpoint metadata cannot replace it.
 
 `list --json` reads Codex and Claude concurrently and emits that order. Each
 uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
 PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
 Mutations recheck ownership, pane, run token, and process group. List jobs
 `exec` cores; cleanup signals PIDs.
+
+A retained dead pane is mutable only when its nonempty tmux token matches usable
+primary metadata. A checkpoint cannot authorize removal. Start, Resume,
+Recover, and Delete repeat this check under the operation lock. A tmux-only
+remnant remains removable without state.
 
 Typed state caches Codex checkpoint assessment by provider, session ID, and
 file identity. A change forces a full scan. Restore ignores this receipt,
@@ -192,7 +200,10 @@ mutation token. Keep the emitter and Swift `Session` decoder in sync.
 `watch --json` emits only change hints and never replaces this snapshot.
 Provider lifecycle records, never terminal text, supply turn state and the
 private activity file in `power.md`. Bounded append caching retains typed turns;
-an unseen oversized gap clears waiting to prevent stale Answer ready.
+an unseen oversized gap clears waiting to prevent stale Answer ready. A
+main-chain Claude `AskUserQuestion` with `stop_reason: tool_use` and a tool ID
+means waiting; only its matching user tool result restores working. Reducer
+changes invalidate old receipts so unchanged prompts are reclassified.
 Typed cleanup uses `cleanup_eligible`.
 
 ### Provider identity and checkpoints
@@ -212,10 +223,62 @@ policy defaults apply only without an allowed override.
 By default, a per-session lock protects a checkpoint every 300 s. It has
 metadata, validated provider JSONL, pane capture, and a repository root from a
 real `.git` ancestor. Codex removes temporary sidecars after its checked SQLite
-backup. Claude archives its matching project session and companions.
+backup. Claude archives its matching project session and companions. A writer
+validates a private sibling, rechecks the exact worker, recovery binding, and
+saved options, then atomically exchanges it with `checkpoint`. Readers cannot
+see a partial generation. Safe prior diagnostics survive a failed refresh.
+Checkpoint, discovery, and heartbeat writers recheck the primary run token,
+worker PID, live managed pane, and pane PID while they hold the session lock.
+An old writer cannot rebind or publish state. Recover holds this lock through
+source validation, retained-pane removal, reselection, and restore. Resume and
+Recover hold the install and project locks from occupancy check through start.
 Provider-created hard links become independent regular files in staging;
 archives and restore destinations still reject hard links and non-plain
-entries. A provider test override can disable the final `/bin/sync`.
+entries. Before any write, List and Recover validate the selected Claude source,
+companion trees, destinations, and `.detach.old` or `.detach.tmp` siblings.
+Unsafe optional data blocks recovery without changing its source. Task names
+match the UUID. Archived and existing team configs name that UUID as lead, so a
+checkpoint cannot replace another session's team. A valid selected live
+generation replaces an older checkpoint only after complete staging. Tests can
+disable durability syncs.
 
-Only allowlisted provider flags are serialized to `resume-args.bin`; a flag
-that should survive Resume or Recover must be added deliberately.
+Resume and Recover keep the last valid checkpoint and saved provider options
+until replacement B passes power and provider readiness. A failed handshake
+keeps that data. A fresh Start clears it. List and Recover share provider-source
+and saved-options checks. A selected live primary generation includes its
+provider ID, transcript, and options; Detach materializes the complete bundle
+before another replacement. An older checkpoint is not equivalent, even with
+the same run token. Every writer reads readiness from primary metadata and
+requires an explicit run token.
+
+The runtime syncs preserved recovery before primary metadata identifies B. It
+syncs new options before readiness names them, and syncs an exchanged checkpoint
+before it prunes prior options.
+
+Codex recovery binds a UUID to one exact rollout path. Every existing path
+component is a plain directory. A damaged rollout needs a matching database row
+or embedded UUID. Recovery never overwrites another thread's rollout and uses a
+private file plus atomic rename.
+
+Primary metadata identifies replacement B while it may live. List and Recover
+require durable shutdown observation. A dead worker and missing launch files do not
+prove that its power wrapper stopped. Normal wrapper return does. Before
+`respawn-pane`, removing the placeholder can prove shutdown; after that call,
+missing launch files prove nothing. A signal exit without provider identity is
+unknown and blocks mutation.
+
+If sync after a checkpoint exchange fails, Detach exchanges the prior
+generation back and removes the other only after rollback sync. An uncertain
+rollback or post-exchange signal keeps both names. A later writer removes an
+abandoned stage only after strict validation and canonical sync. Reset uses a
+typed marker that names its exact prior generation; an empty directory is not
+reset evidence.
+
+Primary metadata, saved options, checkpoint logs, known thread IDs, and exit
+status are plain files in the private session directory. Initialization checks
+their types before it changes a checkpoint. Writers publish replacement files
+with an atomic rename and never append through an untrusted path.
+
+Only allowlisted provider flags are serialized to a run-token-bound options
+file selected by typed metadata. Recover accepts the legacy `resume-args.bin`
+file. A flag that should survive Resume or Recover must be added deliberately.

--- a/tests/fake-claude
+++ b/tests/fake-claude
@@ -11,6 +11,7 @@ args_file="${FAKE_CLAUDE_ARGS_FILE:?}"
 claude_config_dir="${CLAUDE_CONFIG_DIR:?}"
 mode="start"
 session_id=""
+full_task_value="${FAKE_CLAUDE_TASK_VALUE:-full-id}"
 
 printf '%s\n' "$@" >"$args_file"
 
@@ -68,7 +69,8 @@ if [ "$mode" = "resume" ] && [ "${FAKE_CLAUDE_EXPECT_RESTORED:-0}" = "1" ]; then
     [ -d "$companion_dir/tool-results" ] && \
     grep -Fx 'fake file-history checkpoint' "$claude_config_dir/file-history/$session_id/fake-file@v1" >/dev/null 2>&1 && \
     grep -Fx "FAKE_CLAUDE_SESSION=$session_id" "$claude_config_dir/session-env/$session_id/environment" >/dev/null 2>&1 && \
-    jq -e '.task == "full-id"' "$claude_config_dir/tasks/$session_id/task.json" >/dev/null 2>&1 && \
+    jq -e --arg task "$full_task_value" '.task == $task' \
+      "$claude_config_dir/tasks/$session_id/task.json" >/dev/null 2>&1 && \
     jq -e '.task == "short-id"' "$claude_config_dir/tasks/session-$short_id/task.json" >/dev/null 2>&1 && \
     jq -e --arg id "$session_id" '.leadSessionId == $id' \
       "$claude_config_dir/teams/session-$short_id/config.json" >/dev/null 2>&1 || {
@@ -86,7 +88,8 @@ mkdir -p \
   "$claude_config_dir/teams/session-$short_id"
 printf 'fake file-history checkpoint\n' >"$claude_config_dir/file-history/$session_id/fake-file@v1"
 printf 'FAKE_CLAUDE_SESSION=%s\n' "$session_id" >"$claude_config_dir/session-env/$session_id/environment"
-printf '{"task":"full-id"}\n' >"$claude_config_dir/tasks/$session_id/task.json"
+jq -cn --arg task "$full_task_value" '{task: $task}' \
+  >"$claude_config_dir/tasks/$session_id/task.json"
 printf '{"task":"short-id"}\n' >"$claude_config_dir/tasks/session-$short_id/task.json"
 jq -cn --arg id "$session_id" '{leadSessionId: $id}' >"$claude_config_dir/teams/session-$short_id/config.json"
 

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -145,6 +145,9 @@ export DETACH_STATE_BIN="$STATE_HELPER"
 FAKE_POWER_BIN="$TMP_ROOT/fake-detach-power"
 export FAKE_POWER_ARGS_FILE="$TMP_ROOT/power-args.txt"
 export FAKE_POWER_RELEASES_FILE="$TMP_ROOT/power-releases.txt"
+export FAKE_POWER_FAIL_ARM_FILE="$TMP_ROOT/fail-next-power-run"
+export FAKE_POWER_FAIL_RELEASE_FILE="$TMP_ROOT/release-failed-power-run"
+export FAKE_POWER_FAIL_ENTERED_FILE="$TMP_ROOT/entered-failed-power-run"
 printf '%s\n' \
   '#!/bin/bash' \
   'if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then' \
@@ -166,6 +169,16 @@ printf '%s\n' \
   '    shift' \
   '  done' \
   '  [ "${1:-}" = -- ] || exit 2' \
+  '  if [ -f "${FAKE_POWER_FAIL_ARM_FILE:-}" ]; then' \
+  '    [ -z "${FAKE_POWER_FAIL_ENTERED_FILE:-}" ] || printf '\''entered\n'\'' >"$FAKE_POWER_FAIL_ENTERED_FILE"' \
+  '    delay_attempts=0' \
+  '    while [ ! -f "${FAKE_POWER_FAIL_RELEASE_FILE:-}" ] && [ "$delay_attempts" -lt 200 ]; do' \
+  '      delay_attempts=$((delay_attempts + 1))' \
+  '      sleep 0.05' \
+  '    done' \
+  '    [ -f "${FAKE_POWER_FAIL_RELEASE_FILE:-}" ] || exit 124' \
+  '    exit 1' \
+  '  fi' \
   '  [ "${FAKE_POWER_FAIL_RUN:-0}" != 1 ] || exit 1' \
   '  [ -z "$ready_file" ] || : >"$ready_file"' \
   '  [ -z "$pid_file" ] || printf '\''%s\n'\'' "$$" >"$pid_file"' \
@@ -254,6 +267,40 @@ wait_for_file_text() {
     sleep 0.1
   done
   printf 'timed out waiting for %s in %s\n' "$text" "$file" >&2
+  return 1
+}
+
+saved_resume_args_path() {
+  local metadata="$1"
+  local state_dir="$2"
+  local name
+  local token
+
+  name="$("$STATE_HELPER" meta get "$metadata" resume_args_file 2>/dev/null || true)"
+  if [ -n "$name" ]; then
+    case "$name" in *[!A-Za-z0-9._-]*|resume-args-.bin) return 1 ;; esac
+    case "$name" in resume-args-*.bin) ;; *) return 1 ;; esac
+    token="${name#resume-args-}"
+    token="${token%.bin}"
+    [ "$token" = "$("$STATE_HELPER" meta get "$metadata" run_token)" ] || return 1
+    [ -f "$state_dir/$name" ] && [ ! -L "$state_dir/$name" ] || return 1
+    printf '%s\n' "$state_dir/$name"
+    return
+  fi
+  [ -f "$state_dir/resume-args.bin" ] && \
+    [ ! -L "$state_dir/resume-args.bin" ] || return 1
+  printf '%s\n' "$state_dir/resume-args.bin"
+}
+
+require_nul_file_arg() {
+  local file="$1"
+  local expected="$2"
+  local arg
+
+  while IFS= read -r -d '' arg; do
+    [ "$arg" != "$expected" ] || return 0
+  done <"$file"
+  printf 'missing saved argument %s in %s\n' "$expected" "$file" >&2
   return 1
 }
 
@@ -562,8 +609,15 @@ grep -Fx -- '--activity-file' "$FAKE_POWER_ARGS_FILE" >/dev/null
 grep -Fx -- "$power_activity" "$FAKE_POWER_ARGS_FILE" >/dev/null
 grep -Fx -- '--activity-source-file' "$FAKE_POWER_ARGS_FILE" >/dev/null
 grep -Fx -- "$power_activity_source" "$FAKE_POWER_ARGS_FILE" >/dev/null
-printf '{"type":"user","isSidechain":false,"isMeta":false,"sessionId":"%s","message":{"role":"user","content":[{"type":"tool_result"}]},"uuid":"tool-result-event","timestamp":"2099-01-01T00:02:00.000Z"}\n' \
+printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"AskUserQuestion","id":"ask-tool"}]},"uuid":"ask-user-question","timestamp":"2099-01-01T00:01:00.000Z"}\n' \
   "$session_id" >>"$transcript"
+json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "waiting" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "ask-tool" ]
+wait_for_file_text "$power_activity" waiting
+printf '{"type":"user","isSidechain":false,"isMeta":false,"sessionId":"%s","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"ask-tool"}]},"uuid":"tool-result-event","timestamp":"2099-01-01T00:02:00.000Z"}\n' \
+  "$session_id" >>"$transcript"
+wait_for_file_text "$power_activity" working
 printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1"},"uuid":"assistant-chunk-1","timestamp":"2099-01-01T00:03:00.000Z"}\n' \
   "$session_id" >>"$transcript"
 printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1"},"uuid":"assistant-chunk-2","timestamp":"2099-01-01T00:03:01.000Z"}\n' \
@@ -572,7 +626,7 @@ json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin display_name)" = \
   "$human_label" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "working" ]
-[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "$session_id" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "tool-result-event" ]
 printf '{"type":"system","subtype":"turn_duration","isSidechain":false,"sessionId":"%s","uuid":"turn-duration-1","timestamp":"2099-01-01T00:03:02.000Z"}\n' \
   "$session_id" >>"$transcript"
 json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
@@ -693,6 +747,63 @@ recovery|recovery-guardrails)
   bootstrap_claude_checkpoint
   ;;
 esac
+
+if [ "$CLAUDE_TEST_PART" = recovery-guardrails ]; then
+# The writer must apply the same archive-name contract as List and Recover.
+# A rejected candidate must not replace the last recoverable payload or its
+# matching metadata generation.
+export FAKE_CLAUDE_SLEEP=20
+export FAKE_CLAUDE_EXIT=0
+export FAKE_CLAUDE_EXPECT_RESTORED=0
+reset_fake_claude_ready
+"$SCRIPT" claude resume --name "$human_label" --detach "$session_id"
+wait_for_fake_claude_ready
+writer_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
+writer_pane="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$session:" @detach_pane_id)"
+writer_worker_pid="$(tmux -L "$SOCKET" display-message -p \
+  -t "$writer_pane" '#{pane_pid}')"
+[ "$("$STATE_HELPER" meta get "$meta" worker_pid)" = "$writer_worker_pid" ]
+[ "$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$session:" @detach_run_token)" = "$writer_run_token" ]
+"$SCRIPT" claude __checkpoint_once \
+  "$session" "$writer_run_token" "$writer_worker_pid"
+writer_archive_hash="$(shasum -a 256 "$checkpoint/claude-session.tar" | awk '{print $1}')"
+writer_meta_hash="$(shasum -a 256 "$checkpoint/meta.json" | awk '{print $1}')"
+unsafe_writer_file="$CLAUDE_CONFIG_DIR/projects/fake/$session_id/unsafe\\name"
+printf 'unsafe archive name\n' >"$unsafe_writer_file"
+if "$SCRIPT" claude __checkpoint_once \
+     "$session" "$writer_run_token" "$writer_worker_pid"; then
+  printf 'Claude checkpoint accepted an unsafe archive name\n' >&2
+  exit 1
+fi
+[ "$(shasum -a 256 "$checkpoint/claude-session.tar" | awk '{print $1}')" = \
+  "$writer_archive_hash" ]
+[ "$(shasum -a 256 "$checkpoint/meta.json" | awk '{print $1}')" = \
+  "$writer_meta_hash" ]
+grep -F 'archive is not safely recoverable' "$session_dir/checkpoint.log" >/dev/null
+rm -f "$unsafe_writer_file"
+
+# A dangling live optional companion is not absence. The writer must retain
+# the previous complete checkpoint instead of silently omitting that state.
+dangling_writer_source="$CLAUDE_CONFIG_DIR/file-history/$session_id"
+dangling_writer_saved="$TMP_ROOT/claude-file-history-writer-saved"
+mv "$dangling_writer_source" "$dangling_writer_saved"
+ln -s "$TMP_ROOT/missing-live-claude-companion" "$dangling_writer_source"
+if "$SCRIPT" claude __checkpoint_once \
+     "$session" "$writer_run_token" "$writer_worker_pid"; then
+  printf 'Claude checkpoint accepted a dangling live companion symlink\n' >&2
+  exit 1
+fi
+[ "$(shasum -a 256 "$checkpoint/claude-session.tar" | awk '{print $1}')" = \
+  "$writer_archive_hash" ]
+[ "$(shasum -a 256 "$checkpoint/meta.json" | awk '{print $1}')" = \
+  "$writer_meta_hash" ]
+rm "$dangling_writer_source"
+mv "$dangling_writer_saved" "$dangling_writer_source"
+"$SCRIPT" claude stop "$human_label"
+fi
+
 "$STATE_HELPER" meta patch "$checkpoint/meta.json" --string status running --null exit_status
 rm -f "$meta"
 printf '{damaged transcript\n' >"$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl"
@@ -719,6 +830,72 @@ mkdir -p "$unsafe_claude_outside"
 printf 'outside sentinel\n' >"$unsafe_claude_outside/sentinel"
 rmdir "$CLAUDE_CONFIG_DIR/file-history"
 ln -s "$unsafe_claude_outside" "$CLAUDE_CONFIG_DIR/file-history"
+
+# A valid transcript archive is not recoverable when one of its publish
+# destinations is unsafe. List must not advertise Recover, and the command
+# must finish its full non-mutating preflight before it removes a retained
+# pane whose token still matches primary operational metadata.
+cp -p "$checkpoint/meta.json" "$meta"
+unsafe_restore_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
+unsafe_restore_pane="$(tmux -L "$SOCKET" new-session -d -P -F '#{pane_id}' \
+  -s "$session" -n claude)"
+tmux -L "$SOCKET" set-option -q -w -t "$unsafe_restore_pane" remain-on-exit on
+tmux -L "$SOCKET" set-option -q -t "=$session:" @detach 1
+tmux -L "$SOCKET" set-option -q -t "=$session:" @detach_provider claude
+tmux -L "$SOCKET" set-option -q -t "=$session:" @detach_pane_id "$unsafe_restore_pane"
+tmux -L "$SOCKET" set-option -q -t "=$session:" \
+  @detach_run_token "$unsafe_restore_run_token"
+tmux -L "$SOCKET" send-keys -t "$unsafe_restore_pane" exit Enter
+attempts=0
+while [ "$(tmux -L "$SOCKET" display-message -p \
+    -t "$unsafe_restore_pane" '#{pane_dead}')" != "1" ] && \
+    [ "$attempts" -lt 50 ]; do
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "$unsafe_restore_pane" '#{pane_dead}')" = "1" ]
+
+# Destination state is independent of checkpoint integrity. A valid A archive
+# and its saved options must remain byte-identical when that destination makes
+# Resume fail before replacement B can start.
+unsafe_resume_archive_hash="$(shasum -a 256 \
+  "$checkpoint/claude-session.tar" | awk '{print $1}')"
+unsafe_resume_meta_hash="$(shasum -a 256 \
+  "$checkpoint/meta.json" | awk '{print $1}')"
+unsafe_resume_args_file="$(saved_resume_args_path \
+  "$checkpoint/meta.json" "$session_dir")"
+unsafe_resume_args_hash="$(shasum -a 256 \
+  "$unsafe_resume_args_file" | awk '{print $1}')"
+printf '{"type":"user","sessionId":"%s","cwd":"%s","message":{"role":"user","content":"live preflight sentinel"}}\n' \
+  "$session_id" "$ROOT" \
+  >"$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl"
+unsafe_resume_live_hash="$(shasum -a 256 \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" | awk '{print $1}')"
+if "$SCRIPT" claude resume --name "$human_label" --detach "$session_id"; then
+  printf 'Claude Resume accepted an unsafe recovery destination\n' >&2
+  exit 1
+fi
+[ "$(shasum -a 256 "$checkpoint/claude-session.tar" | awk '{print $1}')" = \
+  "$unsafe_resume_archive_hash" ]
+[ "$(shasum -a 256 "$checkpoint/meta.json" | awk '{print $1}')" = \
+  "$unsafe_resume_meta_hash" ]
+[ "$(shasum -a 256 "$unsafe_resume_args_file" | awk '{print $1}')" = \
+  "$unsafe_resume_args_hash" ]
+[ "$(shasum -a 256 \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" | awk '{print $1}')" = \
+  "$unsafe_resume_live_hash" ]
+tmux -L "$SOCKET" has-session -t "=$session"
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "$unsafe_restore_pane" '#{pane_dead}')" = "1" ]
+printf '{damaged transcript\n' \
+  >"$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl"
+
+unsafe_restore_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$unsafe_restore_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+printf '%s' "$unsafe_restore_json" | grep -F '"health_actions":["delete"]' >/dev/null
 if "$SCRIPT" claude recover --detach "$human_label"; then
   printf 'Claude recover accepted a symlink below its canonical config root\n' >&2
   exit 1
@@ -727,7 +904,11 @@ grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 grep -Fx 'outside sentinel' "$unsafe_claude_outside/sentinel" >/dev/null
 [ ! -e "$unsafe_claude_outside/$session_id" ]
-! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+tmux -L "$SOCKET" has-session -t "=$session"
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "$unsafe_restore_pane" '#{pane_dead}')" = "1" ]
+tmux -L "$SOCKET" kill-session -t "=$session"
+rm -f "$meta"
 rm "$CLAUDE_CONFIG_DIR/file-history"
 mkdir -p "$CLAUDE_CONFIG_DIR/file-history"
 
@@ -740,6 +921,12 @@ mkdir -p "$malicious_claude_stage"
 tar -xf "$good_claude_archive" -C "$malicious_claude_stage"
 mkfifo "$malicious_claude_stage/restore-pipe"
 tar -cf "$checkpoint/claude-session.tar" -C "$malicious_claude_stage" .
+malicious_archive_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$malicious_archive_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+printf '%s' "$malicious_archive_json" | \
+  grep -F '"health_actions":["delete"]' >/dev/null
 if "$SCRIPT" claude recover --detach "$human_label"; then
   printf 'Claude recover accepted a special entry in its checkpoint archive\n' >&2
   exit 1
@@ -749,6 +936,126 @@ grep -Fx '{damaged transcript' \
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
 mv -f "$good_claude_archive" "$checkpoint/claude-session.tar"
 rm -rf "$malicious_claude_stage"
+
+# A type-valid archive can still be impossible to extract when a regular file
+# is followed by a child below the same path. Validate the actual extraction
+# before List advertises Recover or Recover changes any live state.
+good_claude_archive="$checkpoint/claude-session.tar.good-conflict-test"
+conflicting_claude_stage="$TMP_ROOT/conflicting-claude-archive"
+conflicting_claude_archive="$TMP_ROOT/conflicting-claude-session.tar"
+cp -p "$checkpoint/claude-session.tar" "$good_claude_archive"
+mkdir -p "$conflicting_claude_stage"
+cp -p "$checkpoint/transcript.jsonl" \
+  "$conflicting_claude_stage/transcript.jsonl"
+printf 'regular ancestor\n' >"$conflicting_claude_stage/project-session"
+tar -cf "$conflicting_claude_archive" -C "$conflicting_claude_stage" \
+  ./transcript.jsonl ./project-session
+rm -f "$conflicting_claude_stage/project-session"
+mkdir -p "$conflicting_claude_stage/project-session"
+printf 'unextractable child\n' \
+  >"$conflicting_claude_stage/project-session/child"
+tar -rf "$conflicting_claude_archive" -C "$conflicting_claude_stage" \
+  ./project-session/child
+mv -f "$conflicting_claude_archive" "$checkpoint/claude-session.tar"
+conflicting_archive_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$conflicting_archive_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+printf '%s' "$conflicting_archive_json" | \
+  grep -F '"health_actions":["delete"]' >/dev/null
+if "$SCRIPT" claude recover --detach "$human_label"; then
+  printf 'Claude recover accepted a structurally conflicting archive\n' >&2
+  exit 1
+fi
+grep -Fx '{damaged transcript' \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+mv -f "$good_claude_archive" "$checkpoint/claude-session.tar"
+rm -rf "$conflicting_claude_stage"
+
+# An archive is UUID-bound beyond its transcript. It cannot carry task names
+# for another session or a team whose typed lead belongs to another UUID, and
+# it cannot replace an existing team owned by another live session.
+foreign_team_id="99999999-aaaa-4bbb-8ccc-dddddddddddd"
+foreign_team_name=foreign-team-victim
+foreign_team="$CLAUDE_CONFIG_DIR/teams/$foreign_team_name"
+foreign_team_guard="$TMP_ROOT/foreign-team-guard"
+identity_archive_good="$TMP_ROOT/identity-claude-session-good.tar"
+identity_archive_stage="$TMP_ROOT/identity-claude-archive"
+rm -rf "$foreign_team" "$identity_archive_stage"
+mkdir -p "$foreign_team" "$identity_archive_stage"
+printf '{"leadSessionId":"%s"}\n' "$foreign_team_id" \
+  >"$foreign_team/config.json"
+printf 'foreign team sentinel\n' >"$foreign_team/sentinel"
+cp -Rp "$foreign_team" "$foreign_team_guard"
+cp -p "$checkpoint/claude-session.tar" "$identity_archive_good"
+tar -xf "$identity_archive_good" -C "$identity_archive_stage"
+mkdir -p "$identity_archive_stage/teams/$foreign_team_name"
+printf '{"leadSessionId":"%s"}\n' "$foreign_team_id" \
+  >"$identity_archive_stage/teams/$foreign_team_name/config.json"
+tar -cf "$checkpoint/claude-session.tar" -C "$identity_archive_stage" .
+identity_archive_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$identity_archive_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+if "$SCRIPT" claude recover --detach "$human_label"; then
+  printf 'Claude recover accepted another session in its archive\n' >&2
+  exit 1
+fi
+grep -Fx '{damaged transcript' \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
+diff -qr "$foreign_team_guard" "$foreign_team" >/dev/null
+
+printf '{"leadSessionId":"%s"}\n' "$session_id" \
+  >"$identity_archive_stage/teams/$foreign_team_name/config.json"
+tar -cf "$checkpoint/claude-session.tar" -C "$identity_archive_stage" .
+identity_destination_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$identity_destination_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+if "$SCRIPT" claude recover --detach "$human_label"; then
+  printf 'Claude recover replaced a team owned by another session\n' >&2
+  exit 1
+fi
+diff -qr "$foreign_team_guard" "$foreign_team" >/dev/null
+mv -f "$identity_archive_good" "$checkpoint/claude-session.tar"
+rm -rf "$identity_archive_stage" "$foreign_team" "$foreign_team_guard"
+
+# Legacy standalone checkpoints consume companion directories too. An unsafe
+# companion source must close Recover in List and in the command even though
+# the standalone transcript itself is valid.
+legacy_archive="$TMP_ROOT/legacy-claude-session.tar"
+mv "$checkpoint/claude-session.tar" "$legacy_archive"
+ln -s "$unsafe_claude_outside" "$checkpoint/claude-file-history"
+unsafe_legacy_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$unsafe_legacy_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+printf '%s' "$unsafe_legacy_json" | grep -F '"health_actions":["delete"]' >/dev/null
+if "$SCRIPT" claude recover --detach "$human_label"; then
+  printf 'Claude recover accepted an unsafe legacy companion source\n' >&2
+  exit 1
+fi
+grep -Fx '{damaged transcript' \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
+rm "$checkpoint/claude-file-history"
+
+# A dangling optional companion symlink is still present state. Recover must
+# reject it instead of treating it as an absent optional directory.
+ln -s "$TMP_ROOT/missing-claude-companion" \
+  "$checkpoint/claude-file-history"
+dangling_legacy_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$dangling_legacy_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+if "$SCRIPT" claude recover --detach "$human_label"; then
+  printf 'Claude recover accepted a dangling legacy companion symlink\n' >&2
+  exit 1
+fi
+grep -Fx '{damaged transcript' \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
+rm "$checkpoint/claude-file-history"
+mv "$legacy_archive" "$checkpoint/claude-session.tar"
 fi
 
 if [ "$CLAUDE_TEST_PART" != recovery-guardrails ] && \
@@ -789,6 +1096,139 @@ claude_scenario_event pass SC-SESSION-RECOVER-CLAUDE
 "$SCRIPT" claude stop "$human_label"
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
 
+# Reusing the harness name for session B must not publish over session A's
+# recovery bundle until the replacement run is ready. Hold the power wrapper
+# past one checkpoint interval, then prove cleanup and Recover still select A.
+second_id="11111111-2222-4333-8444-555555555555"
+printf '{"type":"user","sessionId":"%s","cwd":"%s","message":{"role":"user","content":"session B"}}\n' \
+  "$second_id" "$ROOT" >"$CLAUDE_CONFIG_DIR/projects/fake/$second_id.jsonl"
+resume_checkpoint_copy="$TMP_ROOT/claude-resume-checkpoint"
+resume_args_file="$(saved_resume_args_path "$checkpoint/meta.json" "$session_dir")"
+resume_args_copy="$TMP_ROOT/claude-resume-args.bin"
+cp -Rp "$checkpoint" "$resume_checkpoint_copy"
+cp -p "$resume_args_file" "$resume_args_copy"
+require_nul_file_arg "$resume_args_copy" display-name
+require_nul_file_arg "$resume_args_copy" "$TMP_ROOT/extra-a"
+failed_resume_output="$TMP_ROOT/failed-claude-resume.out"
+stale_starting_meta="$TMP_ROOT/claude-stale-starting-meta.json"
+rm -f \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+: >"$FAKE_POWER_FAIL_ARM_FILE"
+"$SCRIPT" claude resume --name "$human_label" --detach "$second_id" \
+  >"$failed_resume_output" 2>&1 &
+failed_resume_pid=$!
+if ! wait_for_file_text "$FAKE_POWER_FAIL_ENTERED_FILE" entered; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  sed -n '1,80p' "$failed_resume_output" >&2
+  exit 1
+fi
+if ! cp -p "$meta" "$stale_starting_meta"; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'Claude could not preserve replacement B starting metadata\n' >&2
+  exit 1
+fi
+sleep 2
+if ! diff -qr "$resume_checkpoint_copy" "$checkpoint" >/dev/null || \
+   ! cmp -s "$resume_args_copy" "$resume_args_file"; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'Claude Resume changed recovery data before readiness\n' >&2
+  exit 1
+fi
+held_resume_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"" || true)"
+if [ "$(printf '%s' "$held_resume_json" | \
+     "$STATE_HELPER" meta get /dev/stdin agent_session_id 2>/dev/null || true)" != \
+     "$second_id" ] || \
+   [ "$(printf '%s' "$held_resume_json" | \
+     "$STATE_HELPER" meta get /dev/stdin effective_status 2>/dev/null || true)" != \
+     starting ] || \
+   ! printf '%s' "$held_resume_json" | \
+     grep -F '"health_actions":["attach","stop"]' >/dev/null; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'Claude list exposed recovery while replacement B was still starting: %s\n' \
+    "$held_resume_json" >&2
+  exit 1
+fi
+: >"$FAKE_POWER_FAIL_RELEASE_FILE"
+if wait "$failed_resume_pid"; then
+  printf 'Claude Resume passed a failed power handshake\n' >&2
+  exit 1
+fi
+rm -f \
+  "$FAKE_POWER_FAIL_ARM_FILE" \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+if ! diff -qr "$resume_checkpoint_copy" "$checkpoint" >/dev/null || \
+   ! cmp -s "$resume_args_copy" "$resume_args_file"; then
+  printf 'Claude Resume changed recovery data during failed cleanup\n' >&2
+  exit 1
+fi
+[ -z "$("$STATE_HELPER" meta get "$meta" runtime_ready_at 2>/dev/null || true)" ]
+[ -n "$("$STATE_HELPER" meta get \
+  "$meta" runtime_shutdown_observed_at 2>/dev/null || true)" ]
+[ "$("$STATE_HELPER" meta get "$meta" agent_session_id)" = "$second_id" ]
+failed_resume_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$failed_resume_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$failed_resume_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$session_id" ]
+[ "$(printf '%s' "$failed_resume_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = recoverable_checkpoint ]
+printf '%s' "$failed_resume_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+
+# The legacy unversioned file remains a supported recovery input. Move A's
+# saved options there and remove the typed selector so the existing Recover
+# proves the fallback retains Claude's multi-value provider options.
+mv "$resume_args_file" "$session_dir/resume-args.bin"
+"$STATE_HELPER" meta patch "$checkpoint/meta.json" --null resume_args_file
+
+printf '{truncated task\n' >"$CLAUDE_CONFIG_DIR/tasks/$session_id/task.json"
+export FAKE_CLAUDE_EXPECT_RESTORED=1
+reset_fake_claude_ready
+"$SCRIPT" claude recover --detach "$human_label"
+wait_for_fake_claude_ready
+grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$session_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- 'display-name' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$TMP_ROOT/extra-a" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$TMP_ROOT/extra-b" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+"$SCRIPT" claude stop "$human_label"
+
+# Model an abrupt loss after B published its starting metadata and exact
+# process identities, but before readiness. Fixed impossible PIDs make the
+# dead-process proof deterministic. Recover must still select checkpoint A.
+"$STATE_HELPER" meta patch "$stale_starting_meta" \
+  --integer worker_pid 2147483647 \
+  --integer provider_pid 2147483646 \
+  --null runtime_shutdown_observed_at
+cp -p "$stale_starting_meta" "$meta"
+stale_starting_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$session\"")"
+[ "$(printf '%s' "$stale_starting_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$stale_starting_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$session_id" ]
+printf '%s' "$stale_starting_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+printf '{truncated task\n' >"$CLAUDE_CONFIG_DIR/tasks/$session_id/task.json"
+export FAKE_CLAUDE_EXPECT_RESTORED=1
+reset_fake_claude_ready
+"$SCRIPT" claude recover --detach "$human_label"
+wait_for_fake_claude_ready
+grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$session_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- 'display-name' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$TMP_ROOT/extra-a" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+"$SCRIPT" claude stop "$human_label"
+
 # Universal resume must route a known Claude UUID back to Claude. It must also
 # recreate the encoded project directory and all companion artifacts from the
 # checkpoint before Claude starts.
@@ -811,25 +1251,129 @@ grep -Fx -- "$session_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 "$SCRIPT" claude stop "$human_label"
 
 # A stale checkpoint for session A must not block session B when the same
-# harness name is reused for an explicit resume.
-second_id="11111111-2222-4333-8444-555555555555"
+# harness name is reused for a successful explicit resume.
 printf '{"type":"user","sessionId":"%s","cwd":"%s","message":{"role":"user","content":"session B"}}\n' \
   "$second_id" "$ROOT" >"$CLAUDE_CONFIG_DIR/projects/fake/$second_id.jsonl"
 export FAKE_CLAUDE_EXPECT_RESTORED=0
 reset_fake_claude_ready
-"$SCRIPT" claude resume --name "$human_label" --detach "$second_id"
+"$SCRIPT" claude resume --name "$human_label" --detach \
+  "$second_id" --model detach-live-b-model
 wait_for_fake_claude_ready
 grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 grep -Fx -- "$second_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 "$SCRIPT" claude stop "$human_label"
 
+# Model ready live-only B while canonical checkpoint still contains A. A
+# failed replacement C must first publish a complete immutable B generation,
+# including B's saved options, before any provider process can start.
+rm -rf "$checkpoint"
+cp -Rp "$resume_checkpoint_copy" "$checkpoint"
+"$STATE_HELPER" meta patch "$checkpoint/meta.json" --null resume_args_file
+live_b_args="$(saved_resume_args_path "$meta" "$session_dir")"
+require_nul_file_arg "$live_b_args" --model
+require_nul_file_arg "$live_b_args" detach-live-b-model
+rm -f \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+: >"$FAKE_POWER_FAIL_ARM_FILE"
+"$SCRIPT" claude recover --detach "$human_label" \
+  >"$TMP_ROOT/failed-live-b-recover.out" 2>&1 &
+failed_live_b_recover_pid=$!
+if ! wait_for_file_text "$FAKE_POWER_FAIL_ENTERED_FILE" entered; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_live_b_recover_pid" || true
+  exit 1
+fi
+: >"$FAKE_POWER_FAIL_RELEASE_FILE"
+if wait "$failed_live_b_recover_pid"; then
+  printf 'Claude replacement C passed a failed power handshake\n' >&2
+  exit 1
+fi
+rm -f \
+  "$FAKE_POWER_FAIL_ARM_FILE" \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+[ "$("$STATE_HELPER" meta get "$checkpoint/meta.json" agent_session_id)" = \
+  "$second_id" ]
+valid_claude_checkpoint_archive_for_test() {
+  tar -xOf "$1" ./transcript.jsonl | \
+    "$STATE_HELPER" jsonl validate claude /dev/stdin "$2"
+}
+valid_claude_checkpoint_archive_for_test \
+  "$checkpoint/claude-session.tar" "$second_id"
+preserved_live_b_args="$(saved_resume_args_path \
+  "$checkpoint/meta.json" "$session_dir")"
+[ "$preserved_live_b_args" = "$live_b_args" ]
+require_nul_file_arg "$preserved_live_b_args" detach-live-b-model
+
 printf '{truncated task\n' >"$CLAUDE_CONFIG_DIR/tasks/$second_id/task.json"
+printf '{truncated live B transcript\n' \
+  >"$CLAUDE_CONFIG_DIR/projects/fake/$second_id.jsonl"
 export FAKE_CLAUDE_EXPECT_RESTORED=1
 reset_fake_claude_ready
 "$SCRIPT" claude recover --detach "$human_label"
 wait_for_fake_claude_ready
+grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$second_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+"$STATE_HELPER" meta matches "$meta" claude "$second_id"
 "$SCRIPT" claude stop "$human_label"
 export FAKE_CLAUDE_EXPECT_RESTORED=0
+
+# The transcript can stay byte-identical while a Claude companion advances.
+# A failed replacement C must materialize that complete live B bundle instead
+# of taking the same-binding fast path on transcript bytes alone.
+companion_only_value='companion-only B advance'
+companion_only_payload="$(
+  jq -cn --arg task "$companion_only_value" '{task: $task}'
+)"
+printf '%s\n' "$companion_only_payload" \
+  >"$CLAUDE_CONFIG_DIR/tasks/$second_id/task.json"
+companion_only_third_id="66666666-7777-4888-8999-aaaaaaaaaaaa"
+printf '{"type":"user","sessionId":"%s","cwd":"%s","message":{"role":"user","content":"session C"}}\n' \
+  "$companion_only_third_id" "$ROOT" \
+  >"$CLAUDE_CONFIG_DIR/projects/fake/$companion_only_third_id.jsonl"
+rm -f \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+: >"$FAKE_POWER_FAIL_ARM_FILE"
+reset_fake_claude_ready
+"$SCRIPT" claude resume --name "$human_label" --detach \
+  "$companion_only_third_id" \
+  >"$TMP_ROOT/failed-companion-only-resume.out" 2>&1 &
+companion_only_resume_pid=$!
+if ! wait_for_file_text "$FAKE_POWER_FAIL_ENTERED_FILE" entered; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$companion_only_resume_pid" || true
+  exit 1
+fi
+: >"$FAKE_POWER_FAIL_RELEASE_FILE"
+if wait "$companion_only_resume_pid"; then
+  printf 'Claude companion-only replacement passed a failed power handshake\n' >&2
+  exit 1
+fi
+rm -f \
+  "$FAKE_POWER_FAIL_ARM_FILE" \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
+[ "$("$STATE_HELPER" meta get "$checkpoint/meta.json" agent_session_id)" = \
+  "$second_id" ]
+[ "$(tar -xOf "$checkpoint/claude-session.tar" \
+  "./tasks/$second_id/task.json")" = "$companion_only_payload" ]
+printf '{damaged companion after materialization\n' \
+  >"$CLAUDE_CONFIG_DIR/tasks/$second_id/task.json"
+export FAKE_CLAUDE_EXPECT_RESTORED=1
+export FAKE_CLAUDE_TASK_VALUE="$companion_only_value"
+reset_fake_claude_ready
+"$SCRIPT" claude recover --detach "$human_label"
+wait_for_fake_claude_ready
+[ "$(<"$CLAUDE_CONFIG_DIR/tasks/$second_id/task.json")" = \
+  "$companion_only_payload" ]
+"$SCRIPT" claude stop "$human_label"
+unset FAKE_CLAUDE_TASK_VALUE
+export FAKE_CLAUDE_EXPECT_RESTORED=0
+
 if [ "$CLAUDE_TEST_PART" = all ]; then
   default_history_fixture="$TMP_ROOT/default-claude-history-fixture"
   cp -Rp "$DETACH_CLAUDE_STATE_ROOT/sessions/$session" "$default_history_fixture"
@@ -883,11 +1427,40 @@ empty_id="$("$STATE_HELPER" meta get "$empty_meta" agent_session_id)"
 ! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
 rm -rf \
   "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl" \
-  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id"
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/file-history/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/session-env/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/session-${empty_id:0:8}" \
+  "$CLAUDE_CONFIG_DIR/teams/session-${empty_id:0:8}"
 rm -f \
   "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session.tar" \
   "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
+rm -rf \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-file-history" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session-env"
 "$STATE_HELPER" meta patch "$empty_meta" --null transcript_path --null last_checkpoint_at
+cp -p "$empty_meta" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/meta.json"
+rm -f "$empty_meta"
+unsafe_team_dir="$CLAUDE_CONFIG_DIR/teams/unsafe-metadata-only"
+unsafe_team_target="$TMP_ROOT/unsafe-team-config-target"
+mkdir -p "$unsafe_team_dir"
+printf '{"leadSessionId":"unrelated"}\n' >"$unsafe_team_target"
+ln -s "$unsafe_team_target" "$unsafe_team_dir/config.json"
+: >"$FAKE_CLAUDE_ARGS_FILE"
+if "$SCRIPT" resume --detach "$empty_id" >/dev/null 2>&1; then
+  printf 'metadata-only Resume ignored an unsafe team config\n' >&2
+  exit 1
+fi
+[ ! -s "$FAKE_CLAUDE_ARGS_FILE" ]
+! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
+rm -rf "$unsafe_team_dir"
+claude_config_dir_with_history="$CLAUDE_CONFIG_DIR"
+metadata_only_empty_home="$TMP_ROOT/metadata-only-empty-claude-home"
+rm -rf "$metadata_only_empty_home"
+export CLAUDE_CONFIG_DIR="$metadata_only_empty_home"
 reset_fake_claude_ready
 "$SCRIPT" resume --detach "$empty_id"
 wait_for_fake_claude_ready
@@ -896,10 +1469,111 @@ grep -Fx -- '--session-id' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 grep -Fx -- "$empty_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 "$STATE_HELPER" meta matches "$empty_meta" claude "$empty_id"
 "$SCRIPT" claude stop "$empty_label"
+export CLAUDE_CONFIG_DIR="$claude_config_dir_with_history"
 
-# A present invalid transcript must fail closed and must not start Claude.
+# If a later metadata-only Resume fails before readiness, Recover must still
+# select checkpoint A and launch its UUID with --session-id. No transcript or
+# provider payload exists yet for that generation.
+rm -rf \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl" \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/file-history/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/session-env/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/session-${empty_id:0:8}" \
+  "$CLAUDE_CONFIG_DIR/teams/session-${empty_id:0:8}"
+rm -f \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session.tar" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
+rm -rf \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-file-history" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session-env"
+"$STATE_HELPER" meta patch "$empty_meta" \
+  --null transcript_path --null last_checkpoint_at
+cp -p "$empty_meta" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/meta.json"
+rm -f \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+: >"$FAKE_POWER_FAIL_ARM_FILE"
+reset_fake_claude_ready
+"$SCRIPT" claude resume --name "$empty_label" --detach "$empty_id" \
+  >"$TMP_ROOT/failed-empty-resume.out" 2>&1 &
+failed_empty_resume_pid=$!
+if ! wait_for_file_text "$FAKE_POWER_FAIL_ENTERED_FILE" entered; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_empty_resume_pid" || true
+  exit 1
+fi
+: >"$FAKE_POWER_FAIL_RELEASE_FILE"
+if wait "$failed_empty_resume_pid"; then
+  printf 'metadata-only Claude Resume passed a failed power handshake\n' >&2
+  exit 1
+fi
+rm -f \
+  "$FAKE_POWER_FAIL_ARM_FILE" \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
+empty_failed_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$empty_session\"")"
+[ "$(printf '%s' "$empty_failed_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$empty_failed_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$empty_id" ]
+reset_fake_claude_ready
+"$SCRIPT" claude recover --detach "$empty_label"
+wait_for_fake_claude_ready
+grep -Fx -- '--session-id' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+! grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$empty_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+"$STATE_HELPER" meta matches "$empty_meta" claude "$empty_id"
+"$SCRIPT" claude stop "$empty_label"
+
+# Blank metadata means that Claude has not created any UUID-bound state. A
+# present invalid transcript must not be reclassified as metadata-only merely
+# because the valid-transcript resolver ignores it.
+rm -rf \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/file-history/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/session-env/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/session-${empty_id:0:8}" \
+  "$CLAUDE_CONFIG_DIR/teams/session-${empty_id:0:8}"
+rm -f \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session.tar" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
+rm -rf \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-file-history" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session-env"
+"$STATE_HELPER" meta patch "$empty_meta" --null transcript_path
+cp -p "$empty_meta" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/meta.json"
 printf '{truncated claude transcript\n' \
   >"$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl"
+blank_invalid_json="$("$SCRIPT" claude list --json | \
+  grep -F "\"session_name\":\"$empty_session\"")"
+[ "$(printf '%s' "$blank_invalid_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = stopped ]
+[ "$(printf '%s' "$blank_invalid_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
+reset_fake_claude_ready
+: >"$FAKE_CLAUDE_ARGS_FILE"
+if "$SCRIPT" resume --detach "$empty_id"; then
+  printf 'Resume treated a present invalid transcript as metadata-only\n' >&2
+  exit 1
+fi
+[ ! -s "$FAKE_CLAUDE_ARGS_FILE" ]
+! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
+
+# An explicit invalid transcript binding must fail closed too. A second valid
+# file for the same UUID must not replace the path that Detach bound.
+mkdir -p "$CLAUDE_CONFIG_DIR/projects/alternate"
+printf '{"type":"user","sessionId":"%s","cwd":"%s","message":{"role":"user","content":"alternate"}}\n' \
+  "$empty_id" "$ROOT" \
+  >"$CLAUDE_CONFIG_DIR/projects/alternate/$empty_id.jsonl"
 "$STATE_HELPER" meta patch "$empty_meta" \
   --string transcript_path "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl"
 rm -f \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -314,6 +314,40 @@ wait_for_file_text() {
   return 1
 }
 
+saved_resume_args_path() {
+  local metadata="$1"
+  local state_dir="$2"
+  local name
+  local token
+
+  name="$("$STATE_HELPER" meta get "$metadata" resume_args_file 2>/dev/null || true)"
+  if [ -n "$name" ]; then
+    case "$name" in *[!A-Za-z0-9._-]*|resume-args-.bin) return 1 ;; esac
+    case "$name" in resume-args-*.bin) ;; *) return 1 ;; esac
+    token="${name#resume-args-}"
+    token="${token%.bin}"
+    [ "$token" = "$("$STATE_HELPER" meta get "$metadata" run_token)" ] || return 1
+    [ -f "$state_dir/$name" ] && [ ! -L "$state_dir/$name" ] || return 1
+    printf '%s\n' "$state_dir/$name"
+    return
+  fi
+  [ -f "$state_dir/resume-args.bin" ] && \
+    [ ! -L "$state_dir/resume-args.bin" ] || return 1
+  printf '%s\n' "$state_dir/resume-args.bin"
+}
+
+require_nul_file_arg() {
+  local file="$1"
+  local expected="$2"
+  local arg
+
+  while IFS= read -r -d '' arg; do
+    [ "$arg" != "$expected" ] || return 0
+  done <"$file"
+  printf 'missing saved argument %s in %s\n' "$expected" "$file" >&2
+  return 1
+}
+
 require_file_line() {
   local file="$1" expected="$2"
   grep -Fx -- "$expected" "$file" >/dev/null || {
@@ -333,6 +367,9 @@ export FAKE_POWER_STATUS_FILE="$TMP_ROOT/power-status.txt"
 export FAKE_POWER_RELEASES_FILE="$TMP_ROOT/power-releases.txt"
 export FAKE_POWER_DELAY_SESSION="detach-codex-startup-health"
 export FAKE_POWER_DELAY_RELEASE_FILE="$TMP_ROOT/startup-health-release"
+export FAKE_POWER_FAIL_ARM_FILE="$TMP_ROOT/fail-next-power-run"
+export FAKE_POWER_FAIL_RELEASE_FILE="$TMP_ROOT/release-failed-power-run"
+export FAKE_POWER_FAIL_ENTERED_FILE="$TMP_ROOT/entered-failed-power-run"
 printf '%s\n' \
   '#!/bin/bash' \
   'if [ "${1:-}" = status ] && [ "${2:-}" = --json ]; then' \
@@ -357,6 +394,17 @@ printf '%s\n' \
   '    shift' \
   '  done' \
   '  [ "${1:-}" = -- ] || exit 2' \
+  '  if [ -f "${FAKE_POWER_FAIL_ARM_FILE:-}" ]; then' \
+  '    [ -z "${FAKE_POWER_FAIL_ENTERED_FILE:-}" ] || printf '\''entered\n'\'' >"$FAKE_POWER_FAIL_ENTERED_FILE"' \
+  '    delay_attempts=0' \
+  '    while [ ! -f "${FAKE_POWER_FAIL_RELEASE_FILE:-}" ] && [ "$delay_attempts" -lt 200 ]; do' \
+  '      delay_attempts=$((delay_attempts + 1))' \
+  '      sleep 0.05' \
+  '    done' \
+  '    [ -f "${FAKE_POWER_FAIL_RELEASE_FILE:-}" ] || exit 124' \
+  '    if [ "${FAKE_POWER_FAIL_AFTER_READY:-0}" = 1 ] && [ -n "$ready_file" ]; then : >"$ready_file"; fi' \
+  '    exit 1' \
+  '  fi' \
   '  [ "${FAKE_POWER_FAIL_RUN:-0}" != 1 ] || exit 1' \
   '  if [ "$managed_session" = "${FAKE_POWER_DELAY_SESSION:-}" ]; then' \
   '    delay_attempts=0' \
@@ -378,15 +426,23 @@ printf '%s\n' \
   'printf '\''%s\n'\'' "$@" >"$FAKE_ENV_ARGS_FILE"' \
   'exit 0' >"$FAKE_ENV_BIN"
 chmod 0755 "$FAKE_ENV_BIN"
+write_releasable_fake_codex() {
+  local output="$1"
+  local release="$2"
+
+  printf '%s\n' \
+    '#!/bin/bash' \
+    "trap '' HUP" \
+    'export FAKE_CODEX_INIT_DELAY=0' \
+    "export FAKE_CODEX_RELEASE_FILE='$release'" \
+    'export FAKE_CODEX_EXIT=0' \
+    "exec \"$ROOT/tests/fake-codex\" \"\$@\"" >"$output"
+  chmod 0755 "$output"
+}
+
 FAKE_CODEX_LONG_BIN="$TMP_ROOT/fake-codex-long"
-printf '%s\n' \
-  '#!/bin/bash' \
-  "trap '' HUP" \
-  'export FAKE_CODEX_INIT_DELAY=0' \
-  'export FAKE_CODEX_SLEEP=20' \
-  'export FAKE_CODEX_EXIT=0' \
-  "exec \"$ROOT/tests/fake-codex\" \"\$@\"" >"$FAKE_CODEX_LONG_BIN"
-chmod 0755 "$FAKE_CODEX_LONG_BIN"
+write_releasable_fake_codex \
+  "$FAKE_CODEX_LONG_BIN" "$TMP_ROOT/fake-codex-long-release"
 FAKE_GIT_BIN_DIR="$TMP_ROOT/fake-bin"
 export FAKE_GIT_MARKER="$TMP_ROOT/ambient-git-was-invoked"
 mkdir -p "$FAKE_GIT_BIN_DIR"
@@ -644,6 +700,28 @@ if codex_part_selected preflight; then
     "$ROOT/bin/detach-core")"
   printf '%s\n' "$heartbeat_source" | \
     grep -F 'state_update_meta_for_run_without_event' >/dev/null
+  printf '%s\n' "$heartbeat_source" | \
+    grep -F 'runtime_writer_matches_live_worker' >/dev/null
+  printf '%s\n' "$heartbeat_source" | \
+    grep -F '@detach_heartbeat_epoch' >/dev/null
+  printf '%s\n' "$heartbeat_source" | \
+    grep -F 'power_refresh_session_status' >/dev/null
+  checkpoint_source="$(sed -n \
+    '/^checkpoint_once_locked() (/,/^runtime_readiness_is_committed() {/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$checkpoint_source" | \
+    grep -F '[ -n "$run_token" ] && [ -n "$worker_pid" ] || return 1' >/dev/null
+  printf '%s\n' "$checkpoint_source" | \
+    grep -F 'runtime_writer_matches_live_worker' >/dev/null
+  checkpoint_loop_source="$(sed -n \
+    '/^checkpoint_loop() {/,/^runtime_heartbeat_locked() {/p' \
+    "$ROOT/bin/detach-core")"
+  printf '%s\n' "$checkpoint_loop_source" | \
+    grep -F '__discover_live_worker_locked' >/dev/null
+  recover_source="$(sed -n \
+    '/^recover_session() {/,/^main() {/p' "$ROOT/bin/detach-core")"
+  printf '%s\n' "$recover_source" | \
+    grep -F '__recover_session_prepare_locked' >/dev/null
   state_mutation_source="$(sed -n \
     '/^state_update_meta() {/,/^state_update_meta_without_event() {/p' \
     "$ROOT/bin/detach-core")"
@@ -690,13 +768,15 @@ if codex_part_selected preflight; then
     '/^  worker_cleanup() {/,/^  trap worker_cleanup EXIT/p' \
     "$ROOT/bin/detach-core")"
   printf '%s\n' "$worker_cleanup_source" | \
-    grep -F 'DETACH_SUPPRESS_SESSION_EVENT=1 checkpoint_once' >/dev/null
+    grep -F 'DETACH_SUPPRESS_SESSION_EVENT=1' >/dev/null
+  printf '%s\n' "$worker_cleanup_source" | \
+    grep -F 'checkpoint_once "$session" "$run_token" "$$"' >/dev/null
   finalizing_line="$(printf '%s\n' "$worker_cleanup_source" | \
     grep -n -- '--string lifecycle_phase finalizing' | head -1 | cut -d: -f1)"
   final_checkpoint_line="$(printf '%s\n' "$worker_cleanup_source" | \
     grep -n 'checkpoint_once' | tail -1 | cut -d: -f1)"
   terminal_line="$(printf '%s\n' "$worker_cleanup_source" | \
-    grep -n -- '--string lifecycle_phase terminal' | head -1 | cut -d: -f1)"
+    grep -n -- '--string lifecycle_phase terminal' | tail -1 | cut -d: -f1)"
   [ -n "$finalizing_line" ] && [ -n "$final_checkpoint_line" ] && \
     [ -n "$terminal_line" ]
   [ "$finalizing_line" -lt "$final_checkpoint_line" ]
@@ -909,7 +989,8 @@ bootstrap_codex_checkpoint() {
   export FAKE_CODEX_EXIT=0
   export FAKE_CODEX_FOREIGN_FIRST=0
   export FAKE_CODEX_INIT_DELAY=0.1
-  run_codex --name integration --detach -- 'recovery fixture'
+  run_codex --name integration --detach -- \
+    --model detach-recovery-model 'recovery fixture'
   wait_for_tmux_option "$SESSION" @detach_status running
   meta="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/meta.json"
   checkpoint="$DETACH_CODEX_STATE_ROOT/sessions/$SESSION/checkpoint"
@@ -1570,8 +1651,28 @@ if codex_part_selected recovery; then
 if [ "$CODEX_TEST_PART" = recovery ]; then
   bootstrap_codex_checkpoint
 fi
+
+resume_rollout="$("$STATE_HELPER" meta get "$meta" transcript_path)"
+resume_checkpoint_copy="$TMP_ROOT/resume-checkpoint-rollout.jsonl"
+live_rollout_copy="$TMP_ROOT/resume-live-rollout.jsonl"
+cp -p "$checkpoint/rollout.jsonl" "$resume_checkpoint_copy"
+cp -p "$resume_rollout" "$live_rollout_copy"
+
+# Without a backup, Recover must validate the live rollout instead of treating
+# the missing checkpoint as proof that the provider data is usable.
+rm -f "$checkpoint/rollout.jsonl"
+printf '{damaged rollout\n' >"$resume_rollout"
+if run_codex recover --detach integration; then
+  printf 'Codex Recover accepted an invalid live rollout without a checkpoint\n' >&2
+  exit 1
+fi
+! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
+cp -p "$live_rollout_copy" "$resume_rollout"
+cp -p "$resume_checkpoint_copy" "$checkpoint/rollout.jsonl"
+
 "$STATE_HELPER" meta patch "$checkpoint/meta.json" --string status running
 rm -f "$meta"
+printf '{damaged rollout\n' >"$resume_rollout"
 
 export FAKE_CODEX_SLEEP=20
 export FAKE_CODEX_EXIT=0
@@ -1614,17 +1715,113 @@ fi
 [ -s "$checkpoint/rollout.jsonl" ]
 previous_lifecycle_id="$("$STATE_HELPER" meta get "$meta" lifecycle_id)"
 [ -n "$previous_lifecycle_id" ]
-export FAKE_CODEX_INIT_DELAY=5
+restart_session_dir="$(dirname "$meta")"
+  superseded_resume_args="$(saved_resume_args_path \
+    "$checkpoint/meta.json" "$restart_session_dir")"
+  legacy_resume_args="$restart_session_dir/resume-args.bin"
+  [ "$superseded_resume_args" != "$legacy_resume_args" ]
+  cp -p "$superseded_resume_args" "$legacy_resume_args"
+
+  # Fresh initialization must reject an unsafe saved-options entry before it
+  # clears the prior checkpoint generation.
+  unsafe_resume_args="$restart_session_dir/resume-args-unsafe.bin"
+  unsafe_resume_target="$TMP_ROOT/unsafe-resume-args-target"
+  unsafe_resume_checkpoint_guard="$TMP_ROOT/unsafe-resume-checkpoint-guard"
+  printf 'outside saved-options sentinel\n' >"$unsafe_resume_target"
+  cp -Rp "$checkpoint" "$unsafe_resume_checkpoint_guard"
+  ln -s "$unsafe_resume_target" "$unsafe_resume_args"
+  if run_codex __write_initial_meta \
+      "$SESSION" "$ROOT" integration 1 "$DETACH_CODEX_BIN" "" "" \
+      unsafe-resume-args-run 0 >/dev/null 2>&1; then
+    printf 'fresh metadata initialization accepted unsafe saved options\n' >&2
+    exit 1
+  fi
+  grep -Fx 'outside saved-options sentinel' "$unsafe_resume_target" >/dev/null
+  diff -qr "$unsafe_resume_checkpoint_guard" "$checkpoint" >/dev/null
+  rm -f "$unsafe_resume_args"
+
+  unsafe_checkpoint_log="$restart_session_dir/checkpoint.log"
+  saved_checkpoint_log="$TMP_ROOT/saved-checkpoint.log"
+  unsafe_log_target="$TMP_ROOT/unsafe-checkpoint-log-target"
+  mv "$unsafe_checkpoint_log" "$saved_checkpoint_log"
+  printf 'outside checkpoint-log sentinel\n' >"$unsafe_log_target"
+  ln -s "$unsafe_log_target" "$unsafe_checkpoint_log"
+  if run_codex __write_initial_meta \
+      "$SESSION" "$ROOT" integration 1 "$DETACH_CODEX_BIN" "" "" \
+      unsafe-checkpoint-log-run 0 >/dev/null 2>&1; then
+    printf 'fresh metadata initialization accepted an unsafe checkpoint log\n' >&2
+    exit 1
+  fi
+  grep -Fx 'outside checkpoint-log sentinel' "$unsafe_log_target" >/dev/null
+  diff -qr "$unsafe_resume_checkpoint_guard" "$checkpoint" >/dev/null
+  rm -f "$unsafe_checkpoint_log"
+  mv "$saved_checkpoint_log" "$unsafe_checkpoint_log"
+
+  unsafe_exit_status="$restart_session_dir/exit-status"
+  saved_exit_status="$TMP_ROOT/saved-exit-status"
+  unsafe_exit_target="$TMP_ROOT/unsafe-exit-status-target"
+  [ -f "$unsafe_exit_status" ] && [ ! -L "$unsafe_exit_status" ]
+  mv "$unsafe_exit_status" "$saved_exit_status"
+  printf 'outside exit-status sentinel\n' >"$unsafe_exit_target"
+  ln -s "$unsafe_exit_target" "$unsafe_exit_status"
+  if run_codex __write_initial_meta \
+      "$SESSION" "$ROOT" integration 1 "$DETACH_CODEX_BIN" "" "" \
+      unsafe-exit-status-run 0 >/dev/null 2>&1; then
+    printf 'fresh metadata initialization accepted an unsafe exit status\n' >&2
+    exit 1
+  fi
+  grep -Fx 'outside exit-status sentinel' "$unsafe_exit_target" >/dev/null
+  diff -qr "$unsafe_resume_checkpoint_guard" "$checkpoint" >/dev/null
+  rm -f "$unsafe_exit_status"
+  mv "$saved_exit_status" "$unsafe_exit_status"
+
+  saved_primary_meta="$TMP_ROOT/saved-primary-meta.json"
+  mv "$meta" "$saved_primary_meta"
+  mkdir "$meta"
+  printf 'primary metadata directory sentinel\n' >"$meta/sentinel"
+  if run_codex __write_initial_meta \
+      "$SESSION" "$ROOT" integration 1 "$DETACH_CODEX_BIN" "" "" \
+      unsafe-primary-meta-run 0 >/dev/null 2>&1; then
+    printf 'fresh initialization accepted a metadata directory\n' >&2
+    exit 1
+  fi
+  grep -Fx 'primary metadata directory sentinel' "$meta/sentinel" >/dev/null
+  diff -qr "$unsafe_resume_checkpoint_guard" "$checkpoint" >/dev/null
+  rm -rf "$meta"
+  mv "$saved_primary_meta" "$meta"
+
+  # Model a crash immediately after a fresh Start exchanged an intentional
+  # empty checkpoint generation. Its marker identifies the exact old sibling,
+  # so the next Start can finish cleanup without accepting a generic empty
+  # checkpoint as authoritative.
+  reset_crash_stage_name=.checkpoint-stage-reset-crash-fixture
+  reset_crash_stage="$restart_session_dir/$reset_crash_stage_name"
+  mkdir -m 0700 "$reset_crash_stage"
+  printf '%s\n' "$reset_crash_stage_name" \
+    >"$reset_crash_stage/.detach-checkpoint-reset"
+  "$STATE_HELPER" checkpoint exchange \
+    "$restart_session_dir" "$reset_crash_stage_name"
+  [ -f "$checkpoint/.detach-checkpoint-reset" ]
+  [ -f "$reset_crash_stage/meta.json" ]
+
+  export FAKE_CODEX_INIT_DELAY=5
 printf '%s\n' 'allowed_approval_policies = ["untrusted", "on-request", "never"]' >"$DETACH_CODEX_REQUIREMENTS_FILE"
 run_codex --name integration --detach -- 'start a new thread'
 wait_for_file_text "$FAKE_CODEX_ARGS_FILE" 'start a new thread'
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_cli_version)" = "$upgraded_version" ]
 [ "$(grep -Fxc -- '--ask-for-approval' "$FAKE_CODEX_ARGS_FILE")" = "1" ]
 [ "$(grep -Fxc -- 'never' "$FAKE_CODEX_ARGS_FILE")" = "1" ]
-[ ! -e "$checkpoint/rollout.jsonl" ]
-[ ! -e "$checkpoint/.detach-jsonl-validation.json" ]
-[ ! -e "$checkpoint/meta.json" ]
+  [ ! -e "$checkpoint/rollout.jsonl" ]
+  [ ! -e "$checkpoint/.detach-jsonl-validation.json" ]
+  [ ! -e "$checkpoint/meta.json" ]
+  [ ! -e "$checkpoint/.detach-checkpoint-reset" ]
+  [ ! -e "$reset_crash_stage" ] && [ ! -L "$reset_crash_stage" ]
 fresh_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
+fresh_resume_args="$(saved_resume_args_path "$meta" "$restart_session_dir")"
+[ "$fresh_resume_args" != "$superseded_resume_args" ]
+[ "$fresh_resume_args" != "$legacy_resume_args" ]
+[ ! -e "$superseded_resume_args" ]
+[ ! -e "$legacy_resume_args" ]
 fresh_lifecycle_id="$("$STATE_HELPER" meta get "$meta" lifecycle_id)"
 [ -n "$fresh_lifecycle_id" ]
 [ "$fresh_lifecycle_id" != "$previous_lifecycle_id" ]
@@ -1654,6 +1851,776 @@ export FAKE_CODEX_SLEEP=1
 expected_rollout="$("$STATE_HELPER" meta get "$meta" transcript_path)"
 [ -n "$expected_rollout" ]
 [ -f "$expected_rollout" ]
+
+# Resume can reuse a harness name for a different provider UUID. Until that
+# replacement passes both readiness proofs, the complete checkpoint for the
+# previous UUID and its saved options must remain the Recover target.
+failed_resume_id="22222222-3333-4444-8555-666666666666"
+failed_resume_rollout="$CODEX_HOME/sessions/2099/01/01/rollout-test-$failed_resume_id.jsonl"
+printf '%s\n' \
+  "{\"timestamp\":\"2099-01-01T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"$failed_resume_id\",\"cwd\":\"$ROOT\",\"originator\":\"codex_cli_rs\"}}" \
+  >"$failed_resume_rollout"
+failed_resume_rollout_sql="${failed_resume_rollout//\'/\'\'}"
+root_sql="${ROOT//\'/\'\'}"
+test_sqlite "$CODEX_HOME/state_5.sqlite" \
+  "INSERT OR REPLACE INTO threads
+     (id, rollout_path, created_at_ms, updated_at_ms, source, thread_source, cwd)
+   VALUES
+     ('$failed_resume_id', '$failed_resume_rollout_sql', 1, 1, 'cli', 'user', '$root_sql');"
+codex_session_dir="$(dirname "$meta")"
+resume_checkpoint_copy="$TMP_ROOT/codex-resume-checkpoint"
+resume_args_file="$(saved_resume_args_path "$checkpoint/meta.json" "$codex_session_dir")"
+resume_args_copy="$TMP_ROOT/codex-resume-args.bin"
+cp -Rp "$checkpoint" "$resume_checkpoint_copy"
+cp -p "$resume_args_file" "$resume_args_copy"
+require_nul_file_arg "$resume_args_copy" --model
+require_nul_file_arg "$resume_args_copy" detach-recovery-model
+
+# Recovery identity binds both the UUID and its exact Codex rollout path. A
+# corrupt metadata document for A must not restore checkpoint A over B's valid
+# provider file, even though both paths are below the trusted Codex root.
+cross_thread_name=cross-thread-rollout
+cross_thread_session=detach-codex-cross-thread-rollout
+cross_thread_dir="$DETACH_CODEX_STATE_ROOT/sessions/$cross_thread_session"
+cross_thread_checkpoint_guard="$TMP_ROOT/cross-thread-checkpoint"
+cross_thread_rollout_guard="$TMP_ROOT/cross-thread-rollout.jsonl"
+cross_thread_output="$TMP_ROOT/cross-thread-recover.out"
+rm -rf "$cross_thread_dir"
+cp -Rp "$codex_session_dir" "$cross_thread_dir"
+"$STATE_HELPER" meta patch "$cross_thread_dir/meta.json" \
+  --string session_name "$cross_thread_session" \
+  --string display_name "$cross_thread_name" \
+  --string agent_session_id "$expected_id" \
+  --string codex_session_id "$expected_id" \
+  --string transcript_path "$failed_resume_rollout" \
+  --string rollout_path "$failed_resume_rollout"
+"$STATE_HELPER" meta patch "$cross_thread_dir/checkpoint/meta.json" \
+  --string session_name "$cross_thread_session" \
+  --string display_name "$cross_thread_name"
+cp -Rp "$cross_thread_dir/checkpoint" "$cross_thread_checkpoint_guard"
+cp -p "$failed_resume_rollout" "$cross_thread_rollout_guard"
+if run_codex recover --detach "$cross_thread_name" \
+     >"$cross_thread_output" 2>&1; then
+  printf 'Codex Recover overwrote another thread rollout\n' >&2
+  exit 1
+fi
+grep -F 'saved Codex recovery data is missing, unsafe, or invalid' \
+  "$cross_thread_output" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$cross_thread_session" 2>/dev/null
+cmp "$cross_thread_rollout_guard" "$failed_resume_rollout"
+diff -qr "$cross_thread_checkpoint_guard" \
+  "$cross_thread_dir/checkpoint" >/dev/null
+
+# If B is truncated too, the destination bytes no longer prove their owner.
+# With Codex's thread index unavailable, recovery must fail closed rather than
+# treating the damaged file as permission to overwrite it.
+cross_thread_db="$CODEX_HOME/state_5.sqlite"
+cross_thread_saved_db="$CODEX_HOME/state_5.sqlite.unavailable-cross-thread"
+cross_thread_damaged_guard="$TMP_ROOT/cross-thread-damaged.jsonl"
+[ -f "$cross_thread_db" ] && [ ! -L "$cross_thread_db" ]
+[ ! -e "$cross_thread_saved_db" ] && [ ! -L "$cross_thread_saved_db" ]
+printf '{damaged B without identity proof\n' >"$failed_resume_rollout"
+cp -p "$failed_resume_rollout" "$cross_thread_damaged_guard"
+mv "$cross_thread_db" "$cross_thread_saved_db"
+if run_codex recover --detach "$cross_thread_name" \
+     >"$cross_thread_output" 2>&1; then
+  mv "$cross_thread_saved_db" "$cross_thread_db"
+  cp -p "$cross_thread_rollout_guard" "$failed_resume_rollout"
+  printf 'Codex Recover accepted an unowned damaged rollout\n' >&2
+  exit 1
+fi
+mv "$cross_thread_saved_db" "$cross_thread_db"
+cmp "$cross_thread_damaged_guard" "$failed_resume_rollout"
+diff -qr "$cross_thread_checkpoint_guard" \
+  "$cross_thread_dir/checkpoint" >/dev/null
+cp -p "$cross_thread_rollout_guard" "$failed_resume_rollout"
+cross_thread_alias="$CODEX_HOME/sessions/cross-thread-alias"
+cross_thread_alias_rollout="$cross_thread_alias/$(basename "$failed_resume_rollout")"
+ln -s "$(dirname "$failed_resume_rollout")" "$cross_thread_alias"
+if run_codex __prepare_codex_resume_locked \
+     "$cross_thread_session" "$expected_id" "$cross_thread_alias_rollout" \
+     >/dev/null 2>&1; then
+  printf 'Codex Resume accepted an intermediate rollout symlink\n' >&2
+  exit 1
+fi
+cmp "$cross_thread_rollout_guard" "$failed_resume_rollout"
+rm -f "$cross_thread_alias"
+rm -rf "$cross_thread_dir"
+
+# Resume restores provider data only after it crosses the checkpoint lock.
+# While the lock is held, even a damaged live rollout must remain unchanged.
+# This orders Resume after an old writer that already passed its live-worker
+# guard and prevents the restored process from starting with an older payload.
+resume_barrier_name=resume-restore-barrier
+resume_barrier_session=detach-codex-resume-restore-barrier
+resume_barrier_dir="$DETACH_CODEX_STATE_ROOT/sessions/$resume_barrier_session"
+resume_barrier_lock="$DETACH_LOCKS_ROOT/checkpoint-$resume_barrier_session.lock"
+resume_barrier_ready="$TMP_ROOT/resume-barrier-ready"
+resume_barrier_release="$TMP_ROOT/resume-barrier-release"
+resume_barrier_queued="$TMP_ROOT/resume-barrier-queued"
+resume_barrier_lockf="$TMP_ROOT/resume-barrier-lockf"
+resume_barrier_output="$TMP_ROOT/resume-barrier.out"
+rm -rf "$resume_barrier_dir"
+cp -Rp "$codex_session_dir" "$resume_barrier_dir"
+"$STATE_HELPER" meta patch "$resume_barrier_dir/meta.json" \
+  --string session_name "$resume_barrier_session" \
+  --string display_name "$resume_barrier_name"
+"$STATE_HELPER" meta patch "$resume_barrier_dir/checkpoint/meta.json" \
+  --string session_name "$resume_barrier_session" \
+  --string display_name "$resume_barrier_name"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'set -eu' \
+  'if [ "${4:-}" = "$DETACH_TEST_LOCKF_PATH" ]; then' \
+  '  printf '\''queued\n'\'' >"$DETACH_TEST_LOCKF_QUEUED"' \
+  'fi' \
+  'exec /usr/bin/lockf "$@"' >"$resume_barrier_lockf"
+chmod 0755 "$resume_barrier_lockf"
+/usr/bin/lockf -k "$resume_barrier_lock" /bin/sh -c \
+  'printf '\''ready\n'\'' >"$1"; attempts=0; while [ ! -f "$2" ] && [ "$attempts" -lt 400 ]; do attempts=$((attempts + 1)); /bin/sleep 0.05; done; [ -f "$2" ]' \
+  sh "$resume_barrier_ready" "$resume_barrier_release" &
+resume_barrier_holder=$!
+wait_for_file_text "$resume_barrier_ready" ready
+printf '{damaged before Resume barrier\n' >"$expected_rollout"
+resume_barrier_damaged_copy="$TMP_ROOT/resume-barrier-damaged.jsonl"
+cp -p "$expected_rollout" "$resume_barrier_damaged_copy"
+DETACH_LOCKF_BIN="$resume_barrier_lockf" \
+DETACH_TEST_LOCKF_PATH="$resume_barrier_lock" \
+DETACH_TEST_LOCKF_QUEUED="$resume_barrier_queued" \
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex resume --name "$resume_barrier_name" --detach "$expected_id" \
+    >"$resume_barrier_output" 2>&1 &
+resume_barrier_pid=$!
+wait_for_file_text "$resume_barrier_queued" queued
+cmp "$resume_barrier_damaged_copy" "$expected_rollout"
+: >"$resume_barrier_release"
+wait "$resume_barrier_holder"
+if ! wait "$resume_barrier_pid"; then
+  sed -n '1,80p' "$resume_barrier_output" >&2
+  exit 1
+fi
+wait_for_tmux_option "$resume_barrier_session" @detach_status running
+"$STATE_HELPER" jsonl validate codex "$expected_rollout" "$expected_id"
+run_codex stop "$resume_barrier_name"
+run_codex delete --force "$resume_barrier_name"
+
+# Project occupancy is checked before Recover can restore shared provider
+# state. A live session under another name must keep both its process identity
+# and a deliberately damaged same-UUID rollout byte-for-byte unchanged.
+occupancy_target_name=recovery-project-target
+occupancy_target_session=detach-codex-recovery-project-target
+occupancy_target_dir="$DETACH_CODEX_STATE_ROOT/sessions/$occupancy_target_session"
+occupancy_live_name=recovery-project-occupant
+occupancy_live_session=detach-codex-recovery-project-occupant
+rm -rf "$occupancy_target_dir"
+cp -Rp "$codex_session_dir" "$occupancy_target_dir"
+"$STATE_HELPER" meta patch "$occupancy_target_dir/meta.json" \
+  --string session_name "$occupancy_target_session" \
+  --string display_name "$occupancy_target_name"
+"$STATE_HELPER" meta patch "$occupancy_target_dir/checkpoint/meta.json" \
+  --string session_name "$occupancy_target_session" \
+  --string display_name "$occupancy_target_name"
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name "$occupancy_live_name" --detach -- \
+    'project recovery lock coverage'
+wait_for_tmux_option "$occupancy_live_session" @detach_status running
+occupancy_live_token="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$occupancy_live_session:" @detach_run_token)"
+occupancy_live_pane="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$occupancy_live_session:" @detach_pane_id)"
+occupancy_live_pid="$(tmux -L "$SOCKET" display-message -p \
+  -t "$occupancy_live_pane" '#{pane_pid}')"
+printf '{occupied project rollout sentinel\n' >"$expected_rollout"
+occupancy_rollout_copy="$TMP_ROOT/occupied-project-rollout.jsonl"
+cp -p "$expected_rollout" "$occupancy_rollout_copy"
+if run_codex recover --detach "$occupancy_target_name" \
+     >"$TMP_ROOT/occupied-project-recover.out" 2>&1; then
+  printf 'Recover mutated provider state while the project was occupied\n' >&2
+  exit 1
+fi
+grep -F 'project already has a running detached session' \
+  "$TMP_ROOT/occupied-project-recover.out" >/dev/null
+cmp "$occupancy_rollout_copy" "$expected_rollout"
+[ "$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$occupancy_live_session:" @detach_run_token)" = "$occupancy_live_token" ]
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "$occupancy_live_pane" '#{pane_pid}')" = "$occupancy_live_pid" ]
+kill -0 "$occupancy_live_pid"
+run_codex stop "$occupancy_live_name"
+run_codex delete --force "$occupancy_live_name"
+cp -p "$occupancy_target_dir/checkpoint/rollout.jsonl" "$expected_rollout"
+run_codex delete --force "$occupancy_target_name"
+
+# A present checkpoint path is untrusted even when its symlink target contains
+# valid JSONL. Resume must reject it before start and must not read it as a
+# matching provider checkpoint.
+resume_symlink_target="$TMP_ROOT/resume-symlink-target.jsonl"
+resume_symlink_target_copy="$TMP_ROOT/resume-symlink-target-copy.jsonl"
+resume_symlink_meta_copy="$TMP_ROOT/resume-symlink-meta.json"
+resume_symlink_output="$TMP_ROOT/resume-symlink.out"
+cp -p "$failed_resume_rollout" "$resume_symlink_target"
+cp -p "$resume_symlink_target" "$resume_symlink_target_copy"
+cp -p "$meta" "$resume_symlink_meta_copy"
+rm -f "$checkpoint/rollout.jsonl"
+ln -s "$resume_symlink_target" "$checkpoint/rollout.jsonl"
+if run_codex resume --name integration --detach "$failed_resume_id" \
+     >"$resume_symlink_output" 2>&1; then
+  run_codex stop integration >/dev/null 2>&1 || true
+  printf 'Codex Resume accepted a symlinked rollout checkpoint\n' >&2
+  exit 1
+fi
+grep -F 'could not restore the matching rollout checkpoint' \
+  "$resume_symlink_output" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
+cmp "$resume_symlink_meta_copy" "$meta"
+[ -L "$checkpoint/rollout.jsonl" ]
+[ "$(readlink "$checkpoint/rollout.jsonl")" = "$resume_symlink_target" ]
+cmp "$resume_symlink_target_copy" "$resume_symlink_target"
+rm -f "$checkpoint/rollout.jsonl"
+cp -p "$resume_checkpoint_copy/rollout.jsonl" "$checkpoint/rollout.jsonl"
+
+# A checkpoint directory symlink must fail before metadata cloning or payload
+# cleanup can touch its target.
+checkpoint_link_name=checkpoint-directory-symlink
+checkpoint_link_session=detach-codex-checkpoint-directory-symlink
+checkpoint_link_dir="$DETACH_CODEX_STATE_ROOT/sessions/$checkpoint_link_session"
+checkpoint_link_target="$TMP_ROOT/checkpoint-directory-symlink-target"
+checkpoint_link_guard="$TMP_ROOT/checkpoint-directory-symlink-guard"
+mkdir -m 0700 "$checkpoint_link_dir" "$checkpoint_link_target"
+cp -p "$meta" "$checkpoint_link_dir/meta.json"
+"$STATE_HELPER" meta patch "$checkpoint_link_dir/meta.json" \
+  --string session_name "$checkpoint_link_session" \
+  --string display_name "$checkpoint_link_name"
+printf 'external checkpoint sentinel\n' >"$checkpoint_link_target/sentinel"
+cp -Rp "$checkpoint_link_target" "$checkpoint_link_guard"
+ln -s "$checkpoint_link_target" "$checkpoint_link_dir/checkpoint"
+if run_codex __write_initial_meta \
+    "$checkpoint_link_session" "$ROOT" "$checkpoint_link_name" 1 \
+    "$DETACH_CODEX_BIN" "$expected_id" "$expected_rollout" \
+    checkpoint-link-run 1 >/dev/null 2>&1; then
+  printf 'metadata initialization accepted a symlinked checkpoint directory\n' >&2
+  exit 1
+fi
+[ -L "$checkpoint_link_dir/checkpoint" ]
+diff -qr "$checkpoint_link_guard" "$checkpoint_link_target" >/dev/null
+rm -f "$checkpoint_link_dir/checkpoint"
+rm -rf "$checkpoint_link_dir"
+
+failed_resume_output="$TMP_ROOT/failed-codex-resume.out"
+stale_starting_meta="$TMP_ROOT/codex-stale-starting-meta.json"
+rm -f \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+: >"$FAKE_POWER_FAIL_ARM_FILE"
+export FAKE_POWER_FAIL_AFTER_READY=1
+run_codex resume --name integration --detach "$failed_resume_id" \
+  >"$failed_resume_output" 2>&1 &
+failed_resume_pid=$!
+if ! wait_for_file_text "$FAKE_POWER_FAIL_ENTERED_FILE" entered; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  sed -n '1,80p' "$failed_resume_output" >&2
+  exit 1
+fi
+if ! cp -p "$meta" "$stale_starting_meta"; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'Codex could not preserve replacement B starting metadata\n' >&2
+  exit 1
+fi
+# The checkpoint interval is one second in this test. Hold the failed power
+# wrapper beyond that boundary to prove the checkpoint loop remains gated.
+sleep 2
+if run_codex __checkpoint_once "$SESSION" >/dev/null 2>&1; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'tokenless checkpoint bypassed replacement readiness\n' >&2
+  exit 1
+fi
+if ! diff -qr "$resume_checkpoint_copy" "$checkpoint" >/dev/null || \
+   ! cmp -s "$resume_args_copy" "$resume_args_file"; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'Codex Resume changed recovery data before readiness\n' >&2
+  exit 1
+fi
+held_resume_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"" || true)"
+if [ "$(printf '%s' "$held_resume_json" | \
+     "$STATE_HELPER" meta get /dev/stdin agent_session_id 2>/dev/null || true)" != \
+     "$failed_resume_id" ] || \
+   [ "$(printf '%s' "$held_resume_json" | \
+     "$STATE_HELPER" meta get /dev/stdin effective_status 2>/dev/null || true)" != \
+     starting ] || \
+   ! printf '%s' "$held_resume_json" | \
+     grep -F '"health_actions":["attach","stop"]' >/dev/null; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_resume_pid" || true
+  printf 'Codex list exposed recovery while replacement B was still starting: %s\n' \
+    "$held_resume_json" >&2
+  exit 1
+fi
+: >"$FAKE_POWER_FAIL_RELEASE_FILE"
+if wait "$failed_resume_pid"; then
+  printf 'Codex Resume passed a failed power handshake\n' >&2
+  exit 1
+fi
+rm -f \
+  "$FAKE_POWER_FAIL_ARM_FILE" \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+unset FAKE_POWER_FAIL_AFTER_READY
+! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
+if ! diff -qr "$resume_checkpoint_copy" "$checkpoint" >/dev/null || \
+   ! cmp -s "$resume_args_copy" "$resume_args_file"; then
+  printf 'Codex Resume changed recovery data during failed cleanup\n' >&2
+  exit 1
+fi
+[ -z "$("$STATE_HELPER" meta get "$meta" runtime_ready_at 2>/dev/null || true)" ]
+[ -n "$("$STATE_HELPER" meta get "$meta" \
+  runtime_shutdown_observed_at 2>/dev/null || true)" ]
+[ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" = "$failed_resume_id" ]
+failed_resume_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$failed_resume_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$failed_resume_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$expected_id" ]
+[ "$(printf '%s' "$failed_resume_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = recoverable_checkpoint ]
+printf '%s' "$failed_resume_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+
+# Legacy metadata can omit both Codex identity keys. Recover must infer the
+# UUID from its validated checkpoint, bind a complete staged generation, and
+# retain that repaired generation if the replacement fails before readiness.
+legacy_id_name=legacy-null-id
+legacy_id_session=detach-codex-legacy-null-id
+legacy_id_dir="$DETACH_CODEX_STATE_ROOT/sessions/$legacy_id_session"
+legacy_id_checkpoint="$legacy_id_dir/checkpoint"
+rm -rf "$legacy_id_dir"
+cp -Rp "$codex_session_dir" "$legacy_id_dir"
+rm -f "$legacy_id_dir/meta.json"
+"$STATE_HELPER" meta patch "$legacy_id_checkpoint/meta.json" \
+  --string session_name "$legacy_id_session" \
+  --string display_name "$legacy_id_name" \
+  --null agent_session_id \
+  --null codex_session_id
+rm -f \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+: >"$FAKE_POWER_FAIL_ARM_FILE"
+export FAKE_CODEX_SLEEP=20
+run_codex recover --detach "$legacy_id_name" \
+  >"$TMP_ROOT/failed-legacy-id-recover.out" 2>&1 &
+failed_legacy_id_recover_pid=$!
+if ! wait_for_file_text "$FAKE_POWER_FAIL_ENTERED_FILE" entered; then
+  : >"$FAKE_POWER_FAIL_RELEASE_FILE"
+  wait "$failed_legacy_id_recover_pid" || true
+  exit 1
+fi
+[ "$("$STATE_HELPER" meta get \
+  "$legacy_id_checkpoint/meta.json" codex_session_id)" = "$expected_id" ]
+: >"$FAKE_POWER_FAIL_RELEASE_FILE"
+if wait "$failed_legacy_id_recover_pid"; then
+  printf 'legacy-ID replacement passed a failed power handshake\n' >&2
+  exit 1
+fi
+rm -f \
+  "$FAKE_POWER_FAIL_ARM_FILE" \
+  "$FAKE_POWER_FAIL_ENTERED_FILE" \
+  "$FAKE_POWER_FAIL_RELEASE_FILE"
+! tmux -L "$SOCKET" has-session -t "=$legacy_id_session" 2>/dev/null
+[ "$("$STATE_HELPER" meta get \
+  "$legacy_id_checkpoint/meta.json" codex_session_id)" = "$expected_id" ]
+run_codex recover --detach "$legacy_id_name"
+wait_for_tmux_option "$legacy_id_session" @detach_status running
+require_file_line "$FAKE_CODEX_ARGS_FILE" resume
+require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
+run_codex stop "$legacy_id_name"
+run_codex delete --force "$legacy_id_name"
+
+# A Codex checkpoint metadata generation remains recoverable when its backup
+# rollout is absent but the selected live rollout is valid. List and Recover
+# must use the same eligibility rule, so exercise both on an isolated copy.
+missing_backup_name=valid-live-no-backup
+missing_backup_session=detach-codex-valid-live-no-backup
+missing_backup_dir="$DETACH_CODEX_STATE_ROOT/sessions/$missing_backup_session"
+rm -rf "$missing_backup_dir"
+cp -Rp "$codex_session_dir" "$missing_backup_dir"
+"$STATE_HELPER" meta patch "$missing_backup_dir/meta.json" \
+  --string session_name "$missing_backup_session" \
+  --string display_name "$missing_backup_name"
+"$STATE_HELPER" meta patch "$missing_backup_dir/checkpoint/meta.json" \
+  --string session_name "$missing_backup_session" \
+  --string display_name "$missing_backup_name"
+rm -f "$missing_backup_dir/checkpoint/rollout.jsonl"
+missing_backup_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$missing_backup_session\"")"
+[ "$(printf '%s' "$missing_backup_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$missing_backup_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$expected_id" ]
+printf '%s' "$missing_backup_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+export FAKE_CODEX_SLEEP=20
+run_codex recover --detach "$missing_backup_name"
+wait_for_tmux_option "$missing_backup_session" @detach_status running
+require_file_line "$FAKE_CODEX_ARGS_FILE" resume
+require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
+require_file_line "$FAKE_CODEX_ARGS_FILE" detach-recovery-model
+run_codex stop "$missing_backup_name"
+run_codex delete --force "$missing_backup_name"
+
+# An explicit saved-options selector is part of recovery eligibility. Recover
+# must reject a missing file before it restores provider data from checkpoint.
+missing_args_copy="$TMP_ROOT/codex-missing-resume-args.bin"
+missing_args_meta_copy="$TMP_ROOT/codex-missing-resume-args-meta.json"
+mv "$resume_args_file" "$missing_args_copy"
+cp -p "$meta" "$missing_args_meta_copy"
+printf '{damaged rollout\n' >"$expected_rollout"
+missing_args_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$missing_args_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+printf '%s' "$missing_args_json" | grep -F '"health_actions":["delete"]' >/dev/null
+if run_codex recover --detach integration >/dev/null 2>&1; then
+  printf 'Codex Recover accepted a missing saved-options file\n' >&2
+  exit 1
+fi
+grep -Fx '{damaged rollout' "$expected_rollout" >/dev/null
+cmp -s "$missing_args_meta_copy" "$meta"
+mv "$missing_args_copy" "$resume_args_file"
+
+valid_args_copy="$TMP_ROOT/codex-valid-resume-args.bin"
+cp -p "$resume_args_file" "$valid_args_copy"
+printf 'torn-option' >>"$resume_args_file"
+torn_args_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$torn_args_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
+printf '%s' "$torn_args_json" | grep -F '"health_actions":["delete"]' >/dev/null
+if run_codex recover --detach integration >/dev/null 2>&1; then
+  printf 'Codex Recover accepted a torn saved-options file\n' >&2
+  exit 1
+fi
+grep -Fx '{damaged rollout' "$expected_rollout" >/dev/null
+cmp -s "$missing_args_meta_copy" "$meta"
+mv "$valid_args_copy" "$resume_args_file"
+
+printf '{damaged rollout\n' >"$expected_rollout"
+export FAKE_CODEX_SLEEP=20
+export FAKE_CODEX_EXIT=0
+run_codex recover --detach integration
+wait_for_tmux_option "$SESSION" @detach_status running
+require_file_line "$FAKE_CODEX_ARGS_FILE" resume
+require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
+require_file_line "$FAKE_CODEX_ARGS_FILE" detach-recovery-model
+"$STATE_HELPER" jsonl validate codex "$expected_rollout" "$expected_id"
+run_codex stop integration
+
+# A ready marker without a provider PID is the durable launch gap: the child
+# may exist, but its exact identity was never published. Even after the exact
+# worker is dead, List and Recover must keep all actions closed.
+"$STATE_HELPER" meta patch "$stale_starting_meta" \
+  --integer worker_pid 2147483647 \
+  --null provider_pid \
+  --null runtime_shutdown_observed_at
+cp -p "$stale_starting_meta" "$meta"
+launch_gap_token="$("$STATE_HELPER" meta get "$meta" run_token)"
+launch_gap_ready="$codex_session_dir/power-ready-$launch_gap_token"
+launch_gap_checkpoint_copy="$TMP_ROOT/codex-launch-gap-checkpoint"
+cp -Rp "$checkpoint" "$launch_gap_checkpoint_copy"
+: >"$launch_gap_ready"
+launch_gap_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$launch_gap_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = hung ]
+[ "$(printf '%s' "$launch_gap_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = runtime_quiescence_unproven ]
+printf '%s' "$launch_gap_json" | grep -F '"health_actions":[]' >/dev/null
+if run_codex recover --detach integration >/dev/null 2>&1; then
+  printf 'Codex Recover accepted a launch gap without provider identity\n' >&2
+  exit 1
+fi
+[ -f "$launch_gap_ready" ]
+diff -qr "$launch_gap_checkpoint_copy" "$checkpoint" >/dev/null
+rm -f "$launch_gap_ready"
+
+# `initializing` with no PID artifacts is not proof that launch was never
+# attempted. respawn-pane can create the worker before it publishes identity,
+# so this incomplete primary remains actionless without a shutdown marker.
+rm -f "$meta"
+"$STATE_HELPER" meta create "$meta" \
+  --integer schema 1 \
+  --string session_name "$SESSION" \
+  --string project_dir "$ROOT" \
+  --string status starting \
+  --string lifecycle_phase initializing \
+  --string run_token "$launch_gap_token" \
+  --string provider codex \
+  --integer health_schema 1 \
+  --bool preserve_recovery_until_ready true \
+  --null runtime_ready_at \
+  --null worker_pid \
+  --null provider_pid \
+  --null runtime_shutdown_observed_at
+prelaunch_unknown_meta_copy="$TMP_ROOT/codex-prelaunch-unknown-meta.json"
+cp -p "$meta" "$prelaunch_unknown_meta_copy"
+prelaunch_unknown_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$prelaunch_unknown_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = hung ]
+[ "$(printf '%s' "$prelaunch_unknown_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = runtime_quiescence_unproven ]
+printf '%s' "$prelaunch_unknown_json" | grep -F '"health_actions":[]' >/dev/null
+if run_codex recover --detach integration >/dev/null 2>&1; then
+  printf 'Codex Recover inferred shutdown from missing launch artifacts\n' >&2
+  exit 1
+fi
+if run_codex delete --force integration >/dev/null 2>&1; then
+  printf 'Codex Delete inferred shutdown from missing launch artifacts\n' >&2
+  exit 1
+fi
+[ -z "$("$STATE_HELPER" meta get "$meta" \
+  runtime_shutdown_observed_at 2>/dev/null || true)" ]
+cmp -s "$prelaunch_unknown_meta_copy" "$meta"
+diff -qr "$launch_gap_checkpoint_copy" "$checkpoint" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
+! "$DETACH" reconcile --dry-run --json | grep -F "$SESSION" >/dev/null
+
+# Model an abrupt loss after B published its starting metadata and exact
+# process identities, but before readiness. Fixed impossible PIDs make the
+# dead-process proof deterministic. Recover must still select checkpoint A.
+"$STATE_HELPER" meta patch "$stale_starting_meta" \
+  --integer provider_pid 2147483646 \
+  --null runtime_shutdown_observed_at
+cp -p "$stale_starting_meta" "$meta"
+stale_starting_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$SESSION\"")"
+[ "$(printf '%s' "$stale_starting_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$stale_starting_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$expected_id" ]
+printf '%s' "$stale_starting_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+printf '{damaged rollout\n' >"$expected_rollout"
+run_codex recover --detach integration
+wait_for_tmux_option "$SESSION" @detach_status running
+require_file_line "$FAKE_CODEX_ARGS_FILE" resume
+require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
+require_file_line "$FAKE_CODEX_ARGS_FILE" detach-recovery-model
+"$STATE_HELPER" jsonl validate codex "$expected_rollout" "$expected_id"
+run_codex stop integration
+
+# Model a ready run after /clear rebound it from thread A to B, but before the
+# next checkpoint. Primary and checkpoint share one run identity and legacy
+# options, while their provider IDs and rollout paths differ. Recover must
+# validate live B and replace the stale A binding before it starts C.
+ready_name=ready-before-first-checkpoint
+ready_session=detach-codex-ready-before-first-checkpoint
+ready_dir="$DETACH_CODEX_STATE_ROOT/sessions/$ready_session"
+ready_meta="$ready_dir/meta.json"
+ready_checkpoint="$ready_dir/checkpoint"
+rm -rf "$ready_dir"
+cp -Rp "$codex_session_dir" "$ready_dir"
+"$STATE_HELPER" meta patch "$ready_checkpoint/meta.json" \
+  --string session_name "$ready_session" \
+  --string display_name "$ready_name" \
+  --null resume_args_file
+ready_shared_run_token="$("$STATE_HELPER" meta get \
+  "$ready_checkpoint/meta.json" run_token)"
+ready_shared_lifecycle_id="$("$STATE_HELPER" meta get \
+  "$ready_checkpoint/meta.json" lifecycle_id)"
+cp -p "$stale_starting_meta" "$ready_meta"
+"$STATE_HELPER" meta patch "$ready_meta" \
+  --string session_name "$ready_session" \
+  --string display_name "$ready_name" \
+  --string run_token "$ready_shared_run_token" \
+  --string lifecycle_id "$ready_shared_lifecycle_id" \
+  --string status running \
+  --string lifecycle_phase running \
+  --string runtime_ready_at 2099-01-01T00:00:00Z \
+  --null last_checkpoint_at \
+  --null last_checkpoint_epoch \
+  --null resume_args_file \
+  --integer worker_pid 2147483647 \
+  --integer provider_pid 2147483646 \
+  --null runtime_shutdown_observed_at
+printf '%s\0%s\0' --model detach-ready-model >"$ready_dir/resume-args.bin"
+[ "$("$STATE_HELPER" meta get "$ready_meta" codex_session_id)" = "$failed_resume_id" ]
+[ "$("$STATE_HELPER" meta get "$ready_checkpoint/meta.json" codex_session_id)" = \
+  "$expected_id" ]
+[ -n "$("$STATE_HELPER" meta get "$ready_meta" runtime_ready_at)" ]
+[ -z "$("$STATE_HELPER" meta get "$ready_meta" last_checkpoint_at 2>/dev/null || true)" ]
+ready_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$ready_session\"")"
+[ "$(printf '%s' "$ready_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$ready_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$failed_resume_id" ]
+printf '%s' "$ready_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+
+# Recovery handoff fields are typed authority. A present primary with even a
+# scalar type mismatch must not fall back to checkpoint A in List or authorize
+# Recover/Delete. Build corruption without detach-state because the helper
+# itself rejects these invalid writes.
+ready_typed_meta_copy="$TMP_ROOT/ready-typed-meta.json"
+ready_typed_checkpoint_copy="$TMP_ROOT/ready-typed-checkpoint"
+ready_typed_tmp="$ready_meta.typed.tmp"
+cp -p "$ready_meta" "$ready_typed_meta_copy"
+cp -Rp "$ready_checkpoint" "$ready_typed_checkpoint_copy"
+for ready_typed_case in preserve ready shutdown; do
+  case "$ready_typed_case" in
+    preserve)
+      sed 's/"preserve_recovery_until_ready":true/"preserve_recovery_until_ready":"false"/' \
+        "$ready_typed_meta_copy" >"$ready_typed_tmp"
+      grep -F '"preserve_recovery_until_ready":"false"' \
+        "$ready_typed_tmp" >/dev/null
+      ;;
+    ready)
+      sed 's/"runtime_ready_at":"2099-01-01T00:00:00Z"/"runtime_ready_at":false/' \
+        "$ready_typed_meta_copy" >"$ready_typed_tmp"
+      grep -F '"runtime_ready_at":false' "$ready_typed_tmp" >/dev/null
+      ;;
+    shutdown)
+      sed 's/"runtime_shutdown_observed_at":null/"runtime_shutdown_observed_at":0/' \
+        "$ready_typed_meta_copy" >"$ready_typed_tmp"
+      grep -F '"runtime_shutdown_observed_at":0' "$ready_typed_tmp" >/dev/null
+      ;;
+  esac
+  mv -f "$ready_typed_tmp" "$ready_meta"
+  ready_typed_json="$(run_codex list --json | \
+    grep -F "\"session_name\":\"$ready_session\"")"
+  [ "$(printf '%s' "$ready_typed_json" | \
+    "$STATE_HELPER" meta get /dev/stdin effective_status)" = corrupt ]
+  printf '%s' "$ready_typed_json" | grep -F '"health_actions":[]' >/dev/null
+  if run_codex recover --detach "$ready_name" >/dev/null 2>&1; then
+    printf 'Codex Recover accepted mistyped %s metadata\n' \
+      "$ready_typed_case" >&2
+    exit 1
+  fi
+  if run_codex delete --force "$ready_name" >/dev/null 2>&1; then
+    printf 'Codex Delete accepted mistyped %s metadata\n' \
+      "$ready_typed_case" >&2
+    exit 1
+  fi
+  diff -qr "$ready_typed_checkpoint_copy" "$ready_checkpoint" >/dev/null
+  cp -p "$ready_typed_meta_copy" "$ready_meta"
+done
+
+# Resume must validate B's explicit saved-options binding before it can clone
+# B over the still-recoverable checkpoint A. A missing run-bound file fails
+# unchanged even when the legacy options file is present and valid.
+ready_missing_args_name="resume-args-$ready_shared_run_token.bin"
+rm -f "$ready_dir/$ready_missing_args_name"
+"$STATE_HELPER" meta patch "$ready_meta" \
+  --string resume_args_file "$ready_missing_args_name"
+ready_missing_meta_copy="$TMP_ROOT/ready-missing-options-meta.json"
+ready_missing_checkpoint_copy="$TMP_ROOT/ready-missing-options-checkpoint"
+ready_missing_legacy_args_copy="$TMP_ROOT/ready-missing-options-legacy.bin"
+cp -p "$ready_meta" "$ready_missing_meta_copy"
+cp -Rp "$ready_checkpoint" "$ready_missing_checkpoint_copy"
+cp -p "$ready_dir/resume-args.bin" "$ready_missing_legacy_args_copy"
+ready_missing_output="$TMP_ROOT/ready-missing-options-resume.out"
+if run_codex resume --name "$ready_name" --detach "$failed_resume_id" \
+     >"$ready_missing_output" 2>&1; then
+  printf 'Codex Resume accepted a missing selected options file\n' >&2
+  exit 1
+fi
+! grep -F 'Started ' "$ready_missing_output" >/dev/null
+grep -F 'could not initialize session metadata' "$ready_missing_output" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$ready_session" 2>/dev/null
+cmp "$ready_missing_meta_copy" "$ready_meta"
+diff -qr "$ready_missing_checkpoint_copy" "$ready_checkpoint" >/dev/null
+cmp "$ready_missing_legacy_args_copy" "$ready_dir/resume-args.bin"
+"$STATE_HELPER" meta patch "$ready_meta" --null resume_args_file
+
+# A selected Codex generation without its own rollout checkpoint is valid only
+# while its safe live rollout is valid. A damaged B rollout must not replace A
+# metadata, even when A remains recoverable from its own live rollout.
+ready_payload_checkpoint_copy="$TMP_ROOT/ready-payload-checkpoint"
+ready_payload_expected_checkpoint="$TMP_ROOT/ready-payload-expected-checkpoint"
+ready_payload_meta_copy="$TMP_ROOT/ready-payload-meta.json"
+ready_payload_live_copy="$TMP_ROOT/ready-payload-live.jsonl"
+cp -p "$ready_checkpoint/rollout.jsonl" "$ready_payload_checkpoint_copy"
+rm -f "$ready_checkpoint/rollout.jsonl"
+cp -Rp "$ready_checkpoint" "$ready_payload_expected_checkpoint"
+cp -p "$ready_meta" "$ready_payload_meta_copy"
+cp -p "$failed_resume_rollout" "$ready_payload_live_copy"
+printf '{damaged selected rollout\n' >"$failed_resume_rollout"
+ready_payload_output="$TMP_ROOT/ready-payload-resume.out"
+if run_codex resume --name "$ready_name" --detach "$expected_id" \
+     >"$ready_payload_output" 2>&1; then
+  printf 'Codex Resume accepted a damaged selected live rollout\n' >&2
+  exit 1
+fi
+! grep -F 'Started ' "$ready_payload_output" >/dev/null
+grep -F 'could not initialize session metadata' "$ready_payload_output" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$ready_session" 2>/dev/null
+cmp "$ready_payload_meta_copy" "$ready_meta"
+diff -qr "$ready_payload_expected_checkpoint" "$ready_checkpoint" >/dev/null
+cp -p "$ready_payload_checkpoint_copy" "$ready_checkpoint/rollout.jsonl"
+cp -p "$ready_payload_live_copy" "$failed_resume_rollout"
+
+# Recovering ready B starts replacement C. Force a deterministic failure in
+# snapshot_known_threads before respawn-pane is invoked. The starter can prove
+# locally that no C runtime existed, and the usable but stale A checkpoint
+# must first be replaced by the selected B generation and B's saved options.
+prelaunch_fail_sqlite="$TMP_ROOT/prelaunch-fail-sqlite"
+real_sqlite="$(command -v sqlite3)"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'case "$*" in *"SELECT id FROM threads"*"ORDER BY id"*) exit 91 ;; esac' \
+  "exec \"$real_sqlite\" \"\$@\"" \
+  >"$prelaunch_fail_sqlite"
+chmod 0755 "$prelaunch_fail_sqlite"
+prelaunch_failure_output="$TMP_ROOT/prelaunch-recovery-failure.out"
+if DETACH_SQLITE_BIN="$prelaunch_fail_sqlite" \
+   run_codex recover --detach "$ready_name" \
+     >"$prelaunch_failure_output" 2>&1; then
+  printf 'Codex Recover passed a pre-worker snapshot failure\n' >&2
+  exit 1
+fi
+! grep -F 'Started ' "$prelaunch_failure_output" >/dev/null
+grep -F 'could not snapshot existing Codex sessions' \
+  "$prelaunch_failure_output" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$ready_session" 2>/dev/null
+[ -n "$("$STATE_HELPER" meta get "$ready_meta" \
+  runtime_shutdown_observed_at 2>/dev/null || true)" ]
+[ "$("$STATE_HELPER" meta get "$ready_checkpoint/meta.json" \
+  codex_session_id)" = "$failed_resume_id" ]
+"$STATE_HELPER" jsonl validate codex \
+  "$ready_checkpoint/rollout.jsonl" "$failed_resume_id"
+ready_preserved_args="$(saved_resume_args_path \
+  "$ready_checkpoint/meta.json" "$ready_dir")"
+require_nul_file_arg "$ready_preserved_args" detach-ready-model
+ready_after_prelaunch_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$ready_session\"")"
+[ "$(printf '%s' "$ready_after_prelaunch_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = recoverable ]
+[ "$(printf '%s' "$ready_after_prelaunch_json" | \
+  "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$failed_resume_id" ]
+printf '%s' "$ready_after_prelaunch_json" | \
+  grep -F '"health_actions":["recover","delete"]' >/dev/null
+
+# Replacement C may have changed B's live rollout before it failed. Recover
+# must use the newly materialized immutable B payload, not stale checkpoint A
+# or the damaged live provider file.
+printf '{damaged live B after failed C\n' >"$failed_resume_rollout"
+run_codex recover --detach "$ready_name"
+wait_for_tmux_option "$ready_session" @detach_status running
+require_file_line "$FAKE_CODEX_ARGS_FILE" resume
+require_file_line "$FAKE_CODEX_ARGS_FILE" "$failed_resume_id"
+require_file_line "$FAKE_CODEX_ARGS_FILE" detach-ready-model
+"$STATE_HELPER" jsonl validate codex "$failed_resume_rollout" "$failed_resume_id"
+run_codex stop "$ready_name"
+run_codex delete --force "$ready_name"
+
+uppercase_codex="$TMP_ROOT/fake-codex-uppercase-resume"
+uppercase_release="$TMP_ROOT/fake-codex-uppercase-resume-release"
+write_releasable_fake_codex "$uppercase_codex" "$uppercase_release"
 cp -p "$expected_rollout" "$checkpoint/rollout.jsonl"
 printf '{damaged rollout\n' >"$expected_rollout"
 uppercase_id="$(printf '%s' "$expected_id" | tr '[:lower:]' '[:upper:]')"
@@ -1664,7 +2631,9 @@ mkdir -p "$other_cwd"
 # returns. A baseline taken after that poll would wait for a nonexistent extra
 # event.
 status_hint="$(cat "$DETACH_STATE_ROOT/session-change")"
-(cd "$other_cwd" && "$DETACH" resume --name integration --detach "$uppercase_id")
+(cd "$other_cwd" && DETACH_CODEX_BIN="$uppercase_codex" \
+  "$DETACH" resume --name integration --detach "$uppercase_id")
+: >"$uppercase_release"
 wait_for_tmux_option "$SESSION" @detach_status completed
 grep -Fx 'resume' "$FAKE_CODEX_ARGS_FILE" >/dev/null
 grep -Fx "$expected_id" "$FAKE_CODEX_ARGS_FILE" >/dev/null
@@ -1921,7 +2890,57 @@ printf '%s' "$json_line" | grep -F '"session_color":null' >/dev/null
 fi
 
 if codex_part_selected delete; then
-run_codex --name integration --detach -- 'delete refusal coverage'
+# Stop serializes its stop-edge pane capture with an in-flight atomic
+# checkpoint publication. Output produced after the staged capture must remain
+# in canonical checkpoint logs after both operations finish.
+stop_edge_name=checkpoint-stop-edge
+stop_edge_session=detach-codex-checkpoint-stop-edge
+stop_edge_ready="$TMP_ROOT/checkpoint-stop-edge-ready"
+stop_edge_release="$TMP_ROOT/checkpoint-stop-edge-release"
+stop_edge_lock_queued="$TMP_ROOT/checkpoint-stop-edge-lock-queued"
+stop_edge_lockf="$TMP_ROOT/checkpoint-stop-edge-lockf"
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name "$stop_edge_name" --detach -- 'checkpoint Stop edge coverage'
+wait_for_tmux_option "$stop_edge_session" @detach_status running
+stop_edge_meta="$DETACH_CODEX_STATE_ROOT/sessions/$stop_edge_session/meta.json"
+stop_edge_run_token="$("$STATE_HELPER" meta get "$stop_edge_meta" run_token)"
+stop_edge_worker_pid="$("$STATE_HELPER" meta get "$stop_edge_meta" worker_pid)"
+stop_edge_pane="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$stop_edge_session:" @detach_pane_id)"
+DETACH_TEST_CHECKPOINT_PREEXCHANGE_READY="$stop_edge_ready" \
+DETACH_TEST_CHECKPOINT_PREEXCHANGE_RELEASE="$stop_edge_release" \
+  "$SCRIPT" codex __checkpoint_once \
+    "$stop_edge_session" "$stop_edge_run_token" "$stop_edge_worker_pid" \
+    >/dev/null 2>&1 &
+stop_edge_writer=$!
+wait_for_file_text "$stop_edge_ready" ready
+tmux -L "$SOCKET" send-keys -l -t "$stop_edge_pane" \
+  'stop-edge-pane-marker'
+wait_for_pane_text "$SOCKET" "$stop_edge_pane" 'stop-edge-pane-marker'
+printf '%s\n' \
+  '#!/bin/bash' \
+  'set -eu' \
+  'if [ "${4:-}" = "$DETACH_TEST_LOCKF_PATH" ]; then' \
+  '  printf '\''queued\n'\'' >"$DETACH_TEST_LOCKF_QUEUED"' \
+  'fi' \
+  'exec /usr/bin/lockf "$@"' >"$stop_edge_lockf"
+chmod 0755 "$stop_edge_lockf"
+DETACH_LOCKF_BIN="$stop_edge_lockf" \
+DETACH_TEST_LOCKF_PATH="$DETACH_LOCKS_ROOT/checkpoint-$stop_edge_session.lock" \
+DETACH_TEST_LOCKF_QUEUED="$stop_edge_lock_queued" \
+  run_codex stop "$stop_edge_name" >/dev/null 2>&1 &
+stop_edge_stop=$!
+wait_for_file_text "$stop_edge_lock_queued" queued
+: >"$stop_edge_release"
+wait "$stop_edge_writer"
+wait "$stop_edge_stop"
+grep -F 'stop-edge-pane-marker' \
+  "$DETACH_CODEX_STATE_ROOT/sessions/$stop_edge_session/checkpoint/pane.txt" \
+  >/dev/null
+run_codex delete --force "$stop_edge_name"
+
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name integration --detach -- 'delete refusal coverage'
 wait_for_tmux_option "$SESSION" @detach_status running
 live_storage_plan="$("$DETACH" storage cleanup --dry-run --json)"
 ! printf '%s' "$live_storage_plan" | grep -F "\"session_name\":\"$SESSION\"" >/dev/null
@@ -1975,8 +2994,12 @@ codex_scenario_event pass SC-SESSION-DELETE-CODEX
 # on the missing directory.
 remnant_name=delete-remnant
 remnant_session=detach-codex-delete-remnant
-FAKE_CODEX_INIT_DELAY=0 FAKE_CODEX_SLEEP=1 FAKE_CODEX_EXIT=0 \
+remnant_codex="$TMP_ROOT/fake-codex-delete-remnant"
+remnant_release="$TMP_ROOT/fake-codex-delete-remnant-release"
+write_releasable_fake_codex "$remnant_codex" "$remnant_release"
+DETACH_CODEX_BIN="$remnant_codex" \
   run_codex --name "$remnant_name" --detach -- 'tmux-only remnant delete coverage'
+: >"$remnant_release"
 remnant_pane="$(tmux -L "$SOCKET" show-options -qv -t "=$remnant_session:" @detach_pane_id)"
 wait_for_pane_dead "$remnant_pane"
 tmux -L "$SOCKET" has-session -t "=$remnant_session"
@@ -1988,8 +3011,12 @@ run_codex delete --force "$remnant_name"
 # printing a misleading success over leftover state.
 stubborn_name=delete-stubborn
 stubborn_session=detach-codex-delete-stubborn
-FAKE_CODEX_INIT_DELAY=0 FAKE_CODEX_SLEEP=1 FAKE_CODEX_EXIT=0 \
+stubborn_codex="$TMP_ROOT/fake-codex-delete-stubborn"
+stubborn_release="$TMP_ROOT/fake-codex-delete-stubborn-release"
+write_releasable_fake_codex "$stubborn_codex" "$stubborn_release"
+DETACH_CODEX_BIN="$stubborn_codex" \
   run_codex --name "$stubborn_name" --detach -- 'partial delete failure coverage'
+: >"$stubborn_release"
 stubborn_pane="$(tmux -L "$SOCKET" show-options -qv -t "=$stubborn_session:" @detach_pane_id)"
 wait_for_pane_dead "$stubborn_pane"
 stubborn_dir="$DETACH_CODEX_STATE_ROOT/sessions/$stubborn_session"
@@ -2045,7 +3072,7 @@ slow_cleanup_sqlite="$TMP_ROOT/slow-final-checkpoint-sqlite"
 sqlite_delegate="$(command -v sqlite3)"
 printf '%s\n' \
   '#!/bin/bash' \
-  "if [ -f '$slow_cleanup_marker' ]; then" \
+  "if [ -f '$slow_cleanup_marker' ] && [ \"\${DETACH_SUPPRESS_SESSION_EVENT:-0}\" = 1 ]; then" \
   "  : >'$slow_cleanup_started'" \
   "  trap '' HUP INT TERM" \
   '  sleep 30' \
@@ -2175,21 +3202,238 @@ DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
   run_codex --name "$worker_crash_name" --detach -- 'worker crash health coverage'
 worker_crash_meta="$DETACH_CODEX_STATE_ROOT/sessions/$worker_crash_session/meta.json"
 worker_crash_checkpoint="$DETACH_CODEX_STATE_ROOT/sessions/$worker_crash_session/checkpoint/rollout.jsonl"
+worker_crash_checkpoint_meta="$(dirname "$worker_crash_checkpoint")/meta.json"
 attempts=0
 while { [ ! -s "$worker_crash_checkpoint" ] || \
+        ! "$STATE_HELPER" meta usable \
+          "$worker_crash_checkpoint_meta" "$worker_crash_session" \
+          >/dev/null 2>&1 || \
         [ -z "$("$STATE_HELPER" meta get "$worker_crash_meta" agent_session_id 2>/dev/null || true)" ]; } && \
       [ "$attempts" -lt 80 ]; do
   attempts=$((attempts + 1))
   sleep 0.1
 done
 [ -s "$worker_crash_checkpoint" ]
+[ -s "$worker_crash_checkpoint_meta" ]
 [ -s "$(dirname "$worker_crash_checkpoint")/.detach-jsonl-validation.json" ]
 worker_crash_pane="$(tmux -L "$SOCKET" show-options -qv \
   -t "=$worker_crash_session:" @detach_pane_id)"
 worker_crash_pid="$("$STATE_HELPER" meta get "$worker_crash_meta" worker_pid)"
 worker_crash_provider_pid="$("$STATE_HELPER" meta get "$worker_crash_meta" provider_pid)"
 worker_crash_pgid="$(wait_for_process_group_id "$worker_crash_pid")"
+worker_crash_run_token="$("$STATE_HELPER" meta get "$worker_crash_meta" run_token)"
+
+# A checkpoint generation includes the exact run-bound saved options. If that
+# file becomes torn after staging, prepublish validation must retain canonical
+# checkpoint A byte-for-byte.
+worker_crash_args_ready="$TMP_ROOT/worker-crash-args-ready"
+worker_crash_args_release="$TMP_ROOT/worker-crash-args-release"
+worker_crash_args_guard="$TMP_ROOT/worker-crash-args-checkpoint"
+worker_crash_args_copy="$TMP_ROOT/worker-crash-resume-args.bin"
+DETACH_TEST_CHECKPOINT_PREPUBLISH_READY="$worker_crash_args_ready" \
+DETACH_TEST_CHECKPOINT_PREPUBLISH_RELEASE="$worker_crash_args_release" \
+  "$SCRIPT" codex __checkpoint_once \
+    "$worker_crash_session" "$worker_crash_run_token" "$worker_crash_pid" \
+    >/dev/null 2>&1 &
+worker_crash_args_writer=$!
+wait_for_file_text "$worker_crash_args_ready" ready
+cp -Rp "$(dirname "$worker_crash_checkpoint")" "$worker_crash_args_guard"
+worker_crash_resume_args="$(saved_resume_args_path \
+  "$worker_crash_meta" "$(dirname "$worker_crash_meta")")"
+cp -p "$worker_crash_resume_args" "$worker_crash_args_copy"
+printf 'torn-options' >>"$worker_crash_resume_args"
+: >"$worker_crash_args_release"
+if wait "$worker_crash_args_writer"; then
+  printf 'checkpoint published with torn run-bound saved options\n' >&2
+  exit 1
+fi
+diff -qr "$worker_crash_args_guard" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+mv -f "$worker_crash_args_copy" "$worker_crash_resume_args"
+
+# A signal after atomic exchange but before the publish sync must retain both
+# names. The old canonical generation now lives at the stage path, so an EXIT
+# cleanup that was armed for pre-exchange failures would destroy recovery A.
+worker_crash_signal_ready="$TMP_ROOT/worker-crash-signal-ready"
+worker_crash_signal_release="$TMP_ROOT/worker-crash-signal-release"
+worker_crash_signal_preexchange_ready="$TMP_ROOT/worker-crash-signal-preexchange-ready"
+worker_crash_signal_preexchange_release="$TMP_ROOT/worker-crash-signal-preexchange-release"
+worker_crash_signal_pid_file="$TMP_ROOT/worker-crash-signal-pid"
+worker_crash_signal_guard="$TMP_ROOT/worker-crash-signal-checkpoint"
+DETACH_CODEX_SYNC=1 \
+DETACH_TEST_CHECKPOINT_PREEXCHANGE_READY="$worker_crash_signal_preexchange_ready" \
+DETACH_TEST_CHECKPOINT_PREEXCHANGE_RELEASE="$worker_crash_signal_preexchange_release" \
+DETACH_TEST_CHECKPOINT_POSTEXCHANGE_READY="$worker_crash_signal_ready" \
+DETACH_TEST_CHECKPOINT_POSTEXCHANGE_RELEASE="$worker_crash_signal_release" \
+DETACH_TEST_CHECKPOINT_BARRIER_PID_FILE="$worker_crash_signal_pid_file" \
+  "$SCRIPT" codex __checkpoint_once \
+    "$worker_crash_session" "$worker_crash_run_token" "$worker_crash_pid" \
+    >/dev/null 2>&1 &
+worker_crash_signal_writer=$!
+wait_for_file_text "$worker_crash_signal_preexchange_ready" ready
+cp -Rp "$(dirname "$worker_crash_checkpoint")" "$worker_crash_signal_guard"
+rm -f "$worker_crash_signal_pid_file"
+: >"$worker_crash_signal_preexchange_release"
+wait_for_file_text "$worker_crash_signal_ready" ready
+IFS= read -r worker_crash_signal_pid <"$worker_crash_signal_pid_file"
+case "$worker_crash_signal_pid" in
+  ''|*[!0-9]*) printf 'post-exchange writer PID is invalid\n' >&2; exit 1 ;;
+esac
+worker_crash_signal_stage="$(find "$(dirname "$worker_crash_meta")" \
+  -mindepth 1 -maxdepth 1 -type d -name '.checkpoint-stage-*' -print -quit)"
+[ -n "$worker_crash_signal_stage" ]
+diff -qr "$worker_crash_signal_guard" "$worker_crash_signal_stage" >/dev/null
+kill -TERM "$worker_crash_signal_pid"
+if wait "$worker_crash_signal_writer"; then
+  printf 'post-exchange checkpoint writer survived TERM\n' >&2
+  exit 1
+fi
+[ -d "$worker_crash_signal_stage" ] && [ ! -L "$worker_crash_signal_stage" ]
+diff -qr "$worker_crash_signal_guard" "$worker_crash_signal_stage" >/dev/null
+worker_crash_signal_id="$(
+  "$STATE_HELPER" meta get "$worker_crash_checkpoint_meta" codex_session_id
+)"
+"$STATE_HELPER" jsonl validate codex \
+  "$worker_crash_checkpoint" "$worker_crash_signal_id"
+DETACH_CODEX_SYNC=1 "$SCRIPT" codex __checkpoint_once \
+  "$worker_crash_session" "$worker_crash_run_token" "$worker_crash_pid"
+[ -z "$(find "$(dirname "$worker_crash_meta")" -mindepth 1 -maxdepth 1 \
+  -type d -name '.checkpoint-stage-*' -print -quit)" ]
+
+# A failed durability sync after the directory exchange must roll publication
+# back to checkpoint A. If the rollback sync also fails, both directory
+# entries must remain so a crash cannot discard the only durable generation.
+worker_crash_sync_ready="$TMP_ROOT/worker-crash-sync-ready"
+worker_crash_sync_release="$TMP_ROOT/worker-crash-sync-release"
+worker_crash_sync_preexchange_ready="$TMP_ROOT/worker-crash-sync-preexchange-ready"
+worker_crash_sync_preexchange_release="$TMP_ROOT/worker-crash-sync-preexchange-release"
+worker_crash_sync_guard="$TMP_ROOT/worker-crash-sync-checkpoint"
+DETACH_CODEX_SYNC=1 \
+DETACH_TEST_CHECKPOINT_SYNC_FAIL=1 \
+DETACH_TEST_CHECKPOINT_ROLLBACK_SYNC_FAIL=1 \
+DETACH_TEST_CHECKPOINT_PREEXCHANGE_READY="$worker_crash_sync_preexchange_ready" \
+DETACH_TEST_CHECKPOINT_PREEXCHANGE_RELEASE="$worker_crash_sync_preexchange_release" \
+DETACH_TEST_CHECKPOINT_ROLLBACK_READY="$worker_crash_sync_ready" \
+DETACH_TEST_CHECKPOINT_ROLLBACK_RELEASE="$worker_crash_sync_release" \
+  "$SCRIPT" codex __checkpoint_once \
+    "$worker_crash_session" "$worker_crash_run_token" "$worker_crash_pid" \
+    >/dev/null 2>&1 &
+worker_crash_sync_writer=$!
+wait_for_file_text "$worker_crash_sync_preexchange_ready" ready
+cp -Rp "$(dirname "$worker_crash_checkpoint")" "$worker_crash_sync_guard"
+: >"$worker_crash_sync_preexchange_release"
+wait_for_file_text "$worker_crash_sync_ready" ready
+diff -qr "$worker_crash_sync_guard" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+worker_crash_sync_stage="$(find "$(dirname "$worker_crash_meta")" \
+  -mindepth 1 -maxdepth 1 -type d -name '.checkpoint-stage-*' -print -quit)"
+[ -n "$worker_crash_sync_stage" ]
+: >"$worker_crash_sync_release"
+if wait "$worker_crash_sync_writer"; then
+  printf 'checkpoint unexpectedly succeeded after its durability sync failed\n' >&2
+  exit 1
+fi
+diff -qr "$worker_crash_sync_guard" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+[ -d "$worker_crash_sync_stage" ] && [ ! -L "$worker_crash_sync_stage" ]
+/bin/sync
+rm -rf -- "$worker_crash_sync_stage"
+
+# Build a complete replacement checkpoint while holding the checkpoint lock,
+# but pause before its atomic publish. Checkpoint A must remain byte-identical
+# throughout staging, and neither that stale writer nor a queued Recover may
+# change it after the exact worker dies.
+worker_crash_lock="$DETACH_LOCKS_ROOT/checkpoint-$worker_crash_session.lock"
+worker_crash_checkpoint_ready="$TMP_ROOT/worker-crash-checkpoint-ready"
+worker_crash_checkpoint_release="$TMP_ROOT/worker-crash-checkpoint-release"
+worker_crash_queued_lockf="$TMP_ROOT/worker-crash-queued-lockf"
+worker_crash_recover_queued="$TMP_ROOT/worker-crash-recover-queued"
+worker_crash_guard_meta="$TMP_ROOT/worker-crash-guard-meta.json"
+worker_crash_guard_checkpoint="$TMP_ROOT/worker-crash-guard-checkpoint"
+worker_crash_session_dir="$(dirname "$worker_crash_meta")"
+worker_crash_abandoned_stage="$worker_crash_session_dir/.checkpoint-stage-abandoned-crash"
+worker_crash_live_db="$CODEX_HOME/state_5.sqlite"
+worker_crash_saved_db="$CODEX_HOME/state_5.sqlite.unavailable-for-checkpoint-test"
+[ -s "$(dirname "$worker_crash_checkpoint")/codex-state.sqlite" ]
+[ -f "$worker_crash_live_db" ] && [ ! -L "$worker_crash_live_db" ]
+[ ! -e "$worker_crash_saved_db" ] && [ ! -L "$worker_crash_saved_db" ]
+printf '%s\n' \
+  '#!/bin/bash' \
+  'set -eu' \
+  'if [ "${4:-}" = "${DETACH_TEST_LOCKF_PATH:-}" ]; then' \
+  '  printf '\''queued\n'\'' >"$DETACH_TEST_LOCKF_QUEUED"' \
+  'fi' \
+  'exec /usr/bin/lockf "$@"' >"$worker_crash_queued_lockf"
+chmod 0755 "$worker_crash_queued_lockf"
+DETACH_TEST_CHECKPOINT_PREPUBLISH_READY="$worker_crash_checkpoint_ready" \
+DETACH_TEST_CHECKPOINT_PREPUBLISH_RELEASE="$worker_crash_checkpoint_release" \
+DETACH_TEST_ABANDONED_STAGE="$worker_crash_abandoned_stage" \
+DETACH_TEST_CANONICAL_CHECKPOINT="$(dirname "$worker_crash_checkpoint")" \
+DETACH_TEST_GUARD_CHECKPOINT="$worker_crash_guard_checkpoint" \
+DETACH_TEST_LIVE_DB="$worker_crash_live_db" \
+DETACH_TEST_SAVED_DB="$worker_crash_saved_db" \
+DETACH_TEST_SCRIPT="$SCRIPT" \
+DETACH_TEST_SESSION="$worker_crash_session" \
+DETACH_TEST_RUN_TOKEN="$worker_crash_run_token" \
+DETACH_TEST_WORKER_PID="$worker_crash_pid" \
+  /usr/bin/lockf -k "$worker_crash_lock" /bin/sh -c \
+    'mkdir -m 0700 "$DETACH_TEST_ABANDONED_STAGE"
+     printf "abandoned\n" >"$DETACH_TEST_ABANDONED_STAGE/sentinel"
+     cp -Rp "$DETACH_TEST_CANONICAL_CHECKPOINT" "$DETACH_TEST_GUARD_CHECKPOINT"
+     mv "$DETACH_TEST_LIVE_DB" "$DETACH_TEST_SAVED_DB"
+     exec "$DETACH_TEST_SCRIPT" codex __checkpoint_once_locked \
+       "$DETACH_TEST_SESSION" "$DETACH_TEST_RUN_TOKEN" "$DETACH_TEST_WORKER_PID"' \
+    >/dev/null 2>&1 &
+worker_crash_checkpoint_writer=$!
+wait_for_file_text "$worker_crash_checkpoint_ready" ready
+[ ! -e "$worker_crash_abandoned_stage" ] && \
+  [ ! -L "$worker_crash_abandoned_stage" ]
+worker_crash_active_stage="$(find "$worker_crash_session_dir" \
+  -mindepth 1 -maxdepth 1 -type d -name '.checkpoint-stage-*' -print -quit)"
+[ -n "$worker_crash_active_stage" ]
+[ "$(find "$worker_crash_session_dir" -mindepth 1 -maxdepth 1 \
+  -type d -name '.checkpoint-stage-*' -print | wc -l | tr -d '[:space:]')" = 1 ]
+[ "$(test_sqlite "$worker_crash_guard_checkpoint/codex-state.sqlite" \
+  'PRAGMA quick_check;')" = ok ]
+cmp -s "$worker_crash_guard_checkpoint/codex-state.sqlite" \
+  "$worker_crash_active_stage/codex-state.sqlite"
+[ ! -e "$worker_crash_live_db" ] && [ -f "$worker_crash_saved_db" ]
+diff -qr "$worker_crash_guard_checkpoint" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+mv "$worker_crash_saved_db" "$worker_crash_live_db"
+[ -f "$worker_crash_live_db" ] && [ ! -L "$worker_crash_live_db" ]
+cp -p "$worker_crash_meta" "$worker_crash_guard_meta"
 kill -KILL "$worker_crash_pid"
+wait_for_pane_dead "$worker_crash_pane"
+diff -qr "$worker_crash_guard_checkpoint" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+DETACH_LOCKF_BIN="$worker_crash_queued_lockf" \
+DETACH_TEST_LOCKF_PATH="$worker_crash_lock" \
+DETACH_TEST_LOCKF_QUEUED="$worker_crash_recover_queued" \
+  "$SCRIPT" codex recover --detach "$worker_crash_name" \
+    >"$TMP_ROOT/worker-crash-locked-recover.out" 2>&1 &
+worker_crash_locked_recover=$!
+wait_for_file_text "$worker_crash_recover_queued" queued
+: >"$worker_crash_checkpoint_release"
+if wait "$worker_crash_checkpoint_writer"; then
+  printf 'staged checkpoint published after its exact worker died\n' >&2
+  exit 1
+fi
+if wait "$worker_crash_locked_recover"; then
+  printf 'serialized Recover started over a surviving provider\n' >&2
+  exit 1
+fi
+if "$SCRIPT" codex __checkpoint_once \
+    "$worker_crash_session" "$worker_crash_run_token" >/dev/null 2>&1; then
+  printf 'run-token checkpoint bypassed exact worker liveness\n' >&2
+  exit 1
+fi
+cmp -s "$worker_crash_guard_meta" "$worker_crash_meta"
+diff -qr "$worker_crash_guard_checkpoint" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+[ -z "$(find "$(dirname "$worker_crash_meta")" -maxdepth 1 \
+  -name '.checkpoint-stage-*' -print -quit)" ]
+tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
 attempts=0
 while [ "$(tmux -L "$SOCKET" display-message -p -t "$worker_crash_pane" '#{pane_dead}')" != "1" ] && \
       [ "$attempts" -lt 80 ]; do
@@ -2198,6 +3442,57 @@ while [ "$(tmux -L "$SOCKET" display-message -p -t "$worker_crash_pane" '#{pane_
 done
 [ "$(tmux -L "$SOCKET" display-message -p -t "$worker_crash_pane" '#{pane_dead}')" = "1" ]
 kill -0 "$worker_crash_provider_pid"
+
+# A heartbeat that has passed its initial exact-worker guard must repeat that
+# proof before its first metadata or tmux write. Pause at that boundary in a
+# separate live session, kill the worker, and compare both state surfaces.
+heartbeat_crash_name=health-heartbeat-worker-crash
+heartbeat_crash_session=detach-codex-health-heartbeat-worker-crash
+DETACH_CODEX_BIN="$FAKE_CODEX_LONG_BIN" \
+  run_codex --name "$heartbeat_crash_name" --detach -- \
+    'heartbeat postguard crash coverage'
+wait_for_tmux_option "$heartbeat_crash_session" @detach_status running
+heartbeat_crash_meta="$DETACH_CODEX_STATE_ROOT/sessions/$heartbeat_crash_session/meta.json"
+heartbeat_crash_pane="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$heartbeat_crash_session:" @detach_pane_id)"
+heartbeat_crash_pid="$("$STATE_HELPER" meta get "$heartbeat_crash_meta" worker_pid)"
+heartbeat_crash_run_token="$("$STATE_HELPER" meta get \
+  "$heartbeat_crash_meta" run_token)"
+heartbeat_crash_pgid="$(wait_for_process_group_id "$heartbeat_crash_pid")"
+heartbeat_crash_provider_file="$TMP_ROOT/heartbeat-crash-provider-pid"
+heartbeat_crash_ready="$TMP_ROOT/heartbeat-crash-ready"
+heartbeat_crash_release="$TMP_ROOT/heartbeat-crash-release"
+heartbeat_crash_guard_meta="$TMP_ROOT/heartbeat-crash-guard-meta.json"
+heartbeat_crash_guard_tmux="$TMP_ROOT/heartbeat-crash-guard-tmux.txt"
+heartbeat_crash_after_tmux="$TMP_ROOT/heartbeat-crash-after-tmux.txt"
+printf '2147483646\n' >"$heartbeat_crash_provider_file"
+DETACH_TEST_HEARTBEAT_POSTGUARD_READY="$heartbeat_crash_ready" \
+DETACH_TEST_HEARTBEAT_POSTGUARD_RELEASE="$heartbeat_crash_release" \
+  "$SCRIPT" codex __runtime_heartbeat_once \
+    "$heartbeat_crash_session" "$heartbeat_crash_run_token" \
+    "$heartbeat_crash_pid" "$heartbeat_crash_provider_file" 30 \
+    >/dev/null 2>&1 &
+heartbeat_crash_writer=$!
+wait_for_file_text "$heartbeat_crash_ready" ready
+cp -p "$heartbeat_crash_meta" "$heartbeat_crash_guard_meta"
+tmux -L "$SOCKET" show-options -t "=$heartbeat_crash_session:" \
+  >"$heartbeat_crash_guard_tmux"
+kill -KILL "$heartbeat_crash_pid"
+wait_for_pane_dead "$heartbeat_crash_pane"
+: >"$heartbeat_crash_release"
+if wait "$heartbeat_crash_writer"; then
+  printf 'postguard heartbeat published after its exact worker died\n' >&2
+  exit 1
+fi
+cmp -s "$heartbeat_crash_guard_meta" "$heartbeat_crash_meta"
+tmux -L "$SOCKET" show-options -t "=$heartbeat_crash_session:" \
+  >"$heartbeat_crash_after_tmux"
+cmp -s "$heartbeat_crash_guard_tmux" "$heartbeat_crash_after_tmux"
+kill -KILL -- "-$heartbeat_crash_pgid"
+wait_for_process_group_exit "$heartbeat_crash_pgid"
+tmux -L "$SOCKET" kill-session -t "=$heartbeat_crash_session"
+rm -rf "$DETACH_CODEX_STATE_ROOT/sessions/$heartbeat_crash_session"
+
 worker_crash_json="$(run_codex list --json | \
   grep -F "\"session_name\":\"$worker_crash_session\"")"
 [ "$(printf '%s' "$worker_crash_json" | "$STATE_HELPER" meta get /dev/stdin effective_status)" = hung ]
@@ -2213,6 +3508,9 @@ if run_codex recover --detach "$worker_crash_name" >/dev/null 2>&1; then
   printf 'recover unexpectedly started over a surviving provider\n' >&2
   exit 1
 fi
+tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "$worker_crash_pane" '#{pane_dead}')" = "1" ]
 if run_codex delete --force "$worker_crash_name" >/dev/null 2>&1; then
   printf 'delete unexpectedly removed state for a surviving provider\n' >&2
   exit 1
@@ -2228,6 +3526,78 @@ kill -0 "$worker_crash_provider_pid"
 
 kill -KILL -- "-$worker_crash_pgid"
 wait_for_process_group_exit "$worker_crash_pgid"
+
+# A retained dead tmux run is not mutable unless its token still matches the
+# operational primary metadata. Recovery and deletion must leave both the
+# pane and saved state unchanged on a mismatch.
+worker_crash_id="$("$STATE_HELPER" meta get "$worker_crash_meta" codex_session_id)"
+worker_crash_meta_copy="$TMP_ROOT/worker-crash-meta.json"
+worker_crash_checkpoint_copy="$TMP_ROOT/worker-crash-checkpoint"
+cp -p "$worker_crash_meta" "$worker_crash_meta_copy"
+cp -Rp "$(dirname "$worker_crash_checkpoint")" "$worker_crash_checkpoint_copy"
+
+# Batched List may fall back to checkpoint metadata for presentation, but that
+# recovery generation is not operational authority for a retained dead pane.
+# Without primary metadata, neither health nor a command may infer ownership
+# merely because the pane token happens to match checkpoint A.
+worker_crash_missing_primary="$TMP_ROOT/worker-crash-missing-primary.json"
+mv "$worker_crash_meta" "$worker_crash_missing_primary"
+worker_crash_fallback_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$worker_crash_session\"")"
+[ "$(printf '%s' "$worker_crash_fallback_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = corrupt ]
+[ "$(printf '%s' "$worker_crash_fallback_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = run_token_missing ]
+[ "$(printf '%s' "$worker_crash_fallback_json" | \
+  "$STATE_HELPER" meta get /dev/stdin reconcile_action)" = none ]
+printf '%s' "$worker_crash_fallback_json" | grep -F '"health_actions":[]' >/dev/null
+if run_codex recover --detach "$worker_crash_name" >/dev/null 2>&1; then
+  printf 'recover used fallback checkpoint metadata to remove retained tmux\n' >&2
+  exit 1
+fi
+if run_codex delete --force "$worker_crash_name" >/dev/null 2>&1; then
+  printf 'delete used fallback checkpoint metadata to remove retained tmux\n' >&2
+  exit 1
+fi
+tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
+diff -qr "$worker_crash_checkpoint_copy" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+mv "$worker_crash_missing_primary" "$worker_crash_meta"
+
+tmux -L "$SOCKET" set-option -q -t "=$worker_crash_session:" \
+  @detach_run_token stale-retained-token
+worker_crash_mismatch_json="$(run_codex list --json | \
+  grep -F "\"session_name\":\"$worker_crash_session\"")"
+[ "$(printf '%s' "$worker_crash_mismatch_json" | \
+  "$STATE_HELPER" meta get /dev/stdin effective_status)" = corrupt ]
+[ "$(printf '%s' "$worker_crash_mismatch_json" | \
+  "$STATE_HELPER" meta get /dev/stdin health_reason)" = run_token_mismatch ]
+printf '%s' "$worker_crash_mismatch_json" | grep -F '"health_actions":[]' >/dev/null
+if run_codex recover --detach "$worker_crash_name" >/dev/null 2>&1; then
+  printf 'recover removed a retained tmux run with a mismatched token\n' >&2
+  exit 1
+fi
+if run_codex delete --force "$worker_crash_name" >/dev/null 2>&1; then
+  printf 'delete removed a retained tmux run with a mismatched token\n' >&2
+  exit 1
+fi
+if run_codex --name "$worker_crash_name" --detach -- \
+    'must not replace mismatched retained tmux' >/dev/null 2>&1; then
+  printf 'start replaced a retained tmux run with a mismatched token\n' >&2
+  exit 1
+fi
+if run_codex resume --name "$worker_crash_name" --detach \
+    "$worker_crash_id" >/dev/null 2>&1; then
+  printf 'resume replaced a retained tmux run with a mismatched token\n' >&2
+  exit 1
+fi
+tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
+cmp -s "$worker_crash_meta_copy" "$worker_crash_meta"
+diff -qr "$worker_crash_checkpoint_copy" \
+  "$(dirname "$worker_crash_checkpoint")" >/dev/null
+tmux -L "$SOCKET" set-option -q -t "=$worker_crash_session:" \
+  @detach_run_token "$worker_crash_run_token"
+
 attempts=0
 worker_crash_status=""
 while [ "$attempts" -lt 80 ]; do


### PR DESCRIPTION
## Summary

- Preserve the last valid Detach checkpoint while Resume starts a replacement run.
- Publish replacement recovery state only after exact provider identity and power readiness are durable.
- Keep Fresh Start behavior unchanged, and strengthen Codex and Claude recovery ownership and checkpoint validation.
- Present structured Claude AskUserQuestion calls as waiting for the user.
- Forward physical Ctrl+C and Ctrl+V to the embedded PTY while preserving Command shortcuts.

## Contract delta

Before this change, Resume could delete the last Detach-owned checkpoint before the replacement run reached readiness. A failed handshake then weakened or removed the next recovery path.

After this change, Resume keeps the previous recovery generation until the replacement run is proven ready. Checkpoint publication and rollback use run-bound identity and atomic replacement. A new thread can still clear the old checkpoint.

The app now derives Claude waiting state from structured transcript data. The embedded terminal sends control bytes for physical Control shortcuts.

## Local evidence

- Full Swift test suite: 1,098 passed; one release-only test skipped.
- Focused state, health, presentation, terminal keyboard, localization, Claude recovery, and AskUserQuestion tests: PASS.
- Focused Codex resume and delete shards: PASS.
- UI end-to-end stage: PASS after the host was unlocked.
- Static stage, documentation contract, shell syntax, and staged diff checks: PASS.
- A full Codex diagnostic completed every shard successfully, but exceeded the local timing budget while the 10-core host had load average 16.88 and security/indexing processes were consuming sustained CPU. The timing limit was not relaxed. Hosted quality-gates remains the readiness authority.

Closes #178