### PR TITLE
Accept reordered exact impact identities during promotion

### DIFF
--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -135,6 +135,8 @@ Hosted CI is the merge-readiness authority.
   attention issue.
 - `main` promotes a successful pull-request artifact only when its stages equal
   a fresh impact plan and both merges have the same tree and ordered parents.
+  Spec, capability, and journey identities must match without duplicates;
+  their record order can differ. Promotion does not rewrite the manifest.
   Promotion keeps identities and digests. Ambiguity runs a full `ci-main` gate.
 - The active GitHub ruleset for `main` has no bypass actors. It requires a pull
   request, a current strict GitHub Actions `quality-gates` job, merge commits,

--- a/tests/quality_promote_contract.py
+++ b/tests/quality_promote_contract.py
@@ -16,7 +16,9 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "tools"))
 
 from quality_policy import POLICY_FILE, Policy  # noqa: E402
-from quality_promote import PromotionError, read_tsv, validate_promotion  # noqa: E402
+from quality_promote import (  # noqa: E402
+    PromotionError, read_tsv, validate_evidence, validate_promotion,
+)
 
 
 POLICY = Policy(POLICY_FILE)
@@ -350,6 +352,36 @@ def main() -> None:
         root = Path(raw)
         evidence = create_evidence(root / "source")
         fake_gh, fake_git = fake_tools(root)
+
+        mixed_paths = [
+            "tools/quality_gate.py", "tests/run-claude.sh", "tests/release-workflow.sh",
+        ]
+        mixed = create_evidence(root / "mixed-impact", mixed_paths)
+        mixed_manifest_path = mixed / "manifest.tsv"
+        mixed_manifest = read_tsv(mixed_manifest_path, "mixed manifest")
+        expected_mixed = POLICY.impact(mixed_paths).document()
+        for field in ("specs", "capabilities", "journeys"):
+            members = mixed_manifest[field].split(",")
+            assert len(members) > 1
+            for variant, values, accepted in (
+                ("reordered", list(reversed(members)), True),
+                ("duplicate", members + [members[0]], False),
+                ("missing", members[1:], False),
+                ("extra", members + ["unknown-identity"], False),
+            ):
+                candidate = dict(mixed_manifest, **{field: ",".join(values)})
+                mixed_manifest_path.write_text(
+                    "".join(f"{key}\t{value}\n" for key, value in candidate.items()),
+                    encoding="utf-8",
+                )
+                try:
+                    validate_evidence(mixed, POLICY, BASE, expected_mixed)
+                except PromotionError as error:
+                    if accepted or f"quality manifest {field} is not exact" not in str(error):
+                        raise AssertionError(f"unexpected {field}/{variant} failure: {error}") from error
+                else:
+                    if not accepted:
+                        raise AssertionError(f"accepted {field}/{variant} impact")
 
         first = root / "first"
         result = invoke(fake_gh, fake_git, evidence, first)

--- a/tools/quality_promote.py
+++ b/tools/quality_promote.py
@@ -488,12 +488,15 @@ def validate_evidence(
             for stage in expected_impact["stages"]
             if stage != "release-budget"
         ),
-        "specs": ",".join(expected_impact["specs"]),
-        "capabilities": ",".join(expected_impact["capabilities"]),
-        "journeys": ",".join(expected_impact["journeys"]),
     }
     for key, value in expected.items():
         if manifest.get(key) != value:
+            raise PromotionError(f"quality manifest {key} is not exact")
+    # Gate traversal and policy registration can emit the same identities in
+    # different orders. Preserve the bound manifest and compare exact membership.
+    for key in ("specs", "capabilities", "journeys"):
+        members = manifest.get(key, "").split(",")
+        if len(members) != len(set(members)) or set(members) != set(expected_impact[key]):
             raise PromotionError(f"quality manifest {key} is not exact")
     tested_commit = manifest.get("source_commit", "")
     if not COMMIT.fullmatch(tested_commit):


### PR DESCRIPTION
Promotion rejected the successful PR #195 artifact because its spec, capability, and journey lists used gate traversal order, while the fresh policy plan used registration order. The identities matched, but string comparison forced a full main gate.

Compare exact membership for those three identity lists and reject duplicates, missing entries, and extra entries. Stage order, merge provenance, and artifact digests retain their existing checks. The original manifest stays unchanged.

Validation: the new reordered-list regression failed before the fix and passes after it. Promotion, dashboard, documentation, and the selected local quality gate pass. The downloaded PR #195 artifact now passes full promotion validation. Negative tests cover duplicate, missing, and extra identities for every affected list.
