### PR TITLE
Bound helper command output and descendant lifetime

### DIFF
--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -43,38 +43,6 @@ public protocol RootCommandRunning: Sendable {
     func run(_ command: RootCommand) throws -> RootCommandResult
 }
 
-private final class BoundedRootCommandOutput: @unchecked Sendable {
-    private let lock = NSLock()
-    private let maximumBytes: Int
-    private var data = Data()
-    private var didTruncate = false
-
-    init(maximumBytes: Int) {
-        self.maximumBytes = max(0, maximumBytes)
-    }
-
-    func append(_ chunk: Data) {
-        lock.lock()
-        defer { lock.unlock() }
-        let remaining = max(0, maximumBytes - data.count)
-        if chunk.count > remaining { didTruncate = true }
-        guard remaining > 0 else { return }
-        data.append(chunk.prefix(remaining))
-    }
-
-    var string: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return String(decoding: data, as: UTF8.self)
-    }
-
-    var isTruncated: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return didTruncate
-    }
-}
-
 public struct RootProcessCommandRunner: RootCommandRunning {
     public static let defaultTimeout: TimeInterval = 2
     public static let defaultTerminationGrace: TimeInterval = 1
@@ -97,71 +65,26 @@ public struct RootProcessCommandRunner: RootCommandRunning {
     }
 
     public func run(_ command: RootCommand) throws -> RootCommandResult {
-        let process = Process()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.executableURL = URL(fileURLWithPath: command.executable)
-        process.arguments = command.arguments
-        process.environment = [
-            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-            "LC_ALL": "C",
-        ]
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = stdout
-        process.standardError = stderr
-        try process.run()
-
-        let output = BoundedRootCommandOutput(
-            maximumBytes: maximumOutputBytes)
-        let errorOutput = BoundedRootCommandOutput(
-            maximumBytes: maximumOutputBytes)
-        let readers = DispatchGroup()
-        Self.drain(stdout.fileHandleForReading, into: output, group: readers)
-        Self.drain(stderr.fileHandleForReading, into: errorOutput, group: readers)
-
-        let deadline = Date().addingTimeInterval(timeout)
-        while process.isRunning && Date() < deadline {
-            usleep(10_000)
-        }
-        let timedOut = process.isRunning
-        if timedOut {
-            process.terminate()
-            let killDeadline = Date().addingTimeInterval(terminationGrace)
-            while process.isRunning && Date() < killDeadline {
-                usleep(10_000)
-            }
-            if process.isRunning {
-                Darwin.kill(process.processIdentifier, SIGKILL)
-            }
-        }
-        process.waitUntilExit()
-        readers.wait()
-        if timedOut {
+        let result = try BoundedProcessRunner().run(BoundedProcessRequest(
+            executableURL: URL(fileURLWithPath: command.executable),
+            arguments: command.arguments,
+            environment: [
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "LC_ALL": "C",
+            ],
+            timeout: timeout,
+            terminationGrace: terminationGrace,
+            maximumOutputBytes: maximumOutputBytes))
+        if result.timedOut {
             throw PowerHelperPlatformError.commandTimedOut(
                 executable: command.executable)
         }
         return RootCommandResult(
-            exitCode: process.terminationStatus,
-            standardOutput: output.string,
-            standardError: errorOutput.string,
-            standardOutputTruncated: output.isTruncated,
-            standardErrorTruncated: errorOutput.isTruncated)
-    }
-
-    private static func drain(
-        _ handle: FileHandle,
-        into output: BoundedRootCommandOutput,
-        group: DispatchGroup
-    ) {
-        group.enter()
-        DispatchQueue.global(qos: .utility).async {
-            defer { group.leave() }
-            while true {
-                guard let chunk = try? handle.read(upToCount: 4_096),
-                      !chunk.isEmpty else { return }
-                output.append(chunk)
-            }
-        }
+            exitCode: result.exitCode,
+            standardOutput: String(decoding: result.standardOutput, as: UTF8.self),
+            standardError: String(decoding: result.standardError, as: UTF8.self),
+            standardOutputTruncated: result.standardOutputTruncated,
+            standardErrorTruncated: result.standardErrorTruncated)
     }
 }
 

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -32,6 +32,35 @@ final class PowerHelperPlatformTests: XCTestCase {
         }
     }
 
+    func testRootCommandRunnerBoundsInheritedPipesAfterLeaderExit() throws {
+        let started = Date()
+        let result = try RootProcessCommandRunner(
+            timeout: 0.2, terminationGrace: 0.05
+        ).run(RootCommand(
+            executable: "/bin/sh",
+            arguments: ["-c", "(/bin/sleep 3; printf late) & printf ready"]))
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.5)
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.standardOutput, "ready")
+        XCTAssertTrue(result.standardOutputTruncated)
+        XCTAssertTrue(result.standardErrorTruncated)
+    }
+
+    func testRootCommandRunnerTimeoutIncludesPipeDescendants() {
+        let started = Date()
+        let runner = RootProcessCommandRunner(
+            timeout: 0.2, terminationGrace: 0.05)
+
+        XCTAssertThrowsError(try runner.run(RootCommand(
+            executable: "/bin/sh",
+            arguments: ["-c", "trap '' TERM; /bin/sleep 3 & wait"]))) { error in
+            XCTAssertEqual(error as? PowerHelperPlatformError,
+                           .commandTimedOut(executable: "/bin/sh"))
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.5)
+    }
+
     func testRootCommandRunnerDrainsButBoundsCapturedOutput() throws {
         let runner = RootProcessCommandRunner(
             timeout: 2, maximumOutputBytes: 1_024)

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -12,6 +12,12 @@ Power protection has two required layers and one observable combined state:
    It manages only the machine-wide closed-lid setting through absolute
    `/usr/bin/pmset` invocations and a renewable lease registry.
 
+Root commands use the same bounded process-group runner as CLI reads. Each
+command has a two-second default deadline and a one-second TERM grace.
+Dedicated readers bound each output stream. An inherited pipe cannot keep the
+helper waiting after command exit. Incomplete output cannot prove power state.
+The command environment keeps a fixed system PATH and the C locale.
+
 The wrapper must acquire both layers before provider launch. It watches a
 private, run-token-scoped activity file. Before it accepts `waiting`, it also
 validates a recorded inode/mtime/size snapshot and starts an event watcher on the


### PR DESCRIPTION
A root command can exit while a descendant keeps its output pipe open. The helper then waits without a deadline for that descendant, including after a timeout kills only the command leader.

Use the existing bounded process-group runner for root commands. Keep the fixed system environment, output limits, and timeout error. Dedicated readers bound pipe drains, and incomplete output remains an error for power-state consumers.

Validation: two regressions each waited 3.01 seconds before the fix despite a 0.2-second command deadline. All 42 platform tests pass after the fix, including output limits, fixed environment, launch errors, and nonzero status. The selected local diagnostic passed Swift, app, distribution, and tmux; interactive UI activation was blocked by the locked macOS session. The hosted repository gate must pass before merge. Hardware power and release checks were not run.
