### PR TITLE
Show Codex models after long transcript turns

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -3358,7 +3358,8 @@ codex_state_db() {
 }
 
 sql_escape() {
-  printf '%s' "${1//\'/\'\'}"
+  local quote="'"
+  printf '%s' "${1//$quote/$quote$quote}"
 }
 
 snapshot_known_threads() {
@@ -7147,11 +7148,15 @@ list_session_records() {
   local health_preserve_recovery_until_ready
   local health_runtime_ready_at
   local recovery_meta
+  local model_database=""
   local LIST_HEALTH_NOW
 
   ensure_state_dirs
   prepare_list_tmux_health_snapshot
   LIST_HEALTH_NOW="$(date '+%s')"
+  if [ "$PROVIDER" = codex ] && [ "$json_mode" = 1 ]; then
+    model_database="$(codex_state_db 2>/dev/null || true)"
+  fi
   if [ "$json_mode" = "1" ] && [ -x "$POWER_BIN" ]; then
     reported_power_state="${DETACH_LIST_POWER_STATE:-}"
     case "$reported_power_state" in
@@ -7318,6 +7323,18 @@ list_session_records() {
     esac
     [ -n "$TRANSCRIPT_AGENT_TURN_ID" ] || TRANSCRIPT_AGENT_TURN_STATE=""
     if [ "$json_mode" = "1" ]; then
+      # A long Codex turn can push its model record outside the bounded tail.
+      # Older databases have no model column; retain the transcript fallback.
+      if [ -z "$TRANSCRIPT_MODEL" ] && [ -n "$model_database" ] && \
+         [ -n "$META_AGENT_SESSION_ID" ] && [ -n "$META_TRANSCRIPT_PATH" ]; then
+        TRANSCRIPT_MODEL="$(
+          "$SQLITE_BIN" -readonly -noheader -cmd '.timeout 100' "$model_database" \
+            "SELECT model FROM threads
+             WHERE id = '$(sql_escape "$META_AGENT_SESSION_ID")'
+               AND rollout_path = '$(sql_escape "$META_TRANSCRIPT_PATH")'
+             LIMIT 1;" 2>/dev/null || true
+        )"
+      fi
       prepare_list_json_args \
         "$session" "$status" "$id" "$checkpoint" "$cwd" "$created" \
         "$exit_json" "$finished" "$TRANSCRIPT_MODEL" "$TRANSCRIPT_CTX_USED" \

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -37,6 +37,10 @@ TERM then KILL. Parallel calls cannot starve drains. Truncation makes typed
 consumers keep the last valid state. Pipe descendants cannot extend deadlines.
 The event process uses `exec` and ends on cancellation. GUI PATH sorts
 NVM/mise Node directories by semantic version.
+If the bounded transcript tail has no Codex model, JSON List reads the model
+from the provider database. The session ID and rollout path must both match.
+An old database without the model column leaves the transcript result intact.
+SQLite text values support paths with apostrophes on the system Bash.
 
 `client switch` retries reads for 0.5 seconds. PID, UID, source, private socket,
 and managed target must match. Framing must survive `LC_ALL=C`. Failed proof

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3747,6 +3747,56 @@ fi
 # full preservation below in its integration; keep the Codex lane's mirror
 # bounded to exact monotonic slot selection.
 if codex_part_selected history; then
+# Codex writes the model near the start of a turn. A long turn can move that
+# record outside the bounded summary tail. The provider database can supply
+# the model only for the exact managed UUID and rollout path.
+model_home="$TMP_ROOT/model-home's"
+model_state="$TMP_ROOT/model-display-state"
+model_session=detach-codex-model-display
+model_id=11111111-2222-4333-8444-555555555555
+model_transcript="$model_home/sessions/rollout-model.jsonl"
+model_database="$model_home/state_5.sqlite"
+mkdir -p "$model_home/sessions" "$model_state/sessions/$model_session"
+printf '%s\n' \
+  "{\"type\":\"session_meta\",\"payload\":{\"id\":\"$model_id\"}}" \
+  '{"type":"turn_context","payload":{"model":"gpt-transcript-old"}}' \
+  >"$model_transcript"
+printf '{"payload":{"padding":"' >>"$model_transcript"
+dd if=/dev/zero bs=1024 count=300 2>/dev/null | tr '\000' x >>"$model_transcript"
+printf '"}}\n' >>"$model_transcript"
+"$STATE_HELPER" meta create "$model_state/sessions/$model_session/meta.json" \
+  --integer schema 1 --string session_name "$model_session" \
+  --string project_dir "$ROOT" --string status stopped \
+  --string agent_session_id "$model_id" --string transcript_path "$model_transcript"
+model_transcript_sql="$(printf '%s' "$model_transcript" | sed "s/'/''/g")"
+test_sqlite "$model_database" \
+  "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, model TEXT);
+   INSERT INTO threads VALUES ('$model_id', '$model_transcript_sql', 'gpt-database');"
+require_list_model() {
+  local expected="$1" result
+  result="$(CODEX_HOME="$model_home" DETACH_CODEX_STATE_ROOT="$model_state" \
+    run_codex list --json)"
+  printf '%s' "$result" | grep -F "\"model\":$expected" >/dev/null || {
+    printf 'Codex list did not report model %s\n' "$expected" >&2
+    return 1
+  }
+}
+require_list_model '"gpt-database"'
+test_sqlite "$model_database" "UPDATE threads SET model = 'gpt-database-updated';"
+require_list_model '"gpt-database-updated"'
+test_sqlite "$model_database" "UPDATE threads SET rollout_path = '/different/rollout.jsonl';"
+require_list_model null
+test_sqlite "$model_database" \
+  "UPDATE threads SET rollout_path = '$model_transcript_sql', id = 'different-thread';"
+require_list_model null
+test_sqlite "$model_database" "UPDATE threads SET id = '$model_id', model = NULL;"
+require_list_model null
+test_sqlite "$model_database" "ALTER TABLE threads RENAME COLUMN model TO legacy_model;"
+require_list_model null
+printf '%s\n' '{"type":"turn_context","payload":{"model":"gpt-tail-fallback"}}' \
+  >>"$model_transcript"
+require_list_model '"gpt-tail-fallback"'
+
 default_slug="$(basename "$ROOT" | LC_ALL=C tr -cs 'A-Za-z0-9_-' '-' | \
   sed 's/^-*//; s/-*$//')"
 [ -n "$default_slug" ] || default_slug=project


### PR DESCRIPTION
Codex can write a model record more than 256 KiB before the end of a long turn. JSON List then loses the model even though the provider database still knows it.

When the bounded transcript summary has no model, read the provider database row that matches both the managed session UUID and rollout path. Read-only queries have a short lock wait. Missing rows, mismatched paths, and databases without the model column preserve the transcript result. Fix the shared SQL text escape for apostrophes on the system Bash without adding a subprocess.

Validation: the long-turn fixture failed before the change and passes after it. Seven integration cases cover database updates, exact identity/path matching, NULL, old schemas, transcript fallback, and an apostrophe in the path. Existing cold/warm 25-session list performance checks pass. The selected local gate passed Codex, packaging, distribution, and tmux checks; it also exposed independent UI invocation-count and Claude fake-power barrier failures, which remain under investigation. The authoritative hosted repository gate passed at this head (run 33922714464). Hardware power and release checks were not run.
