### PR TITLE
Validate PR evidence paths before remote mutations

### DIFF
--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -147,7 +147,9 @@ Hosted CI is the merge-readiness authority.
   exact head check. It then enables native auto-merge for that head and waits
   at most the merge deadline. It disables auto-merge on timeout. The command
   rejects a changed head, an invalid ruleset, and a repair attempt above the
-  policy maximum. It writes current-policy evidence under `app/build/`.
+  policy maximum. It validates the evidence path and creates its parent
+  before it calls GitHub. Invalid paths cannot trigger a merge. It writes
+  current-policy evidence under `app/build/`.
 - Weekly Dependabot checks pinned Actions and Swift packages. It groups each
   ecosystem into at most one pull request to protect the feedback queue. The
   bounded weekly/manual CodeQL workflow scans Actions on Linux and arm64 Swift

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -16,7 +16,8 @@ change real power state, upload assets, or claim publication.
 - Invoking `scripts/release-version X.Y.Z` authorizes its automated commit,
   tag, and publication steps. Push the release head to its unique
   `detach-release/vX.Y.Z` branch. `scripts/release-pr` creates or resumes one
-  exact pull request. The normal strict `quality-gates` job must pass before
+  exact pull request. It validates the evidence path before it creates or
+  merges a pull request. The normal strict `quality-gates` job must pass before
   bounded auto-merge. The final merge must have the tested source and release
   head as its ordered parents and the tested tree. Tag that merge, verify the
   remote `main` and tag, and remove only the matching temporary branch. No

--- a/tests/quality_merge_contract.py
+++ b/tests/quality_merge_contract.py
@@ -135,8 +135,10 @@ def invoke(
     mode: str = "success",
     repair: int = 0,
     policy: Path | None = None,
+    test_mode: bool = True,
+    output: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    output = root / f"{mode}-{repair}.json"
+    output = output or root / f"{mode}-{repair}.json"
     environment = os.environ.copy()
     environment.update(
         {
@@ -147,6 +149,9 @@ def invoke(
             "MERGE_STATE": str(root / f"state-{mode}-{repair}"),
         }
     )
+    if not test_mode:
+        environment.pop("DETACH_QUALITY_MERGE_TEST_MODE", None)
+        environment["PATH"] = str(fake.parent) + os.pathsep + environment.get("PATH", "")
     if policy is not None:
         environment["DETACH_QUALITY_POLICY"] = str(policy)
     return subprocess.run(
@@ -178,6 +183,29 @@ def main() -> None:
         root = Path(directory)
         fake = root / "gh"
         fake_gh(fake)
+
+        forbidden = invoke(root, fake, "forbidden-output", test_mode=False)
+        require_failure(forbidden, "merge evidence must use app/build/quality-merge.json")
+        assert not (root / "state-forbidden-output-0/calls.log").exists(), (
+            "invalid output reached GitHub before validation")
+
+        for mode in ["directory-output", "symlink-output", "dangling-output"]:
+            output = root / f"{mode}-0.json"
+            if mode == "directory-output":
+                output.mkdir()
+            else:
+                target = root / f"{mode}-target"
+                if mode == "symlink-output":
+                    target.write_text("preserve", encoding="utf-8")
+                output.symlink_to(target)
+            require_failure(invoke(root, fake, mode), "merge evidence output is unsafe")
+            assert not (root / f"state-{mode}-0/calls.log").exists()
+
+        parent_file = root / "parent-file"
+        parent_file.write_text("preserve", encoding="utf-8")
+        parent_result = invoke(root, fake, "parent-file", output=parent_file / "summary.json")
+        assert parent_result.returncode == 2, parent_result.stdout
+        assert not (root / "state-parent-file-0/calls.log").exists()
 
         result = invoke(root, fake)
         assert result.returncode == 0, result.stdout

--- a/tests/release_pr_contract.py
+++ b/tests/release_pr_contract.py
@@ -102,7 +102,9 @@ else:
     path.chmod(0o755)
 
 
-def invoke(root: Path, fake: Path, mode: str) -> subprocess.CompletedProcess[str]:
+def invoke(
+    root: Path, fake: Path, mode: str, *, test_mode: bool = True
+) -> subprocess.CompletedProcess[str]:
     output = root / f"{mode}.json"
     environment = os.environ.copy()
     environment.update(
@@ -116,6 +118,10 @@ def invoke(root: Path, fake: Path, mode: str) -> subprocess.CompletedProcess[str
             "RELEASE_PR_STATE": str(root / f"state-{mode}"),
         }
     )
+    if not test_mode:
+        environment.pop("DETACH_RELEASE_PR_TEST_MODE", None)
+        environment.pop("DETACH_QUALITY_MERGE_TEST_MODE", None)
+        environment["PATH"] = str(fake.parent) + os.pathsep + environment.get("PATH", "")
     return subprocess.run(
         [
             str(ROOT / "scripts/release-pr"),
@@ -140,6 +146,22 @@ def main() -> None:
         root = Path(directory)
         fake = root / "gh"
         fake_gh(fake)
+        forbidden = invoke(root, fake, "forbidden-output", test_mode=False)
+        assert forbidden.returncode == 2, forbidden.stdout
+        assert "release PR evidence must use app/build/release-pr.json" in forbidden.stdout
+        assert not (root / "state-forbidden-output/calls").exists()
+
+        for mode in ["directory-output", "dangling-output"]:
+            output = root / f"{mode}.json"
+            if mode == "directory-output":
+                output.mkdir()
+            else:
+                output.symlink_to(root / "absent-target")
+            invalid = invoke(root, fake, mode)
+            assert invalid.returncode == 2, invalid.stdout
+            assert "release PR evidence output is unsafe" in invalid.stdout
+            assert not (root / f"state-{mode}/calls").exists()
+
         success = invoke(root, fake, "success")
         assert success.returncode == 0, success.stdout
         summary = json.loads((root / "success.json").read_text(encoding="utf-8"))

--- a/tools/quality_merge.py
+++ b/tools/quality_merge.py
@@ -373,12 +373,16 @@ def wait_for_merge(
         sleep_until_next_poll(deadline, poll_seconds)
 
 
-def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+def prepare_summary_path(path: Path, test_mode: bool) -> None:
     if not test_mode and path.resolve() != DEFAULT_OUTPUT.resolve():
         raise MergeError("merge evidence must use app/build/quality-merge.json")
-    if path.exists() and (not path.is_file() or path.is_symlink()):
+    if path.is_symlink() or (path.exists() and not path.is_file()):
         raise MergeError("merge evidence output is unsafe")
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+    prepare_summary_path(path, test_mode)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
         temporary.write_text(
@@ -468,6 +472,8 @@ def main() -> int:
     args = parser().parse_args()
     try:
         policy = Policy(POLICY_FILE)
+        prepare_summary_path(
+            args.output, os.environ.get("DETACH_QUALITY_MERGE_TEST_MODE") == "1")
         summary = execute(args, policy)
         write_summary(
             args.output,

--- a/tools/release_pr.py
+++ b/tools/release_pr.py
@@ -149,12 +149,16 @@ def validate_completed_gate(
     return run["id"]
 
 
-def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+def prepare_summary_path(path: Path, test_mode: bool) -> None:
     if not test_mode and path.resolve() != DEFAULT_OUTPUT.resolve():
         raise ReleasePrError("release PR evidence must use app/build/release-pr.json")
-    if path.exists() and (not path.is_file() or path.is_symlink()):
+    if path.is_symlink() or (path.exists() and not path.is_file()):
         raise ReleasePrError("release PR evidence output is unsafe")
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+    prepare_summary_path(path, test_mode)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
         temporary.write_text(
@@ -242,6 +246,7 @@ def main() -> int:
     args = parser().parse_args()
     test_mode = os.environ.get("DETACH_RELEASE_PR_TEST_MODE") == "1"
     try:
+        prepare_summary_path(args.output, test_mode)
         summary = execute(args, Policy(POLICY_FILE))
         write_summary(args.output, summary, test_mode)
     except (ReleasePrError, MergeError, OSError, ValueError) as error:


### PR DESCRIPTION
The PR tools validate the evidence output only after creating or merging a pull request. An invalid output argument can therefore report failure after a successful remote mutation.

Validate the command-owned output path and prepare its parent before GitHub calls. Reject directories and both existing and dangling symlinks. Revalidate the path when writing the result. Keep the reusable merge operation independent of the caller's evidence path.

Validation: fake GitHub regressions reproduced remote calls before rejection in both commands. The new cases pass without any GitHub call. Existing merge and release PR contracts, selected gate contracts, app build, publication preflight, release preflight, and hermetic release workflow pass. Local interactive UI activation was blocked by the locked macOS session. The hosted repository gate must pass before merge. No external release or publication was performed.
