### PR TITLE
Split routed specs and report bound size warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,15 +38,14 @@ claim verified compliance without review against the official standard.
 ## Context and specification policy
 
 - Keep this file under 200 lines and limited to common rules.
-- Do not add architecture tutorials or file inventories here. Put a
-  durable invariant in the narrowest file under `docs/specs/`; put a
-  temporary task plan under ignored `docs/work/`.
+- Put durable invariants in the narrowest `docs/specs/` file and temporary plans
+  in `docs/work/`. Keep tutorials and inventories out.
 - `CLAUDE.md` must contain only `@AGENTS.md`. Never copy this content
   into it or create a second lowercase agent-instruction file.
 - Do not import detailed specs: Claude loads imports eagerly. Use the context
   map below.
 - Specs state observable outcomes, non-goals, invariants, owning paths, and
-  verification. Avoid implementation narration that code already makes clear.
+  verification. Avoid code narration.
 - Complex plans are living, self-contained handoff artifacts. Record decisions,
   discoveries, progress, and end-to-end evidence; delete or archive obsolete
   local plans when the task ends.
@@ -55,16 +54,18 @@ claim verified compliance without review against the official standard.
 
 ## Context map
 
-| Change area | Read | Fast feedback |
+| Change | Read | Fast feedback |
 | --- | --- | --- |
-| CLI, session lifecycle, state, storage, install, tmux | `docs/specs/runtime.md` | one Swift filter, `tests/run.sh`, `tests/run-claude.sh`, or `tests/distribution.sh` |
-| Power wrapper/helper, watchdog, clamshell | `docs/specs/power.md` | `cd app && swift test --filter Power` (or the named suite) |
-| App UI, onboarding, presentation, Sparkle | `docs/specs/app.md` | `cd app && swift test --filter <Suite>` |
-| Packaging, release, publication | `docs/specs/release.md` | one of `tests/{release,publish}-*.sh` |
-| Agent docs, specs, test workflow | `docs/specs/documentation.md` | `tests/docs-contract.sh` |
+| Runtime CLI, lifecycle, install, tmux | `docs/specs/runtime.md` | `tests/{run,run-claude,distribution}.sh` |
+| State, storage, events | `docs/specs/state.md` | one Swift state filter |
+| Power, helper, watchdog | `docs/specs/power.md` | one Swift Power filter |
+| App UI, terminal, UI smoke | `docs/specs/app.md` | one Swift app filter |
+| Setup, settings, diagnostics, updates | `docs/specs/app-setup.md` | one Swift app filter |
+| Package, release, publication | `docs/specs/release.md` | `tests/{release,publish}-*.sh` |
+| Docs, specs, test workflow | `docs/specs/documentation.md` | `tests/docs-contract.sh` |
 
-For an unfamiliar or cross-cutting path, start at `docs/specs/README.md`. Do not
-read every spec preemptively.
+For unfamiliar or cross-cutting work, start at `docs/specs/README.md`. Do not
+read every spec.
 
 ## Verification loop
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -20,9 +20,9 @@ then update every affected durable artifact in the same change.
 
 ## Choosing context
 
-Use the five-row context map in `AGENTS.md`. The filenames are deliberately
-literal: runtime, power, app, release, and documentation. Read one by default
-and another only when the change crosses a real subsystem boundary. Use
+Use the context map in `AGENTS.md`. The filenames are deliberately literal.
+Read one spec by default and another only when the change crosses a real
+subsystem boundary. Use
 `../testing.md` only when the focused command or gate semantics are unclear.
 Do not load every document preemptively.
 

--- a/docs/specs/app-setup.md
+++ b/docs/specs/app-setup.md
@@ -1,0 +1,68 @@
+# App setup, settings, and update specification
+
+## Onboarding and readiness
+
+Onboarding uses `SetupGuidance.step(for:)`; failure outranks provider discovery.
+An `.enabled` service alone never completes permissions. The live poller reads
+without side effects and reconciles once after enablement. Only a finished
+helper journal and an open root gate advance the step. `requiresApproval` is
+not enabled. Done, Repair, and first-run sync reread the watchdog heartbeat.
+Success needs a fresh heartbeat and records completion once. A long wait offers
+monitor retry, never a bypass. A failed doctor refresh or a different runtime
+identity withdraws earlier helper readiness.
+
+After onboarding, bootstrap, refresh, power or provider regressions, and an
+update held by active leases keep the dashboard. Settings shows errors; new
+starts still require both power layers. Only an invalid app location or runtime
+payload mismatch restores setup guidance. Provider installation uses the
+official command in the user's terminal through the private `.command`
+mechanism. Without an outcome channel it reports only that the CLI is not
+detected. When helper/plist bytes change after an
+app update, unregister, await completion, then use the bounded retry for the
+transient SMAppService Code=1 race. Do not replace a helper with active leases:
+defer the update. Report a normal outcome; retry on the next activation.
+
+The per-user watchdog adds a launch-readiness rule: macOS can report an approved
+agent as enabled while no launchd job loaded after approval. During first
+onboarding or Repair, an enabled watchdog without a fresh heartbeat uses the
+durable unregister/barrier/register transaction. Ordinary activation does not
+replace it for a temporarily stale heartbeat.
+
+Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
+
+## Settings and monitoring
+
+Settings → General owns both menu bar toggles. Settings → System keeps the only
+Mac Power status and approval controls. Settings follows the hosting screen;
+System scrolls. Temperature safety has its own warning shape and the
+text **Mac can sleep: temperature**.
+
+Settings → System owns the only **Mac Power** status and approval block. Helper
+Ready requires a doctor live XPC check. Registration alone is Needs attention.
+During doctor or reconciliation, show Checking, not failure. Power
+requires a healthy watchdog heartbeat no older than three minutes; otherwise it
+is `unknown`. A vnode source reads atomic changes at once; one wall-clock
+deadline marks silence stale. A timestamp-only write moves it and redraws the
+age silently. Settings open and activation resync. No app-level
+heartbeat timer runs. The first monitor read and explicit refreshes share one
+sequence. A stale constructor snapshot cannot arrive after a newer document.
+
+## Update contract
+
+Sparkle 2 is pinned. Sparkle keeps its symlink layout and is signed inside-out.
+Only ad-hoc builds disable library validation.
+`UpdaterService` starts only in `/Applications` with a valid HTTPS feed URL and
+32-byte Ed25519 public key.
+A generated or published appcast must contain exactly one arm64 hardware
+requirement, so Intel clients never see the update.
+A Sparkle update replaces the app. Bootstrap activates the new
+immutable CLI payload before the watcher and first fresh list start. It does
+not rewrite live-session binaries. Sparkle errors
+for a disk image or App Translocation say to move Detach to
+`/Applications`. Temporary-directory and download errors say to check the
+network and free disk space, then retry. Archive, signature,
+validation, and installation errors provide the manual DMG path and the
+Settings > System Repair path, and state that the active CLI did not
+change. If replacement completes but CLI or helper sync fails, the prior CLI
+stays active and Repair remains available. Background sync keeps
+the dashboard; a later activation retries it.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -11,43 +11,6 @@ underline, strikethrough, and reverse video. Reverse swaps colors against
 `ANSIParser.terminalBackground`, also the `LogTextView` background. Font
 scaling changes only the font.
 
-Onboarding uses `SetupGuidance.step(for:)`; failure outranks provider discovery.
-An `.enabled` service alone never completes permissions. The live poller reads
-without side effects and reconciles once after enablement. Only a finished
-helper journal and an open root gate advance the step. `requiresApproval` is
-not enabled. Done, Repair, and first-run sync reread the watchdog heartbeat.
-Success needs a fresh heartbeat and records completion once. A long wait offers
-monitor retry, never a bypass. A failed doctor refresh or a different runtime
-identity withdraws earlier helper readiness.
-
-After onboarding, bootstrap, refresh, power or provider regressions, and an
-update held by active leases keep the dashboard. Settings shows errors; new
-starts still require both power layers. Only an invalid app location or runtime
-payload mismatch restores setup guidance. Provider installation uses the
-official command in the user's terminal through the private `.command`
-mechanism. Without an outcome channel it reports only that the CLI is not
-detected. When helper/plist bytes change after an
-app update, unregister, await completion, then use the bounded retry for the
-transient SMAppService Code=1 race. Do not replace a helper with active leases:
-defer the update. Report a normal outcome; retry on the next activation.
-
-Each readiness build puts one `detach-app-build:<UUID>` in its executable and
-signed marker. UI smoke uses a stripped private copy below
-`/private/tmp/detach-ui-e2e.*` without production payloads. An escaped path,
-unsafe identity, build mismatch, or payload fails closed.
-
-Smoke restores focus and the pointer, then sends ordered AppKit events to
-controls. It covers all main surfaces, focus, session actions, and
-onboarding. Stop disconnects first. Stages have deadlines. Coverage isolates
-the normal bundle, instrumented copy, tests, binary, and profiles. The driver
-detects clipped controls before an action.
-
-The per-user watchdog adds a launch-readiness rule: macOS can report an approved
-agent as enabled while no launchd job loaded after approval. During first
-onboarding or Repair, an enabled watchdog without a fresh heartbeat uses the
-durable unregister/barrier/register transaction. Ordinary activation does not
-replace it for a temporarily stale heartbeat.
-
 The menu bar is display-only. Its prompt mark is filled for protected, dim for
 sleep allowed, badged for attention, and outlined for unknown. Starting,
 running, and recovering sessions are active; hung sessions are not. Green means
@@ -65,10 +28,6 @@ trailing read. No list timer runs. Dead or unready watchers and failed lists ret
 with 2–60 s backoff. Cold start waits 1 s for `ready`; a late `ready` repeats the
 snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
 checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
-Settings → General owns both menu bar toggles. Settings → System keeps the only
-Mac Power status and approval controls. Settings follows the hosting screen;
-System scrolls. Temperature safety has its own warning shape and the
-text **Mac can sleep: temperature**.
 
 The dashboard separates identity, status, and Mac Power. Identity is a thin
 tmux-colored capsule. Status is a filled circle. Power uses a neutral surface
@@ -78,66 +37,6 @@ and semantic color. Clicking the UUID chip copies the full UUID and shows
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.
 
-Bounded CLI calls drain outputs on dedicated threads and use process-group
-TERM then KILL. Parallel calls cannot starve drains. Truncation makes typed
-consumers keep the last valid state. Pipe descendants cannot extend deadlines.
-The event process uses `exec` and ends on cancellation. GUI PATH sorts
-NVM/mise Node directories by semantic version.
-
-Helper replacement is a durable fail-closed transaction. One versioned journal
-records the phase, goal, target digest, boot UUID, and lifetime-barrier contract.
-Each transition uses atomic rename and file/directory fsync before its side
-effect. A per-user `flock` protects the journal. The root helper also creates a
-stable root-owned `0644` inode under `/var/run`; every app user opens it read-only and holds one exclusive
-kernel `flock` across the complete asynchronous SMAppService transaction. This
-is the machine-wide single-writer barrier across Fast User Switching, and the
-kernel releases it if the app crashes. Only the current non-root console user's
-app may perform register or unregister mutations, checked again immediately
-before each mutation. Root persists `unregistration_pending`, blocks
-acquire/renew without a wall-clock expiry, and restores and reads back only the
-setting Detach owns.
-
-The helper takes a root-owned lifetime `flock` before its listener answers and
-holds it until exit. An enabled job without this boot's lock is dead. The app
-writes `unregisterSubmitted` only after it observes that lock. Registration
-needs the fresh unregister callback, or exact `notRegistered` status plus the
-released lock or a changed boot UUID; `unavailable` is insufficient. Errors
-keep the journal and root gate closed. After an app crash, another console user
-uses the root-created files to resume at `unregisterSubmitted`, never as a
-pristine install.
-
-Before registering a replacement the app fsyncs `registering` with the target
-digest. After macOS reports the new helper enabled, a successful cancel XPC
-reply proves launch readiness and reopens the gate; only then is the definition
-recorded and the journal cleared. Approval and retry failures remain pending for
-the next launch. An ordinary helper SIGTERM/SIGINT uses only the process-local
-termination gate and must not create persistent update state.
-
-Settings → System owns the only **Mac Power** status and approval block. Helper
-Ready requires a doctor live XPC check. Registration alone is Needs attention.
-During doctor or reconciliation, show Checking, not failure. Power
-requires a healthy watchdog heartbeat no older than three minutes; otherwise it
-is `unknown`. A vnode source reads atomic changes at once; one wall-clock
-deadline marks silence stale. A timestamp-only write moves it and redraws the
-age silently. Settings open and activation resync. No app-level
-heartbeat timer runs. The first monitor read and explicit refreshes share one
-sequence. A stale constructor snapshot cannot arrive after a newer document.
-
-The watchdog heartbeat carries the effective power state and typed raw
-thermal state/latch. With notifications enabled, the app emits one
-localized temperature-safety warning on each inactive-to-active latch
-transition, including when borrowed external protection makes the effective
-power state unavailable; repeated documents never duplicate the warning.
-
-The watchdog is a signed per-user LaunchAgent with an embedded
-`__TEXT,__info_plist`. It resolves `~/.local/bin/detach` at runtime, calls
-`detach power status --json` through the same process-group runner with a
-five-second deadline, and writes private health state. The privileged
-daemon is a distinct demand-launched LaunchDaemon. Neither plist may contain a
-user-specific path. Native power protection requires no Apple Events or
-Automation entitlement.
-
-Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
 A first-run setup card stays mounted during retry. App Start uses `--detach`,
 keeps sheet errors, and selects the new session. Start, Resume, and Recover open
 `detach <provider> attach --terminal-features sync <session>` in one visible
@@ -182,21 +81,16 @@ Notifications are opt-in and deduplicated. Stop intent is not failure;
 `interrupted` and `hung` get one 350 ms recheck. Ordered detection never waits
 for delivery.
 
-Sparkle 2 and SwiftTerm 1.19.0 are pinned. The exact SwiftTerm shader bundle is
-shipped and verified. Sparkle keeps its symlink layout and is signed inside-out.
-Only ad-hoc builds disable library validation.
-`UpdaterService` starts only in `/Applications` with a valid HTTPS feed URL and
-32-byte Ed25519 public key.
-A generated or published appcast must contain exactly one arm64 hardware
-requirement, so Intel clients never see the update.
-A Sparkle update replaces the app. Bootstrap activates the new
-immutable CLI payload before the watcher and first fresh list start. It does
-not rewrite live-session binaries. Sparkle errors
-for a disk image or App Translocation say to move Detach to
-`/Applications`. Temporary-directory and download errors say to check the
-network and free disk space, then retry. Archive, signature,
-validation, and installation errors provide the manual DMG path and the
-Settings > System Repair path, and state that the active CLI did not
-change. If replacement completes but CLI or helper sync fails, the prior CLI
-stays active and Repair remains available. Background sync keeps
-the dashboard; a later activation retries it.
+SwiftTerm 1.19.0 is pinned. The exact SwiftTerm shader bundle is shipped and
+verified.
+
+Each readiness build puts one `detach-app-build:<UUID>` in its executable and
+signed marker. UI smoke uses a stripped private copy below
+`/private/tmp/detach-ui-e2e.*` without production payloads. An escaped path,
+unsafe identity, build mismatch, or payload fails closed.
+
+Smoke restores focus and the pointer, then sends ordered AppKit events to
+controls. It covers all main surfaces, focus, session actions, and
+onboarding. Stop disconnects first. Stages have deadlines. Coverage isolates
+the normal bundle, instrumented copy, tests, binary, and profiles. The driver
+detects clipped controls before an action.

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -13,8 +13,9 @@ Hosted CI is the merge-readiness authority.
   instructions or additional imports.
 - Root instructions stay below 200 lines and 8 KiB. Detailed architecture does
   not return to the automatic startup context.
-- No individual spec exceeds 16 KiB. Read more than one only when a change
-  crosses real subsystem boundaries.
+- No individual spec exceeds 16 KiB. The static check and dashboard warn above
+  12 KiB so a split is planned first. Read a second spec only for a real
+  cross-subsystem change.
 - `AGENTS.md` contains one small human-readable context map. There is no second
   routing DSL or tool for an agent to learn.
 - New or changed English text in `README.md` and `docs/` uses
@@ -119,10 +120,11 @@ Hosted CI is the merge-readiness authority.
   `main` run with direct or promoted evidence, or a green scheduled mutation
   run. Bounded quality care can also deploy its validated result before it
   marks an attention run as failed. Care evidence binds the source commit and
-  SHA-256 digests of its eval and history inputs. The dashboard shows measured
-  coverage, ranked UI coverage opportunities, mutation score, workflow evals,
-  feedback p95 and SLO, and security state when they exist. The security state
-  comes from a typed current-policy
+  SHA-256 digests of its eval and history inputs. A digest-bound gate artifact
+  supplies routed-spec sizes. The dashboard also shows measured coverage,
+  ranked UI coverage opportunities, mutation score, workflow evals, feedback
+  p95 and SLO, and security state when they exist. The security state comes
+  from a typed current-policy
   artifact. It includes both CodeQL job results, the analyzed commit, an
   identity fingerprint, and the exact workflow link. A later main, care, or
   mutation deploy restores the newest valid current-policy security and care

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -83,6 +83,35 @@ bundle is replaced with the same version. For a legacy watchdog without a
 lifetime lock, the exact bundled executable may prove that the old
 registration is still live.
 
+Helper replacement is a durable fail-closed transaction. One versioned journal
+records the phase, goal, target digest, boot UUID, and lifetime-barrier contract.
+Each transition uses atomic rename and file/directory fsync before its side
+effect. A per-user `flock` protects the journal. The root helper also creates a
+stable root-owned `0644` inode under `/var/run`; every app user opens it read-only and holds one exclusive
+kernel `flock` across the complete asynchronous SMAppService transaction. This
+is the machine-wide single-writer barrier across Fast User Switching, and the
+kernel releases it if the app crashes. Only the current non-root console user's
+app may perform register or unregister mutations, checked again immediately
+before each mutation. Root persists `unregistration_pending`, blocks
+acquire/renew without a wall-clock expiry, and restores and reads back only the
+setting Detach owns.
+
+The helper takes a root-owned lifetime `flock` before its listener answers and
+holds it until exit. An enabled job without this boot's lock is dead. The app
+writes `unregisterSubmitted` only after it observes that lock. Registration
+needs the fresh unregister callback, or exact `notRegistered` status plus the
+released lock or a changed boot UUID; `unavailable` is insufficient. Errors
+keep the journal and root gate closed. After an app crash, another console user
+uses the root-created files to resume at `unregisterSubmitted`, never as a
+pristine install.
+
+Before registering a replacement the app fsyncs `registering` with the target
+digest. After macOS reports the new helper enabled, a successful cancel XPC
+reply proves launch readiness and reopens the gate; only then is the definition
+recorded and the journal cleared. Approval and retry failures remain pending for
+the next launch. An ordinary helper SIGTERM/SIGINT uses only the process-local
+termination gate and must not create persistent update state.
+
 Before it creates the listener or changes power state, the helper must pass a
 strict check of its own signature with Security network access enabled. This
 check lets macOS refresh the system trust result that the listener needs for
@@ -136,6 +165,20 @@ directories appear. Each document replaces one freshness deadline; the
 deadline publishes `unknown` if the watchdog stops. Menu bar, Settings, and
 temperature notifications share this state and run no repeating heartbeat
 reader.
+
+The watchdog heartbeat carries the effective power state and typed raw
+thermal state/latch. With notifications enabled, the app emits one
+localized temperature-safety warning on each inactive-to-active latch
+transition, including when borrowed external protection makes the effective
+power state unavailable; repeated documents never duplicate the warning.
+
+The watchdog is a signed per-user LaunchAgent with an embedded
+`__TEXT,__info_plist`. It resolves `~/.local/bin/detach` at runtime, calls
+`detach power status --json` through the same process-group runner with a
+five-second deadline, and writes private health state. The privileged
+daemon is a distinct demand-launched LaunchDaemon. Neither plist may contain a
+user-specific path. Native power protection requires no Apple Events or
+Automation entitlement.
 
 The default initial acquire carries an eight-second absolute server deadline.
 If protection is not confirmed before it, root rolls back only that request's

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -1,4 +1,4 @@
-# Runtime, state, and session specification
+# Runtime and session specification
 
 ## Installed distribution
 
@@ -32,6 +32,12 @@ Tests inject paths through explicit `DETACH_*` environments. An app CLI strips
 them except in isolated UI tests. Production resolves tmux and state/power
 helpers only as immutable siblings. Providers resolve through `PATH`.
 
+Bounded CLI calls drain outputs on dedicated threads and use process-group
+TERM then KILL. Parallel calls cannot starve drains. Truncation makes typed
+consumers keep the last valid state. Pipe descendants cannot extend deadlines.
+The event process uses `exec` and ends on cancellation. GUI PATH sorts
+NVM/mise Node directories by semantic version.
+
 `client switch` retries reads for 0.5 seconds. PID, UID, source, private socket,
 and managed target must match. Framing must survive `LC_ALL=C`. Failed proof
 causes no mutation. Attach can hold a frame until the target redraws.
@@ -40,69 +46,6 @@ Core self-reinvokes critical mutations under `lockf`. Start, Resume, Stop,
 Recover, and Delete hold a session lock before install, project, and checkpoint
 locks. Each lock covers the child; the install lock covers readiness and the
 worst hold.
-
-### Typed state boundary
-
-`detach-state` is the JSON boundary. Never edit JSON in shell. It owns typed
-metadata, JSONL, health, reconcile, storage, emit, and event operations.
-`meta snapshots` enumerates one owned sessions root through anchored directory
-descriptors. It rejects unsafe directories and opens only owned regular files
-of at most 1 MiB with `O_NOFOLLOW`.
-Integer conversion must not trap. Storage reports allocated and logical bytes,
-excludes provider storage, does not follow symlinks, and authorizes cleanup
-only after a complete scan with explicit `cleanup_eligible: true`.
-
-Per-session `meta.json` schema 1 stores internal `session_name`, optional
-`display_name`, and `run_token`; older documents remain valid. Each patch locks
-its read-change-atomic-replace transaction, so concurrent writers keep disjoint
-fields. Run tokens stop stale workers from overwriting replacement runs. New
-runs publish `health_schema=1`, exact worker/provider PIDs, heartbeat, and
-checkpoint epoch. Health combines tmux, run token, PID ownership, metadata, and
-checkpoint freshness. Stale data cannot make a proven live provider hung. A
-runtime without managed tmux blocks mutations until its exact processes exit.
-`preserve_recovery_until_ready` is Boolean; `runtime_ready_at` and
-`runtime_shutdown_observed_at` are strings. A mistyped primary is unusable.
-Checkpoint metadata cannot replace it.
-
-`list --json` reads Codex and Claude concurrently and emits that order. Each
-uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
-PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
-Mutations recheck ownership, pane, run token, and process group. List jobs
-`exec` cores; cleanup signals PIDs.
-
-A retained dead pane is mutable only when its nonempty tmux token matches usable
-primary metadata. A checkpoint cannot authorize removal. Start, Resume,
-Recover, and Delete repeat this check under the operation lock. A tmux-only
-remnant remains removable without state.
-
-Typed state caches Codex checkpoint assessment by provider, session ID, and
-file identity. A change forces a full scan. Restore ignores this receipt,
-validates a temporary copy, then replaces the live file. List summaries use an
-atomic receipt bound to provider, path, device, inode, size, and nanosecond
-mtime. An unchanged identity skips the 256 KiB tail read.
-
-State is private (`umask 077`) under
-`~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
-conversations. Public operations reject symlinked or foreign-owned mutable
-roots before traversal. The checked Codex SQLite backup is never restored
-automatically.
-
-Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
-Before deletion, the app re-reads and matches the shown status and byte
-counts. The provider command waits up to 30 s for the checkpoint lock,
-then rechecks managed tmux liveness and ownership, rejecting symlinked or
-foreign-owned state/session directories. A partial failure keeps and reports
-each failed session.
-
-### Session change events
-
-`watch --json` execs the helper and follows parent. Hints require
-`list --json`. FSEvents accepts only metadata-named transcripts. Exact vnode
-sources cover 64 live transcripts, including old
-runtimes. Bursts yield leading and 150 ms trailing hints. Drops or root changes
-yield `resync`. Lifecycle signals refresh roots; heartbeats do not. The
-publisher writes `session-change` under state root. Activation repairs loss.
-Watcher shutdown drains native callbacks before its output can close.
 
 ### Session lifecycle and tmux
 
@@ -192,19 +135,6 @@ the original copy tables immediately.
 `tmux-extended-keys` defaults on and maps recognized `S-Enter` to stable
 `M-Enter`; off restores the original binding or plain Enter. It adds
 `*:extkeys` and `*:hyperlinks` once; OSC 8 links stay independent.
-
-`list --json` emits JSONL schema 1 with optional `display_name`, power and turn
-state, opaque turn ID, PIDs, health, reconcile, freshness, ownership, cleanup,
-`stop_requested_at`, and a per-run opaque `lifecycle_id` distinct from the
-mutation token. Keep the emitter and Swift `Session` decoder in sync.
-`watch --json` emits only change hints and never replaces this snapshot.
-Provider lifecycle records, never terminal text, supply turn state and the
-private activity file in `power.md`. Bounded append caching retains typed turns;
-an unseen oversized gap clears waiting to prevent stale Answer ready. A
-main-chain Claude `AskUserQuestion` with `stop_reason: tool_use` and a tool ID
-means waiting; only its matching user tool result restores working. Reducer
-changes invalidate old receipts so unchanged prompts are reclassified.
-Typed cleanup uses `cleanup_eligible`.
 
 ### Provider identity and checkpoints
 

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -1,0 +1,79 @@
+# Typed state, storage, and event specification
+
+## Typed state boundary
+
+`detach-state` is the JSON boundary. Never edit JSON in shell. It owns typed
+metadata, JSONL, health, reconcile, storage, emit, and event operations.
+`meta snapshots` enumerates one owned sessions root through anchored directory
+descriptors. It rejects unsafe directories and opens only owned regular files
+of at most 1 MiB with `O_NOFOLLOW`.
+Integer conversion must not trap. Storage reports allocated and logical bytes,
+excludes provider storage, does not follow symlinks, and authorizes cleanup
+only after a complete scan with explicit `cleanup_eligible: true`.
+
+Per-session `meta.json` schema 1 stores internal `session_name`, optional
+`display_name`, and `run_token`; older documents remain valid. Each patch locks
+its read-change-atomic-replace transaction, so concurrent writers keep disjoint
+fields. Run tokens stop stale workers from overwriting replacement runs. New
+runs publish `health_schema=1`, exact worker/provider PIDs, heartbeat, and
+checkpoint epoch. Health combines tmux, run token, PID ownership, metadata, and
+checkpoint freshness. Stale data cannot make a proven live provider hung. A
+runtime without managed tmux blocks mutations until its exact processes exit.
+`preserve_recovery_until_ready` is Boolean; `runtime_ready_at` and
+`runtime_shutdown_observed_at` are strings. A mistyped primary is unusable.
+Checkpoint metadata cannot replace it.
+
+`list --json` reads Codex and Claude concurrently and emits that order. Each
+uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
+PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
+Mutations recheck ownership, pane, run token, and process group. List jobs
+`exec` cores; cleanup signals PIDs.
+
+A retained dead pane is mutable only when its nonempty tmux token matches usable
+primary metadata. A checkpoint cannot authorize removal. Start, Resume,
+Recover, and Delete repeat this check under the operation lock. A tmux-only
+remnant remains removable without state.
+
+Typed state caches Codex checkpoint assessment by provider, session ID, and
+file identity. A change forces a full scan. Restore ignores this receipt,
+validates a temporary copy, then replaces the live file. List summaries use an
+atomic receipt bound to provider, path, device, inode, size, and nanosecond
+mtime. An unchanged identity skips the 256 KiB tail read.
+
+State is private (`umask 077`) under
+`~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
+conversations. Public operations reject symlinked or foreign-owned mutable
+roots before traversal. The checked Codex SQLite backup is never restored
+automatically.
+
+Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
+Before deletion, the app re-reads and matches the shown status and byte
+counts. The provider command waits up to 30 s for the checkpoint lock,
+then rechecks managed tmux liveness and ownership, rejecting symlinked or
+foreign-owned state/session directories. A partial failure keeps and reports
+each failed session.
+
+## Session change events
+
+`watch --json` execs the helper and follows parent. Hints require
+`list --json`. FSEvents accepts only metadata-named transcripts. Exact vnode
+sources cover 64 live transcripts, including old
+runtimes. Bursts yield leading and 150 ms trailing hints. Drops or root changes
+yield `resync`. Lifecycle signals refresh roots; heartbeats do not. The
+publisher writes `session-change` under state root. Activation repairs loss.
+Watcher shutdown drains native callbacks before its output can close.
+
+## Snapshot contract
+
+`list --json` emits JSONL schema 1 with optional `display_name`, power and turn
+state, opaque turn ID, PIDs, health, reconcile, freshness, ownership, cleanup,
+`stop_requested_at`, and a per-run opaque `lifecycle_id` distinct from the
+mutation token. Keep the emitter and Swift `Session` decoder in sync.
+`watch --json` emits only change hints and never replaces this snapshot.
+Provider lifecycle records, never terminal text, supply turn state and the
+private activity file in `power.md`. Bounded append caching retains typed turns;
+an unseen oversized gap clears waiting to prevent stale Answer ready. A
+main-chain Claude `AskUserQuestion` with `stop_reason: tool_use` and a tool ID
+means waiting; only its matching user tool result restores working. Reducer
+changes invalidate old receipts so unchanged prompts are reclassified.
+Typed cleanup uses `cleanup_eligible`.

--- a/quality/evals.json
+++ b/quality/evals.json
@@ -33,6 +33,7 @@
           "quality-system",
           "documentation",
           "session-lifecycle",
+          "session-state",
           "power-protection",
           "app-experience",
           "onboarding",
@@ -47,6 +48,8 @@
           "J-DOCS-CONSISTENCY",
           "J-SESSION-CREATE",
           "J-SESSION-PERSIST",
+          "J-STATE-CLEANUP",
+          "J-STATE-RECOVER",
           "J-SESSION-RECOVER",
           "J-SESSION-STOP",
           "J-SESSION-DELETE",
@@ -94,11 +97,14 @@
           "runtime"
         ],
         "capabilities": [
-          "session-lifecycle"
+          "session-lifecycle",
+          "session-state"
         ],
         "journeys": [
           "J-SESSION-CREATE",
           "J-SESSION-PERSIST",
+          "J-STATE-CLEANUP",
+          "J-STATE-RECOVER",
           "J-SESSION-RECOVER",
           "J-SESSION-STOP",
           "J-SESSION-DELETE"
@@ -130,11 +136,14 @@
           "runtime"
         ],
         "capabilities": [
-          "session-lifecycle"
+          "session-lifecycle",
+          "session-state"
         ],
         "journeys": [
           "J-SESSION-CREATE",
           "J-SESSION-PERSIST",
+          "J-STATE-CLEANUP",
+          "J-STATE-RECOVER",
           "J-SESSION-RECOVER",
           "J-SESSION-STOP",
           "J-SESSION-DELETE"
@@ -167,11 +176,14 @@
         ],
         "capabilities": [
           "session-lifecycle",
+          "session-state",
           "app-experience"
         ],
         "journeys": [
           "J-SESSION-CREATE",
           "J-SESSION-PERSIST",
+          "J-STATE-CLEANUP",
+          "J-STATE-RECOVER",
           "J-SESSION-RECOVER",
           "J-SESSION-STOP",
           "J-SESSION-DELETE",
@@ -292,14 +304,17 @@
         "specs": [
           "documentation",
           "runtime",
+          "state",
           "power",
           "app",
+          "app-setup",
           "release"
         ],
         "capabilities": [
           "quality-system",
           "documentation",
           "session-lifecycle",
+          "session-state",
           "power-protection",
           "app-experience",
           "onboarding",
@@ -314,6 +329,8 @@
           "J-DOCS-CONSISTENCY",
           "J-SESSION-CREATE",
           "J-SESSION-PERSIST",
+          "J-STATE-CLEANUP",
+          "J-STATE-RECOVER",
           "J-SESSION-RECOVER",
           "J-SESSION-STOP",
           "J-SESSION-DELETE",

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -25,18 +25,28 @@
       "id": "session-lifecycle",
       "journeys": [
         "J-SESSION-CREATE",
-        "J-SESSION-PERSIST",
         "J-SESSION-RECOVER",
         "J-SESSION-STOP",
         "J-SESSION-DELETE"
       ],
       "requirements": [
-        "QC-RUNTIME-STATE",
         "QC-RUNTIME-OWNERSHIP",
-        "QC-RUNTIME-STORAGE",
         "QC-RUNTIME-TRANSITION"
       ],
       "spec": "docs/specs/runtime.md"
+    },
+    {
+      "id": "session-state",
+      "journeys": [
+        "J-SESSION-PERSIST",
+        "J-STATE-CLEANUP",
+        "J-STATE-RECOVER"
+      ],
+      "requirements": [
+        "QC-RUNTIME-STATE",
+        "QC-RUNTIME-STORAGE"
+      ],
+      "spec": "docs/specs/state.md"
     },
     {
       "id": "power-protection",
@@ -84,7 +94,7 @@
       "requirements": [
         "QC-APP-ONBOARDING"
       ],
-      "spec": "docs/specs/app.md"
+      "spec": "docs/specs/app-setup.md"
     },
     {
       "id": "settings",
@@ -94,7 +104,7 @@
       "requirements": [
         "QC-APP-SETTINGS"
       ],
-      "spec": "docs/specs/app.md"
+      "spec": "docs/specs/app-setup.md"
     },
     {
       "id": "update",
@@ -105,7 +115,7 @@
       "requirements": [
         "QC-APP-UPDATE"
       ],
-      "spec": "docs/specs/app.md"
+      "spec": "docs/specs/app-setup.md"
     },
     {
       "id": "diagnostics",
@@ -115,7 +125,7 @@
       "requirements": [
         "QC-APP-DOCTOR"
       ],
-      "spec": "docs/specs/app.md"
+      "spec": "docs/specs/app-setup.md"
     },
     {
       "id": "installation",
@@ -397,7 +407,6 @@
       "capability": "session-lifecycle",
       "id": "J-SESSION-CREATE",
       "requirements": [
-        "QC-RUNTIME-STATE",
         "QC-RUNTIME-OWNERSHIP"
       ],
       "scenarios": [
@@ -407,11 +416,10 @@
       "summary": "A user creates a managed provider session."
     },
     {
-      "capability": "session-lifecycle",
+      "capability": "session-state",
       "id": "J-SESSION-PERSIST",
       "requirements": [
-        "QC-RUNTIME-STATE",
-        "QC-RUNTIME-STORAGE"
+        "QC-RUNTIME-STATE"
       ],
       "scenarios": [
         "SC-SESSION-PERSIST-CODEX",
@@ -420,11 +428,35 @@
       "summary": "A live session remains available after the app exits."
     },
     {
+      "capability": "session-state",
+      "id": "J-STATE-CLEANUP",
+      "requirements": [
+        "QC-RUNTIME-STATE"
+      ],
+      "scenarios": [
+        "SC-SESSION-DELETE-CODEX",
+        "SC-SESSION-DELETE-CLAUDE",
+        "SC-UI-SESSION-DELETE"
+      ],
+      "summary": "A user removes only typed state that a complete scan marks eligible."
+    },
+    {
+      "capability": "session-state",
+      "id": "J-STATE-RECOVER",
+      "requirements": [
+        "QC-RUNTIME-STORAGE"
+      ],
+      "scenarios": [
+        "SC-SESSION-RECOVER-CODEX",
+        "SC-SESSION-RECOVER-CLAUDE"
+      ],
+      "summary": "A user restores recovery state only after complete validation."
+    },
+    {
       "capability": "session-lifecycle",
       "id": "J-SESSION-RECOVER",
       "requirements": [
         "QC-RUNTIME-OWNERSHIP",
-        "QC-RUNTIME-STORAGE",
         "QC-RUNTIME-TRANSITION"
       ],
       "scenarios": [
@@ -450,8 +482,7 @@
       "capability": "session-lifecycle",
       "id": "J-SESSION-DELETE",
       "requirements": [
-        "QC-RUNTIME-OWNERSHIP",
-        "QC-RUNTIME-STORAGE"
+        "QC-RUNTIME-OWNERSHIP"
       ],
       "scenarios": [
         "SC-SESSION-DELETE-CODEX",
@@ -712,9 +743,11 @@
     "merge_wait_seconds": 300,
     "mutation_score_percent": 100,
     "mutation_timeout_seconds": 240,
-    "pr_feedback_seconds": 600
+    "pr_feedback_seconds": 600,
+    "routed_spec_limit_bytes": 16384,
+    "routed_spec_warning_bytes": 12288
   },
-  "policy": 54,
+  "policy": 55,
   "release_domains": [
     {
       "gates": "-",
@@ -759,7 +792,7 @@
   "requirements": [
     {
       "id": "QC-RUNTIME-STATE",
-      "spec": "docs/specs/runtime.md",
+      "spec": "docs/specs/state.md",
       "summary": "Typed state is the only shared state mutation boundary."
     },
     {
@@ -769,7 +802,7 @@
     },
     {
       "id": "QC-RUNTIME-STORAGE",
-      "spec": "docs/specs/runtime.md",
+      "spec": "docs/specs/state.md",
       "summary": "Restores validate path, symlink, identity, and JSONL data before replacement."
     },
     {
@@ -829,22 +862,22 @@
     },
     {
       "id": "QC-APP-DOCTOR",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "summary": "Doctor output derives from typed runtime state."
     },
     {
       "id": "QC-APP-ONBOARDING",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "summary": "Onboarding leads a new user through supported provider and approval setup."
     },
     {
       "id": "QC-APP-SETTINGS",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "summary": "Settings changes persist and affect only their declared behavior."
     },
     {
       "id": "QC-APP-UPDATE",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "summary": "Update state and application preserve the signed arm64 contract."
     },
     {
@@ -1270,8 +1303,8 @@
       "pattern": "app/Sources/DetachKit/DetachState*.swift",
       "priority": 900,
       "release_domain": "safe",
-      "spec": "docs/specs/runtime.md",
-      "test_domain": "state-runtime"
+      "spec": "docs/specs/state.md",
+      "test_domain": "state-source"
     },
     {
       "pattern": "app/Sources/DetachKit/Session*.swift",
@@ -1281,18 +1314,46 @@
       "test_domain": "state-runtime"
     },
     {
+      "pattern": "app/Sources/DetachKit/Session.swift",
+      "priority": 910,
+      "release_domain": "safe",
+      "spec": "docs/specs/state.md",
+      "test_domain": "state-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/SessionEvents.swift",
+      "priority": 910,
+      "release_domain": "safe",
+      "spec": "docs/specs/state.md",
+      "test_domain": "state-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/SessionHealth.swift",
+      "priority": 910,
+      "release_domain": "safe",
+      "spec": "docs/specs/app.md",
+      "test_domain": "session-health-source"
+    },
+    {
+      "pattern": "app/Sources/DetachKit/SessionMaintenance.swift",
+      "priority": 910,
+      "release_domain": "safe",
+      "spec": "docs/specs/state.md",
+      "test_domain": "state-source"
+    },
+    {
       "pattern": "app/Sources/DetachKit/Storage*.swift",
       "priority": 900,
       "release_domain": "safe",
-      "spec": "docs/specs/runtime.md",
-      "test_domain": "state-runtime"
+      "spec": "docs/specs/state.md",
+      "test_domain": "state-source"
     },
     {
       "pattern": "app/Sources/DetachState/*.swift",
       "priority": 900,
       "release_domain": "safe",
-      "spec": "docs/specs/runtime.md",
-      "test_domain": "state-runtime"
+      "spec": "docs/specs/state.md",
+      "test_domain": "state-source"
     },
     {
       "pattern": "app/Sources/DetachKit/DetachPower*.swift",
@@ -1319,8 +1380,8 @@
       "pattern": "app/Sources/DetachKit/BoundedProcessRunner.swift",
       "priority": 900,
       "release_domain": "both",
-      "spec": "docs/specs/power.md",
-      "test_domain": "power"
+      "spec": "docs/specs/runtime.md",
+      "test_domain": "bounded-process-source"
     },
     {
       "pattern": "app/Sources/DetachPower/*.swift",
@@ -1348,7 +1409,7 @@
       "priority": 900,
       "release_domain": "both",
       "spec": "docs/specs/power.md",
-      "test_domain": "power"
+      "test_domain": "installation-store-source"
     },
     {
       "pattern": "app/Sources/DetachApp/PowerHelper*.swift",
@@ -1369,69 +1430,69 @@
       "priority": 880,
       "release_domain": "install",
       "spec": "docs/specs/app.md",
-      "test_domain": "onboarding-source"
+      "test_domain": "app-shell-source"
     },
     {
       "pattern": "app/Sources/DetachApp/Onboarding*.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "onboarding-source"
     },
     {
       "pattern": "app/Sources/DetachApp/RootView.swift",
       "priority": 880,
-      "release_domain": "install",
+      "release_domain": "safe",
       "spec": "docs/specs/app.md",
-      "test_domain": "onboarding-source"
+      "test_domain": "root-view-source"
     },
     {
       "pattern": "app/Sources/DetachApp/SetupGuidance.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "onboarding-source"
     },
     {
       "pattern": "app/Sources/DetachApp/Settings*.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "settings-source"
     },
     {
       "pattern": "app/Sources/DetachApp/UpdaterService.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "update-source"
     },
     {
       "pattern": "app/Sources/DetachKit/DetachCLI.swift",
       "priority": 880,
-      "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "release_domain": "safe",
+      "spec": "docs/specs/runtime.md",
       "test_domain": "runtime-source"
     },
     {
       "pattern": "app/Sources/DetachKit/DoctorReport.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "diagnostics-source"
     },
     {
       "pattern": "app/Sources/DetachKit/Localization.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "onboarding-source"
     },
     {
       "pattern": "app/Sources/DetachKit/UpdateConfiguration.swift",
       "priority": 880,
       "release_domain": "install",
-      "spec": "docs/specs/app.md",
+      "spec": "docs/specs/app-setup.md",
       "test_domain": "update-source"
     },
     {
@@ -1523,7 +1584,7 @@
       "priority": 870,
       "release_domain": "safe",
       "spec": "docs/specs/app.md",
-      "test_domain": "swift-source"
+      "test_domain": "ui-e2e-source"
     },
     {
       "pattern": "app/Sources/DetachApp/*.swift",
@@ -2414,7 +2475,6 @@
       "id": "runtime",
       "journeys": [
         "J-SESSION-CREATE",
-        "J-SESSION-PERSIST",
         "J-SESSION-RECOVER",
         "J-SESSION-STOP",
         "J-SESSION-DELETE"
@@ -2422,14 +2482,13 @@
       "owned_patterns": [
         "app/Sources/DetachKit/*.swift",
         "app/Sources/DetachKit/ANSIText.swift",
-        "app/Sources/DetachKit/DetachState*.swift",
+        "app/Sources/DetachKit/BoundedProcessRunner.swift",
+        "app/Sources/DetachKit/DetachCLI.swift",
         "app/Sources/DetachKit/LogPoller.swift",
         "app/Sources/DetachKit/Session*.swift",
-        "app/Sources/DetachKit/Storage*.swift",
         "app/Sources/DetachKit/Terminal*.swift",
         "app/Sources/DetachKit/Tip.swift",
         "app/Sources/DetachKit/Tmux*.swift",
-        "app/Sources/DetachState/*.swift",
         "bin/*",
         "bin/detach",
         "bin/detach-core",
@@ -2445,40 +2504,6 @@
       ],
       "path": "docs/specs/runtime.md",
       "requirements": [
-        {
-          "id": "QC-RUNTIME-STATE",
-          "journeys": [
-            "J-SESSION-CREATE",
-            "J-SESSION-PERSIST"
-          ],
-          "scenarios": [
-            {
-              "command": "tests/run.sh",
-              "id": "SC-SESSION-CREATE-CODEX",
-              "stage": "codex",
-              "status": "instrumented"
-            },
-            {
-              "command": "tests/run-claude.sh",
-              "id": "SC-SESSION-CREATE-CLAUDE",
-              "stage": "claude",
-              "status": "instrumented"
-            },
-            {
-              "command": "tests/run.sh",
-              "id": "SC-SESSION-PERSIST-CODEX",
-              "stage": "codex",
-              "status": "instrumented"
-            },
-            {
-              "command": "tests/run-claude.sh",
-              "id": "SC-SESSION-PERSIST-CLAUDE",
-              "stage": "claude",
-              "status": "instrumented"
-            }
-          ],
-          "summary": "Typed state is the only shared state mutation boundary."
-        },
         {
           "id": "QC-RUNTIME-OWNERSHIP",
           "journeys": [
@@ -2552,11 +2577,54 @@
           "summary": "Session operations prove the exact run token and process ownership."
         },
         {
-          "id": "QC-RUNTIME-STORAGE",
+          "id": "QC-RUNTIME-TRANSITION",
+          "journeys": [
+            "J-SESSION-RECOVER"
+          ],
+          "scenarios": [
+            {
+              "command": "tests/run.sh",
+              "id": "SC-SESSION-RECOVER-CODEX",
+              "stage": "codex",
+              "status": "instrumented"
+            },
+            {
+              "command": "tests/run-claude.sh",
+              "id": "SC-SESSION-RECOVER-CLAUDE",
+              "stage": "claude",
+              "status": "instrumented"
+            }
+          ],
+          "summary": "Session transitions preserve exact process identity."
+        }
+      ],
+      "summary": "Runtime and session operations preserve exact ownership."
+    },
+    {
+      "capabilities": [
+        "session-state"
+      ],
+      "id": "state",
+      "journeys": [
+        "J-SESSION-PERSIST",
+        "J-STATE-CLEANUP",
+        "J-STATE-RECOVER"
+      ],
+      "owned_patterns": [
+        "app/Sources/DetachKit/DetachState*.swift",
+        "app/Sources/DetachKit/Session.swift",
+        "app/Sources/DetachKit/SessionEvents.swift",
+        "app/Sources/DetachKit/SessionMaintenance.swift",
+        "app/Sources/DetachKit/Storage*.swift",
+        "app/Sources/DetachState/*.swift"
+      ],
+      "path": "docs/specs/state.md",
+      "requirements": [
+        {
+          "id": "QC-RUNTIME-STATE",
           "journeys": [
             "J-SESSION-PERSIST",
-            "J-SESSION-RECOVER",
-            "J-SESSION-DELETE"
+            "J-STATE-CLEANUP"
           ],
           "scenarios": [
             {
@@ -2568,18 +2636,6 @@
             {
               "command": "tests/run-claude.sh",
               "id": "SC-SESSION-PERSIST-CLAUDE",
-              "stage": "claude",
-              "status": "instrumented"
-            },
-            {
-              "command": "tests/run.sh",
-              "id": "SC-SESSION-RECOVER-CODEX",
-              "stage": "codex",
-              "status": "instrumented"
-            },
-            {
-              "command": "tests/run-claude.sh",
-              "id": "SC-SESSION-RECOVER-CLAUDE",
               "stage": "claude",
               "status": "instrumented"
             },
@@ -2602,12 +2658,12 @@
               "status": "instrumented"
             }
           ],
-          "summary": "Restores validate path, symlink, identity, and JSONL data before replacement."
+          "summary": "Typed state is the only shared state mutation boundary."
         },
         {
-          "id": "QC-RUNTIME-TRANSITION",
+          "id": "QC-RUNTIME-STORAGE",
           "journeys": [
-            "J-SESSION-RECOVER"
+            "J-STATE-RECOVER"
           ],
           "scenarios": [
             {
@@ -2623,10 +2679,10 @@
               "status": "instrumented"
             }
           ],
-          "summary": "Session transitions preserve exact process identity."
+          "summary": "Restores validate path, symlink, identity, and JSONL data before replacement."
         }
       ],
-      "summary": "Runtime state and session operations preserve exact ownership."
+      "summary": "Typed state, storage, and change events remain safe and coherent."
     },
     {
       "capabilities": [
@@ -2645,7 +2701,6 @@
         "app/Sources/DetachApp/InstallationStore.swift",
         "app/Sources/DetachApp/PowerHelper*.swift",
         "app/Sources/DetachApp/Watchdog*.swift",
-        "app/Sources/DetachKit/BoundedProcessRunner.swift",
         "app/Sources/DetachKit/ClamshellLockRunner.swift",
         "app/Sources/DetachKit/DetachPower*.swift",
         "app/Sources/DetachKit/Power*.swift",
@@ -2780,11 +2835,7 @@
     },
     {
       "capabilities": [
-        "app-experience",
-        "onboarding",
-        "settings",
-        "update",
-        "diagnostics"
+        "app-experience"
       ],
       "id": "app",
       "journeys": [
@@ -2793,14 +2844,7 @@
         "J-APP-EMPTY",
         "J-APP-FAILURE",
         "J-APP-FOCUS",
-        "J-APP-NEW-SESSION",
-        "J-ONBOARD-FIRST-RUN",
-        "J-ONBOARD-PROVIDER",
-        "J-ONBOARD-APPROVAL",
-        "J-SETTINGS-CHANGE",
-        "J-UPDATE-CHECK",
-        "J-UPDATE-APPLY",
-        "J-DOCTOR-REPORT"
+        "J-APP-NEW-SESSION"
       ],
       "owned_patterns": [
         "app/Package.resolved",
@@ -2819,12 +2863,9 @@
         "app/Sources/DetachApp/LogTextView.swift",
         "app/Sources/DetachApp/MenuBar*.swift",
         "app/Sources/DetachApp/NewSessionSheet.swift",
-        "app/Sources/DetachApp/Onboarding*.swift",
         "app/Sources/DetachApp/QuickChat.swift",
         "app/Sources/DetachApp/RootView.swift",
         "app/Sources/DetachApp/Session*.swift",
-        "app/Sources/DetachApp/Settings*.swift",
-        "app/Sources/DetachApp/SetupGuidance.swift",
         "app/Sources/DetachApp/SidebarView.swift",
         "app/Sources/DetachApp/TerminalPreferencePicker.swift",
         "app/Sources/DetachApp/TextSize.swift",
@@ -2832,11 +2873,7 @@
         "app/Sources/DetachApp/TipsBar.swift",
         "app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift",
         "app/Sources/DetachApp/UIE2E*.swift",
-        "app/Sources/DetachApp/UpdaterService.swift",
-        "app/Sources/DetachKit/DetachCLI.swift",
-        "app/Sources/DetachKit/DoctorReport.swift",
-        "app/Sources/DetachKit/Localization.swift",
-        "app/Sources/DetachKit/UpdateConfiguration.swift",
+        "app/Sources/DetachKit/SessionHealth.swift",
         "app/Tests/*",
         "tests/fake-ui-cli",
         "tests/ui-e2e-contract.sh",
@@ -2923,7 +2960,38 @@
             }
           ],
           "summary": "Session tips remain deterministic and user visible."
-        },
+        }
+      ],
+      "summary": "The app presents and changes only typed product state."
+    },
+    {
+      "capabilities": [
+        "onboarding",
+        "settings",
+        "update",
+        "diagnostics"
+      ],
+      "id": "app-setup",
+      "journeys": [
+        "J-ONBOARD-FIRST-RUN",
+        "J-ONBOARD-PROVIDER",
+        "J-ONBOARD-APPROVAL",
+        "J-SETTINGS-CHANGE",
+        "J-UPDATE-CHECK",
+        "J-UPDATE-APPLY",
+        "J-DOCTOR-REPORT"
+      ],
+      "owned_patterns": [
+        "app/Sources/DetachApp/Onboarding*.swift",
+        "app/Sources/DetachApp/Settings*.swift",
+        "app/Sources/DetachApp/SetupGuidance.swift",
+        "app/Sources/DetachApp/UpdaterService.swift",
+        "app/Sources/DetachKit/DoctorReport.swift",
+        "app/Sources/DetachKit/Localization.swift",
+        "app/Sources/DetachKit/UpdateConfiguration.swift"
+      ],
+      "path": "docs/specs/app-setup.md",
+      "requirements": [
         {
           "id": "QC-APP-DOCTOR",
           "journeys": [
@@ -3024,7 +3092,7 @@
           "summary": "Update state and application preserve the signed arm64 contract."
         }
       ],
-      "summary": "The app presents and changes only typed product state."
+      "summary": "App setup, settings, diagnostics, and updates fail closed."
     },
     {
       "capabilities": [
@@ -3236,8 +3304,18 @@
       "stages": "static"
     },
     {
-      "capabilities": "session-lifecycle",
+      "capabilities": "session-lifecycle,session-state",
       "id": "state-runtime",
+      "stages": "static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "session-state",
+      "id": "state-source",
+      "stages": "static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "session-lifecycle,session-state,app-experience",
+      "id": "session-health-source",
       "stages": "static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget"
     },
     {
@@ -3246,8 +3324,33 @@
       "stages": "static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget"
     },
     {
+      "capabilities": "session-lifecycle,session-state,power-protection",
+      "id": "bounded-process-source",
+      "stages": "static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget"
+    },
+    {
       "capabilities": "app-experience",
       "id": "swift-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "app-experience,onboarding",
+      "id": "root-view-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "power-protection,onboarding,settings,update,diagnostics,installation",
+      "id": "installation-store-source",
+      "stages": "static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget"
+    },
+    {
+      "capabilities": "app-experience,onboarding,settings,update",
+      "id": "app-shell-source",
+      "stages": "static,swift,quality-contracts,app,release-budget"
+    },
+    {
+      "capabilities": "app-experience,onboarding,settings",
+      "id": "ui-e2e-source",
       "stages": "static,swift,quality-contracts,app,release-budget"
     },
     {
@@ -3271,12 +3374,12 @@
       "stages": "static,swift,quality-contracts,app,release-budget"
     },
     {
-      "capabilities": "session-lifecycle",
+      "capabilities": "session-lifecycle,session-state",
       "id": "runtime-source",
       "stages": "static,swift,quality-contracts,app,release-budget"
     },
     {
-      "capabilities": "session-lifecycle,app-experience",
+      "capabilities": "session-lifecycle,session-state,app-experience",
       "id": "session-ui-source",
       "stages": "static,swift,quality-contracts,app,release-budget"
     },
@@ -3291,7 +3394,7 @@
       "stages": "static,swift,quality-contracts,app,tmux-runtime,release-budget"
     },
     {
-      "capabilities": "session-lifecycle",
+      "capabilities": "session-lifecycle,session-state",
       "id": "cli",
       "stages": "static,app,codex,claude,distribution,tmux-runtime,release-budget"
     },
@@ -3316,12 +3419,12 @@
       "stages": "static,app,tmux-runtime,release-preflight,release-budget"
     },
     {
-      "capabilities": "session-lifecycle",
+      "capabilities": "session-lifecycle,session-state",
       "id": "codex-test",
       "stages": "static,codex,release-budget"
     },
     {
-      "capabilities": "session-lifecycle",
+      "capabilities": "session-lifecycle,session-state",
       "id": "claude-test",
       "stages": "static,claude,release-budget"
     },

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -83,21 +83,20 @@ It lists current specification ownership and verification links.
 ## `runtime`
 
 - Path: `docs/specs/runtime.md`
-- Summary: Runtime state and session operations preserve exact ownership.
+- Summary: Runtime and session operations preserve exact ownership.
 - Capabilities: `session-lifecycle`
 
 ### Owned path patterns
 
 - `app/Sources/DetachKit/*.swift`
 - `app/Sources/DetachKit/ANSIText.swift`
-- `app/Sources/DetachKit/DetachState*.swift`
+- `app/Sources/DetachKit/BoundedProcessRunner.swift`
+- `app/Sources/DetachKit/DetachCLI.swift`
 - `app/Sources/DetachKit/LogPoller.swift`
 - `app/Sources/DetachKit/Session*.swift`
-- `app/Sources/DetachKit/Storage*.swift`
 - `app/Sources/DetachKit/Terminal*.swift`
 - `app/Sources/DetachKit/Tip.swift`
 - `app/Sources/DetachKit/Tmux*.swift`
-- `app/Sources/DetachState/*.swift`
 - `bin/*`
 - `bin/detach`
 - `bin/detach-core`
@@ -115,10 +114,30 @@ It lists current specification ownership and verification links.
 
 | Requirement | Journeys | Scenarios | Outcome |
 | --- | --- | --- | --- |
-| `QC-RUNTIME-STATE` | `J-SESSION-CREATE`<br>`J-SESSION-PERSIST` | `SC-SESSION-CREATE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-CREATE-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-PERSIST-CODEX` (instrumented, `codex`)<br>`SC-SESSION-PERSIST-CLAUDE` (instrumented, `claude`) | Typed state is the only shared state mutation boundary. |
 | `QC-RUNTIME-OWNERSHIP` | `J-SESSION-CREATE`<br>`J-SESSION-RECOVER`<br>`J-SESSION-STOP`<br>`J-SESSION-DELETE` | `SC-SESSION-CREATE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-CREATE-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-STOP-CODEX` (instrumented, `codex`)<br>`SC-SESSION-STOP-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-STOP` (instrumented, `ui-e2e`)<br>`SC-SESSION-DELETE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-DELETE-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-DELETE` (instrumented, `ui-e2e`) | Session operations prove the exact run token and process ownership. |
-| `QC-RUNTIME-STORAGE` | `J-SESSION-PERSIST`<br>`J-SESSION-RECOVER`<br>`J-SESSION-DELETE` | `SC-SESSION-PERSIST-CODEX` (instrumented, `codex`)<br>`SC-SESSION-PERSIST-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-DELETE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-DELETE-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-DELETE` (instrumented, `ui-e2e`) | Restores validate path, symlink, identity, and JSONL data before replacement. |
 | `QC-RUNTIME-TRANSITION` | `J-SESSION-RECOVER` | `SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`) | Session transitions preserve exact process identity. |
+
+## `state`
+
+- Path: `docs/specs/state.md`
+- Summary: Typed state, storage, and change events remain safe and coherent.
+- Capabilities: `session-state`
+
+### Owned path patterns
+
+- `app/Sources/DetachKit/DetachState*.swift`
+- `app/Sources/DetachKit/Session.swift`
+- `app/Sources/DetachKit/SessionEvents.swift`
+- `app/Sources/DetachKit/SessionMaintenance.swift`
+- `app/Sources/DetachKit/Storage*.swift`
+- `app/Sources/DetachState/*.swift`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
+| `QC-RUNTIME-STATE` | `J-SESSION-PERSIST`<br>`J-STATE-CLEANUP` | `SC-SESSION-PERSIST-CODEX` (instrumented, `codex`)<br>`SC-SESSION-PERSIST-CLAUDE` (instrumented, `claude`)<br>`SC-SESSION-DELETE-CODEX` (instrumented, `codex`)<br>`SC-SESSION-DELETE-CLAUDE` (instrumented, `claude`)<br>`SC-UI-SESSION-DELETE` (instrumented, `ui-e2e`) | Typed state is the only shared state mutation boundary. |
+| `QC-RUNTIME-STORAGE` | `J-STATE-RECOVER` | `SC-SESSION-RECOVER-CODEX` (instrumented, `codex`)<br>`SC-SESSION-RECOVER-CLAUDE` (instrumented, `claude`) | Restores validate path, symlink, identity, and JSONL data before replacement. |
 
 ## `power`
 
@@ -133,7 +152,6 @@ It lists current specification ownership and verification links.
 - `app/Sources/DetachApp/InstallationStore.swift`
 - `app/Sources/DetachApp/PowerHelper*.swift`
 - `app/Sources/DetachApp/Watchdog*.swift`
-- `app/Sources/DetachKit/BoundedProcessRunner.swift`
 - `app/Sources/DetachKit/ClamshellLockRunner.swift`
 - `app/Sources/DetachKit/DetachPower*.swift`
 - `app/Sources/DetachKit/Power*.swift`
@@ -158,7 +176,7 @@ It lists current specification ownership and verification links.
 
 - Path: `docs/specs/app.md`
 - Summary: The app presents and changes only typed product state.
-- Capabilities: `app-experience`, `onboarding`, `settings`, `update`, `diagnostics`
+- Capabilities: `app-experience`
 
 ### Owned path patterns
 
@@ -178,12 +196,9 @@ It lists current specification ownership and verification links.
 - `app/Sources/DetachApp/LogTextView.swift`
 - `app/Sources/DetachApp/MenuBar*.swift`
 - `app/Sources/DetachApp/NewSessionSheet.swift`
-- `app/Sources/DetachApp/Onboarding*.swift`
 - `app/Sources/DetachApp/QuickChat.swift`
 - `app/Sources/DetachApp/RootView.swift`
 - `app/Sources/DetachApp/Session*.swift`
-- `app/Sources/DetachApp/Settings*.swift`
-- `app/Sources/DetachApp/SetupGuidance.swift`
 - `app/Sources/DetachApp/SidebarView.swift`
 - `app/Sources/DetachApp/TerminalPreferencePicker.swift`
 - `app/Sources/DetachApp/TextSize.swift`
@@ -191,11 +206,7 @@ It lists current specification ownership and verification links.
 - `app/Sources/DetachApp/TipsBar.swift`
 - `app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift`
 - `app/Sources/DetachApp/UIE2E*.swift`
-- `app/Sources/DetachApp/UpdaterService.swift`
-- `app/Sources/DetachKit/DetachCLI.swift`
-- `app/Sources/DetachKit/DoctorReport.swift`
-- `app/Sources/DetachKit/Localization.swift`
-- `app/Sources/DetachKit/UpdateConfiguration.swift`
+- `app/Sources/DetachKit/SessionHealth.swift`
 - `app/Tests/*`
 - `tests/fake-ui-cli`
 - `tests/ui-e2e-contract.sh`
@@ -208,6 +219,27 @@ It lists current specification ownership and verification links.
 | `QC-HEALTH-FRESHNESS` | `J-APP-DASHBOARD` | `SC-UI-DASHBOARD` (instrumented, `ui-e2e`) | Health claims use typed fresh state. |
 | `QC-HEALTH-PRESENTATION` | `J-APP-DASHBOARD`<br>`J-APP-DETAIL`<br>`J-APP-EMPTY`<br>`J-APP-FAILURE`<br>`J-APP-FOCUS`<br>`J-APP-NEW-SESSION` | `SC-UI-DASHBOARD` (instrumented, `ui-e2e`)<br>`SC-UI-SESSION-DETAIL` (instrumented, `ui-e2e`)<br>`SC-UI-EMPTY` (instrumented, `ui-e2e`)<br>`SC-UI-FAILURE` (instrumented, `ui-e2e`)<br>`SC-UI-FOCUS` (instrumented, `ui-e2e`)<br>`SC-UI-NEW-SESSION` (instrumented, `ui-e2e`) | The app presents typed health state without parsing terminal text. |
 | `QC-APP-TIPS` | `J-APP-EMPTY` | `SC-UI-EMPTY` (instrumented, `ui-e2e`) | Session tips remain deterministic and user visible. |
+
+## `app-setup`
+
+- Path: `docs/specs/app-setup.md`
+- Summary: App setup, settings, diagnostics, and updates fail closed.
+- Capabilities: `onboarding`, `settings`, `update`, `diagnostics`
+
+### Owned path patterns
+
+- `app/Sources/DetachApp/Onboarding*.swift`
+- `app/Sources/DetachApp/Settings*.swift`
+- `app/Sources/DetachApp/SetupGuidance.swift`
+- `app/Sources/DetachApp/UpdaterService.swift`
+- `app/Sources/DetachKit/DoctorReport.swift`
+- `app/Sources/DetachKit/Localization.swift`
+- `app/Sources/DetachKit/UpdateConfiguration.swift`
+
+### Requirement verification
+
+| Requirement | Journeys | Scenarios | Outcome |
+| --- | --- | --- | --- |
 | `QC-APP-DOCTOR` | `J-DOCTOR-REPORT` | `SC-DOCTOR-REPORT` (instrumented, `distribution`) | Doctor output derives from typed runtime state. |
 | `QC-APP-ONBOARDING` | `J-ONBOARD-FIRST-RUN`<br>`J-ONBOARD-PROVIDER`<br>`J-ONBOARD-APPROVAL` | `SC-APP-ONBOARDING-UNIT` (legacy-stage, `swift`)<br>`SC-UI-ONBOARD-FIRST-RUN` (instrumented, `ui-e2e`)<br>`SC-UI-ONBOARD-PROVIDER` (instrumented, `ui-e2e`)<br>`SC-UI-ONBOARD-APPROVAL` (instrumented, `ui-e2e`) | Onboarding leads a new user through supported provider and approval setup. |
 | `QC-APP-SETTINGS` | `J-SETTINGS-CHANGE` | `SC-APP-SETTINGS-UNIT` (legacy-stage, `swift`)<br>`SC-UI-SETTINGS` (instrumented, `ui-e2e`) | Settings changes persist and affect only their declared behavior. |

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,9 +1,11 @@
 schema	1
-policy	54
+policy	55
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
-spec	runtime	docs/specs/runtime.md	Runtime state and session operations preserve exact ownership.
+spec	runtime	docs/specs/runtime.md	Runtime and session operations preserve exact ownership.
+spec	state	docs/specs/state.md	Typed state, storage, and change events remain safe and coherent.
 spec	power	docs/specs/power.md	Power protection fails safe across both required layers.
 spec	app	docs/specs/app.md	The app presents and changes only typed product state.
+spec	app-setup	docs/specs/app-setup.md	App setup, settings, diagnostics, and updates fail closed.
 spec	release	docs/specs/release.md	Distribution and publication preserve verified immutable artifacts.
 limit	pr_feedback_seconds	600
 limit	local_feedback_seconds	120
@@ -12,6 +14,8 @@ limit	max_repair_loops	2
 limit	changed_line_coverage_percent	90
 limit	mutation_score_percent	100
 limit	mutation_timeout_seconds	240
+limit	routed_spec_warning_bytes	12288
+limit	routed_spec_limit_bytes	16384
 stage	10	static	120	true
 stage	20	gate-contract	300	true
 stage	30	swift	1200	true
@@ -30,24 +34,31 @@ dependency	app	ui-e2e
 test-domain	policy	static,gate-contract	quality-system
 test-domain	quality-core	*	*
 test-domain	docs	static	documentation
-test-domain	state-runtime	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
+test-domain	state-runtime	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle,session-state
+test-domain	state-source	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-state
+test-domain	session-health-source	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle,session-state,app-experience
 test-domain	power	static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget	power-protection
+test-domain	bounded-process-source	static,swift,quality-contracts,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle,session-state,power-protection
 test-domain	swift-source	static,swift,quality-contracts,app,release-budget	app-experience
+test-domain	root-view-source	static,swift,quality-contracts,app,release-budget	app-experience,onboarding
+test-domain	installation-store-source	static,swift,quality-contracts,app,distribution,tmux-runtime,release-budget	power-protection,onboarding,settings,update,diagnostics,installation
+test-domain	app-shell-source	static,swift,quality-contracts,app,release-budget	app-experience,onboarding,settings,update
+test-domain	ui-e2e-source	static,swift,quality-contracts,app,release-budget	app-experience,onboarding,settings
 test-domain	onboarding-source	static,swift,quality-contracts,app,release-budget	onboarding
 test-domain	settings-source	static,swift,quality-contracts,app,release-budget	settings
 test-domain	update-source	static,swift,quality-contracts,app,release-budget	update
 test-domain	diagnostics-source	static,swift,quality-contracts,app,release-budget	diagnostics
-test-domain	runtime-source	static,swift,quality-contracts,app,release-budget	session-lifecycle
-test-domain	session-ui-source	static,swift,quality-contracts,app,release-budget	session-lifecycle,app-experience
+test-domain	runtime-source	static,swift,quality-contracts,app,release-budget	session-lifecycle,session-state
+test-domain	session-ui-source	static,swift,quality-contracts,app,release-budget	session-lifecycle,session-state,app-experience
 test-domain	swift-test	static,swift,quality-contracts,release-budget	quality-system
 test-domain	package	static,swift,quality-contracts,app,tmux-runtime,release-budget	installation,update
-test-domain	cli	static,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle
+test-domain	cli	static,app,codex,claude,distribution,tmux-runtime,release-budget	session-lifecycle,session-state
 test-domain	install	static,app,distribution,tmux-runtime,release-budget	installation
 test-domain	tmux-build	static,app,codex,claude,tmux-runtime,release-budget	session-lifecycle
 test-domain	release-tool	static,app,release-preflight,publish-preflight,release-workflow,release-budget	update,publication
 test-domain	app-script	static,app,tmux-runtime,release-preflight,release-budget	installation
-test-domain	codex-test	static,codex,release-budget	session-lifecycle
-test-domain	claude-test	static,claude,release-budget	session-lifecycle
+test-domain	codex-test	static,codex,release-budget	session-lifecycle,session-state
+test-domain	claude-test	static,claude,release-budget	session-lifecycle,session-state
 test-domain	distribution-test	static,app,distribution,release-budget	installation
 test-domain	runtime-test	static,app,tmux-runtime,release-budget	session-lifecycle,power-protection
 test-domain	ui-test	static,app,release-budget	app-experience
@@ -134,30 +145,34 @@ route	950	*.md	docs	safe	docs/specs/documentation.md
 route	950	docs/assets/*	docs	safe	docs/specs/documentation.md
 route	960	AGENTS.md	docs	safe	docs/specs/documentation.md
 route	960	CLAUDE.md	docs	safe	docs/specs/documentation.md
-route	900	app/Sources/DetachKit/DetachState*.swift	state-runtime	safe	docs/specs/runtime.md
+route	900	app/Sources/DetachKit/DetachState*.swift	state-source	safe	docs/specs/state.md
 route	900	app/Sources/DetachKit/Session*.swift	state-runtime	safe	docs/specs/runtime.md
-route	900	app/Sources/DetachKit/Storage*.swift	state-runtime	safe	docs/specs/runtime.md
-route	900	app/Sources/DetachState/*.swift	state-runtime	safe	docs/specs/runtime.md
+route	910	app/Sources/DetachKit/Session.swift	state-source	safe	docs/specs/state.md
+route	910	app/Sources/DetachKit/SessionEvents.swift	state-source	safe	docs/specs/state.md
+route	910	app/Sources/DetachKit/SessionHealth.swift	session-health-source	safe	docs/specs/app.md
+route	910	app/Sources/DetachKit/SessionMaintenance.swift	state-source	safe	docs/specs/state.md
+route	900	app/Sources/DetachKit/Storage*.swift	state-source	safe	docs/specs/state.md
+route	900	app/Sources/DetachState/*.swift	state-source	safe	docs/specs/state.md
 route	900	app/Sources/DetachKit/DetachPower*.swift	power	both	docs/specs/power.md
 route	900	app/Sources/DetachKit/Power*.swift	power	both	docs/specs/power.md
 route	900	app/Sources/DetachKit/ClamshellLockRunner.swift	power	both	docs/specs/power.md
-route	900	app/Sources/DetachKit/BoundedProcessRunner.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachKit/BoundedProcessRunner.swift	bounded-process-source	both	docs/specs/runtime.md
 route	900	app/Sources/DetachPower/*.swift	power	both	docs/specs/power.md
 route	900	app/Sources/DetachPowerHelper/*.swift	power	both	docs/specs/power.md
 route	900	app/Sources/DetachWatchdog/*.swift	power	both	docs/specs/power.md
-route	900	app/Sources/DetachApp/InstallationStore.swift	power	both	docs/specs/power.md
+route	900	app/Sources/DetachApp/InstallationStore.swift	installation-store-source	both	docs/specs/power.md
 route	900	app/Sources/DetachApp/PowerHelper*.swift	power	both	docs/specs/power.md
 route	900	app/Sources/DetachApp/Watchdog*.swift	power	both	docs/specs/power.md
-route	880	app/Sources/DetachApp/DetachApp.swift	onboarding-source	install	docs/specs/app.md
-route	880	app/Sources/DetachApp/Onboarding*.swift	onboarding-source	install	docs/specs/app.md
-route	880	app/Sources/DetachApp/RootView.swift	onboarding-source	install	docs/specs/app.md
-route	880	app/Sources/DetachApp/SetupGuidance.swift	onboarding-source	install	docs/specs/app.md
-route	880	app/Sources/DetachApp/Settings*.swift	settings-source	install	docs/specs/app.md
-route	880	app/Sources/DetachApp/UpdaterService.swift	update-source	install	docs/specs/app.md
-route	880	app/Sources/DetachKit/DetachCLI.swift	runtime-source	install	docs/specs/app.md
-route	880	app/Sources/DetachKit/DoctorReport.swift	diagnostics-source	install	docs/specs/app.md
-route	880	app/Sources/DetachKit/Localization.swift	onboarding-source	install	docs/specs/app.md
-route	880	app/Sources/DetachKit/UpdateConfiguration.swift	update-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/DetachApp.swift	app-shell-source	install	docs/specs/app.md
+route	880	app/Sources/DetachApp/Onboarding*.swift	onboarding-source	install	docs/specs/app-setup.md
+route	880	app/Sources/DetachApp/RootView.swift	root-view-source	safe	docs/specs/app.md
+route	880	app/Sources/DetachApp/SetupGuidance.swift	onboarding-source	install	docs/specs/app-setup.md
+route	880	app/Sources/DetachApp/Settings*.swift	settings-source	install	docs/specs/app-setup.md
+route	880	app/Sources/DetachApp/UpdaterService.swift	update-source	install	docs/specs/app-setup.md
+route	880	app/Sources/DetachKit/DetachCLI.swift	runtime-source	safe	docs/specs/runtime.md
+route	880	app/Sources/DetachKit/DoctorReport.swift	diagnostics-source	install	docs/specs/app-setup.md
+route	880	app/Sources/DetachKit/Localization.swift	onboarding-source	install	docs/specs/app-setup.md
+route	880	app/Sources/DetachKit/UpdateConfiguration.swift	update-source	install	docs/specs/app-setup.md
 route	870	app/Sources/DetachApp/EmptySessionsView.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/LogTextView.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/MenuBar*.swift	swift-source	safe	docs/specs/app.md
@@ -170,7 +185,7 @@ route	870	app/Sources/DetachApp/TextSize.swift	swift-source	safe	docs/specs/app.
 route	870	app/Sources/DetachApp/Theme.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/TipsBar.swift	swift-source	safe	docs/specs/app.md
 route	870	app/Sources/DetachApp/TmuxExtendedKeysSettingsController.swift	swift-source	safe	docs/specs/app.md
-route	870	app/Sources/DetachApp/UIE2E*.swift	swift-source	safe	docs/specs/app.md
+route	870	app/Sources/DetachApp/UIE2E*.swift	ui-e2e-source	safe	docs/specs/app.md
 route	850	app/Sources/DetachApp/*.swift	swift-source	unknown	docs/specs/app.md
 route	870	app/Sources/DetachKit/ANSIText.swift	swift-source	safe	docs/specs/runtime.md
 route	870	app/Sources/DetachKit/LogPoller.swift	swift-source	safe	docs/specs/runtime.md
@@ -238,22 +253,25 @@ route	700	app/.gitignore	metadata	safe	docs/specs/documentation.md
 route	100	*.sh	unknown	unknown	docs/specs/documentation.md
 capability	quality-system	docs/specs/documentation.md	QC-QUALITY-POLICY,QC-QUALITY-SUPPLY-CHAIN	J-QUALITY-CHANGE
 capability	documentation	docs/specs/documentation.md	QC-DOC-CONSISTENCY	J-DOCS-CONSISTENCY
-capability	session-lifecycle	docs/specs/runtime.md	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	J-SESSION-CREATE,J-SESSION-PERSIST,J-SESSION-RECOVER,J-SESSION-STOP,J-SESSION-DELETE
+capability	session-lifecycle	docs/specs/runtime.md	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-TRANSITION	J-SESSION-CREATE,J-SESSION-RECOVER,J-SESSION-STOP,J-SESSION-DELETE
+capability	session-state	docs/specs/state.md	QC-RUNTIME-STATE,QC-RUNTIME-STORAGE	J-SESSION-PERSIST,J-STATE-CLEANUP,J-STATE-RECOVER
 capability	power-protection	docs/specs/power.md	QC-POWER-ASSERTION,QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC,QC-POWER-PROTECTION,QC-POWER-CLI,QC-POWER-PLATFORM	J-POWER-ENABLE,J-POWER-LOW-BATTERY,J-POWER-HELPER-LEASE,J-POWER-CLOSED-LID
 capability	app-experience	docs/specs/app.md	QC-HEALTH-FRESHNESS,QC-HEALTH-PRESENTATION,QC-APP-TIPS	J-APP-DASHBOARD,J-APP-DETAIL,J-APP-EMPTY,J-APP-FAILURE,J-APP-FOCUS,J-APP-NEW-SESSION
-capability	onboarding	docs/specs/app.md	QC-APP-ONBOARDING	J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL
-capability	settings	docs/specs/app.md	QC-APP-SETTINGS	J-SETTINGS-CHANGE
-capability	update	docs/specs/app.md	QC-APP-UPDATE	J-UPDATE-CHECK,J-UPDATE-APPLY
-capability	diagnostics	docs/specs/app.md	QC-APP-DOCTOR	J-DOCTOR-REPORT
+capability	onboarding	docs/specs/app-setup.md	QC-APP-ONBOARDING	J-ONBOARD-FIRST-RUN,J-ONBOARD-PROVIDER,J-ONBOARD-APPROVAL
+capability	settings	docs/specs/app-setup.md	QC-APP-SETTINGS	J-SETTINGS-CHANGE
+capability	update	docs/specs/app-setup.md	QC-APP-UPDATE	J-UPDATE-CHECK,J-UPDATE-APPLY
+capability	diagnostics	docs/specs/app-setup.md	QC-APP-DOCTOR	J-DOCTOR-REPORT
 capability	installation	docs/specs/release.md	QC-RELEASE-INSTALL	J-INSTALL-CLEAN,J-INSTALL-REPAIR,J-INSTALL-UNINSTALL
 capability	publication	docs/specs/release.md	QC-RELEASE-PUBLISH	J-PUBLISH-ARTIFACTS
 journey	J-QUALITY-CHANGE	quality-system	QC-QUALITY-POLICY,QC-QUALITY-SUPPLY-CHAIN	SC-POLICY-CONTRACT,SC-PROMOTION-CONTRACT,SC-MERGE-CONTRACT,SC-SECURITY-CONTRACT	A policy change keeps local feedback focused and hosted evidence complete.
 journey	J-DOCS-CONSISTENCY	documentation	QC-DOC-CONSISTENCY	SC-DOCS-CONTRACT	Documentation and executable contracts stay synchronized.
-journey	J-SESSION-CREATE	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-OWNERSHIP	SC-SESSION-CREATE-CODEX,SC-SESSION-CREATE-CLAUDE	A user creates a managed provider session.
-journey	J-SESSION-PERSIST	session-lifecycle	QC-RUNTIME-STATE,QC-RUNTIME-STORAGE	SC-SESSION-PERSIST-CODEX,SC-SESSION-PERSIST-CLAUDE	A live session remains available after the app exits.
-journey	J-SESSION-RECOVER	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE,QC-RUNTIME-TRANSITION	SC-SESSION-RECOVER-CODEX,SC-SESSION-RECOVER-CLAUDE	A user recovers the exact owned session after interruption.
+journey	J-SESSION-CREATE	session-lifecycle	QC-RUNTIME-OWNERSHIP	SC-SESSION-CREATE-CODEX,SC-SESSION-CREATE-CLAUDE	A user creates a managed provider session.
+journey	J-SESSION-PERSIST	session-state	QC-RUNTIME-STATE	SC-SESSION-PERSIST-CODEX,SC-SESSION-PERSIST-CLAUDE	A live session remains available after the app exits.
+journey	J-STATE-CLEANUP	session-state	QC-RUNTIME-STATE	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE,SC-UI-SESSION-DELETE	A user removes only typed state that a complete scan marks eligible.
+journey	J-STATE-RECOVER	session-state	QC-RUNTIME-STORAGE	SC-SESSION-RECOVER-CODEX,SC-SESSION-RECOVER-CLAUDE	A user restores recovery state only after complete validation.
+journey	J-SESSION-RECOVER	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-TRANSITION	SC-SESSION-RECOVER-CODEX,SC-SESSION-RECOVER-CLAUDE	A user recovers the exact owned session after interruption.
 journey	J-SESSION-STOP	session-lifecycle	QC-RUNTIME-OWNERSHIP	SC-SESSION-STOP-CODEX,SC-SESSION-STOP-CLAUDE,SC-UI-SESSION-STOP	A user stops only the selected owned session.
-journey	J-SESSION-DELETE	session-lifecycle	QC-RUNTIME-OWNERSHIP,QC-RUNTIME-STORAGE	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE,SC-UI-SESSION-DELETE	A user deletes selected eligible sessions without affecting current work.
+journey	J-SESSION-DELETE	session-lifecycle	QC-RUNTIME-OWNERSHIP	SC-SESSION-DELETE-CODEX,SC-SESSION-DELETE-CLAUDE,SC-UI-SESSION-DELETE	A user deletes selected eligible sessions without affecting current work.
 journey	J-POWER-ENABLE	power-protection	QC-POWER-ASSERTION,QC-POWER-LEASE,QC-POWER-CLI,QC-POWER-PLATFORM	SC-POWER-UNIT	A protected session acquires both required power protections.
 journey	J-POWER-LOW-BATTERY	power-protection	QC-POWER-PROTECTION	SC-POWER-LOW-BATTERY	Low battery removes unsafe protection and reports the reason.
 journey	J-POWER-HELPER-LEASE	power-protection	QC-POWER-AUTH,QC-POWER-LEASE,QC-POWER-XPC	SC-POWER-HELPER	The helper accepts only an authorized bounded lease.
@@ -344,9 +362,9 @@ critical	app/Sources/DetachKit/PowerHelperXPC.swift	QC-POWER-XPC
 critical	app/Sources/DetachKit/PowerHelperPlatform.swift	QC-POWER-PLATFORM
 critical	app/Sources/DetachKit/SessionStore.swift	QC-RUNTIME-OWNERSHIP
 critical	app/Sources/DetachKit/DoctorReport.swift	QC-APP-DOCTOR
-requirement	QC-RUNTIME-STATE	docs/specs/runtime.md	Typed state is the only shared state mutation boundary.
+requirement	QC-RUNTIME-STATE	docs/specs/state.md	Typed state is the only shared state mutation boundary.
 requirement	QC-RUNTIME-OWNERSHIP	docs/specs/runtime.md	Session operations prove the exact run token and process ownership.
-requirement	QC-RUNTIME-STORAGE	docs/specs/runtime.md	Restores validate path, symlink, identity, and JSONL data before replacement.
+requirement	QC-RUNTIME-STORAGE	docs/specs/state.md	Restores validate path, symlink, identity, and JSONL data before replacement.
 requirement	QC-POWER-ASSERTION	docs/specs/power.md	Power protection owns a user IOKit assertion.
 requirement	QC-POWER-AUTH	docs/specs/power.md	Helper authorization binds audit token, console user, signing, and deadline.
 requirement	QC-POWER-LEASE	docs/specs/power.md	The root helper lease is bounded and ownership safe.
@@ -358,10 +376,10 @@ requirement	QC-HEALTH-FRESHNESS	docs/specs/app.md	Health claims use typed fresh 
 requirement	QC-HEALTH-PRESENTATION	docs/specs/app.md	The app presents typed health state without parsing terminal text.
 requirement	QC-RUNTIME-TRANSITION	docs/specs/runtime.md	Session transitions preserve exact process identity.
 requirement	QC-APP-TIPS	docs/specs/app.md	Session tips remain deterministic and user visible.
-requirement	QC-APP-DOCTOR	docs/specs/app.md	Doctor output derives from typed runtime state.
-requirement	QC-APP-ONBOARDING	docs/specs/app.md	Onboarding leads a new user through supported provider and approval setup.
-requirement	QC-APP-SETTINGS	docs/specs/app.md	Settings changes persist and affect only their declared behavior.
-requirement	QC-APP-UPDATE	docs/specs/app.md	Update state and application preserve the signed arm64 contract.
+requirement	QC-APP-DOCTOR	docs/specs/app-setup.md	Doctor output derives from typed runtime state.
+requirement	QC-APP-ONBOARDING	docs/specs/app-setup.md	Onboarding leads a new user through supported provider and approval setup.
+requirement	QC-APP-SETTINGS	docs/specs/app-setup.md	Settings changes persist and affect only their declared behavior.
+requirement	QC-APP-UPDATE	docs/specs/app-setup.md	Update state and application preserve the signed arm64 contract.
 requirement	QC-RELEASE-INSTALL	docs/specs/release.md	Install, repair, and uninstall mutate only Detach-owned payloads and selected state.
 requirement	QC-RELEASE-PUBLISH	docs/specs/release.md	Publication exposes only independently verified allowlisted artifacts.
 requirement	QC-QUALITY-POLICY	docs/specs/documentation.md	One current policy owns quality selection and traceability.

--- a/tests/docs-contract.sh
+++ b/tests/docs-contract.sh
@@ -44,8 +44,10 @@ done
 required=(
   docs/specs/README.md
   docs/specs/runtime.md
+  docs/specs/state.md
   docs/specs/power.md
   docs/specs/app.md
+  docs/specs/app-setup.md
   docs/specs/release.md
   docs/specs/documentation.md
   docs/testing.md
@@ -57,13 +59,25 @@ for file in "${required[@]}"; do
   [ -f "$ROOT/$file" ] || fail "missing $file"
 done
 
+spec_warning="$(awk -F '\t' '$1 == "limit" && $2 == "routed_spec_warning_bytes" {print $3}' \
+  "$ROOT/quality/policy.tsv")"
+spec_limit="$(awk -F '\t' '$1 == "limit" && $2 == "routed_spec_limit_bytes" {print $3}' \
+  "$ROOT/quality/policy.tsv")"
+[[ "$spec_warning" =~ ^[1-9][0-9]*$ ]] || fail 'routed spec warning is missing or invalid'
+[[ "$spec_limit" =~ ^[1-9][0-9]*$ ]] || fail 'routed spec limit is missing or invalid'
+[ "$spec_warning" -lt "$spec_limit" ] || fail 'routed spec warning must be below the hard limit'
+
 for spec in "$ROOT"/docs/specs/*.md; do
   bytes="$(wc -c <"$spec" | tr -d ' ')"
-  [ "$bytes" -le 16384 ] ||
-    fail "${spec#"$ROOT/"} is ${bytes} bytes; routed spec limit is 16384"
+  [ "$bytes" -le "$spec_limit" ] ||
+    fail "${spec#"$ROOT/"} is ${bytes} bytes; routed spec limit is ${spec_limit}"
+  if [ "$bytes" -gt "$spec_warning" ]; then
+    printf 'docs-contract: warning: %s is %s bytes; plan a split before %s\n' \
+      "${spec#"$ROOT/"}" "$bytes" "$spec_limit" >&2
+  fi
 done
 
-for spec in runtime power app release documentation; do
+for spec in runtime state power app app-setup release documentation; do
   [ "$(grep -Fc "docs/specs/$spec.md" "$ROOT/AGENTS.md")" -eq 1 ] ||
     fail "context map must reference $spec.md exactly once"
 done

--- a/tests/quality-dashboard.sh
+++ b/tests/quality-dashboard.sh
@@ -99,10 +99,31 @@ cat >"$RUN_DIR/coverage-opportunities.json" <<JSON
   "suite": "ui"
 }
 JSON
+cat >"$RUN_DIR/spec-sizes.json" <<JSON
+{
+  "input_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "limit_bytes": 16384,
+  "policy": $POLICY_VERSION,
+  "schema": 1,
+  "source_commit": "0123456789abcdef0123456789abcdef01234567",
+  "specifications": [
+    {"bytes": 1, "headroom_bytes": 16383, "id": "documentation", "path": "docs/specs/documentation.md", "status": "healthy"},
+    {"bytes": 12288, "headroom_bytes": 4096, "id": "runtime", "path": "docs/specs/runtime.md", "status": "healthy"},
+    {"bytes": 12289, "headroom_bytes": 4095, "id": "state", "path": "docs/specs/state.md", "status": "warning"},
+    {"bytes": 16384, "headroom_bytes": 0, "id": "power", "path": "docs/specs/power.md", "status": "warning"},
+    {"bytes": 256, "headroom_bytes": 16128, "id": "app", "path": "docs/specs/app.md", "status": "healthy"},
+    {"bytes": 512, "headroom_bytes": 15872, "id": "app-setup", "path": "docs/specs/app-setup.md", "status": "healthy"},
+    {"bytes": 1024, "headroom_bytes": 15360, "id": "release", "path": "docs/specs/release.md", "status": "healthy"}
+  ],
+  "status": "warning",
+  "warning_bytes": 12288
+}
+JSON
 metrics_digest="$(shasum -a 256 "$RUN_DIR/quality-metrics.json" | awk '{print $1}')"
 opportunities_digest="$(shasum -a 256 "$RUN_DIR/coverage-opportunities.json" | awk '{print $1}')"
-printf 'schema\t1\nfile\tcoverage-opportunities.json\t%s\nfile\tquality-metrics.json\t%s\n' \
-  "$opportunities_digest" "$metrics_digest" \
+spec_sizes_digest="$(shasum -a 256 "$RUN_DIR/spec-sizes.json" | awk '{print $1}')"
+printf 'schema\t1\nfile\tcoverage-opportunities.json\t%s\nfile\tquality-metrics.json\t%s\nfile\tspec-sizes.json\t%s\n' \
+  "$opportunities_digest" "$metrics_digest" "$spec_sizes_digest" \
   >"$RUN_DIR/artifacts.tsv"
 artifacts_digest="$(shasum -a 256 "$RUN_DIR/artifacts.tsv" | awk '{print $1}')"
 cat >"$RUN_DIR/manifest.tsv" <<EOF
@@ -130,10 +151,25 @@ summary_sha256	$summary_digest
 result	passed
 EOF
 
+refresh_spec_size_bindings() {
+  local run_dir="$1" artifact_digest inventory_digest
+  artifact_digest="$(shasum -a 256 "$run_dir/spec-sizes.json" | awk '{print $1}')"
+  awk -F '\t' -v OFS='\t' -v digest="$artifact_digest" \
+    '$1 == "file" && $2 == "spec-sizes.json" {$3=digest} {print}' \
+    "$run_dir/artifacts.tsv" >"$run_dir/artifacts.tsv.tmp"
+  mv "$run_dir/artifacts.tsv.tmp" "$run_dir/artifacts.tsv"
+  inventory_digest="$(shasum -a 256 "$run_dir/artifacts.tsv" | awk '{print $1}')"
+  awk -F '\t' -v OFS='\t' -v digest="$inventory_digest" \
+    '$1 == "artifacts_sha256" {$2=digest} {print}' \
+    "$run_dir/manifest.tsv" >"$run_dir/manifest.tsv.tmp"
+  mv "$run_dir/manifest.tsv.tmp" "$run_dir/manifest.tsv"
+}
+
 PRIOR_RUN="$RESULT_ROOT/20260810T100000Z-1"
 mkdir -p "$PRIOR_RUN"
 awk -F '\t' -v OFS='\t' \
-  '$1 == "policy" {$2=21} {print}' \
+  '$1 == "input_fingerprint" || $1 == "artifacts_sha256" || $1 == "specs" {next}
+   $1 == "policy" {$2=21} {print}' \
   "$RUN_DIR/manifest.tsv" >"$PRIOR_RUN/manifest.tsv"
 
 cat >"$MUTATION_SUMMARY" <<JSON
@@ -256,14 +292,19 @@ grep -F '8/8 passed · passed · 1 repaired failure retained · source' "$OUTPUT
   fail 'workflow-eval summary is missing'
 grep -F 'p95 285s · alert 480s · SLO 600s · healthy' "$OUTPUT/index.html" >/dev/null || \
   fail 'feedback latency summary is missing'
+grep -F 'Routed specification sizes' "$OUTPUT/index.html" >/dev/null || \
+  fail 'routed specification size table is missing'
+grep -F 'Warn above 12,288 bytes. Hard limit: 16,384 bytes.' \
+  "$OUTPUT/index.html" >/dev/null || fail 'routed specification thresholds are missing'
 grep -F "CodeQL actions passed + swift passed · passed · weekly-and-manual · source ${SOURCE_COMMIT:0:10} · " \
   "$OUTPUT/index.html" >/dev/null || fail 'security result is missing'
 grep -F 'href="https://github.com/owner/repository/actions/runs/901">run 901</a>' \
   "$OUTPUT/index.html" >/dev/null || fail 'security run link is missing'
 ! grep -F '<svg' "$OUTPUT/index.html" >/dev/null || fail 'dashboard contains hand-drawn SVG'
 
-python3 - "$OUTPUT/data.json" "$SECURITY_SUMMARY" <<'PY'
+python3 - "$OUTPUT/data.json" "$SECURITY_SUMMARY" "$ROOT" <<'PY'
 import json
+from pathlib import Path
 import sys
 with open(sys.argv[1], encoding="utf-8") as source:
     data = json.load(source)
@@ -279,6 +320,30 @@ assert data["quality"]["coverage_opportunities"]["opportunities"][0]["path"].end
 )
 assert data["quality"]["mutation"]["score_percent"] == 100
 assert data["quality"]["merge"] == "not-yet-emitted"
+specification_sizes = data["quality"]["specification_sizes"]
+assert specification_sizes["warning_bytes"] == 12_288
+assert specification_sizes["limit_bytes"] == 16_384
+size_by_id = {
+    record["id"]: record for record in specification_sizes["specifications"]
+}
+assert set(size_by_id) == {
+    "documentation", "runtime", "state", "power", "app", "app-setup", "release"
+}
+assert size_by_id["documentation"] == {
+    "bytes": 1,
+    "headroom_bytes": 16_383,
+    "id": "documentation",
+    "path": "docs/specs/documentation.md",
+    "status": "healthy",
+}
+assert (Path(sys.argv[3]) / "docs/specs/documentation.md").stat().st_size != 1
+assert size_by_id["runtime"]["bytes"] == 12_288
+assert size_by_id["runtime"]["status"] == "healthy"
+assert size_by_id["state"]["bytes"] == 12_289
+assert size_by_id["state"]["status"] == "warning"
+assert size_by_id["power"]["bytes"] == 16_384
+assert size_by_id["power"]["status"] == "warning"
+assert all(record["status"] != "over-limit" for record in size_by_id.values())
 with open(sys.argv[2], encoding="utf-8") as source:
     security = json.load(source)
 assert data["quality"]["security"] == {
@@ -301,7 +366,13 @@ assert [journey["id"] for journey in data["journeys"]] == [
 ]
 
 sys.path.insert(0, "tools")
-from quality_dashboard import DashboardError, parse_merge_evidence
+from quality_dashboard import (
+    DashboardError, parse_merge_evidence, specification_size_status,
+)
+assert specification_size_status(12_288, 12_288, 16_384) == "healthy"
+assert specification_size_status(12_289, 12_288, 16_384) == "warning"
+assert specification_size_status(16_384, 12_288, 16_384) == "warning"
+assert specification_size_status(16_385, 12_288, 16_384) == "over-limit"
 assert parse_merge_evidence(
     "Merge change\n\nQuality-Policy: %s\nQuality-Repair-Attempt: 1\n" % data["run"]["policy"],
     data["run"]["policy"], 2,
@@ -453,6 +524,122 @@ fi
 grep -F 'manifest is missing: specs' "$TMP_ROOT/missing-specs.out" >/dev/null || \
   fail 'missing affected-spec failure is unclear'
 mv "$TMP_ROOT/current-manifest.tsv" "$RUN_DIR/manifest.tsv"
+
+mv "$RUN_DIR/promotion.tsv" "$TMP_ROOT/current-promotion.tsv"
+cp "$RUN_DIR/spec-sizes.json" "$TMP_ROOT/spec-sizes.original.json"
+cp "$RUN_DIR/artifacts.tsv" "$TMP_ROOT/artifacts.original.tsv"
+cp "$RUN_DIR/manifest.tsv" "$TMP_ROOT/manifest.original.tsv"
+
+restore_spec_size_evidence() {
+  rm -f "$RUN_DIR/spec-sizes.json" "$RUN_DIR/artifacts.tsv" "$RUN_DIR/manifest.tsv"
+  cp "$TMP_ROOT/spec-sizes.original.json" "$RUN_DIR/spec-sizes.json"
+  cp "$TMP_ROOT/artifacts.original.tsv" "$RUN_DIR/artifacts.tsv"
+  cp "$TMP_ROOT/manifest.original.tsv" "$RUN_DIR/manifest.tsv"
+}
+
+rm "$RUN_DIR/spec-sizes.json"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/missing-spec-sizes" >"$TMP_ROOT/missing-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted missing routed specification size evidence'
+fi
+grep -F 'routed specification sizes is missing or unsafe' \
+  "$TMP_ROOT/missing-spec-sizes.out" >/dev/null || \
+  fail 'missing routed specification size failure is unclear'
+restore_spec_size_evidence
+
+rm "$RUN_DIR/spec-sizes.json"
+ln -s "$TMP_ROOT/spec-sizes.original.json" "$RUN_DIR/spec-sizes.json"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/symlink-spec-sizes" >"$TMP_ROOT/symlink-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted symlinked routed specification size evidence'
+fi
+grep -F 'routed specification sizes is missing or unsafe' \
+  "$TMP_ROOT/symlink-spec-sizes.out" >/dev/null || \
+  fail 'symlinked routed specification size failure is unclear'
+restore_spec_size_evidence
+
+printf 'tampered\n' >>"$RUN_DIR/spec-sizes.json"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/tampered-spec-sizes" >"$TMP_ROOT/tampered-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted routed specification sizes with a stale digest'
+fi
+grep -F 'routed specification sizes digest does not match the artifact inventory' \
+  "$TMP_ROOT/tampered-spec-sizes.out" >/dev/null || \
+  fail 'routed specification size digest failure is unclear'
+restore_spec_size_evidence
+
+python3 - "$RUN_DIR/spec-sizes.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path, encoding="utf-8"))
+document["schema"] = 2
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(document, target)
+PY
+refresh_spec_size_bindings "$RUN_DIR"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/schema-spec-sizes" >"$TMP_ROOT/schema-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted an unsupported routed specification size schema'
+fi
+grep -F 'routed specification sizes schema is unsupported' \
+  "$TMP_ROOT/schema-spec-sizes.out" >/dev/null || \
+  fail 'routed specification size schema failure is unclear'
+restore_spec_size_evidence
+
+python3 - "$RUN_DIR/spec-sizes.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path, encoding="utf-8"))
+document["policy"] += 1
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(document, target)
+PY
+refresh_spec_size_bindings "$RUN_DIR"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/policy-spec-sizes" >"$TMP_ROOT/policy-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted routed specification sizes from another policy'
+fi
+grep -F 'routed specification sizes policy does not match the run' \
+  "$TMP_ROOT/policy-spec-sizes.out" >/dev/null || \
+  fail 'routed specification size policy failure is unclear'
+restore_spec_size_evidence
+
+python3 - "$RUN_DIR/spec-sizes.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path, encoding="utf-8"))
+document["source_commit"] = "f" * 40
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(document, target)
+PY
+refresh_spec_size_bindings "$RUN_DIR"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/source-spec-sizes" >"$TMP_ROOT/source-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted routed specification sizes from another source'
+fi
+grep -F 'routed specification sizes source identity does not match the run' \
+  "$TMP_ROOT/source-spec-sizes.out" >/dev/null || \
+  fail 'routed specification size source failure is unclear'
+restore_spec_size_evidence
+
+python3 - "$RUN_DIR/spec-sizes.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+document = json.load(open(path, encoding="utf-8"))
+document["specifications"][0]["path"] = "../escape.md"
+with open(path, "w", encoding="utf-8") as target:
+    json.dump(document, target)
+PY
+refresh_spec_size_bindings "$RUN_DIR"
+if "$ROOT/scripts/quality-dashboard" generate --result-root "$RESULT_ROOT" \
+    --output "$TMP_ROOT/path-spec-sizes" >"$TMP_ROOT/path-spec-sizes.out" 2>&1; then
+  fail 'dashboard accepted an escaping routed specification path'
+fi
+grep -F 'routed specification path is unsafe: ../escape.md' \
+  "$TMP_ROOT/path-spec-sizes.out" >/dev/null || \
+  fail 'routed specification path failure is unclear'
+restore_spec_size_evidence
+mv "$TMP_ROOT/current-promotion.tsv" "$RUN_DIR/promotion.tsv"
 
 PYTHONDONTWRITEBYTECODE=1 python3 - "$ROOT/tools/quality_dashboard.py" "$OUTPUT" <<'PY'
 import importlib.util

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -196,7 +196,8 @@ fi
 prepare_template() {
   local stage
   mkdir -p "$TEMPLATE_REPO/scripts" "$TEMPLATE_REPO/tests/quality-gate-fixtures" \
-    "$TEMPLATE_REPO/app/build" "$TEMPLATE_REPO/quality/generated" "$TEMPLATE_REPO/tools"
+    "$TEMPLATE_REPO/app/build" "$TEMPLATE_REPO/docs/specs" \
+    "$TEMPLATE_REPO/quality/generated" "$TEMPLATE_REPO/tools"
   install -m 0755 "$ROOT/scripts/quality-gate" "$TEMPLATE_REPO/scripts/quality-gate"
   install -m 0755 "$ROOT/scripts/quality-shard" "$TEMPLATE_REPO/scripts/quality-shard"
   install -m 0755 "$ROOT/scripts/quality-policy" "$TEMPLATE_REPO/scripts/quality-policy"
@@ -214,6 +215,7 @@ prepare_template() {
   install -m 0644 "$ROOT/quality/policy.tsv" "$TEMPLATE_REPO/quality/policy.tsv"
   install -m 0644 "$ROOT/quality/generated/policy.json" \
     "$TEMPLATE_REPO/quality/generated/policy.json"
+  install -m 0644 "$ROOT"/docs/specs/*.md "$TEMPLATE_REPO/docs/specs/"
   install -m 0755 "$ROOT/tests/release-budget-ratchet.sh" \
     "$ROOT/tests/shell-safety.sh" "$ROOT/tests/quality-policy.sh" \
     "$ROOT/tests/quality-dashboard.sh" "$TEMPLATE_REPO/tests/"
@@ -1221,6 +1223,7 @@ grep -F $'architecture\t' "$run_dir/environment.tsv" >/dev/null
 grep -F $'xcode\t' "$run_dir/environment.tsv" >/dev/null
 grep -F $'swift\t' "$run_dir/environment.tsv" >/dev/null
 grep -F $'schema\t1' "$run_dir/artifacts.tsv" >/dev/null
+grep -F $'file\tspec-sizes.json\t' "$run_dir/artifacts.tsv" >/dev/null
 grep -F $'scenarios.jsonl\t' "$run_dir/artifacts.tsv" >/dev/null
 grep -F $'scenarios.junit.xml\t' "$run_dir/artifacts.tsv" >/dev/null
 grep -F '"id":"SC-DOCS-CONTRACT"' "$run_dir/scenarios.jsonl" >/dev/null
@@ -1231,6 +1234,60 @@ grep -F -- '- Specifications: `documentation`' "$run_dir/summary.md" >/dev/null
 grep -F '| `static` | passed |' "$run_dir/summary.md" >/dev/null
 grep -F '| `SC-DOCS-CONTRACT` | `static` | passed |' "$run_dir/summary.md" >/dev/null
 grep -F 'markdown=' "$REPO/evidence.out" >/dev/null
+python3 - "$run_dir/spec-sizes.json" "$run_dir/manifest.tsv" <<'PY'
+import json
+import sys
+
+document = json.load(open(sys.argv[1], encoding="utf-8"))
+manifest = dict(
+    line.rstrip("\n").split("\t", 1)
+    for line in open(sys.argv[2], encoding="utf-8")
+)
+assert document["schema"] == 1
+assert document["policy"] == int(manifest["policy"])
+assert document["source_commit"] == manifest["source_commit"]
+assert document["input_fingerprint"] == manifest["input_fingerprint"]
+assert document["warning_bytes"] < document["limit_bytes"]
+assert [record["id"] for record in document["specifications"]] == [
+    "documentation", "runtime", "state", "power", "app", "app-setup", "release",
+]
+for record in document["specifications"]:
+    size = record["bytes"]
+    expected = (
+        "over-limit" if size > document["limit_bytes"]
+        else "warning" if size > document["warning_bytes"]
+        else "healthy"
+    )
+    assert record["status"] == expected
+    assert record["headroom_bytes"] == max(0, document["limit_bytes"] - size)
+PY
+cp "$run_dir/spec-sizes.json" "$TMP_ROOT/first-spec-sizes.json"
+gate >"$REPO/evidence-repeat.out"
+repeat_run="$(find "$RESULT_ROOT" -mindepth 1 -maxdepth 1 -type d \
+  ! -path "$run_dir" -print | head -1)"
+cmp "$TMP_ROOT/first-spec-sizes.json" "$repeat_run/spec-sizes.json" >/dev/null || {
+  printf 'quality gate specification-size evidence is not deterministic\n' >&2
+  exit 1
+}
+
+setup_fixture spec-size-missing
+rm "$REPO/docs/specs/runtime.md"
+if gate --stage static >"$REPO/spec-size-missing.out" 2>&1; then
+  printf 'quality gate accepted a missing routed specification\n' >&2
+  exit 1
+fi
+grep -F 'routed specification is missing or unsafe: docs/specs/runtime.md' \
+  "$REPO/spec-size-missing.out" >/dev/null
+
+setup_fixture spec-size-symlink
+mv "$REPO/docs/specs/runtime.md" "$REPO/docs/specs/runtime-target.md"
+ln -s runtime-target.md "$REPO/docs/specs/runtime.md"
+if gate --stage static >"$REPO/spec-size-symlink.out" 2>&1; then
+  printf 'quality gate accepted a symlinked routed specification\n' >&2
+  exit 1
+fi
+grep -F 'routed specification is missing or unsafe: docs/specs/runtime.md' \
+  "$REPO/spec-size-symlink.out" >/dev/null
 
 setup_fixture result-symlink
 mkdir -p "$REPO/real-results"

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -33,7 +33,7 @@ git -C "$ROOT" check-ignore --no-index -q -- docs/assets/internal.html || \
 python3 "$ROOT/tests/quality_policy_contract.py"
 policy_version="$("$ROOT/scripts/quality-policy" version)"
 [[ "$policy_version" =~ ^[1-9][0-9]*$ ]] || fail 'invalid policy version'
-[ "$("$ROOT/scripts/quality-policy" specs | wc -l | tr -d ' ')" = 5 ] || \
+[ "$("$ROOT/scripts/quality-policy" specs | wc -l | tr -d ' ')" = 7 ] || \
   fail 'current specification inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" stages all | wc -l | tr -d ' ')" = 14 ] || \
   fail 'unexpected stage count'
@@ -48,9 +48,9 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
   fail 'required Swift suite inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" requirements | wc -l | tr -d ' ')" = 23 ] || \
   fail 'critical requirement inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" capabilities | wc -l | tr -d ' ')" = 11 ] || \
+[ "$("$ROOT/scripts/quality-policy" capabilities | wc -l | tr -d ' ')" = 12 ] || \
   fail 'capability inventory is incomplete'
-[ "$("$ROOT/scripts/quality-policy" journeys | wc -l | tr -d ' ')" = 28 ] || \
+[ "$("$ROOT/scripts/quality-policy" journeys | wc -l | tr -d ' ')" = 30 ] || \
   fail 'journey inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" scenarios | wc -l | tr -d ' ')" = 44 ] || \
   fail 'scenario inventory is incomplete'
@@ -72,7 +72,7 @@ grep -F '`QC-QUALITY-POLICY`' \
   fail 'generated specification view omits the policy requirement'
 
 expect_route docs/testing.md policy safe false
-expect_route app/Sources/DetachKit/DetachStateCommand.swift state-runtime safe false
+expect_route app/Sources/DetachKit/DetachStateCommand.swift state-source safe false
 expect_route app/Sources/DetachKit/PowerProtection.swift power both false
 expect_route app/Sources/DetachKit/TerminalLauncher.swift runtime-source safe false
 expect_route app/Sources/DetachApp/OnboardingView.swift onboarding-source install false
@@ -87,9 +87,12 @@ onboarding="$("$ROOT/scripts/quality-policy" classify app/Sources/DetachApp/Onbo
 [[ "$(field "$onboarding" 11)" = *J-ONBOARD-FIRST-RUN* ]] || \
   fail 'onboarding journey impact is missing'
 session="$("$ROOT/scripts/quality-policy" classify app/Sources/DetachKit/SessionStore.swift)"
-[ "$(field "$session" 10)" = session-lifecycle ] || fail 'session capability impact is missing'
+[ "$(field "$session" 10)" = session-lifecycle,session-state ] || \
+  fail 'session capability impact is missing'
 [[ "$(field "$session" 11)" = *J-SESSION-RECOVER* ]] || \
   fail 'session recovery journey impact is missing'
+[[ "$(field "$session" 11)" = *J-SESSION-PERSIST* ]] || \
+  fail 'session persistence journey impact is missing'
 
 unknown="$("$ROOT/scripts/quality-policy" classify product/new-runtime)"
 [ "$(field "$unknown" 1)" = unknown ] || fail 'new product path must fail safe'

--- a/tests/quality_policy_contract.py
+++ b/tests/quality_policy_contract.py
@@ -38,11 +38,123 @@ def main() -> None:
     policy = Policy(POLICY)
     specs = policy.specification_document()
 
-    require(len(specs) == 5, "expected five current specifications")
+    require(len(specs) == 7, "expected seven current specifications")
     require(
         {spec["id"] for spec in specs}
-        == {"documentation", "runtime", "power", "app", "release"},
+        == {
+            "documentation", "runtime", "state", "power", "app",
+            "app-setup", "release",
+        },
         "specification identities changed unexpectedly",
+    )
+    require(
+        policy.limits["routed_spec_warning_bytes"] == 12_288
+        and policy.limits["routed_spec_limit_bytes"] == 16_384,
+        "routed specification size limits changed unexpectedly",
+    )
+    route_cases = (
+        (
+            "app/Sources/DetachKit/DetachStateCommand.swift",
+            "state-source", "safe", "docs/specs/state.md",
+            "app/Sources/DetachKit/DetachState*.swift",
+            "session-state",
+        ),
+        (
+            "app/Sources/DetachKit/Session.swift",
+            "state-source", "safe", "docs/specs/state.md",
+            "app/Sources/DetachKit/Session.swift",
+            "session-state",
+        ),
+        (
+            "app/Sources/DetachKit/SessionEvents.swift",
+            "state-source", "safe", "docs/specs/state.md",
+            "app/Sources/DetachKit/SessionEvents.swift",
+            "session-state",
+        ),
+        (
+            "app/Sources/DetachKit/SessionHealth.swift",
+            "session-health-source", "safe", "docs/specs/app.md",
+            "app/Sources/DetachKit/SessionHealth.swift",
+            "session-lifecycle,session-state,app-experience",
+        ),
+        (
+            "app/Sources/DetachKit/SessionMaintenance.swift",
+            "state-source", "safe", "docs/specs/state.md",
+            "app/Sources/DetachKit/SessionMaintenance.swift",
+            "session-state",
+        ),
+        (
+            "app/Sources/DetachKit/SessionStore.swift",
+            "state-runtime", "safe", "docs/specs/runtime.md",
+            "app/Sources/DetachKit/Session*.swift",
+            "session-lifecycle,session-state",
+        ),
+        (
+            "app/Sources/DetachKit/BoundedProcessRunner.swift",
+            "bounded-process-source", "both", "docs/specs/runtime.md",
+            "app/Sources/DetachKit/BoundedProcessRunner.swift",
+            "session-lifecycle,session-state,power-protection",
+        ),
+        (
+            "app/Sources/DetachApp/DetachApp.swift",
+            "app-shell-source", "install", "docs/specs/app.md",
+            "app/Sources/DetachApp/DetachApp.swift",
+            "app-experience,onboarding,settings,update",
+        ),
+        (
+            "app/Sources/DetachApp/InstallationStore.swift",
+            "installation-store-source", "both", "docs/specs/power.md",
+            "app/Sources/DetachApp/InstallationStore.swift",
+            "power-protection,onboarding,settings,update,diagnostics,installation",
+        ),
+        (
+            "app/Sources/DetachApp/PowerHelperService.swift",
+            "power", "both", "docs/specs/power.md",
+            "app/Sources/DetachApp/PowerHelper*.swift",
+            "power-protection",
+        ),
+        (
+            "app/Sources/DetachApp/OnboardingView.swift",
+            "onboarding-source", "install", "docs/specs/app-setup.md",
+            "app/Sources/DetachApp/Onboarding*.swift",
+            "onboarding",
+        ),
+        (
+            "app/Sources/DetachApp/RootView.swift",
+            "root-view-source", "safe", "docs/specs/app.md",
+            "app/Sources/DetachApp/RootView.swift",
+            "app-experience,onboarding",
+        ),
+        (
+            "app/Sources/DetachKit/DetachCLI.swift",
+            "runtime-source", "safe", "docs/specs/runtime.md",
+            "app/Sources/DetachKit/DetachCLI.swift",
+            "session-lifecycle,session-state",
+        ),
+        (
+            "app/Sources/DetachApp/UIE2ETestDriver.swift",
+            "ui-e2e-source", "safe", "docs/specs/app.md",
+            "app/Sources/DetachApp/UIE2E*.swift",
+            "app-experience,onboarding,settings",
+        ),
+    )
+    for path, test_domain, release_domain, spec, pattern, capabilities in route_cases:
+        classification = policy.classify(path)
+        require(
+            (
+                classification.test_domain,
+                classification.release_domain,
+                classification.spec,
+                classification.pattern,
+                classification.capabilities,
+            ) == (test_domain, release_domain, spec, pattern, capabilities),
+            f"source route changed unexpectedly: {path}",
+        )
+    health_impact = policy.impact(["app/Sources/DetachKit/SessionHealth.swift"])
+    require(
+        {"swift", "app", "codex", "claude", "distribution", "tmux-runtime"}
+        <= set(health_impact.stages),
+        "session health changes omit runtime ownership evidence",
     )
     require(
         all("status" not in spec for spec in specs),
@@ -62,6 +174,16 @@ def main() -> None:
         set(requirements) == set(policy.requirements),
         "the specification view omits a requirement",
     )
+    require(
+        requirements["QC-RUNTIME-STATE"]["journeys"]
+        == ["J-SESSION-PERSIST", "J-STATE-CLEANUP"],
+        "typed state evidence does not cover persistence and safe cleanup",
+    )
+    require(
+        requirements["QC-RUNTIME-STORAGE"]["journeys"]
+        == ["J-STATE-RECOVER"],
+        "validated restore evidence is not owned by the state recovery journey",
+    )
     for identifier, requirement in requirements.items():
         require(requirement["journeys"], f"{identifier} has no user journey")
         automated = [
@@ -71,6 +193,14 @@ def main() -> None:
         ]
         require(automated, f"{identifier} has no automated scenario")
 
+    expect_error(
+        source.replace(
+            "limit\trouted_spec_warning_bytes\t12288",
+            "limit\trouted_spec_warning_bytes\t16384",
+            1,
+        ),
+        "routed spec warning must be below the hard limit",
+    )
     expect_error(
         source.replace(
             "spec\tdocumentation\tdocs/specs/documentation.md\t",
@@ -100,7 +230,7 @@ def main() -> None:
     )
     expect_error(
         source.replace(
-            "requirement\tQC-APP-SETTINGS\tdocs/specs/app.md\t",
+            "requirement\tQC-APP-SETTINGS\tdocs/specs/app-setup.md\t",
             "requirement\tQC-APP-SETTINGS\tdocs/specs/runtime.md\t",
             1,
         ),

--- a/tests/quality_promote_contract.py
+++ b/tests/quality_promote_contract.py
@@ -99,7 +99,36 @@ def opportunities_document() -> dict[str, object]:
     }
 
 
-def create_evidence(root: Path, paths: list[str] | None = None) -> Path:
+def spec_sizes_document() -> dict[str, object]:
+    warning = POLICY.limits["routed_spec_warning_bytes"]
+    limit = POLICY.limits["routed_spec_limit_bytes"]
+    return {
+        "input_fingerprint": "1" * 64,
+        "limit_bytes": limit,
+        "policy": POLICY.version,
+        "schema": 1,
+        "source_commit": TESTED,
+        "specifications": [
+            {
+                "bytes": 1,
+                "headroom_bytes": limit - 1,
+                "id": identifier,
+                "path": path,
+                "status": "healthy",
+            }
+            for identifier, (path, _) in POLICY.specs.items()
+        ],
+        "status": "healthy",
+        "warning_bytes": warning,
+    }
+
+
+def create_evidence(
+    root: Path,
+    paths: list[str] | None = None,
+    *,
+    include_spec_sizes: bool = True,
+) -> Path:
     paths = paths or ["tools/quality_gate.py"]
     impact = POLICY.impact(paths)
     run_dir = root / "20260812T120000Z-1"
@@ -128,12 +157,17 @@ def create_evidence(root: Path, paths: list[str] | None = None) -> Path:
     (run_dir / "scenarios.junit.xml").write_text(
         '<testsuite name="quality" tests="0"/>\n', encoding="utf-8"
     )
+    if include_spec_sizes:
+        write_json(run_dir / "spec-sizes.json", spec_sizes_document())
+    required_names = ["scenarios.jsonl", "scenarios.junit.xml"]
+    if include_spec_sizes:
+        required_names.append("spec-sizes.json")
     artifacts = run_dir / "artifacts.tsv"
     artifacts.write_text(
         "schema\t1\n"
         + "".join(
             f"file\t{name}\t{digest(run_dir / name)}\n"
-            for name in (*metric_names, "scenarios.jsonl", "scenarios.junit.xml")
+            for name in (*metric_names, *required_names)
         ),
         encoding="utf-8",
     )
@@ -345,6 +379,52 @@ def main() -> None:
             docs_run, read_tsv(docs_run / "manifest.tsv", "docs manifest")
         ) is None:
             raise AssertionError("documentation impact was not promoted")
+
+        missing_spec_sizes = create_evidence(
+            root / "missing-spec-sizes-source", include_spec_sizes=False
+        )
+        missing_output = root / "missing-spec-sizes"
+        missing = invoke(
+            fake_gh,
+            fake_git,
+            missing_spec_sizes,
+            missing_output,
+            expected=2,
+        )
+        require(missing, "required evidence artifact is missing: spec-sizes.json")
+
+        for field, value, diagnostic in (
+            ("source_commit", "f" * 40, "source identity does not match"),
+            ("input_fingerprint", "f" * 64, "source identity does not match"),
+            ("limit_bytes", 16385, "limits do not match"),
+            ("specifications", [], "identities do not match"),
+            ("status", "over-limit", "size status is invalid"),
+        ):
+            invalid = create_evidence(root / f"invalid-spec-{field}")
+            document = spec_sizes_document()
+            document[field] = value
+            write_json(invalid / "spec-sizes.json", document)
+            inventory = invalid / "artifacts.tsv"
+            inventory.write_text(
+                "\n".join(
+                    f"file\tspec-sizes.json\t{digest(invalid / 'spec-sizes.json')}"
+                    if line.startswith("file\tspec-sizes.json\t") else line
+                    for line in inventory.read_text(encoding="utf-8").splitlines()
+                ) + "\n", encoding="utf-8",
+            )
+            invalid_manifest = invalid / "manifest.tsv"
+            invalid_manifest.write_text(
+                "\n".join(
+                    f"artifacts_sha256\t{digest(inventory)}"
+                    if line.startswith("artifacts_sha256\t") else line
+                    for line in invalid_manifest.read_text(encoding="utf-8").splitlines()
+                ) + "\n", encoding="utf-8",
+            )
+            rejected = invoke(
+                fake_gh, fake_git, invalid, root / f"rejected-spec-{field}",
+                expected=2,
+            )
+            require(rejected, diagnostic)
 
         eventual = root / "eventual-pr"
         invoke(fake_gh, fake_git, evidence, eventual, mode="eventual-pr")

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -47,7 +47,8 @@ setup_fixture() {
     return
   fi
   mkdir -p "$REPO/scripts" "$REPO/tests/quality-gate-fixtures" "$REPO/app/scripts" \
-    "$REPO/app/.build/artifacts/sparkle/Sparkle/bin" "$REPO/quality" "$REPO/tools" \
+    "$REPO/app/.build/artifacts/sparkle/Sparkle/bin" "$REPO/docs/specs" \
+    "$REPO/quality" "$REPO/tools" \
     "$BIN" "$APPS" "$FIXTURE/hooks" \
     "$REMOTE_ASSETS"
 
@@ -63,6 +64,7 @@ setup_fixture() {
   install -m 0644 "$ROOT/tools/quality_policy.py" "$REPO/tools/quality_policy.py"
   install -m 0644 "$ROOT/tools/release_sbom.py" "$REPO/tools/release_sbom.py"
   install -m 0644 "$ROOT/app/Package.resolved" "$REPO/app/Package.resolved"
+  install -m 0644 "$ROOT"/docs/specs/*.md "$REPO/docs/specs/"
   install -m 0644 "$ROOT/quality/policy.tsv" "$REPO/quality/policy.tsv"
   install -m 0755 "$ROOT/app/scripts/verify-appcast.sh" \
     "$REPO/app/scripts/verify-appcast.sh"

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -1093,6 +1093,19 @@ grep -Fx -- "$TMP_ROOT/extra-b" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 [ -s "$CLAUDE_CONFIG_DIR/teams/session-${session_id:0:8}/config.json" ]
 claude_scenario_event pass SC-SESSION-RECOVER-CLAUDE
 
+# The byte-preservation check below needs an up-to-date A generation. Resume
+# may legitimately materialize newer A data before it starts replacement B.
+# Do not depend on the background or bounded Stop checkpoint finishing first.
+preserved_run_token="$("$STATE_HELPER" meta get "$meta" run_token)"
+preserved_pane="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$session:" @detach_pane_id)"
+preserved_worker_pid="$(tmux -L "$SOCKET" display-message -p \
+  -t "$preserved_pane" '#{pane_pid}')"
+[ "$("$STATE_HELPER" meta get "$meta" worker_pid)" = "$preserved_worker_pid" ]
+[ "$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$session:" @detach_run_token)" = "$preserved_run_token" ]
+"$SCRIPT" claude __checkpoint_once \
+  "$session" "$preserved_run_token" "$preserved_worker_pid"
 "$SCRIPT" claude stop "$human_label"
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
 

--- a/tools/quality_dashboard.py
+++ b/tools/quality_dashboard.py
@@ -29,7 +29,10 @@ from quality_metrics import (
     validate_opportunities,
 )
 from quality_mutation import MutationError, validate_summary
-from quality_promote import PromotionError, validate_promotion
+from quality_promote import (
+    PromotionError, specification_size_status, validate_promotion,
+    validate_specification_sizes,
+)
 from quality_security import SecurityError, validate_summary as validate_security_summary
 
 
@@ -53,6 +56,7 @@ FAILURE_STATUSES = {"failed", "environment-failed", "timeout", "interrupted"}
 PASS_STATUSES = {"passed", "reused"}
 MERGE_POLICY = re.compile(r"^Quality-Policy: ([1-9][0-9]*)$", re.MULTILINE)
 MERGE_REPAIR = re.compile(r"^Quality-Repair-Attempt: ([0-9]+)$", re.MULTILINE)
+DIGEST = re.compile(r"^[0-9a-f]{64}$")
 
 
 class DashboardError(Exception):
@@ -97,6 +101,8 @@ def read_manifest(
         "summary_sha256",
         "result",
     }
+    if require_dashboard_fields:
+        required.update(("input_fingerprint", "artifacts_sha256", "specs"))
     missing = required - values.keys()
     if missing:
         raise DashboardError(f"manifest is missing: {sorted(missing)[0]}")
@@ -104,8 +110,13 @@ def read_manifest(
         raise DashboardError("manifest schema is unsupported")
     if not values["policy"].isdigit():
         raise DashboardError("manifest policy is invalid")
-    if require_dashboard_fields and not values.get("specs"):
-        raise DashboardError("manifest is missing: specs")
+    if require_dashboard_fields:
+        if not DIGEST.fullmatch(values["input_fingerprint"]):
+            raise DashboardError("manifest input fingerprint is invalid")
+        if not DIGEST.fullmatch(values["artifacts_sha256"]):
+            raise DashboardError("manifest artifact inventory digest is invalid")
+        if not values["specs"]:
+            raise DashboardError("manifest is missing: specs")
     if values["authority"] not in ("local-diagnostic", "ci-merge", "ci-main", "release"):
         raise DashboardError("manifest authority is invalid")
     if values["result"] not in ("passed", "failed", "interrupted", "diagnostic"):
@@ -116,6 +127,56 @@ def read_manifest(
     if not values["finished_at"]:
         raise DashboardError("manifest describes an unfinished run")
     return values
+
+
+def read_artifact_inventory(
+    run_dir: Path, manifest: dict[str, str]
+) -> dict[str, str]:
+    inventory = safe_file(run_dir / "artifacts.tsv", "artifact inventory")
+    if hashlib.sha256(inventory.read_bytes()).hexdigest() != manifest["artifacts_sha256"]:
+        raise DashboardError("artifact inventory digest does not match the manifest")
+    lines = inventory.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0] != "schema\t1":
+        raise DashboardError("artifact inventory schema is invalid")
+    records: dict[str, str] = {}
+    for line_number, line in enumerate(lines[1:], 2):
+        fields = line.split("\t")
+        if len(fields) != 3 or fields[0] != "file" or fields[1] in records:
+            raise DashboardError(
+                f"artifact inventory line {line_number} is malformed or duplicate"
+            )
+        relative, digest = fields[1], fields[2]
+        relative_path = Path(relative)
+        if (
+            not relative
+            or relative_path.is_absolute()
+            or relative_path.parts in ((), (".",))
+            or ".." in relative_path.parts
+            or "\n" in relative
+            or "\t" in relative
+            or not DIGEST.fullmatch(digest)
+        ):
+            raise DashboardError(
+                f"artifact inventory line {line_number} is unsafe or invalid"
+            )
+        records[relative] = digest
+    return records
+
+
+def read_bound_artifact(
+    run_dir: Path,
+    manifest: dict[str, str],
+    relative: str,
+    label: str,
+) -> Path:
+    records = read_artifact_inventory(run_dir, manifest)
+    expected_digest = records.get(relative)
+    if expected_digest is None:
+        raise DashboardError(f"{label} digest is missing from the artifact inventory")
+    artifact = safe_file(run_dir / relative, label)
+    if hashlib.sha256(artifact.read_bytes()).hexdigest() != expected_digest:
+        raise DashboardError(f"{label} digest does not match the artifact inventory")
+    return artifact
 
 
 def read_summary(run_dir: Path, manifest: dict[str, str]) -> list[dict[str, Any]]:
@@ -149,26 +210,9 @@ def read_metrics(run_dir: Path, manifest: dict[str, str]) -> Optional[dict[str, 
     metrics_path = run_dir / "quality-metrics.json"
     if not metrics_path.exists():
         return None
-    artifacts_path = safe_file(run_dir / "artifacts.tsv", "artifact inventory")
-    artifacts_digest = hashlib.sha256(artifacts_path.read_bytes()).hexdigest()
-    if artifacts_digest != manifest["artifacts_sha256"]:
-        raise DashboardError("artifact inventory digest does not match the manifest")
-    metric_digests: list[str] = []
-    for line_number, line in enumerate(
-        artifacts_path.read_text(encoding="utf-8").splitlines(), 1
-    ):
-        fields = line.split("\t")
-        if fields == ["schema", "1"]:
-            continue
-        if len(fields) != 3 or fields[0] != "file":
-            raise DashboardError(f"artifact inventory line {line_number} is malformed")
-        if fields[1] == "quality-metrics.json":
-            metric_digests.append(fields[2])
-    if len(metric_digests) != 1:
-        raise DashboardError("quality metrics digest is missing or duplicated")
-    actual_digest = hashlib.sha256(safe_file(metrics_path, "quality metrics").read_bytes()).hexdigest()
-    if actual_digest != metric_digests[0]:
-        raise DashboardError("quality metrics digest does not match the inventory")
+    metrics_path = read_bound_artifact(
+        run_dir, manifest, "quality-metrics.json", "quality metrics"
+    )
     try:
         metrics = validate_metrics(json.loads(metrics_path.read_text(encoding="utf-8")))
     except (MetricsError, json.JSONDecodeError, UnicodeError) as error:
@@ -185,27 +229,9 @@ def read_coverage_opportunities(
 ) -> Optional[dict[str, Any]]:
     if metrics is None:
         return None
-    opportunities_path = safe_file(
-        run_dir / "coverage-opportunities.json", "coverage opportunities"
+    opportunities_path = read_bound_artifact(
+        run_dir, manifest, "coverage-opportunities.json", "coverage opportunities"
     )
-    artifacts_path = safe_file(run_dir / "artifacts.tsv", "artifact inventory")
-    if hashlib.sha256(artifacts_path.read_bytes()).hexdigest() != manifest["artifacts_sha256"]:
-        raise DashboardError("artifact inventory digest does not match the manifest")
-    expected_digests: list[str] = []
-    for line_number, line in enumerate(
-        artifacts_path.read_text(encoding="utf-8").splitlines(), 1
-    ):
-        fields = line.split("\t")
-        if fields == ["schema", "1"]:
-            continue
-        if len(fields) != 3 or fields[0] != "file":
-            raise DashboardError(f"artifact inventory line {line_number} is malformed")
-        if fields[1] == "coverage-opportunities.json":
-            expected_digests.append(fields[2])
-    if len(expected_digests) != 1:
-        raise DashboardError("coverage opportunities digest is missing or duplicated")
-    if hashlib.sha256(opportunities_path.read_bytes()).hexdigest() != expected_digests[0]:
-        raise DashboardError("coverage opportunities digest does not match the inventory")
     try:
         opportunities = validate_opportunities(
             json.loads(opportunities_path.read_text(encoding="utf-8"))
@@ -230,6 +256,19 @@ def read_policy() -> dict[str, Any]:
     if policy.get("schema") != 1 or not isinstance(policy.get("policy"), int):
         raise DashboardError("generated policy schema is invalid")
     return policy
+
+
+def read_specification_sizes(
+    run_dir: Path, manifest: dict[str, str], policy: dict[str, Any]
+) -> dict[str, Any]:
+    artifact = read_bound_artifact(
+        run_dir, manifest, "spec-sizes.json", "routed specification sizes"
+    )
+    try:
+        document = json.loads(artifact.read_text(encoding="utf-8"))
+        return validate_specification_sizes(document, manifest, policy)
+    except (json.JSONDecodeError, UnicodeError, PromotionError) as error:
+        raise DashboardError(str(error)) from error
 
 
 def read_mutation_summary(
@@ -307,7 +346,7 @@ def collect_trends(result_root: Path, current: Path) -> list[dict[str, Any]]:
         if not candidate.is_dir() or candidate.is_symlink():
             continue
         try:
-            manifest = read_manifest(candidate)
+            manifest = read_manifest(candidate, require_dashboard_fields=False)
             commit, authority, _ = effective_identity(candidate, manifest)
         except DashboardError:
             continue
@@ -501,6 +540,7 @@ def build_data(
     security = read_security_summary(
         security_summary, int(manifest["policy"])
     )
+    specification_sizes = read_specification_sizes(run_dir, manifest, policy)
     return {
         "schema": 4,
         "run": {
@@ -550,16 +590,18 @@ def build_data(
                 int(policy["limits"]["max_repair_loops"]),
             ),
             "security": security_automation(security),
+            "specification_sizes": specification_sizes,
         },
         "trends": trends,
     }
 
 
 def status_class(status: str) -> str:
-    if status in ("passed", "reused"):
+    if status in ("passed", "reused", "healthy"):
         return "good"
     if status in (
-        "planned", "not-selected", "incomplete", "manual-release", "blocked", "diagnostic"
+        "planned", "not-selected", "incomplete", "manual-release", "blocked", "diagnostic",
+        "warning",
     ):
         return "warn"
     return "bad"
@@ -706,6 +748,20 @@ def render_html(data: dict[str, Any]) -> str:
             f'CodeQL {" + ".join(security["codeql_languages"])} · '
             f'{security["status"]} · {security["cadence"]} · outside PR feedback'
         )
+    specification_sizes = quality["specification_sizes"]
+    specification_rows = "\n".join(
+        f'<tr><td><code>{html.escape(record["id"])}</code></td>'
+        f'<td><code>{html.escape(record["path"])}</code></td>'
+        f'<td class="number">{record["bytes"]:,}</td>'
+        f'<td class="number">{record["headroom_bytes"]:,}</td>'
+        f'<td><span class="status {status_class(record["status"])}">'
+        f'{html.escape(record["status"])}</span></td></tr>'
+        for record in specification_sizes["specifications"]
+    )
+    specification_note = (
+        f'Warn above {specification_sizes["warning_bytes"]:,} bytes. '
+        f'Hard limit: {specification_sizes["limit_bytes"]:,} bytes.'
+    )
     return f'''<!doctype html>
 <html lang="en">
 <head>
@@ -780,6 +836,7 @@ def render_html(data: dict[str, Any]) -> str:
       <div class="gap"><span class="eyebrow">Bounded merge</span><p>{html.escape(merge_text)}</p></div>
       <div class="gap"><span class="eyebrow">Security</span><p>{security_html}</p></div>
     </div></section>
+    <section><h2>Routed specification sizes</h2><p class="section-note">{html.escape(specification_note)}</p><div class="table-wrap"><table><thead><tr><th>Specification</th><th>Path</th><th class="number">Bytes</th><th class="number">Headroom</th><th>Status</th></tr></thead><tbody>{specification_rows}</tbody></table></div></section>
     {opportunity_section}
     <section><h2>Recent runs</h2><div class="table-wrap"><table><thead><tr><th>Commit</th><th>Authority</th><th>Result</th><th class="number">Wall</th><th>Finished</th></tr></thead><tbody>{trend_rows}</tbody></table></div></section>
   </main>

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -752,6 +753,7 @@ class QualityGate:
         write_private(self.summary, RESULT_HEADER)
         write_private(self.environment, self.environment_document())
         write_private(self.artifacts, "schema\t1\n")
+        self.write_specification_sizes()
         (self.run_dir / "scenario-events").mkdir(mode=0o700)
         (self.run_dir / "stage-scenarios").mkdir(mode=0o700)
         self.write_static_files()
@@ -815,12 +817,93 @@ class QualityGate:
         raw = b"".join(os.fsencode(path) + b"\0" for path in self.static_paths())
         write_private_bytes(self.run_dir / "static-files.z", raw)
 
+    def write_specification_sizes(self) -> None:
+        warning = self.policy.limits["routed_spec_warning_bytes"]
+        limit = self.policy.limits["routed_spec_limit_bytes"]
+        specification_root = ROOT / "docs/specs"
+        try:
+            root_mode = specification_root.lstat().st_mode
+        except OSError as error:
+            raise GateError(
+                f"routed specification root is missing or unsafe: {error}"
+            ) from error
+        if not stat.S_ISDIR(root_mode):
+            raise GateError("routed specification root is missing or unsafe")
+        resolved_root = specification_root.resolve()
+        if resolved_root != ROOT / "docs/specs":
+            raise GateError("routed specification root is missing or unsafe")
+        records: list[dict[str, object]] = []
+        for identifier, (raw_path, _) in self.policy.specs.items():
+            relative = Path(raw_path)
+            path = ROOT / relative
+            try:
+                if (
+                    relative.is_absolute()
+                    or relative.parts != ("docs", "specs", f"{identifier}.md")
+                    or path.parent.resolve() != resolved_root
+                ):
+                    raise GateError(
+                        f"routed specification path is unsafe: {raw_path}"
+                    )
+                try:
+                    file_status = path.lstat()
+                except FileNotFoundError as error:
+                    raise GateError(
+                        f"routed specification is missing or unsafe: {raw_path}"
+                    ) from error
+                if not stat.S_ISREG(file_status.st_mode):
+                    raise GateError(
+                        f"routed specification is missing or unsafe: {raw_path}"
+                    )
+                size = file_status.st_size
+            except OSError as error:
+                raise GateError(
+                    f"cannot measure routed specification {identifier}: {error}"
+                ) from error
+            status = (
+                "over-limit" if size > limit
+                else "warning" if size > warning
+                else "healthy"
+            )
+            records.append(
+                {
+                    "bytes": size,
+                    "headroom_bytes": max(0, limit - size),
+                    "id": identifier,
+                    "path": raw_path,
+                    "status": status,
+                }
+            )
+        statuses = {record["status"] for record in records}
+        overall = (
+            "over-limit" if "over-limit" in statuses
+            else "warning" if "warning" in statuses
+            else "healthy"
+        )
+        document = {
+            "input_fingerprint": self.input_fingerprint,
+            "limit_bytes": limit,
+            "policy": self.policy_version,
+            "schema": 1,
+            "source_commit": self.source_commit,
+            "specifications": records,
+            "status": overall,
+            "warning_bytes": warning,
+        }
+        write_private(
+            self.run_dir / "spec-sizes.json",
+            json.dumps(
+                document, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+            ) + "\n",
+        )
+
     def artifact_inventory(self) -> None:
         files: list[Path] = []
         for name in (
             "quality-metrics.json",
             "quality-metrics-swift.json",
             "coverage-opportunities.json",
+            "spec-sizes.json",
             "shards.tsv",
         ):
             evidence = self.run_dir / name
@@ -1074,6 +1157,7 @@ class QualityGate:
                 relative == "quality-metrics.json"
                 or relative == "quality-metrics-swift.json"
                 or relative == "coverage-opportunities.json"
+                or relative == "spec-sizes.json"
                 or relative == "scenarios.jsonl"
                 or relative == "scenarios.junit.xml"
                 or relative == "repair-bundle.json"

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -396,6 +396,14 @@ class Policy:
         if not self.specs:
             raise PolicyError("at least one current specification is required")
         registered_specs = {path for path, _ in self.specs.values()}
+        for required_limit in (
+            "routed_spec_warning_bytes",
+            "routed_spec_limit_bytes",
+        ):
+            if required_limit not in self.limits:
+                raise PolicyError(f"quality policy limit is missing: {required_limit}")
+        if self.limits["routed_spec_warning_bytes"] >= self.limits["routed_spec_limit_bytes"]:
+            raise PolicyError("routed spec warning must be below the hard limit")
         if "static" not in self.stages_by_name:
             raise PolicyError("static stage is required")
         if "unknown" not in self.test_domains or "unknown" not in self.release_domains:

--- a/tools/quality_promote.py
+++ b/tools/quality_promote.py
@@ -254,7 +254,11 @@ def artifact_inventory(
         if sha256(artifact) != fields[2]:
             raise PromotionError(f"evidence artifact digest does not match: {fields[1]}")
         values[fields[1]] = fields[2]
-    required_artifacts = ["scenarios.jsonl", "scenarios.junit.xml"]
+    required_artifacts = [
+        "scenarios.jsonl",
+        "scenarios.junit.xml",
+        "spec-sizes.json",
+    ]
     if require_metrics:
         required_artifacts.extend(
             ("coverage-opportunities.json", "quality-metrics.json")
@@ -336,6 +340,134 @@ def changed_paths(executable: str, base_commit: str, head_commit: str) -> list[s
     return paths
 
 
+def specification_size_status(size: int, warning: int, limit: int) -> str:
+    if size > limit:
+        return "over-limit"
+    if size > warning:
+        return "warning"
+    return "healthy"
+
+
+def validate_specification_sizes(
+    document: Any, manifest: dict[str, str], policy: dict[str, Any]
+) -> dict[str, Any]:
+    if (
+        not isinstance(document, dict)
+        or type(document.get("schema")) is not int
+        or document.get("schema") != 1
+    ):
+        raise PromotionError("routed specification sizes schema is unsupported")
+    expected_keys = {
+        "input_fingerprint",
+        "limit_bytes",
+        "policy",
+        "schema",
+        "source_commit",
+        "specifications",
+        "status",
+        "warning_bytes",
+    }
+    if set(document) != expected_keys:
+        raise PromotionError("routed specification sizes schema is invalid")
+    if (
+        type(document["policy"]) is not int
+        or document["policy"] != int(manifest["policy"])
+    ):
+        raise PromotionError("routed specification sizes policy does not match the run")
+    if (
+        document["source_commit"] != manifest["source_commit"]
+        or document["input_fingerprint"] != manifest["input_fingerprint"]
+    ):
+        raise PromotionError(
+            "routed specification sizes source identity does not match the run"
+        )
+    limits = policy.get("limits")
+    if not isinstance(limits, dict):
+        raise PromotionError("generated policy limits are invalid")
+    warning = limits.get("routed_spec_warning_bytes")
+    limit = limits.get("routed_spec_limit_bytes")
+    if (
+        not isinstance(warning, int)
+        or isinstance(warning, bool)
+        or not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or warning < 1
+        or warning >= limit
+    ):
+        raise PromotionError("routed specification size limits are invalid")
+    if (
+        type(document["warning_bytes"]) is not int
+        or type(document["limit_bytes"]) is not int
+        or document["warning_bytes"] != warning
+        or document["limit_bytes"] != limit
+    ):
+        raise PromotionError(
+            "routed specification size limits do not match the policy"
+        )
+    policy_specifications = policy.get("specifications")
+    if not isinstance(policy_specifications, list) or not policy_specifications:
+        raise PromotionError("generated policy specifications are invalid")
+    expected_identities: list[tuple[str, str]] = []
+    for specification in policy_specifications:
+        if not isinstance(specification, dict):
+            raise PromotionError("generated policy specification is invalid")
+        identifier = specification.get("id")
+        raw_path = specification.get("path")
+        if not isinstance(identifier, str) or not isinstance(raw_path, str):
+            raise PromotionError("generated policy specification identity is invalid")
+        relative = Path(raw_path)
+        if relative.parts != ("docs", "specs", f"{identifier}.md"):
+            raise PromotionError(
+                f"generated policy specification path is unsafe: {raw_path}"
+            )
+        expected_identities.append((identifier, raw_path))
+    records = document["specifications"]
+    if not isinstance(records, list) or len(records) != len(expected_identities):
+        raise PromotionError("routed specification identities do not match the policy")
+    actual_identities: list[tuple[str, str]] = []
+    record_keys = {"bytes", "headroom_bytes", "id", "path", "status"}
+    for record in records:
+        if not isinstance(record, dict) or set(record) != record_keys:
+            raise PromotionError("routed specification size record is invalid")
+        identifier = record["id"]
+        raw_path = record["path"]
+        if not isinstance(identifier, str) or not isinstance(raw_path, str):
+            raise PromotionError("routed specification identity is invalid")
+        relative = Path(raw_path)
+        if relative.parts != ("docs", "specs", f"{identifier}.md"):
+            raise PromotionError(
+                f"routed specification path is unsafe: {raw_path}"
+            )
+        actual_identities.append((identifier, raw_path))
+        size = record["bytes"]
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise PromotionError(
+                f"routed specification size is invalid: {identifier}"
+            )
+        status = specification_size_status(size, warning, limit)
+        headroom = record["headroom_bytes"]
+        if (
+            type(headroom) is not int
+            or headroom != max(0, limit - size)
+            or not isinstance(record["status"], str)
+            or record["status"] != status
+        ):
+            raise PromotionError(
+                f"routed specification size derivation is invalid: {identifier}"
+            )
+    if actual_identities != expected_identities:
+        raise PromotionError("routed specification identities do not match the policy")
+    statuses = {record["status"] for record in records}
+    overall = (
+        "over-limit" if "over-limit" in statuses
+        else "warning" if "warning" in statuses
+        else "healthy"
+    )
+    if document["status"] != overall:
+        raise PromotionError("routed specification size status is invalid")
+    return document
+
+
 def validate_evidence(
     run_dir: Path,
     policy: Policy,
@@ -376,6 +508,18 @@ def validate_evidence(
     validate_summary(run_dir, manifest, policy, expected_stages)
     require_metrics = "quality-contracts" in expected_stages
     artifact_inventory(run_dir, manifest, require_metrics=require_metrics)
+    if not DIGEST.fullmatch(manifest.get("input_fingerprint", "")):
+        raise PromotionError("quality manifest input fingerprint is invalid")
+    try:
+        specification_sizes = json.loads(
+            (run_dir / "spec-sizes.json").read_text(encoding="utf-8")
+        )
+    except (json.JSONDecodeError, UnicodeError) as error:
+        raise PromotionError("routed specification sizes JSON is invalid") from error
+    validate_specification_sizes(
+        specification_sizes, manifest,
+        {"limits": policy.limits, "specifications": policy.specification_document()},
+    )
     if not require_metrics:
         return manifest, sha256(manifest_path)
     from quality_metrics import read_json, validate_metrics, validate_opportunities


### PR DESCRIPTION
Contract additions no longer depend on spare space in two overloaded specifications. Typed state moves to `state.md`, setup and update behavior moves to `app-setup.md`, and helper transactions move to the power contract. The context map and policy traceability select the new owners.

The existing 16 KiB hard limit stays in force. Static checks and the dashboard warn above 12 KiB. Each gate records specification sizes in `spec-sizes.json`, bound to the run identity and artifact digest. Dashboard and promotion validate the same schema, identities, thresholds, and derived values; retained history does not require presentation-only fields.

Source routing preserves runtime coverage for shared session-health logic. Tests cover threshold boundaries, checkout drift, invalid or tampered evidence, history compatibility, and promotion. The Claude recovery fixture explicitly checkpoints A before testing byte preservation while replacement B is unready, removing its dependency on background checkpoint timing.

Validation: focused contracts and workflow evals (9/9) pass. The full local gate passed all 13 functional stages, including packaged UI, both providers, installation, and artifact contracts. Its release timing postflight failed: wall 269/240 s, Codex 179/110 s, Claude 145/60 s. The remaining performance gap is unresolved; no timing limit was raised and no unchanged timing retry was used. Hosted `quality-gates` is required before merge. No release or hardware power checks were run.

Closes #137.
