### PR TITLE
Preserve session observation lifetime and refresh deadlines

### DIFF
--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -331,7 +331,7 @@ final class SessionTranscriptFileMonitor: @unchecked Sendable {
         if DispatchQueue.getSpecific(key: queueKey) == nil { queue.sync {} }
     }
 
-    private func armSource(for path: String) {
+    private func armSource(for path: String, refreshAfterRegistration: Bool = false) {
         guard path.hasPrefix("/"),
               URL(fileURLWithPath: path).standardizedFileURL.path == path else {
             return
@@ -360,7 +360,15 @@ final class SessionTranscriptFileMonitor: @unchecked Sendable {
                 guard let self,
                       self.targetPaths.contains(path),
                       self.sources[path] == nil else { return }
-                self.armSource(for: path)
+                self.armSource(for: path, refreshAfterRegistration: true)
+            }
+        }
+        if refreshAfterRegistration {
+            source.setRegistrationHandler { [weak self, weak source] in
+                guard let self, let source, self.sources[path] === source else { return }
+                // Writes to the replacement inode before registration have no
+                // vnode event. Refresh once the new source closes that gap.
+                self.onChange()
             }
         }
         source.setCancelHandler { Darwin.close(descriptor) }

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -79,6 +79,7 @@ public final class SessionStore {
     @ObservationIgnored private var refreshRetryTask: Task<Void, Never>?
     @ObservationIgnored private var refreshRetryAttempt = 0
     @ObservationIgnored private var transientConfirmationTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingTransientSessionIDs: Set<String> = []
     @ObservationIgnored private var confirmedTransientSessionIDs: Set<String> = []
     @ObservationIgnored private var eventGeneration: UInt64 = 0
     /// Epoch invalidates results from a previous CLI/observation lifetime.
@@ -222,11 +223,19 @@ public final class SessionStore {
         // this observation lifetime. A stopped store must launch no later CLI
         // work until an explicit refresh or a new watcher starts it again.
         refreshEpoch &+= 1
+        // Requests made before stop belong to the old lifetime, including
+        // those queued behind a read that cannot be cancelled immediately.
+        refreshCompletedGeneration = refreshRequestGeneration
+        let stoppedWaiters = refreshWaiters
+        refreshWaiters = []
+        for waiter in stoppedWaiters { waiter.continuation.resume(returning: []) }
         refreshRetryTask?.cancel()
         refreshRetryTask = nil
         refreshRetryAttempt = 0
         transientConfirmationTask?.cancel()
         transientConfirmationTask = nil
+        pendingTransientSessionIDs = []
+        confirmedTransientSessionIDs = []
         eventReadinessTimeoutTask?.cancel()
         eventReadinessTimeoutTask = nil
         eventReadinessTimedOutGeneration = nil
@@ -348,7 +357,8 @@ public final class SessionStore {
             let servicedGeneration = refreshRequestGeneration
             let epoch = refreshEpoch
             latestSnapshot = await performRefresh(epoch: epoch)
-            refreshCompletedGeneration = servicedGeneration
+            refreshCompletedGeneration = max(
+                refreshCompletedGeneration, servicedGeneration)
 
             var pending: [RefreshWaiter] = []
             for waiter in refreshWaiters {
@@ -525,16 +535,18 @@ public final class SessionStore {
             .filter { Self.isTransient($0.effectiveStatus) }
             .map(\.id))
         confirmedTransientSessionIDs.formIntersection(transientIDs)
-        guard !transientIDs.isEmpty else {
-            transientConfirmationTask?.cancel()
-            transientConfirmationTask = nil
-            return
-        }
+        pendingTransientSessionIDs.formIntersection(transientIDs)
+        // Keep the original deadline while any of its transitions remain.
+        // Other sessions can emit snapshots continuously. They must not
+        // postpone confirmation or mark a newly joined transition early.
+        if !pendingTransientSessionIDs.isEmpty { return }
+        transientConfirmationTask?.cancel()
+        transientConfirmationTask = nil
         let unconfirmedIDs = transientIDs.subtracting(
             confirmedTransientSessionIDs)
         guard !unconfirmedIDs.isEmpty else { return }
 
-        transientConfirmationTask?.cancel()
+        pendingTransientSessionIDs = unconfirmedIDs
         transientConfirmationTask = Task { [weak self] in
             do {
                 try await self?.confirmationSleep(350_000_000)
@@ -542,7 +554,8 @@ public final class SessionStore {
                 return
             }
             guard !Task.isCancelled, let self else { return }
-            self.confirmedTransientSessionIDs.formUnion(unconfirmedIDs)
+            self.confirmedTransientSessionIDs.formUnion(self.pendingTransientSessionIDs)
+            self.pendingTransientSessionIDs = []
             self.transientConfirmationTask = nil
             await self.refresh()
         }

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -440,6 +440,7 @@ final class SessionEventsTests: XCTestCase {
 
         let first = expectation(description: "replacement observed")
         let second = expectation(description: "replacement rearmed")
+        let third = expectation(description: "append observed after registration")
         let lock = NSLock()
         nonisolated(unsafe) var deliveryCount = 0
         let queue = DispatchQueue(label: "detach-session-vnode-rearm-test")
@@ -450,6 +451,7 @@ final class SessionEventsTests: XCTestCase {
             }
             if count == 1 { first.fulfill() }
             if count == 2 { second.fulfill() }
+            if count == 3 { third.fulfill() }
         }
         monitor.update(paths: [
             "relative/transcript.jsonl",
@@ -459,17 +461,47 @@ final class SessionEventsTests: XCTestCase {
         queue.sync { monitor.update(paths: [transcript.path]) }
 
         try Data("replacement\n".utf8).write(to: transcript, options: .atomic)
-        wait(for: [first], timeout: 1)
-        Thread.sleep(forTimeInterval: 0.1)
+        wait(for: [first, second], timeout: 2, enforceOrder: true)
         let handle = try FileHandle(forWritingTo: transcript)
         try handle.seekToEnd()
         try handle.write(contentsOf: Data("append\n".utf8))
         try handle.synchronize()
         try handle.close()
 
-        wait(for: [second], timeout: 1)
+        wait(for: [third], timeout: 2)
         monitor.update(paths: [])
         monitor.stop()
+    }
+
+    func testTranscriptMonitorReportsWritesDuringReplacementRegistration() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-session-vnode-gap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let transcript = root.appendingPathComponent("managed.jsonl")
+        try Data().write(to: transcript)
+        let refreshed = expectation(description: "replacement registration refreshes missed writes")
+        let queue = DispatchQueue(label: "detach-session-vnode-gap-test")
+        nonisolated(unsafe) var deliveryCount = 0
+        let monitor = SessionTranscriptFileMonitor(queue: queue) {
+            deliveryCount += 1
+            if deliveryCount == 1 {
+                // This callback still watches the old inode. Write the new
+                // file before the replacement source can be registered.
+                do {
+                    let handle = try FileHandle(forWritingTo: transcript)
+                    defer { try? handle.close() }
+                    try handle.seekToEnd()
+                    try handle.write(contentsOf: Data("gap append\n".utf8))
+                } catch { XCTFail("Could not append replacement fixture: \(error)") }
+            } else if deliveryCount == 2 {
+                refreshed.fulfill()
+            }
+        }
+        defer { monitor.stop() }
+        monitor.update(paths: [transcript.path])
+        try Data("replacement\n".utf8).write(to: transcript, options: .atomic)
+        wait(for: [refreshed], timeout: 2)
     }
 
     func testParentMonitorObservesProcessExit() throws {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -59,12 +59,14 @@ private actor DelayedCLI: DetachCLIRunning {
 
 private actor OverlappingStartCLI: DetachCLIRunning {
     private let listOutput: String
+    private let suspendsAfterFirstCall: Bool
     private var listCallCount = 0
     private var listContinuations: [Int: CheckedContinuation<CLIResult, Never>] = [:]
     private var listWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
-    init(listOutput: String) {
+    init(listOutput: String, suspendsAfterFirstCall: Bool = true) {
         self.listOutput = listOutput
+        self.suspendsAfterFirstCall = suspendsAfterFirstCall
     }
 
     func run(
@@ -78,6 +80,9 @@ private actor OverlappingStartCLI: DetachCLIRunning {
         let ready = listWaiters.filter { $0.0 <= call }
         listWaiters.removeAll { $0.0 <= call }
         ready.forEach { $0.1.resume() }
+        if call > 1, !suspendsAfterFirstCall {
+            return CLIResult(exitCode: 0, stdout: listOutput, stderr: "", timedOut: false)
+        }
         return await withCheckedContinuation { continuation in
             listContinuations[call] = continuation
         }
@@ -493,6 +498,64 @@ final class SessionStoreTests: XCTestCase {
         let finalCallCount = await cli.currentListCallCount
         XCTAssertEqual(finalCallCount, 2)
         XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
+    }
+
+    func testStopDiscardsQueuedRefreshesWithoutPublishingOrLaunchingAnotherList() async {
+        let cli = OverlappingStartCLI(listOutput: line, suspendsAfterFirstCall: false)
+        let store = SessionStore(cli: cli)
+        var snapshots: [[Session]] = []
+        store.onSnapshot = { snapshots.append($0) }
+        let first = Task { await store.refresh() }
+        await cli.waitForListCall(1)
+        let queued = expectation(description: "refresh queued")
+        let second = Task { @MainActor in
+            queued.fulfill()
+            return await store.refresh()
+        }
+        await fulfillment(of: [queued], timeout: 1)
+
+        store.stopObserving()
+        await cli.finishListCall(1)
+        _ = await first.value
+        let queuedResult = await second.value
+
+        let calls = await cli.currentListCallCount
+        XCTAssertEqual(calls, 1)
+        XCTAssertTrue(queuedResult.isEmpty)
+        XCTAssertTrue(snapshots.isEmpty)
+        XCTAssertTrue(store.sessions.isEmpty)
+        XCTAssertFalse(store.hasFreshSnapshot)
+
+        await store.refresh()
+        let callsAfterExplicitRefresh = await cli.currentListCallCount
+        XCTAssertEqual(callsAfterExplicitRefresh, 2)
+        XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
+    }
+
+    func testExplicitRefreshAfterStopWaitsForThePreviousReadAndPublishes() async {
+        let cli = OverlappingStartCLI(listOutput: line, suspendsAfterFirstCall: false)
+        let store = SessionStore(cli: cli)
+        let first = Task { await store.refresh() }
+        await cli.waitForListCall(1)
+        store.stopObserving()
+
+        let queued = expectation(description: "new lifetime refresh queued")
+        let second = Task { @MainActor in
+            queued.fulfill()
+            return await store.refresh()
+        }
+        await fulfillment(of: [queued], timeout: 1)
+        let callsBeforeCompletion = await cli.currentListCallCount
+        XCTAssertEqual(callsBeforeCompletion, 1)
+
+        await cli.finishListCall(1, output: "")
+        _ = await first.value
+        let fresh = await second.value
+        let calls = await cli.currentListCallCount
+        XCTAssertEqual(calls, 2)
+        XCTAssertEqual(fresh.first?.id, "detach-codex-p-1")
+        XCTAssertEqual(store.sessions, fresh)
+        XCTAssertTrue(store.hasFreshSnapshot)
     }
 
     func testStartDetachedKeepsFailuresAndTimeoutsInTheCaller() async {
@@ -952,6 +1015,75 @@ final class SessionStoreTests: XCTestCase {
 
         XCTAssertEqual(snapshotCount, 2)
         XCTAssertEqual(confirmationCalls, 1)
+    }
+
+    func testSnapshotBurstsKeepTheOriginalTransientConfirmationDeadline() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"hung""#))
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { delay in await probe.sleep(nanoseconds: delay) },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        await store.refresh()
+        await probe.waitForCallCount(1)
+        for _ in 0..<5 { await store.refresh() }
+        // A main-actor barrier lets any incorrectly restarted deadline enter
+        // the probe before the count is checked.
+        await Task { @MainActor in }.value
+        let calls = await probe.calls()
+        XCTAssertEqual(calls, 1)
+
+        let confirmed = expectation(description: "original deadline confirms")
+        store.onSnapshot = { _ in confirmed.fulfill() }
+        await probe.resumeSleepers()
+        await fulfillment(of: [confirmed], timeout: 1)
+        XCTAssertEqual(cli.calls.count, 7)
+        store.stopObserving()
+    }
+
+    func testNewTransientGetsItsOwnConfirmationAfterThePendingDeadline() async {
+        let cli = FakeCLI()
+        let hung = line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"hung""#)
+        let interrupted = hung.replacingOccurrences(of: "p-1", with: "p-2")
+            .replacingOccurrences(of: "hung", with: "interrupted")
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in await probe.sleep() },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        cli.responses["list --json"] = ok(hung)
+        await store.refresh()
+        await probe.waitForCallCount(1)
+
+        cli.responses["list --json"] = ok(hung + "\n" + interrupted)
+        await store.refresh()
+        let firstConfirmation = expectation(description: "first transition confirmed")
+        store.onSnapshot = { _ in firstConfirmation.fulfill() }
+        await probe.resumeSleepers()
+        await fulfillment(of: [firstConfirmation], timeout: 1)
+        await probe.waitForCallCount(2)
+
+        let secondConfirmation = expectation(description: "new transition confirmed")
+        store.onSnapshot = { _ in secondConfirmation.fulfill() }
+        await probe.resumeSleepers()
+        await fulfillment(of: [secondConfirmation], timeout: 1)
+        XCTAssertEqual(cli.calls.count, 4)
+
+        // A new observation lifetime must confirm again even if the same
+        // session names still report transient state.
+        store.stopObserving()
+        store.onSnapshot = nil
+        await store.refresh()
+        await probe.waitForCallCount(3)
+        store.stopObserving()
+        await probe.resumeSleepers()
     }
 
     func testDefaultConfirmationDelayPublishesTheFollowUpSnapshot() async {

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -24,7 +24,9 @@ Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. Typed heartbeat and
 `detach watch --json` sources supply them. A schema-1 hint, activation, or
 `resync` starts a serialized `list --json`. Hints during a read share one ordered
-trailing read. No list timer runs. Dead or unready watchers and failed lists retry
+trailing read. Stop discards queued reads and prevents old results from updating
+the store. A new explicit read remains serialized with an active old read.
+No list timer runs. Dead or unready watchers and failed lists retry
 with 2–60 s backoff. Cold start waits 1 s for `ready`; a late `ready` repeats the
 snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
 checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
@@ -78,8 +80,10 @@ When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
 Notifications are opt-in and deduplicated. Stop intent is not failure;
-`interrupted` and `hung` get one 350 ms recheck. Ordered detection never waits
-for delivery.
+`interrupted` and `hung` get one 350 ms recheck. Snapshot bursts do not restart
+that deadline. A new transition waits for the pending recheck, then gets its
+own deadline. Stable state cancels an obsolete recheck. Each observation
+lifetime confirms its own transitions. Ordered detection never waits for delivery.
 
 SwiftTerm 1.19.0 is pinned. The exact SwiftTerm shader bundle is shipped and
 verified.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -30,6 +30,8 @@ No list timer runs. Dead or unready watchers and failed lists retry
 with 2–60 s backoff. Cold start waits 1 s for `ready`; a late `ready` repeats the
 snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
 checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
+After a transcript file is replaced, registration of its new file observer
+emits a refresh hint. Writes before registration must not leave the UI stale.
 
 The dashboard separates identity, status, and Mac Power. Identity is a thin
 tmux-colored capsule. Status is a filled circle. Power uses a neutral surface


### PR DESCRIPTION
A stopped SessionStore could still publish a queued refresh, snapshot bursts could postpone transient-state confirmation, and writes during transcript-file observer replacement could leave the UI stale.

Retire queued refreshes when observation stops, preserve the first confirmation deadline while giving new transitions their own check, and emit a refresh hint after the replacement file observer is registered. An explicit refresh after stop still works, and stale observer callbacks remain suppressed.

Regression evidence: the original store implementation failed seven assertions; the replacement-observer regressions also failed before the fix. All 73 focused SessionStore and SessionEvents tests pass. The full selected local diagnostic passed every functional stage and coverage contract. Its existing integration timing limits still failed: Codex 190/110 seconds, Claude 175/60 seconds, total 264/240 seconds. That performance issue remains under separate investigation. Release and hardware power checks were not run.
