### PR TITLE
Reject special state files before blocking reads

### DIFF
--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -1295,7 +1295,7 @@ public enum DetachStateCommand {
         name: String
     ) -> Data? {
         let descriptor = openat(
-            directory, name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            directory, name, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else { return nil }
         defer { close(descriptor) }
         var item = stat()
@@ -1749,7 +1749,7 @@ public enum DetachStateCommand {
         }
 
         let descriptor = openat(
-            directory, fileName, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            directory, fileName, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else {
             throw DetachStateCommandError.invalidTranscript
         }

--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -291,7 +291,7 @@ public struct PowerHelperLifetimeBarrier: Sendable {
     /// its separately persisted boot-session evidence to accept `.missing`.
     public func status() throws -> PowerHelperLifetimeBarrierStatus {
         let descriptor = Darwin.open(
-            fileURL.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            fileURL.path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else {
             let code = errno
             if code == ENOENT { return .missing }
@@ -476,7 +476,7 @@ public struct PowerHelperSystemHandoffLock: Sendable {
     /// handled separately by the app; an existing file is never recreated.
     public func acquire() throws -> PowerHelperSystemHandoffLease? {
         let descriptor = Darwin.open(
-            fileURL.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            fileURL.path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else {
             let code = errno
             if code == ENOENT { return nil }

--- a/app/Sources/DetachKit/Storage.swift
+++ b/app/Sources/DetachKit/Storage.swift
@@ -585,7 +585,8 @@ private struct StorageScanner {
     }
 
     private func readOwnedRegularFile(_ path: String, maximumBytes: Int) -> Data? {
-        let descriptor = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        // Open must not wait on a special file before fstat can reject it.
+        let descriptor = open(path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else { return nil }
         defer { close(descriptor) }
         var item = stat()

--- a/app/Tests/DetachKitTests/FIFOReadTests.swift
+++ b/app/Tests/DetachKitTests/FIFOReadTests.swift
@@ -1,0 +1,124 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import DetachKit
+
+final class FIFOReadTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-fifo-read-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: root)
+    }
+
+    func testStorageRejectsFIFOMetadataWithoutWaitingForAWriter() throws {
+        let name = "detach-codex-fifo"
+        let providerRoot = root.appendingPathComponent("codex")
+        let sessionRoot = providerRoot.appendingPathComponent("sessions/\(name)")
+        try FileManager.default.createDirectory(at: sessionRoot, withIntermediateDirectories: true)
+        let fifo = sessionRoot.appendingPathComponent("meta.json")
+        let stateRoot = root.path
+        let inventory = Data("""
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"fifo","effective_status":"orphaned","cleanup_eligible":false}
+        """.utf8)
+
+        try checkWithoutWriter(fifo) {
+            let report = try StorageInspector.report(
+                stateRoot: stateRoot,
+                providerRoots: [.codex: providerRoot.path],
+                excludedRoots: [],
+                inventory: inventory)
+            XCTAssertFalse(report.complete)
+            XCTAssertEqual(report.sessions.first?.blockedReason, "invalid_metadata")
+            XCTAssertEqual(report.sessions.first?.deletable, false)
+        }
+    }
+
+    func testMetadataSnapshotsRejectFIFOCheckpointWithoutWaitingForAWriter() throws {
+        let sessions = root.appendingPathComponent("sessions")
+        let checkpoint = sessions.appendingPathComponent("detach-codex-fifo/checkpoint")
+        try FileManager.default.createDirectory(at: checkpoint, withIntermediateDirectories: true)
+
+        try checkWithoutWriter(checkpoint.appendingPathComponent("meta.json")) {
+            let result = try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", sessions.path,
+            ])
+            let fields = result.split(separator: 0, omittingEmptySubsequences: false)
+                .map { String(decoding: $0, as: UTF8.self) }
+            XCTAssertEqual(fields.prefix(2), ["detach-codex-fifo", "false"])
+        }
+    }
+
+    func testCachedValidationRejectsFIFOTranscriptWithoutWaitingForAWriter() throws {
+        let transcript = root.appendingPathComponent("transcript.jsonl")
+        try checkWithoutWriter(transcript) {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+            }
+        }
+    }
+
+    func testCachedValidationIgnoresFIFOReceiptWithoutWaitingForAWriter() throws {
+        let transcript = root.appendingPathComponent("transcript.jsonl")
+        try Data(#"{"type":"session_meta","payload":{"id":"session-1"}}"#.utf8)
+            .write(to: transcript)
+        try checkWithoutWriter(root.appendingPathComponent(".detach-jsonl-validation.json")) {
+            XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+                "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+            ]))
+        }
+    }
+
+    func testLifetimeProbeRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = root.appendingPathComponent("lifetime.lock")
+        let barrier = PowerHelperLifetimeBarrier(fileURL: fifo, expectedOwner: geteuid())
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try barrier.status()) { error in
+                XCTAssertEqual(error as? PowerHelperPlatformError, .insecureLifetimeLock)
+            }
+        }
+    }
+
+    func testSystemHandoffProbeRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = root.appendingPathComponent("handoff.lock")
+        let lock = PowerHelperSystemHandoffLock(fileURL: fifo, expectedOwner: geteuid())
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try lock.acquire()) { error in
+                XCTAssertEqual(error as? PowerHelperPlatformError, .insecureSystemHandoffLock)
+            }
+        }
+    }
+
+    /// A regression must fail within a bound and leave no blocked test thread.
+    /// The rescue writer opens only after that failure and never supplies data.
+    private func checkWithoutWriter(
+        _ fifo: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        operation: @escaping @Sendable () throws -> Void
+    ) throws {
+        XCTAssertEqual(mkfifo(fifo.path, 0o644), 0, file: file, line: line)
+        let completed = DispatchGroup()
+        completed.enter()
+        DispatchQueue.global().async {
+            defer { completed.leave() }
+            do { try operation() }
+            catch { XCTFail("Unexpected error: \(error)", file: file, line: line) }
+        }
+        let result = completed.wait(timeout: .now() + 1)
+        XCTAssertEqual(result, .success, "File validation waited for a FIFO writer", file: file, line: line)
+        if result == .timedOut {
+            let rescue = open(fifo.path, O_RDWR | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+            defer { if rescue >= 0 { close(rescue) } }
+            XCTAssertGreaterThanOrEqual(rescue, 0, file: file, line: line)
+            XCTAssertEqual(completed.wait(timeout: .now() + 1), .success, file: file, line: line)
+        }
+    }
+}

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -73,6 +73,8 @@ submitted unregister phase under the system and per-user transaction locks.
 Only a busy lifetime lock permits the prepare call. A replacement is not
 registered until the old lifetime lock is released or an exact absent-job
 callback provides the required completion barrier.
+Lifetime and system handoff probes reject special files without waiting for
+a FIFO writer. File validation precedes lock acquisition.
 
 An enabled registration with a matching bundled-definition digest is not
 enough to prove liveness. At startup, a missing or released lifetime lock that

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -6,7 +6,10 @@
 metadata, JSONL, health, reconcile, storage, emit, and event operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
 descriptors. It rejects unsafe directories and opens only owned regular files
-of at most 1 MiB with `O_NOFOLLOW`.
+of at most 1 MiB with `O_NOFOLLOW`. Storage metadata, checkpoint fallback
+metadata, and cached transcript validation use nonblocking file opens before
+they check the file type. This includes validation receipts. A FIFO cannot
+delay these reads while it waits for a writer.
 Integer conversion must not trap. Storage reports allocated and logical bytes,
 excludes provider storage, does not follow symlinks, and authorizes cleanup
 only after a complete scan with explicit `cleanup_eligible: true`.


### PR DESCRIPTION
A FIFO at a metadata, transcript, receipt, or helper lock path can block open before the regular-file check runs. This can hang storage inspection, recovery validation, or helper liveness checks.

Use nonblocking read opens before the existing descriptor-based file type, ownership, and size checks. Invalid special files still fail closed. Regular files and lock ownership rules keep their existing behavior.

Validation: all six bounded FIFO regressions failed before the change and pass after it; 85 focused state, storage, and power tests pass. The selected local diagnostic exposed an intermittent Codex missing-backup recovery failure. A separate instrumented recovery run passed; that intermittent failure remains under investigation. The hosted repository gate must pass before merge. Hardware power and release checks were not run.
