### PR TITLE
Keep session titles readable and Settings windows on screen

### DIFF
--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -147,7 +147,8 @@ struct RootView: View {
             await notifications.configure(enabled: notificationsEnabled)
         }
 // quality-coverage:begin ui-e2e-instrumentation
-        .task {
+        .task(id: initialSetupComplete) {
+            guard initialSetupComplete else { return }
             await UIE2ETestDriver.runIfRequested(
                 installation: installation,
                 store: store,

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -234,20 +234,14 @@ struct SessionDetailView: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .help(session.displayTitle)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        uiE2EGeometryProbe(identifier: "session-detail-title")
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                 statusPill
-                if let model = session.model {
-                    Text(model)
-                        .appFont(.caption, weight: .semibold)
-                        .lineLimit(1)
-                        .padding(.horizontal, 7).padding(.vertical, 2)
-                        .background(Capsule().fill(providerTint.opacity(0.16)))
-                        .foregroundStyle(providerTint)
-                        // Pills keep their single line; the title truncates first.
-                        .layoutPriority(1)
-                }
-                if session.contextSummary != nil {
-                    ContextGauge(session: session)
-                }
                 Spacer()
             }
             metadataRail
@@ -307,6 +301,17 @@ struct SessionDetailView: View {
     private var metadataRail: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
+                if let model = session.model {
+                    Text(model)
+                        .appFont(.caption, weight: .semibold)
+                        .lineLimit(1)
+                        .padding(.horizontal, 7).padding(.vertical, 3)
+                        .background(Capsule().fill(providerTint.opacity(0.16)))
+                        .foregroundStyle(providerTint)
+                }
+                if session.contextSummary != nil {
+                    ContextGauge(session: session)
+                }
                 if let reason = session.healthReasonLabel {
                     Label(reason, systemImage: "exclamationmark.triangle.fill")
                         .appFont(.caption)

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -1508,19 +1508,28 @@ final class SettingsWindowFrameView: NSView {
 
     private func pinToHostingScreen() {
         guard let window, width > 0 else { return }
-        let visibleHeight = window.screen?.visibleFrame.height ?? 720
+        let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame
         let size = CGSize(
             width: width,
             height: SettingsWindowLayout.contentHeight(
                 base: baseHeight,
                 fontPointSize: fontPointSize,
-                visibleScreenHeight: visibleHeight))
+                visibleScreenHeight: visibleFrame?.height ?? 720))
         window.contentMinSize = size
         window.contentMaxSize = size
         let current = window.contentView?.bounds.size ?? .zero
         if abs(current.width - size.width) > 0.5
             || abs(current.height - size.height) > 0.5 {
             window.setContentSize(size)
+        }
+        if let visibleFrame {
+            let frame = window.frame
+            let origin = CGPoint(
+                x: max(visibleFrame.minX, min(frame.minX, visibleFrame.maxX - frame.width)),
+                y: max(visibleFrame.minY, min(frame.minY, visibleFrame.maxY - frame.height)))
+            if origin != frame.origin {
+                window.setFrameOrigin(origin)
+            }
         }
     }
 }

--- a/app/Sources/DetachApp/UIE2EGeometryProbe.swift
+++ b/app/Sources/DetachApp/UIE2EGeometryProbe.swift
@@ -83,7 +83,8 @@ final class UIE2EGeometryView: NSView {
     }
     override func accessibilityLabel() -> String? { semanticLabel }
     override func accessibilityFrame() -> NSRect {
-        UIE2EGeometryRegistry.frame(for: identifierValue) ?? .zero
+        publishFrame()
+        return UIE2EGeometryRegistry.frame(for: identifierValue) ?? .zero
     }
     override func isAccessibilityEnabled() -> Bool { semanticEnabled }
 

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -362,6 +362,11 @@ enum UIE2ETestDriver {
             guard label(reconnectButton) == L10n.string("Reconnect") else {
                 throw Failure(message: "exited attach client does not offer Reconnect")
             }
+            try await waitUntil("disconnected session log is readable") {
+                guard let scrollView = find(identifier: "session-preview-log") as? NSScrollView,
+                      let textView = scrollView.documentView as? NSTextView else { return false }
+                return textView.string.contains("UI fixture log for \(recoverableID)")
+            }
             try await clickUntil(
                 reconnectButton,
                 name: "in-app reconnect action",
@@ -851,6 +856,21 @@ enum UIE2ETestDriver {
                 find(identifier: "session-detail-detach-codex-ui-quick") != nil
             }
             checks.append("quick-chat-command-starts-session")
+
+            guard let shortcutID = shortcuts.sessionID(for: 1) else {
+                throw Failure(message: "no session has the first window-reopen shortcut")
+            }
+            mainWindow.close()
+            try await waitUntil("main window closes") { !mainWindow.isVisible }
+            NSApp.activate(ignoringOtherApps: true)
+            try await keyPress("1", keyCode: 18, modifiers: [.command])
+            _ = try await element(identifier: "session-detail-\(shortcutID)")
+            guard NSApp.windows.contains(where: {
+                $0.identifier?.rawValue == "main" && $0.isVisible
+            }) else {
+                throw Failure(message: "session shortcut did not reopen the main window")
+            }
+            checks.append("session-shortcut-reopens-closed-main-window")
 
             try await restoreFocus(
                 to: previousFrontmost, policy: previousActivationPolicy)
@@ -1353,11 +1373,21 @@ enum UIE2ETestDriver {
         }
         for font in [AppFontSize.defaultValue, AppFontSize.allowedRange.upperBound] {
             AppSettings.defaults.set(font, forKey: AppFontSize.storageKey)
-            // Allow the preference change to update the split view minimum.
-            try await Task.sleep(nanoseconds: 50_000_000)
+            try await waitUntil("session title uses font \(font)") {
+                guard let title = UIE2EGeometryRegistry.frame(for: "session-detail-title")
+                else { return false }
+                let pointSize = AppFontRole.title2.pointSize(base: font)
+                return title.height >= pointSize && title.height < pointSize + 12
+            }
             window.setContentSize(AppFontSize.minimumWindowSize(for: font))
             window.contentView?.layoutSubtreeIfNeeded()
-            try await Task.sleep(nanoseconds: 50_000_000)
+            try await waitUntil("session title is inside the resized window") {
+                elements().compactMap { $0 as? UIE2EGeometryView }
+                    .filter { $0.identifierValue == "session-detail-title" }
+                    .forEach { $0.publishFrame() }
+                return UIE2EGeometryRegistry.frame(for: "session-detail-title")
+                    .map { window.frame.contains($0) } == true
+            }
             let title = try await measuredFrame(
                 identifier: "session-detail-title", name: "session title")
             guard title.width >= font * 5, title.height >= font,
@@ -1459,6 +1489,9 @@ enum UIE2ETestDriver {
     ) async throws -> CGRect {
         var result: CGRect?
         try await waitUntil("real control geometry for \(name)") {
+            elements().compactMap { $0 as? UIE2EGeometryView }
+                .filter { $0.identifierValue == identifier }
+                .forEach { $0.publishFrame() }
             result = UIE2EGeometryRegistry.frame(for: identifier)
             return result?.isEmpty == false
         }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -975,6 +975,8 @@ enum UIE2ETestDriver {
         guard visible.insetBy(dx: -2, dy: -2).contains(frame) else {
             throw Failure(message: "Settings window is off the hosting screen")
         }
+        try await verifySettingsTextGrowth(in: settingsWindow, visible: visible)
+        checks.append("settings-text-growth-stays-on-screen")
         checks.append("settings-window-stays-on-screen")
         let systemTab = try await buttonLabeled(
             L10n.string("System"), attempts: 40)
@@ -984,6 +986,47 @@ enum UIE2ETestDriver {
             identifier: "settings-installation", name: "Installation")
         checks.append("settings-system-reveals-storage-and-installation")
         return checks
+    }
+
+    private static func verifySettingsTextGrowth(
+        in window: NSWindow,
+        visible: CGRect
+    ) async throws {
+        let originalPreference = AppSettings.defaults.object(forKey: AppFontSize.storageKey)
+        let originalFont = originalPreference as? Double ?? AppFontSize.defaultValue
+        AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+        let originalFrame = window.frame
+        defer {
+            AppSettings.defaults.set(originalPreference, forKey: AppFontSize.storageKey)
+            window.setFrame(originalFrame, display: true)
+        }
+        window.setFrameOrigin(CGPoint(
+            x: visible.maxX - window.frame.width, y: visible.minY))
+        let slider = try await element(role: .slider)
+        try requireGeometry(slider, name: "settings text size slider")
+        let sliderFrame = frame(slider)
+        try await click(
+            frame: CGRect(x: sliderFrame.maxX - 3, y: sliderFrame.midY - 1,
+                          width: 2, height: 2),
+            name: "maximum settings text size", owningWindow: window)
+        let apply = try await buttonLabeled(L10n.string("Apply"))
+        try await waitUntil("text size draft can be applied") { isEnabled(apply) }
+        guard AppSettings.defaults.double(forKey: AppFontSize.storageKey) == originalFont,
+              abs(window.frame.width - originalFrame.width) < 1 else {
+            throw Failure(message: "text size draft resized Settings before Apply")
+        }
+        try await click(apply, name: "apply maximum text size")
+        try await waitUntil("Settings grows within the hosting screen") {
+            AppSettings.defaults.double(forKey: AppFontSize.storageKey)
+                == AppFontSize.allowedRange.upperBound
+                && window.frame.width > originalFrame.width + 100
+                && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
+        }
+        AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+        try await waitUntil("Settings restores its original text size") {
+            abs(window.frame.width - originalFrame.width) < 1
+                && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
+        }
     }
 
     private static func runOnboardingFirstRun(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -330,6 +330,8 @@ enum UIE2ETestDriver {
                     "UI fixture log for \(recoverableID)")
             }
             checks.append("non-live-session-switch-uses-warm-cache")
+            try await verifySessionTitleAtMinimumWindowSize(mainWindow)
+            checks.append("session-title-survives-narrow-window-and-large-text")
             let recoverButton = try await element(
                 identifier: "session-action-recover-in-app")
             let recoverFallback = try await element(
@@ -1338,6 +1340,32 @@ enum UIE2ETestDriver {
             }
         }
         throw Failure(message: "\(name) did not produce \(resultIdentifier)")
+    }
+
+    private static func verifySessionTitleAtMinimumWindowSize(
+        _ window: NSWindow
+    ) async throws {
+        let originalFrame = window.frame
+        let originalFont = AppSettings.defaults.object(forKey: AppFontSize.storageKey)
+        defer {
+            AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+            window.setFrame(originalFrame, display: true)
+        }
+        for font in [AppFontSize.defaultValue, AppFontSize.allowedRange.upperBound] {
+            AppSettings.defaults.set(font, forKey: AppFontSize.storageKey)
+            // Allow the preference change to update the split view minimum.
+            try await Task.sleep(nanoseconds: 50_000_000)
+            window.setContentSize(AppFontSize.minimumWindowSize(for: font))
+            window.contentView?.layoutSubtreeIfNeeded()
+            try await Task.sleep(nanoseconds: 50_000_000)
+            let title = try await measuredFrame(
+                identifier: "session-detail-title", name: "session title")
+            guard title.width >= font * 5, title.height >= font,
+                  window.frame.contains(title) else {
+                throw Failure(message:
+                    "session title disappeared or collapsed at font \(font): \(title)")
+            }
+        }
     }
 
     private static func clickUntil(

--- a/app/Tests/DetachAppTests/TextSizeTests.swift
+++ b/app/Tests/DetachAppTests/TextSizeTests.swift
@@ -148,6 +148,52 @@ final class TextSizeTests: XCTestCase {
         XCTAssertEqual(contentView.bounds.height, expectedHeight, accuracy: 0.001)
     }
 
+    @MainActor
+    func testSettingsGrowthKeepsRightAndBottomEdgesOnScreen() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let visible = screen.visibleFrame
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 400),
+            styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        let frameView = SettingsWindowFrameView(frame: .zero)
+        try XCTUnwrap(window.contentView).addSubview(frameView)
+        window.setFrameOrigin(NSPoint(
+            x: visible.maxX - window.frame.width, y: visible.minY))
+        XCTAssertTrue(visible.contains(window.frame))
+
+        frameView.apply(width: 760, baseHeight: 780, fontPointSize: 22)
+
+        XCTAssertTrue(visible.contains(window.frame), "Settings moved off screen: \(window.frame)")
+        let largeTop = window.frame.maxY
+        frameView.apply(width: 560, baseHeight: 450, fontPointSize: 14)
+        XCTAssertTrue(visible.contains(window.frame))
+        XCTAssertEqual(window.frame.maxY, largeTop, accuracy: 0.5)
+        let settled = window.frame
+        frameView.apply(width: 560, baseHeight: 450, fontPointSize: 14)
+        XCTAssertEqual(window.frame, settled)
+    }
+
+    @MainActor
+    func testSettingsScreenChangeMovesAnOffscreenFrameBackInside() throws {
+        let visible = try XCTUnwrap(NSScreen.main).visibleFrame
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 400),
+            styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        let frameView = SettingsWindowFrameView(frame: .zero)
+        try XCTUnwrap(window.contentView).addSubview(frameView)
+        frameView.apply(width: 560, baseHeight: 450, fontPointSize: 14)
+        window.setFrameOrigin(NSPoint(x: visible.maxX - 50, y: visible.maxY - 50))
+
+        NotificationCenter.default.post(
+            name: NSWindow.didChangeScreenNotification, object: window)
+
+        XCTAssertTrue(visible.contains(window.frame), "Settings remained off screen: \(window.frame)")
+    }
+
     func testLogResizeUsesExactPointSizeAndPreservesTraitsAndColors() throws {
         let regular = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
         let bold = NSFont.monospacedSystemFont(ofSize: 10, weight: .bold)

--- a/docs/specs/app-setup.md
+++ b/docs/specs/app-setup.md
@@ -34,7 +34,9 @@ Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
 
 Settings → General owns both menu bar toggles. Settings → System keeps the only
 Mac Power status and approval controls. Settings follows the hosting screen;
-System scrolls. Temperature safety has its own warning shape and the
+System scrolls. A size or screen change moves the window inside the visible
+screen area. A window that already fits keeps its position.
+Temperature safety has its own warning shape and the
 text **Mac can sleep: temperature**.
 
 Settings → System owns the only **Mac Power** status and approval block. Helper

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -63,7 +63,9 @@ Detached live logs reread every 2 s. Cold attach uses one passive SwiftTerm
 overlay; cached bytes never enter the live buffer. Live switching keeps its PTY.
 tmux holds the frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
-action geometry. A cold passive screen leaves within one second.
+action geometry. The model and context gauge stay in the metadata row. They
+cannot reduce the title to zero width in a narrow window or with large text.
+A cold passive screen leaves within one second.
 New session accepts an optional printable UTF-8 name up to 100 bytes and
 rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -51,7 +51,7 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   if [ -f "$ROOT/fake/resumed" ]; then
     completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"running","created_at":"2026-07-22T07:00:00Z","agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"protected","health_actions":["attach","stop"]}'
   fi
-  recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","effective_status":"recoverable","created_at":"2026-07-22T07:40:00Z","finished_at":"2026-07-22T07:50:00Z","exit_status":1,"session_color":"#F97316","power_protection_state":"allowed","health_actions":["recover","delete"]}'
+  recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","model":"gpt-ui-fixture-long-model-name","context_used_tokens":185000,"context_window":200000,"effective_status":"recoverable","created_at":"2026-07-22T07:40:00Z","finished_at":"2026-07-22T07:50:00Z","exit_status":1,"session_color":"#F97316","power_protection_state":"allowed","health_actions":["recover","delete"]}'
   if [ -f "$ROOT/fake/recovered" ]; then
     recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","effective_status":"running","created_at":"2026-07-22T07:40:00Z","session_color":"#F97316","power_protection_state":"protected","health_actions":["attach","stop"]}'
   fi

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -323,6 +323,7 @@ run_app_scenario() {
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
       session-shortcut-selects-assigned-session|\
+      settings-text-growth-stays-on-screen|\
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
       new-session-advanced-keeps-top-edge|\
@@ -394,6 +395,7 @@ run_app_scenario main sessions 32 \
   settings-session-defaults-visible \
   settings-quick-chat-provider-persists \
   settings-quick-chat-folder-panel \
+  settings-text-growth-stays-on-screen \
   settings-window-stays-on-screen \
   settings-system-reveals-storage-and-installation \
   quick-chat-command-starts-session \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -318,6 +318,7 @@ run_app_scenario() {
       live-terminal-routes-control-v|\
       live-session-switch-reuses-synchronized-client|\
       non-live-session-switch-uses-warm-cache|\
+      session-title-survives-narrow-window-and-large-text|\
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
       session-shortcut-selects-assigned-session|\
@@ -364,6 +365,7 @@ run_app_scenario main sessions 32 \
   dashboard-accessible \
   sidebar-shortcut-guide-visible \
   non-live-session-switch-uses-warm-cache \
+  session-title-survives-narrow-window-and-large-text \
   recover-and-reconnect-run-in-app-with-terminal-fallback \
   sidebar-selects-completed-session \
   session-uuid-copies-from-text-side \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -56,7 +56,8 @@ preserve_failure_diagnostics() {
   }
   mkdir -p "$ARTIFACT_DIR"
   chmod 0700 "$ARTIFACT_DIR"
-  for source in "$APP_LOG" "$RESULT" "$FAKE_DIR/invocations.log"; do
+  for source in "$TEST_ROOT"/app-*.log "$TEST_ROOT"/result-*.json \
+      "$FAKE_DIR/invocations.log"; do
     [ -f "$source" ] && [ ! -L "$source" ] || continue
     destination="$ARTIFACT_DIR/$(basename "$source")"
     install -m 0600 "$source" "$destination"
@@ -346,6 +347,7 @@ run_app_scenario() {
       settings-quick-chat-provider-persists) ;;
       settings-quick-chat-folder-panel) ;;
       quick-chat-command-starts-session) ;;
+      session-shortcut-reopens-closed-main-window) ;;
       *) printf 'UI e2e: unowned check: %s\n' "$check" >&2; exit 1 ;;
     esac
     if [ -n "${pass:-}" ]; then
@@ -395,6 +397,7 @@ run_app_scenario main sessions 32 \
   settings-window-stays-on-screen \
   settings-system-reveals-storage-and-installation \
   quick-chat-command-starts-session \
+  session-shortcut-reopens-closed-main-window \
   installed-app-focus-restored
 run_app_scenario onboarding-first-run empty 8 onboarding-first-run-completes
 run_app_scenario onboarding-provider empty 8 onboarding-detects-provider


### PR DESCRIPTION
Long session names can collapse to zero width beside a model and context gauge. Keep the title and status in the first row and place metadata in the horizontal rail. Settings windows also move back inside the hosting screen after a size or screen change.

Native regressions reproduced both failures before the changes. Verify the title at the minimum window size with default and maximum text, and verify Settings growth at the right and bottom screen edges. The packaged UI journey moves the text slider, checks that the draft does not resize the window, presses Apply, and checks all window edges. Refresh UI probe coordinates when measured after a window move. Start the hermetic journey after app setup, wait for the disconnected log, and exercise the session shortcut after closing the main window. Preserve logs from every UI scenario on failure.

Validation: native Settings and RootView tests pass. English and Russian layout captures cover narrow detail views and the advanced session form at both text sizes. The initial selected local gate passed. Follow-up Swift and app gates pass; the latest local interactive UI run was blocked by the locked macOS session (CGSession reported screenLocked=1). Earlier hosted runs exposed nondeterministic UI coverage, and one artifact upload failed with ETIMEDOUT. The updated hosted repository gate must pass before merge. Hardware power and release checks were not run.
