### PR TITLE
Fix stale session state, clipped headers, and unbounded waits

### DIFF
--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -147,7 +147,8 @@ struct RootView: View {
             await notifications.configure(enabled: notificationsEnabled)
         }
 // quality-coverage:begin ui-e2e-instrumentation
-        .task {
+        .task(id: initialSetupComplete) {
+            guard initialSetupComplete else { return }
             await UIE2ETestDriver.runIfRequested(
                 installation: installation,
                 store: store,

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -234,20 +234,14 @@ struct SessionDetailView: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .help(session.displayTitle)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        uiE2EGeometryProbe(identifier: "session-detail-title")
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                 statusPill
-                if let model = session.model {
-                    Text(model)
-                        .appFont(.caption, weight: .semibold)
-                        .lineLimit(1)
-                        .padding(.horizontal, 7).padding(.vertical, 2)
-                        .background(Capsule().fill(providerTint.opacity(0.16)))
-                        .foregroundStyle(providerTint)
-                        // Pills keep their single line; the title truncates first.
-                        .layoutPriority(1)
-                }
-                if session.contextSummary != nil {
-                    ContextGauge(session: session)
-                }
                 Spacer()
             }
             metadataRail
@@ -307,6 +301,17 @@ struct SessionDetailView: View {
     private var metadataRail: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
+                if let model = session.model {
+                    Text(model)
+                        .appFont(.caption, weight: .semibold)
+                        .lineLimit(1)
+                        .padding(.horizontal, 7).padding(.vertical, 3)
+                        .background(Capsule().fill(providerTint.opacity(0.16)))
+                        .foregroundStyle(providerTint)
+                }
+                if session.contextSummary != nil {
+                    ContextGauge(session: session)
+                }
                 if let reason = session.healthReasonLabel {
                     Label(reason, systemImage: "exclamationmark.triangle.fill")
                         .appFont(.caption)

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -472,6 +472,15 @@ struct SettingsView: View {
                     .frame(width: 150)
                     .accessibilityLabel(L10n.string("Text size"))
                     .accessibilityValue(L10n.format("%d pt", Int(previewFontPointSize)))
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        if AppSettings.uiE2E != nil {
+                            UIE2EGeometryProbe(identifier: "settings-text-size")
+                        }
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                     Text(verbatim: "A")
                         .font(.system(size: 16))
                         .foregroundStyle(.secondary)
@@ -488,6 +497,19 @@ struct SettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .tint(Brand.indigo)
                     .disabled(fontSizeDraft?.hasChanges != true)
+// quality-coverage:begin ui-e2e-instrumentation
+#if !DEBUG
+                    .background {
+                        if AppSettings.uiE2E != nil {
+                            UIE2EGeometryProbe(
+                                identifier: "settings-apply-text-size",
+                                semanticLabel: L10n.string("Apply"),
+                                semanticRole: .button,
+                                semanticEnabled: fontSizeDraft?.hasChanges == true)
+                        }
+                    }
+#endif
+// quality-coverage:end ui-e2e-instrumentation
                 }
                 Toggle(L10n.string("Show tips"), isOn: $tipsEnabled)
 // quality-coverage:begin ui-e2e-instrumentation

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -1508,19 +1508,28 @@ final class SettingsWindowFrameView: NSView {
 
     private func pinToHostingScreen() {
         guard let window, width > 0 else { return }
-        let visibleHeight = window.screen?.visibleFrame.height ?? 720
+        let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame
         let size = CGSize(
             width: width,
             height: SettingsWindowLayout.contentHeight(
                 base: baseHeight,
                 fontPointSize: fontPointSize,
-                visibleScreenHeight: visibleHeight))
+                visibleScreenHeight: visibleFrame?.height ?? 720))
         window.contentMinSize = size
         window.contentMaxSize = size
         let current = window.contentView?.bounds.size ?? .zero
         if abs(current.width - size.width) > 0.5
             || abs(current.height - size.height) > 0.5 {
             window.setContentSize(size)
+        }
+        if let visibleFrame {
+            let frame = window.frame
+            let origin = CGPoint(
+                x: max(visibleFrame.minX, min(frame.minX, visibleFrame.maxX - frame.width)),
+                y: max(visibleFrame.minY, min(frame.minY, visibleFrame.maxY - frame.height)))
+            if origin != frame.origin {
+                window.setFrameOrigin(origin)
+            }
         }
     }
 }

--- a/app/Sources/DetachApp/UIE2EGeometryProbe.swift
+++ b/app/Sources/DetachApp/UIE2EGeometryProbe.swift
@@ -83,7 +83,8 @@ final class UIE2EGeometryView: NSView {
     }
     override func accessibilityLabel() -> String? { semanticLabel }
     override func accessibilityFrame() -> NSRect {
-        UIE2EGeometryRegistry.frame(for: identifierValue) ?? .zero
+        publishFrame()
+        return UIE2EGeometryRegistry.frame(for: identifierValue) ?? .zero
     }
     override func isAccessibilityEnabled() -> Bool { semanticEnabled }
 

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -959,8 +959,12 @@ enum UIE2ETestDriver {
             throw Failure(message: "quick chat folder panel is not an open panel")
         }
         openPanel.cancel(nil)
+        trace("cancelled folder panel: visible=\(openPanel.isVisible), "
+            + "attached=\(openPanel.sheetParent != nil)")
         try await waitUntil("quick chat folder panel closes") {
-            find(identifier: "open-panel") == nil
+            !openPanel.isVisible && openPanel.sheetParent == nil
+                && NSApp.modalWindow !== openPanel
+                && find(identifier: "open-panel") == nil
                 && NSApp.windows.allSatisfy(\.sheets.isEmpty)
         }
         checks.append("settings-quick-chat-folder-panel")
@@ -1016,8 +1020,6 @@ enum UIE2ETestDriver {
               abs(window.frame.width - originalFrame.width) < 1 else {
             throw Failure(message: "text size draft resized Settings before Apply")
         }
-        window.setFrameOrigin(CGPoint(
-            x: visible.maxX - window.frame.width, y: visible.minY))
         try await revealGeometry(
             identifier: "settings-apply-text-size", name: "text size Apply")
         try await clickMeasuredControl(
@@ -1030,6 +1032,22 @@ enum UIE2ETestDriver {
         }
         AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
         try await waitUntil("Settings restores its original text size") {
+            abs(window.frame.width - originalFrame.width) < 1
+                && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
+        }
+        trace("Settings Apply changed the font and window size")
+        // Exercise screen-edge growth separately from control input. A
+        // programmatic window move must not race the real Apply click.
+        window.setFrameOrigin(CGPoint(
+            x: visible.maxX - window.frame.width, y: visible.minY))
+        AppSettings.defaults.set(
+            AppFontSize.allowedRange.upperBound, forKey: AppFontSize.storageKey)
+        try await waitUntil("Settings grows from the screen edge") {
+            window.frame.width > originalFrame.width + 100
+                && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
+        }
+        AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+        try await waitUntil("Settings restores its size at the screen edge") {
             abs(window.frame.width - originalFrame.width) < 1
                 && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
         }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -980,8 +980,6 @@ enum UIE2ETestDriver {
         guard visible.insetBy(dx: -2, dy: -2).contains(frame) else {
             throw Failure(message: "Settings window is off the hosting screen")
         }
-        try await verifySettingsTextGrowth(in: settingsWindow, visible: visible)
-        checks.append("settings-text-growth-stays-on-screen")
         checks.append("settings-window-stays-on-screen")
         let systemTab = try await buttonLabeled(
             L10n.string("System"), attempts: 40)
@@ -990,6 +988,15 @@ enum UIE2ETestDriver {
         try await revealGeometry(
             identifier: "settings-installation", name: "Installation")
         checks.append("settings-system-reveals-storage-and-installation")
+        let generalTab = try await buttonLabeled(
+            L10n.string("General"), attempts: 40)
+        _ = try await clickUntilElement(
+            generalTab, name: "General settings tab",
+            resultIdentifier: "settings-show-tips")
+        // Placement checks run last so no later control click consumes a
+        // cached accessibility frame from before a programmatic window move.
+        try await verifySettingsTextGrowth(in: settingsWindow, visible: visible)
+        checks.append("settings-text-growth-stays-on-screen")
         return checks
     }
 

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -362,6 +362,11 @@ enum UIE2ETestDriver {
             guard label(reconnectButton) == L10n.string("Reconnect") else {
                 throw Failure(message: "exited attach client does not offer Reconnect")
             }
+            try await waitUntil("disconnected session log is readable") {
+                guard let scrollView = find(identifier: "session-preview-log") as? NSScrollView,
+                      let textView = scrollView.documentView as? NSTextView else { return false }
+                return textView.string.contains("UI fixture log for \(recoverableID)")
+            }
             try await clickUntil(
                 reconnectButton,
                 name: "in-app reconnect action",
@@ -851,6 +856,21 @@ enum UIE2ETestDriver {
                 find(identifier: "session-detail-detach-codex-ui-quick") != nil
             }
             checks.append("quick-chat-command-starts-session")
+
+            guard let shortcutID = shortcuts.sessionID(for: 1) else {
+                throw Failure(message: "no session has the first window-reopen shortcut")
+            }
+            mainWindow.close()
+            try await waitUntil("main window closes") { !mainWindow.isVisible }
+            NSApp.activate(ignoringOtherApps: true)
+            try await keyPress("1", keyCode: 18, modifiers: [.command])
+            _ = try await element(identifier: "session-detail-\(shortcutID)")
+            guard NSApp.windows.contains(where: {
+                $0.identifier?.rawValue == "main" && $0.isVisible
+            }) else {
+                throw Failure(message: "session shortcut did not reopen the main window")
+            }
+            checks.append("session-shortcut-reopens-closed-main-window")
 
             try await restoreFocus(
                 to: previousFrontmost, policy: previousActivationPolicy)
@@ -1353,11 +1373,21 @@ enum UIE2ETestDriver {
         }
         for font in [AppFontSize.defaultValue, AppFontSize.allowedRange.upperBound] {
             AppSettings.defaults.set(font, forKey: AppFontSize.storageKey)
-            // Allow the preference change to update the split view minimum.
-            try await Task.sleep(nanoseconds: 50_000_000)
+            try await waitUntil("session title uses font \(font)") {
+                guard let title = UIE2EGeometryRegistry.frame(for: "session-detail-title")
+                else { return false }
+                let pointSize = AppFontRole.title2.pointSize(base: font)
+                return title.height >= pointSize && title.height < pointSize + 12
+            }
             window.setContentSize(AppFontSize.minimumWindowSize(for: font))
             window.contentView?.layoutSubtreeIfNeeded()
-            try await Task.sleep(nanoseconds: 50_000_000)
+            try await waitUntil("session title is inside the resized window") {
+                elements().compactMap { $0 as? UIE2EGeometryView }
+                    .filter { $0.identifierValue == "session-detail-title" }
+                    .forEach { $0.publishFrame() }
+                return UIE2EGeometryRegistry.frame(for: "session-detail-title")
+                    .map { window.frame.contains($0) } == true
+            }
             let title = try await measuredFrame(
                 identifier: "session-detail-title", name: "session title")
             guard title.width >= font * 5, title.height >= font,
@@ -1459,6 +1489,9 @@ enum UIE2ETestDriver {
     ) async throws -> CGRect {
         var result: CGRect?
         try await waitUntil("real control geometry for \(name)") {
+            elements().compactMap { $0 as? UIE2EGeometryView }
+                .filter { $0.identifierValue == identifier }
+                .forEach { $0.publishFrame() }
             result = UIE2EGeometryRegistry.frame(for: identifier)
             return result?.isEmpty == false
         }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -975,6 +975,8 @@ enum UIE2ETestDriver {
         guard visible.insetBy(dx: -2, dy: -2).contains(frame) else {
             throw Failure(message: "Settings window is off the hosting screen")
         }
+        try await verifySettingsTextGrowth(in: settingsWindow, visible: visible)
+        checks.append("settings-text-growth-stays-on-screen")
         checks.append("settings-window-stays-on-screen")
         let systemTab = try await buttonLabeled(
             L10n.string("System"), attempts: 40)
@@ -984,6 +986,47 @@ enum UIE2ETestDriver {
             identifier: "settings-installation", name: "Installation")
         checks.append("settings-system-reveals-storage-and-installation")
         return checks
+    }
+
+    private static func verifySettingsTextGrowth(
+        in window: NSWindow,
+        visible: CGRect
+    ) async throws {
+        let originalPreference = AppSettings.defaults.object(forKey: AppFontSize.storageKey)
+        let originalFont = originalPreference as? Double ?? AppFontSize.defaultValue
+        AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+        let originalFrame = window.frame
+        defer {
+            AppSettings.defaults.set(originalPreference, forKey: AppFontSize.storageKey)
+            window.setFrame(originalFrame, display: true)
+        }
+        window.setFrameOrigin(CGPoint(
+            x: visible.maxX - window.frame.width, y: visible.minY))
+        let slider = try await element(role: .slider)
+        try requireGeometry(slider, name: "settings text size slider")
+        let sliderFrame = frame(slider)
+        try await click(
+            frame: CGRect(x: sliderFrame.maxX - 3, y: sliderFrame.midY - 1,
+                          width: 2, height: 2),
+            name: "maximum settings text size", owningWindow: window)
+        let apply = try await buttonLabeled(L10n.string("Apply"))
+        try await waitUntil("text size draft can be applied") { isEnabled(apply) }
+        guard AppSettings.defaults.double(forKey: AppFontSize.storageKey) == originalFont,
+              abs(window.frame.width - originalFrame.width) < 1 else {
+            throw Failure(message: "text size draft resized Settings before Apply")
+        }
+        try await click(apply, name: "apply maximum text size")
+        try await waitUntil("Settings grows within the hosting screen") {
+            AppSettings.defaults.double(forKey: AppFontSize.storageKey)
+                == AppFontSize.allowedRange.upperBound
+                && window.frame.width > originalFrame.width + 100
+                && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
+        }
+        AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+        try await waitUntil("Settings restores its original text size") {
+            abs(window.frame.width - originalFrame.width) < 1
+                && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
+        }
     }
 
     private static func runOnboardingFirstRun(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -156,6 +156,7 @@ enum UIE2ETestDriver {
     private static var scenarioDeadline = TimeInterval.greatestFiniteMagnitude
     private static var nextMouseEventNumber = Int(
         ProcessInfo.processInfo.systemUptime * 1_000)
+    private static let mouseClickInterval: TimeInterval = 0.03
     private static var cursorRestorePoint: CGPoint?
 
     static func runIfRequested(
@@ -1612,6 +1613,35 @@ enum UIE2ETestDriver {
         return result!
     }
 
+    static func mouseClickEvents(
+        at windowPoint: CGPoint,
+        windowNumber: Int,
+        name: String
+    ) throws -> [NSEvent] {
+        var events: [NSEvent] = []
+        let timestamp = ProcessInfo.processInfo.systemUptime
+        let eventNumber = nextMouseEventNumber
+        nextMouseEventNumber += 1
+        for type in [NSEvent.EventType.leftMouseDown, .leftMouseUp] {
+            guard let event = NSEvent.mouseEvent(
+                with: type,
+                location: windowPoint,
+                modifierFlags: [],
+                timestamp: timestamp + Double(events.count) * mouseClickInterval,
+                windowNumber: windowNumber,
+                context: nil,
+                eventNumber: eventNumber,
+                clickCount: 1,
+                pressure: type == .leftMouseDown ? 1 : 0)
+            else { continue }
+            events.append(event)
+        }
+        guard events.count == 2 else {
+            throw Failure(message: "cannot create mouse pair for \(name)")
+        }
+        return events
+    }
+
     private static func click(
         frame targetFrame: CGRect,
         name: String,
@@ -1645,35 +1675,15 @@ enum UIE2ETestDriver {
             }
             trace("hit chain for \(name): \(names.joined(separator: " > "))")
         }
-        var events: [NSEvent] = []
-        let timestamp = ProcessInfo.processInfo.systemUptime
-        let clickInterval: TimeInterval = 0.03
-        for type in [NSEvent.EventType.leftMouseDown, .leftMouseUp] {
-            let eventNumber = nextMouseEventNumber
-            nextMouseEventNumber += 1
-            guard let event = NSEvent.mouseEvent(
-                with: type,
-                location: windowPoint,
-                modifierFlags: [],
-                timestamp: timestamp + Double(events.count) * clickInterval,
-                windowNumber: window.windowNumber,
-                context: nil,
-                eventNumber: eventNumber,
-                clickCount: 1,
-                pressure: type == .leftMouseDown ? 1 : 0)
-            else { continue }
-            events.append(event)
-        }
-        guard events.count == 2 else {
-            throw Failure(message: "cannot create mouse pair for \(name)")
-        }
+        let events = try mouseClickEvents(
+            at: windowPoint, windowNumber: window.windowNumber, name: name)
         // AppKit permits postEvent from a subthread. Delay mouseUp so SwiftUI
         // receives a physical-duration click even inside a tracking loop. Put
         // mouseUp at the queue tail so a busy main thread cannot process it
         // before the mouseDown event at the queue head.
         let mouseUp = UIE2EDeferredMouseUp(application: NSApp, event: events[1])
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
-            deadline: .now() + clickInterval
+            deadline: .now() + mouseClickInterval
         ) {
             mouseUp.post()
         }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -10,19 +10,16 @@ enum UIE2EControlFault {
     static var stopActionAttempts = 0
 }
 
-private final class UIE2EDeferredMouseEvent: @unchecked Sendable {
+private final class UIE2EDeferredMouseUp: @unchecked Sendable {
     private let application: NSApplication
     private let event: NSEvent
-    private let cursorPosition: CGPoint?
 
-    init(application: NSApplication, event: NSEvent, cursorPosition: CGPoint? = nil) {
+    init(application: NSApplication, event: NSEvent) {
         self.application = application
         self.event = event
-        self.cursorPosition = cursorPosition
     }
 
     func post() {
-        if let cursorPosition { CGWarpMouseCursorPosition(cursorPosition) }
         application.postEvent(event, atStart: false)
     }
 }
@@ -1012,14 +1009,7 @@ enum UIE2ETestDriver {
             identifier: "settings-text-size", name: "settings text size slider")
         let sliderFrame = try await measuredFrame(
             identifier: "settings-text-size", name: "settings text size slider")
-        let range = AppFontSize.allowedRange
-        let fraction = (originalFont - range.lowerBound)
-            / (range.upperBound - range.lowerBound)
-        try await drag(
-            from: CGPoint(x: sliderFrame.minX + 8 + (sliderFrame.width - 16) * fraction,
-                          y: sliderFrame.midY),
-            to: CGPoint(x: sliderFrame.maxX - 8, y: sliderFrame.midY),
-            in: window, name: "maximum settings text size")
+        try await incrementSliderToMaximum(in: sliderFrame)
         let apply = try await element(identifier: "settings-apply-text-size")
         try await waitUntil("text size draft can be applied") { isEnabled(apply) }
         guard AppSettings.defaults.double(forKey: AppFontSize.storageKey) == originalFont,
@@ -1044,6 +1034,29 @@ enum UIE2ETestDriver {
                 && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
         }
         completed = true
+    }
+
+    private static func incrementSliderToMaximum(in measuredFrame: CGRect) async throws {
+        let slider = try await element(role: .slider)
+        guard frame(slider).intersects(measuredFrame),
+              let maximum = slider.accessibilityMaxValue() as? NSNumber else {
+            throw Failure(message: "text size slider has no native range or matching frame")
+        }
+        // Invoke the real control's standard increment action. The locator
+        // probe supplies geometry only and cannot change the slider value.
+        for _ in 0...Int(AppFontSize.allowedRange.upperBound - AppFontSize.allowedRange.lowerBound) {
+            guard let previous = value(slider) as? NSNumber else {
+                throw Failure(message: "text size slider has no native value")
+            }
+            if previous.doubleValue >= maximum.doubleValue { return }
+            guard slider.accessibilityPerformIncrement() else {
+                throw Failure(message: "text size slider rejected its increment action")
+            }
+            try await waitUntil("native text size slider increment", attempts: 20) {
+                (value(slider) as? NSNumber)?.doubleValue != previous.doubleValue
+            }
+        }
+        throw Failure(message: "text size slider did not reach its maximum")
     }
 
     private static func captureSettingsFailure(_ window: NSWindow) {
@@ -1640,7 +1653,7 @@ enum UIE2ETestDriver {
         // receives a physical-duration click even inside a tracking loop. Put
         // mouseUp at the queue tail so a busy main thread cannot process it
         // before the mouseDown event at the queue head.
-        let mouseUp = UIE2EDeferredMouseEvent(application: NSApp, event: events[1])
+        let mouseUp = UIE2EDeferredMouseUp(application: NSApp, event: events[1])
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + clickInterval
         ) {
@@ -1650,65 +1663,10 @@ enum UIE2ETestDriver {
         try await Task.sleep(nanoseconds: 60_000_000)
     }
 
-    private static func drag(
-        from start: CGPoint,
-        to end: CGPoint,
-        in window: NSWindow,
-        name: String
-    ) async throws {
-        trace("dragging \(name) from \(start) to \(end), key=\(window.isKeyWindow)")
-        try moveCursor(to: start, name: name)
-        trace("drag pointer in window: \(window.mouseLocationOutsideOfEventStream), "
-            + "expected \(window.convertPoint(fromScreen: start))")
-        // Gesture recognition needs movement after its initial drag event.
-        // A single jump followed by mouseUp can only begin the gesture.
-        var sequence: [(NSEvent.EventType, CGPoint)] = [(.leftMouseDown, start)]
-        for step in 1...6 {
-            let fraction = Double(step) / 6
-            sequence.append((.leftMouseDragged, CGPoint(
-                x: start.x + (end.x - start.x) * fraction,
-                y: start.y + (end.y - start.y) * fraction)))
-        }
-        sequence.append((.leftMouseUp, end))
-        var events: [NSEvent] = []
-        let timestamp = ProcessInfo.processInfo.systemUptime
-        for (index, item) in sequence.enumerated() {
-            nextMouseEventNumber += 1
-            guard let event = NSEvent.mouseEvent(
-                with: item.0, location: window.convertPoint(fromScreen: item.1),
-                modifierFlags: [], timestamp: timestamp + Double(index) * 0.05,
-                windowNumber: window.windowNumber, context: nil,
-                eventNumber: nextMouseEventNumber, clickCount: 1,
-                pressure: item.0 == .leftMouseUp ? 0 : 1)
-            else { throw Failure(message: "cannot create drag event for \(name)") }
-            events.append(event)
-        }
-        for index in 1..<events.count {
-            let delivery = UIE2EDeferredMouseEvent(
-                application: NSApp, event: events[index],
-                cursorPosition: try cursorPoint(for: sequence[index].1, name: name))
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(
-                deadline: .now() + Double(index) * 0.05
-            ) { delivery.post() }
-        }
-        NSApp.postEvent(events[0], atStart: true)
-        try await Task.sleep(nanoseconds: 400_000_000)
-    }
-
     private static func moveCursor(
         to screenPoint: CGPoint,
         name: String
     ) throws {
-        let point = try cursorPoint(for: screenPoint, name: name)
-        guard CGWarpMouseCursorPosition(point) == .success else {
-            throw Failure(message: "cannot position the pointer for \(name)")
-        }
-    }
-
-    private static func cursorPoint(
-        for screenPoint: CGPoint,
-        name: String
-    ) throws -> CGPoint {
         guard cursorRestorePoint != nil else {
             throw Failure(message: "cannot preserve pointer position for \(name)")
         }
@@ -1721,10 +1679,13 @@ enum UIE2ETestDriver {
         else {
             throw Failure(message: "cannot resolve the display for \(name)")
         }
-        return UIE2ECursorPositionResolver.quartzPoint(
+        let quartzPoint = UIE2ECursorPositionResolver.quartzPoint(
             for: screenPoint,
             screenFrame: screen.frame,
             displayBounds: CGDisplayBounds(CGDirectDisplayID(screenNumber.uint32Value)))
+        guard CGWarpMouseCursorPosition(quartzPoint) == .success else {
+            throw Failure(message: "cannot position the pointer for \(name)")
+        }
     }
 
     private static func keyPress(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -330,6 +330,8 @@ enum UIE2ETestDriver {
                     "UI fixture log for \(recoverableID)")
             }
             checks.append("non-live-session-switch-uses-warm-cache")
+            try await verifySessionTitleAtMinimumWindowSize(mainWindow)
+            checks.append("session-title-survives-narrow-window-and-large-text")
             let recoverButton = try await element(
                 identifier: "session-action-recover-in-app")
             let recoverFallback = try await element(
@@ -1338,6 +1340,32 @@ enum UIE2ETestDriver {
             }
         }
         throw Failure(message: "\(name) did not produce \(resultIdentifier)")
+    }
+
+    private static func verifySessionTitleAtMinimumWindowSize(
+        _ window: NSWindow
+    ) async throws {
+        let originalFrame = window.frame
+        let originalFont = AppSettings.defaults.object(forKey: AppFontSize.storageKey)
+        defer {
+            AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
+            window.setFrame(originalFrame, display: true)
+        }
+        for font in [AppFontSize.defaultValue, AppFontSize.allowedRange.upperBound] {
+            AppSettings.defaults.set(font, forKey: AppFontSize.storageKey)
+            // Allow the preference change to update the split view minimum.
+            try await Task.sleep(nanoseconds: 50_000_000)
+            window.setContentSize(AppFontSize.minimumWindowSize(for: font))
+            window.contentView?.layoutSubtreeIfNeeded()
+            try await Task.sleep(nanoseconds: 50_000_000)
+            let title = try await measuredFrame(
+                identifier: "session-detail-title", name: "session title")
+            guard title.width >= font * 5, title.height >= font,
+                  window.frame.contains(title) else {
+                throw Failure(message:
+                    "session title disappeared or collapsed at font \(font): \(title)")
+            }
+        }
     }
 
     private static func clickUntil(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1002,20 +1002,24 @@ enum UIE2ETestDriver {
         }
         window.setFrameOrigin(CGPoint(
             x: visible.maxX - window.frame.width, y: visible.minY))
-        let slider = try await element(role: .slider)
-        try requireGeometry(slider, name: "settings text size slider")
-        let sliderFrame = frame(slider)
-        try await click(
-            frame: CGRect(x: sliderFrame.maxX - 3, y: sliderFrame.midY - 1,
-                          width: 2, height: 2),
-            name: "maximum settings text size", owningWindow: window)
-        let apply = try await buttonLabeled(L10n.string("Apply"))
+        try await revealGeometry(
+            identifier: "settings-text-size", name: "settings text size slider")
+        let sliderFrame = try await measuredFrame(
+            identifier: "settings-text-size", name: "settings text size slider")
+        try await clickMeasuredControl(
+            identifier: "settings-text-size", name: "maximum settings text size",
+            offset: CGSize(width: sliderFrame.width - 4, height: 0),
+            size: CGSize(width: 2, height: sliderFrame.height))
+        let apply = try await element(identifier: "settings-apply-text-size")
         try await waitUntil("text size draft can be applied") { isEnabled(apply) }
         guard AppSettings.defaults.double(forKey: AppFontSize.storageKey) == originalFont,
               abs(window.frame.width - originalFrame.width) < 1 else {
             throw Failure(message: "text size draft resized Settings before Apply")
         }
-        try await click(apply, name: "apply maximum text size")
+        try await revealGeometry(
+            identifier: "settings-apply-text-size", name: "text size Apply")
+        try await clickMeasuredControl(
+            identifier: "settings-apply-text-size", name: "apply maximum text size")
         try await waitUntil("Settings grows within the hosting screen") {
             AppSettings.defaults.double(forKey: AppFontSize.storageKey)
                 == AppFontSize.allowedRange.upperBound

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1005,8 +1005,6 @@ enum UIE2ETestDriver {
             AppSettings.defaults.set(originalPreference, forKey: AppFontSize.storageKey)
             window.setFrame(originalFrame, display: true)
         }
-        window.setFrameOrigin(CGPoint(
-            x: visible.maxX - window.frame.width, y: visible.minY))
         try await activate(window)
         window.contentView?.layoutSubtreeIfNeeded()
         window.displayIfNeeded()
@@ -1028,6 +1026,8 @@ enum UIE2ETestDriver {
               abs(window.frame.width - originalFrame.width) < 1 else {
             throw Failure(message: "text size draft resized Settings before Apply")
         }
+        window.setFrameOrigin(CGPoint(
+            x: visible.maxX - window.frame.width, y: visible.minY))
         try await revealGeometry(
             identifier: "settings-apply-text-size", name: "text size Apply")
         try await clickMeasuredControl(
@@ -1658,10 +1658,18 @@ enum UIE2ETestDriver {
     ) async throws {
         trace("dragging \(name) from \(start) to \(end), key=\(window.isKeyWindow)")
         try moveCursor(to: start, name: name)
-        let endCursor = try cursorPoint(for: end, name: name)
-        let sequence: [(NSEvent.EventType, CGPoint)] = [
-            (.leftMouseDown, start), (.leftMouseDragged, end), (.leftMouseUp, end),
-        ]
+        trace("drag pointer in window: \(window.mouseLocationOutsideOfEventStream), "
+            + "expected \(window.convertPoint(fromScreen: start))")
+        // Gesture recognition needs movement after its initial drag event.
+        // A single jump followed by mouseUp can only begin the gesture.
+        var sequence: [(NSEvent.EventType, CGPoint)] = [(.leftMouseDown, start)]
+        for step in 1...6 {
+            let fraction = Double(step) / 6
+            sequence.append((.leftMouseDragged, CGPoint(
+                x: start.x + (end.x - start.x) * fraction,
+                y: start.y + (end.y - start.y) * fraction)))
+        }
+        sequence.append((.leftMouseUp, end))
         var events: [NSEvent] = []
         let timestamp = ProcessInfo.processInfo.systemUptime
         for (index, item) in sequence.enumerated() {
@@ -1677,13 +1685,14 @@ enum UIE2ETestDriver {
         }
         for index in 1..<events.count {
             let delivery = UIE2EDeferredMouseEvent(
-                application: NSApp, event: events[index], cursorPosition: endCursor)
+                application: NSApp, event: events[index],
+                cursorPosition: try cursorPoint(for: sequence[index].1, name: name))
             DispatchQueue.global(qos: .userInitiated).asyncAfter(
                 deadline: .now() + Double(index) * 0.05
             ) { delivery.post() }
         }
         NSApp.postEvent(events[0], atStart: true)
-        try await Task.sleep(nanoseconds: 150_000_000)
+        try await Task.sleep(nanoseconds: 400_000_000)
     }
 
     private static func moveCursor(

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -1049,9 +1049,9 @@ enum UIE2ETestDriver {
                 throw Failure(message: "text size slider has no native value")
             }
             if previous.doubleValue >= maximum.doubleValue { return }
-            guard slider.accessibilityPerformIncrement() else {
-                throw Failure(message: "text size slider rejected its increment action")
-            }
+            // SwiftUI can return false even when its native value changes.
+            // Require the observable change instead of that return flag.
+            _ = slider.accessibilityPerformIncrement()
             try await waitUntil("native text size slider increment", attempts: 20) {
                 (value(slider) as? NSNumber)?.doubleValue != previous.doubleValue
             }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -10,16 +10,19 @@ enum UIE2EControlFault {
     static var stopActionAttempts = 0
 }
 
-private final class UIE2EDeferredMouseUp: @unchecked Sendable {
+private final class UIE2EDeferredMouseEvent: @unchecked Sendable {
     private let application: NSApplication
     private let event: NSEvent
+    private let cursorPosition: CGPoint?
 
-    init(application: NSApplication, event: NSEvent) {
+    init(application: NSApplication, event: NSEvent, cursorPosition: CGPoint? = nil) {
         self.application = application
         self.event = event
+        self.cursorPosition = cursorPosition
     }
 
     func post() {
+        if let cursorPosition { CGWarpMouseCursorPosition(cursorPosition) }
         application.postEvent(event, atStart: false)
     }
 }
@@ -996,20 +999,29 @@ enum UIE2ETestDriver {
         let originalFont = originalPreference as? Double ?? AppFontSize.defaultValue
         AppSettings.defaults.set(originalFont, forKey: AppFontSize.storageKey)
         let originalFrame = window.frame
+        var completed = false
         defer {
+            if !completed { captureSettingsFailure(window) }
             AppSettings.defaults.set(originalPreference, forKey: AppFontSize.storageKey)
             window.setFrame(originalFrame, display: true)
         }
         window.setFrameOrigin(CGPoint(
             x: visible.maxX - window.frame.width, y: visible.minY))
+        try await activate(window)
+        window.contentView?.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
         try await revealGeometry(
             identifier: "settings-text-size", name: "settings text size slider")
         let sliderFrame = try await measuredFrame(
             identifier: "settings-text-size", name: "settings text size slider")
-        try await clickMeasuredControl(
-            identifier: "settings-text-size", name: "maximum settings text size",
-            offset: CGSize(width: sliderFrame.width - 4, height: 0),
-            size: CGSize(width: 2, height: sliderFrame.height))
+        let range = AppFontSize.allowedRange
+        let fraction = (originalFont - range.lowerBound)
+            / (range.upperBound - range.lowerBound)
+        try await drag(
+            from: CGPoint(x: sliderFrame.minX + 8 + (sliderFrame.width - 16) * fraction,
+                          y: sliderFrame.midY),
+            to: CGPoint(x: sliderFrame.maxX - 8, y: sliderFrame.midY),
+            in: window, name: "maximum settings text size")
         let apply = try await element(identifier: "settings-apply-text-size")
         try await waitUntil("text size draft can be applied") { isEnabled(apply) }
         guard AppSettings.defaults.double(forKey: AppFontSize.storageKey) == originalFont,
@@ -1031,6 +1043,18 @@ enum UIE2ETestDriver {
             abs(window.frame.width - originalFrame.width) < 1
                 && visible.insetBy(dx: -2, dy: -2).contains(window.frame)
         }
+        completed = true
+    }
+
+    private static func captureSettingsFailure(_ window: NSWindow) {
+        guard let configuration = AppSettings.uiE2E,
+              let view = window.contentView,
+              let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds)
+        else { return }
+        view.cacheDisplay(in: view.bounds, to: bitmap)
+        guard let data = bitmap.representation(using: .png, properties: [:]) else { return }
+        try? data.write(to: configuration.root.appendingPathComponent(
+            "window-settings-failure.png"), options: .atomic)
     }
 
     private static func runOnboardingFirstRun(
@@ -1616,7 +1640,7 @@ enum UIE2ETestDriver {
         // receives a physical-duration click even inside a tracking loop. Put
         // mouseUp at the queue tail so a busy main thread cannot process it
         // before the mouseDown event at the queue head.
-        let mouseUp = UIE2EDeferredMouseUp(application: NSApp, event: events[1])
+        let mouseUp = UIE2EDeferredMouseEvent(application: NSApp, event: events[1])
         DispatchQueue.global(qos: .userInitiated).asyncAfter(
             deadline: .now() + clickInterval
         ) {
@@ -1626,10 +1650,56 @@ enum UIE2ETestDriver {
         try await Task.sleep(nanoseconds: 60_000_000)
     }
 
+    private static func drag(
+        from start: CGPoint,
+        to end: CGPoint,
+        in window: NSWindow,
+        name: String
+    ) async throws {
+        trace("dragging \(name) from \(start) to \(end), key=\(window.isKeyWindow)")
+        try moveCursor(to: start, name: name)
+        let endCursor = try cursorPoint(for: end, name: name)
+        let sequence: [(NSEvent.EventType, CGPoint)] = [
+            (.leftMouseDown, start), (.leftMouseDragged, end), (.leftMouseUp, end),
+        ]
+        var events: [NSEvent] = []
+        let timestamp = ProcessInfo.processInfo.systemUptime
+        for (index, item) in sequence.enumerated() {
+            nextMouseEventNumber += 1
+            guard let event = NSEvent.mouseEvent(
+                with: item.0, location: window.convertPoint(fromScreen: item.1),
+                modifierFlags: [], timestamp: timestamp + Double(index) * 0.05,
+                windowNumber: window.windowNumber, context: nil,
+                eventNumber: nextMouseEventNumber, clickCount: 1,
+                pressure: item.0 == .leftMouseUp ? 0 : 1)
+            else { throw Failure(message: "cannot create drag event for \(name)") }
+            events.append(event)
+        }
+        for index in 1..<events.count {
+            let delivery = UIE2EDeferredMouseEvent(
+                application: NSApp, event: events[index], cursorPosition: endCursor)
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                deadline: .now() + Double(index) * 0.05
+            ) { delivery.post() }
+        }
+        NSApp.postEvent(events[0], atStart: true)
+        try await Task.sleep(nanoseconds: 150_000_000)
+    }
+
     private static func moveCursor(
         to screenPoint: CGPoint,
         name: String
     ) throws {
+        let point = try cursorPoint(for: screenPoint, name: name)
+        guard CGWarpMouseCursorPosition(point) == .success else {
+            throw Failure(message: "cannot position the pointer for \(name)")
+        }
+    }
+
+    private static func cursorPoint(
+        for screenPoint: CGPoint,
+        name: String
+    ) throws -> CGPoint {
         guard cursorRestorePoint != nil else {
             throw Failure(message: "cannot preserve pointer position for \(name)")
         }
@@ -1642,13 +1712,10 @@ enum UIE2ETestDriver {
         else {
             throw Failure(message: "cannot resolve the display for \(name)")
         }
-        let quartzPoint = UIE2ECursorPositionResolver.quartzPoint(
+        return UIE2ECursorPositionResolver.quartzPoint(
             for: screenPoint,
             screenFrame: screen.frame,
             displayBounds: CGDisplayBounds(CGDirectDisplayID(screenNumber.uint32Value)))
-        guard CGWarpMouseCursorPosition(quartzPoint) == .success else {
-            throw Failure(message: "cannot position the pointer for \(name)")
-        }
     }
 
     private static func keyPress(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -1295,7 +1295,7 @@ public enum DetachStateCommand {
         name: String
     ) -> Data? {
         let descriptor = openat(
-            directory, name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            directory, name, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else { return nil }
         defer { close(descriptor) }
         var item = stat()
@@ -1749,7 +1749,7 @@ public enum DetachStateCommand {
         }
 
         let descriptor = openat(
-            directory, fileName, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            directory, fileName, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else {
             throw DetachStateCommandError.invalidTranscript
         }

--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -291,7 +291,7 @@ public struct PowerHelperLifetimeBarrier: Sendable {
     /// its separately persisted boot-session evidence to accept `.missing`.
     public func status() throws -> PowerHelperLifetimeBarrierStatus {
         let descriptor = Darwin.open(
-            fileURL.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            fileURL.path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else {
             let code = errno
             if code == ENOENT { return .missing }
@@ -476,7 +476,7 @@ public struct PowerHelperSystemHandoffLock: Sendable {
     /// handled separately by the app; an existing file is never recreated.
     public func acquire() throws -> PowerHelperSystemHandoffLease? {
         let descriptor = Darwin.open(
-            fileURL.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+            fileURL.path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else {
             let code = errno
             if code == ENOENT { return nil }

--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -43,38 +43,6 @@ public protocol RootCommandRunning: Sendable {
     func run(_ command: RootCommand) throws -> RootCommandResult
 }
 
-private final class BoundedRootCommandOutput: @unchecked Sendable {
-    private let lock = NSLock()
-    private let maximumBytes: Int
-    private var data = Data()
-    private var didTruncate = false
-
-    init(maximumBytes: Int) {
-        self.maximumBytes = max(0, maximumBytes)
-    }
-
-    func append(_ chunk: Data) {
-        lock.lock()
-        defer { lock.unlock() }
-        let remaining = max(0, maximumBytes - data.count)
-        if chunk.count > remaining { didTruncate = true }
-        guard remaining > 0 else { return }
-        data.append(chunk.prefix(remaining))
-    }
-
-    var string: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return String(decoding: data, as: UTF8.self)
-    }
-
-    var isTruncated: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return didTruncate
-    }
-}
-
 public struct RootProcessCommandRunner: RootCommandRunning {
     public static let defaultTimeout: TimeInterval = 2
     public static let defaultTerminationGrace: TimeInterval = 1
@@ -97,71 +65,26 @@ public struct RootProcessCommandRunner: RootCommandRunning {
     }
 
     public func run(_ command: RootCommand) throws -> RootCommandResult {
-        let process = Process()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.executableURL = URL(fileURLWithPath: command.executable)
-        process.arguments = command.arguments
-        process.environment = [
-            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
-            "LC_ALL": "C",
-        ]
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = stdout
-        process.standardError = stderr
-        try process.run()
-
-        let output = BoundedRootCommandOutput(
-            maximumBytes: maximumOutputBytes)
-        let errorOutput = BoundedRootCommandOutput(
-            maximumBytes: maximumOutputBytes)
-        let readers = DispatchGroup()
-        Self.drain(stdout.fileHandleForReading, into: output, group: readers)
-        Self.drain(stderr.fileHandleForReading, into: errorOutput, group: readers)
-
-        let deadline = Date().addingTimeInterval(timeout)
-        while process.isRunning && Date() < deadline {
-            usleep(10_000)
-        }
-        let timedOut = process.isRunning
-        if timedOut {
-            process.terminate()
-            let killDeadline = Date().addingTimeInterval(terminationGrace)
-            while process.isRunning && Date() < killDeadline {
-                usleep(10_000)
-            }
-            if process.isRunning {
-                Darwin.kill(process.processIdentifier, SIGKILL)
-            }
-        }
-        process.waitUntilExit()
-        readers.wait()
-        if timedOut {
+        let result = try BoundedProcessRunner().run(BoundedProcessRequest(
+            executableURL: URL(fileURLWithPath: command.executable),
+            arguments: command.arguments,
+            environment: [
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "LC_ALL": "C",
+            ],
+            timeout: timeout,
+            terminationGrace: terminationGrace,
+            maximumOutputBytes: maximumOutputBytes))
+        if result.timedOut {
             throw PowerHelperPlatformError.commandTimedOut(
                 executable: command.executable)
         }
         return RootCommandResult(
-            exitCode: process.terminationStatus,
-            standardOutput: output.string,
-            standardError: errorOutput.string,
-            standardOutputTruncated: output.isTruncated,
-            standardErrorTruncated: errorOutput.isTruncated)
-    }
-
-    private static func drain(
-        _ handle: FileHandle,
-        into output: BoundedRootCommandOutput,
-        group: DispatchGroup
-    ) {
-        group.enter()
-        DispatchQueue.global(qos: .utility).async {
-            defer { group.leave() }
-            while true {
-                guard let chunk = try? handle.read(upToCount: 4_096),
-                      !chunk.isEmpty else { return }
-                output.append(chunk)
-            }
-        }
+            exitCode: result.exitCode,
+            standardOutput: String(decoding: result.standardOutput, as: UTF8.self),
+            standardError: String(decoding: result.standardError, as: UTF8.self),
+            standardOutputTruncated: result.standardOutputTruncated,
+            standardErrorTruncated: result.standardErrorTruncated)
     }
 }
 

--- a/app/Sources/DetachKit/PowerRunActivity.swift
+++ b/app/Sources/DetachKit/PowerRunActivity.swift
@@ -48,7 +48,7 @@ public struct FilePowerRunActivityReader: PowerRunActivityReading {
     }
 
     static func openValidated(path: String, flags: Int32) -> Int32? {
-        let descriptor = Darwin.open(path, flags | O_NOFOLLOW)
+        let descriptor = Darwin.open(path, flags | O_NONBLOCK | O_NOFOLLOW)
         guard descriptor >= 0 else { return nil }
 
         var information = stat()

--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -331,7 +331,7 @@ final class SessionTranscriptFileMonitor: @unchecked Sendable {
         if DispatchQueue.getSpecific(key: queueKey) == nil { queue.sync {} }
     }
 
-    private func armSource(for path: String) {
+    private func armSource(for path: String, refreshAfterRegistration: Bool = false) {
         guard path.hasPrefix("/"),
               URL(fileURLWithPath: path).standardizedFileURL.path == path else {
             return
@@ -360,7 +360,15 @@ final class SessionTranscriptFileMonitor: @unchecked Sendable {
                 guard let self,
                       self.targetPaths.contains(path),
                       self.sources[path] == nil else { return }
-                self.armSource(for: path)
+                self.armSource(for: path, refreshAfterRegistration: true)
+            }
+        }
+        if refreshAfterRegistration {
+            source.setRegistrationHandler { [weak self, weak source] in
+                guard let self, let source, self.sources[path] === source else { return }
+                // Writes to the replacement inode before registration have no
+                // vnode event. Refresh once the new source closes that gap.
+                self.onChange()
             }
         }
         source.setCancelHandler { Darwin.close(descriptor) }

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -38,6 +38,20 @@ public final class SessionStore {
         let continuation: CheckedContinuation<[Session], Never>
     }
 
+    private struct TransientTransition: Hashable {
+        let sessionID: String
+        let lifecycleID: String?
+        let createdAt: Date?
+        let status: EffectiveStatus
+
+        init(_ session: Session) {
+            sessionID = session.id
+            lifecycleID = session.lifecycleID
+            createdAt = session.lifecycleID == nil ? session.createdAt : nil
+            status = session.effectiveStatus
+        }
+    }
+
     private enum Mutation {
         case stop
         case delete
@@ -79,8 +93,8 @@ public final class SessionStore {
     @ObservationIgnored private var refreshRetryTask: Task<Void, Never>?
     @ObservationIgnored private var refreshRetryAttempt = 0
     @ObservationIgnored private var transientConfirmationTask: Task<Void, Never>?
-    @ObservationIgnored private var pendingTransientSessionIDs: Set<String> = []
-    @ObservationIgnored private var confirmedTransientSessionIDs: Set<String> = []
+    @ObservationIgnored private var pendingTransientTransitions: Set<TransientTransition> = []
+    @ObservationIgnored private var confirmedTransientTransitions: Set<TransientTransition> = []
     @ObservationIgnored private var eventGeneration: UInt64 = 0
     /// Epoch invalidates results from a previous CLI/observation lifetime.
     @ObservationIgnored private var refreshEpoch: UInt64 = 0
@@ -234,8 +248,8 @@ public final class SessionStore {
         refreshRetryAttempt = 0
         transientConfirmationTask?.cancel()
         transientConfirmationTask = nil
-        pendingTransientSessionIDs = []
-        confirmedTransientSessionIDs = []
+        pendingTransientTransitions = []
+        confirmedTransientTransitions = []
         eventReadinessTimeoutTask?.cancel()
         eventReadinessTimeoutTask = nil
         eventReadinessTimedOutGeneration = nil
@@ -531,22 +545,22 @@ public final class SessionStore {
     }
 
     private func scheduleTransientConfirmation(for snapshot: [Session]) {
-        let transientIDs = Set(snapshot.lazy
+        let transientTransitions = Set(snapshot.lazy
             .filter { Self.isTransient($0.effectiveStatus) }
-            .map(\.id))
-        confirmedTransientSessionIDs.formIntersection(transientIDs)
-        pendingTransientSessionIDs.formIntersection(transientIDs)
+            .map(TransientTransition.init))
+        confirmedTransientTransitions.formIntersection(transientTransitions)
+        pendingTransientTransitions.formIntersection(transientTransitions)
         // Keep the original deadline while any of its transitions remain.
         // Other sessions can emit snapshots continuously. They must not
         // postpone confirmation or mark a newly joined transition early.
-        if !pendingTransientSessionIDs.isEmpty { return }
+        if !pendingTransientTransitions.isEmpty { return }
         transientConfirmationTask?.cancel()
         transientConfirmationTask = nil
-        let unconfirmedIDs = transientIDs.subtracting(
-            confirmedTransientSessionIDs)
-        guard !unconfirmedIDs.isEmpty else { return }
+        let unconfirmedTransitions = transientTransitions.subtracting(
+            confirmedTransientTransitions)
+        guard !unconfirmedTransitions.isEmpty else { return }
 
-        pendingTransientSessionIDs = unconfirmedIDs
+        pendingTransientTransitions = unconfirmedTransitions
         transientConfirmationTask = Task { [weak self] in
             do {
                 try await self?.confirmationSleep(350_000_000)
@@ -554,8 +568,8 @@ public final class SessionStore {
                 return
             }
             guard !Task.isCancelled, let self else { return }
-            self.confirmedTransientSessionIDs.formUnion(self.pendingTransientSessionIDs)
-            self.pendingTransientSessionIDs = []
+            self.confirmedTransientTransitions.formUnion(self.pendingTransientTransitions)
+            self.pendingTransientTransitions = []
             self.transientConfirmationTask = nil
             await self.refresh()
         }

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -79,6 +79,7 @@ public final class SessionStore {
     @ObservationIgnored private var refreshRetryTask: Task<Void, Never>?
     @ObservationIgnored private var refreshRetryAttempt = 0
     @ObservationIgnored private var transientConfirmationTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingTransientSessionIDs: Set<String> = []
     @ObservationIgnored private var confirmedTransientSessionIDs: Set<String> = []
     @ObservationIgnored private var eventGeneration: UInt64 = 0
     /// Epoch invalidates results from a previous CLI/observation lifetime.
@@ -222,11 +223,19 @@ public final class SessionStore {
         // this observation lifetime. A stopped store must launch no later CLI
         // work until an explicit refresh or a new watcher starts it again.
         refreshEpoch &+= 1
+        // Requests made before stop belong to the old lifetime, including
+        // those queued behind a read that cannot be cancelled immediately.
+        refreshCompletedGeneration = refreshRequestGeneration
+        let stoppedWaiters = refreshWaiters
+        refreshWaiters = []
+        for waiter in stoppedWaiters { waiter.continuation.resume(returning: []) }
         refreshRetryTask?.cancel()
         refreshRetryTask = nil
         refreshRetryAttempt = 0
         transientConfirmationTask?.cancel()
         transientConfirmationTask = nil
+        pendingTransientSessionIDs = []
+        confirmedTransientSessionIDs = []
         eventReadinessTimeoutTask?.cancel()
         eventReadinessTimeoutTask = nil
         eventReadinessTimedOutGeneration = nil
@@ -348,7 +357,8 @@ public final class SessionStore {
             let servicedGeneration = refreshRequestGeneration
             let epoch = refreshEpoch
             latestSnapshot = await performRefresh(epoch: epoch)
-            refreshCompletedGeneration = servicedGeneration
+            refreshCompletedGeneration = max(
+                refreshCompletedGeneration, servicedGeneration)
 
             var pending: [RefreshWaiter] = []
             for waiter in refreshWaiters {
@@ -525,16 +535,18 @@ public final class SessionStore {
             .filter { Self.isTransient($0.effectiveStatus) }
             .map(\.id))
         confirmedTransientSessionIDs.formIntersection(transientIDs)
-        guard !transientIDs.isEmpty else {
-            transientConfirmationTask?.cancel()
-            transientConfirmationTask = nil
-            return
-        }
+        pendingTransientSessionIDs.formIntersection(transientIDs)
+        // Keep the original deadline while any of its transitions remain.
+        // Other sessions can emit snapshots continuously. They must not
+        // postpone confirmation or mark a newly joined transition early.
+        if !pendingTransientSessionIDs.isEmpty { return }
+        transientConfirmationTask?.cancel()
+        transientConfirmationTask = nil
         let unconfirmedIDs = transientIDs.subtracting(
             confirmedTransientSessionIDs)
         guard !unconfirmedIDs.isEmpty else { return }
 
-        transientConfirmationTask?.cancel()
+        pendingTransientSessionIDs = unconfirmedIDs
         transientConfirmationTask = Task { [weak self] in
             do {
                 try await self?.confirmationSleep(350_000_000)
@@ -542,7 +554,8 @@ public final class SessionStore {
                 return
             }
             guard !Task.isCancelled, let self else { return }
-            self.confirmedTransientSessionIDs.formUnion(unconfirmedIDs)
+            self.confirmedTransientSessionIDs.formUnion(self.pendingTransientSessionIDs)
+            self.pendingTransientSessionIDs = []
             self.transientConfirmationTask = nil
             await self.refresh()
         }

--- a/app/Sources/DetachKit/Storage.swift
+++ b/app/Sources/DetachKit/Storage.swift
@@ -585,7 +585,8 @@ private struct StorageScanner {
     }
 
     private func readOwnedRegularFile(_ path: String, maximumBytes: Int) -> Data? {
-        let descriptor = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        // Open must not wait on a special file before fstat can reject it.
+        let descriptor = open(path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
         guard descriptor >= 0 else { return nil }
         defer { close(descriptor) }
         var item = stat()

--- a/app/Tests/DetachAppTests/TextSizeTests.swift
+++ b/app/Tests/DetachAppTests/TextSizeTests.swift
@@ -148,6 +148,52 @@ final class TextSizeTests: XCTestCase {
         XCTAssertEqual(contentView.bounds.height, expectedHeight, accuracy: 0.001)
     }
 
+    @MainActor
+    func testSettingsGrowthKeepsRightAndBottomEdgesOnScreen() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let visible = screen.visibleFrame
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 400),
+            styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        let frameView = SettingsWindowFrameView(frame: .zero)
+        try XCTUnwrap(window.contentView).addSubview(frameView)
+        window.setFrameOrigin(NSPoint(
+            x: visible.maxX - window.frame.width, y: visible.minY))
+        XCTAssertTrue(visible.contains(window.frame))
+
+        frameView.apply(width: 760, baseHeight: 780, fontPointSize: 22)
+
+        XCTAssertTrue(visible.contains(window.frame), "Settings moved off screen: \(window.frame)")
+        let largeTop = window.frame.maxY
+        frameView.apply(width: 560, baseHeight: 450, fontPointSize: 14)
+        XCTAssertTrue(visible.contains(window.frame))
+        XCTAssertEqual(window.frame.maxY, largeTop, accuracy: 0.5)
+        let settled = window.frame
+        frameView.apply(width: 560, baseHeight: 450, fontPointSize: 14)
+        XCTAssertEqual(window.frame, settled)
+    }
+
+    @MainActor
+    func testSettingsScreenChangeMovesAnOffscreenFrameBackInside() throws {
+        let visible = try XCTUnwrap(NSScreen.main).visibleFrame
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 400),
+            styleMask: [.titled], backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        let frameView = SettingsWindowFrameView(frame: .zero)
+        try XCTUnwrap(window.contentView).addSubview(frameView)
+        frameView.apply(width: 560, baseHeight: 450, fontPointSize: 14)
+        window.setFrameOrigin(NSPoint(x: visible.maxX - 50, y: visible.maxY - 50))
+
+        NotificationCenter.default.post(
+            name: NSWindow.didChangeScreenNotification, object: window)
+
+        XCTAssertTrue(visible.contains(window.frame), "Settings remained off screen: \(window.frame)")
+    }
+
     func testLogResizeUsesExactPointSizeAndPreservesTraitsAndColors() throws {
         let regular = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
         let bold = NSFont.monospacedSystemFont(ofSize: 10, weight: .bold)

--- a/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EEventWindowResolverTests.swift
@@ -4,6 +4,23 @@ import XCTest
 
 @MainActor
 final class UIE2EEventWindowResolverTests: XCTestCase {
+    func testMouseClickPairsShareTheNativeEventNumber() throws {
+        let first = try UIE2ETestDriver.mouseClickEvents(
+            at: CGPoint(x: 20, y: 30), windowNumber: 0, name: "first click")
+        let second = try UIE2ETestDriver.mouseClickEvents(
+            at: CGPoint(x: 20, y: 30), windowNumber: 0, name: "second click")
+        for pair in [first, second] {
+            XCTAssertEqual(pair.map(\.type), [.leftMouseDown, .leftMouseUp])
+            // CoreGraphics requires matching down/up events to share a number.
+            XCTAssertEqual(pair[0].eventNumber, pair[1].eventNumber)
+            let down = try XCTUnwrap(pair[0].cgEvent)
+            let up = try XCTUnwrap(pair[1].cgEvent)
+            XCTAssertEqual(down.getIntegerValueField(.mouseEventNumber),
+                           up.getIntegerValueField(.mouseEventNumber))
+        }
+        XCTAssertNotEqual(first[0].eventNumber, second[0].eventNumber)
+    }
+
     func testCursorPointMapsBetweenOffsetDisplayCoordinateSystems() {
         let screenFrame = CGRect(x: -800, y: 200, width: 800, height: 600)
         let displayBounds = CGRect(x: 1_600, y: 900, width: 800, height: 600)

--- a/app/Tests/DetachKitTests/FIFOReadTests.swift
+++ b/app/Tests/DetachKitTests/FIFOReadTests.swift
@@ -1,0 +1,124 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import DetachKit
+
+final class FIFOReadTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-fifo-read-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: root)
+    }
+
+    func testStorageRejectsFIFOMetadataWithoutWaitingForAWriter() throws {
+        let name = "detach-codex-fifo"
+        let providerRoot = root.appendingPathComponent("codex")
+        let sessionRoot = providerRoot.appendingPathComponent("sessions/\(name)")
+        try FileManager.default.createDirectory(at: sessionRoot, withIntermediateDirectories: true)
+        let fifo = sessionRoot.appendingPathComponent("meta.json")
+        let stateRoot = root.path
+        let inventory = Data("""
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"fifo","effective_status":"orphaned","cleanup_eligible":false}
+        """.utf8)
+
+        try checkWithoutWriter(fifo) {
+            let report = try StorageInspector.report(
+                stateRoot: stateRoot,
+                providerRoots: [.codex: providerRoot.path],
+                excludedRoots: [],
+                inventory: inventory)
+            XCTAssertFalse(report.complete)
+            XCTAssertEqual(report.sessions.first?.blockedReason, "invalid_metadata")
+            XCTAssertEqual(report.sessions.first?.deletable, false)
+        }
+    }
+
+    func testMetadataSnapshotsRejectFIFOCheckpointWithoutWaitingForAWriter() throws {
+        let sessions = root.appendingPathComponent("sessions")
+        let checkpoint = sessions.appendingPathComponent("detach-codex-fifo/checkpoint")
+        try FileManager.default.createDirectory(at: checkpoint, withIntermediateDirectories: true)
+
+        try checkWithoutWriter(checkpoint.appendingPathComponent("meta.json")) {
+            let result = try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", sessions.path,
+            ])
+            let fields = result.split(separator: 0, omittingEmptySubsequences: false)
+                .map { String(decoding: $0, as: UTF8.self) }
+            XCTAssertEqual(fields.prefix(2), ["detach-codex-fifo", "false"])
+        }
+    }
+
+    func testCachedValidationRejectsFIFOTranscriptWithoutWaitingForAWriter() throws {
+        let transcript = root.appendingPathComponent("transcript.jsonl")
+        try checkWithoutWriter(transcript) {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+            }
+        }
+    }
+
+    func testCachedValidationIgnoresFIFOReceiptWithoutWaitingForAWriter() throws {
+        let transcript = root.appendingPathComponent("transcript.jsonl")
+        try Data(#"{"type":"session_meta","payload":{"id":"session-1"}}"#.utf8)
+            .write(to: transcript)
+        try checkWithoutWriter(root.appendingPathComponent(".detach-jsonl-validation.json")) {
+            XCTAssertNoThrow(try DetachStateCommand.run(arguments: [
+                "jsonl", "validate-cached", "codex", transcript.path, "session-1",
+            ]))
+        }
+    }
+
+    func testLifetimeProbeRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = root.appendingPathComponent("lifetime.lock")
+        let barrier = PowerHelperLifetimeBarrier(fileURL: fifo, expectedOwner: geteuid())
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try barrier.status()) { error in
+                XCTAssertEqual(error as? PowerHelperPlatformError, .insecureLifetimeLock)
+            }
+        }
+    }
+
+    func testSystemHandoffProbeRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = root.appendingPathComponent("handoff.lock")
+        let lock = PowerHelperSystemHandoffLock(fileURL: fifo, expectedOwner: geteuid())
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try lock.acquire()) { error in
+                XCTAssertEqual(error as? PowerHelperPlatformError, .insecureSystemHandoffLock)
+            }
+        }
+    }
+
+    /// A regression must fail within a bound and leave no blocked test thread.
+    /// The rescue writer opens only after that failure and never supplies data.
+    private func checkWithoutWriter(
+        _ fifo: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        operation: @escaping @Sendable () throws -> Void
+    ) throws {
+        XCTAssertEqual(mkfifo(fifo.path, 0o644), 0, file: file, line: line)
+        let completed = DispatchGroup()
+        completed.enter()
+        DispatchQueue.global().async {
+            defer { completed.leave() }
+            do { try operation() }
+            catch { XCTFail("Unexpected error: \(error)", file: file, line: line) }
+        }
+        let result = completed.wait(timeout: .now() + 1)
+        XCTAssertEqual(result, .success, "File validation waited for a FIFO writer", file: file, line: line)
+        if result == .timedOut {
+            let rescue = open(fifo.path, O_RDWR | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+            defer { if rescue >= 0 { close(rescue) } }
+            XCTAssertGreaterThanOrEqual(rescue, 0, file: file, line: line)
+            XCTAssertEqual(completed.wait(timeout: .now() + 1), .success, file: file, line: line)
+        }
+    }
+}

--- a/app/Tests/DetachKitTests/FIFOReadTests.swift
+++ b/app/Tests/DetachKitTests/FIFOReadTests.swift
@@ -76,6 +76,36 @@ final class FIFOReadTests: XCTestCase {
         }
     }
 
+    func testActivityReaderRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = root.appendingPathComponent("activity")
+        try checkWithoutWriter(fifo) {
+            XCTAssertEqual(FilePowerRunActivityReader().state(atPath: fifo.path), .working)
+        }
+    }
+
+    func testActivityWatcherRejectsFIFOHandoffWithoutWaitingForAWriter() throws {
+        let activity = root.appendingPathComponent("activity")
+        try Data("waiting\n".utf8).write(to: activity)
+        let fifo = root.appendingPathComponent("activity-source")
+        try checkWithoutWriter(fifo) {
+            let result = try FilePowerRunActivityWatcher().run(
+                activityFile: activity.path,
+                activitySourceFile: fifo.path,
+                onStateChange: { XCTAssertEqual($0, .working) },
+                operation: { ChildCommandResult(exitCode: 17) })
+            XCTAssertEqual(result.exitCode, 17)
+        }
+    }
+
+    func testHeartbeatReaderRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = root.appendingPathComponent("watchdog-status.json")
+        try checkWithoutWriter(fifo) {
+            let snapshot = PowerHeartbeatReader(statusURL: fifo).read()
+            XCTAssertFalse(snapshot.isFresh)
+            XCTAssertEqual(snapshot.effectivePowerState, .unknown)
+        }
+    }
+
     func testLifetimeProbeRejectsFIFOWithoutWaitingForAWriter() throws {
         let fifo = root.appendingPathComponent("lifetime.lock")
         let barrier = PowerHelperLifetimeBarrier(fileURL: fifo, expectedOwner: geteuid())
@@ -116,7 +146,7 @@ final class FIFOReadTests: XCTestCase {
         XCTAssertEqual(result, .success, "File validation waited for a FIFO writer", file: file, line: line)
         if result == .timedOut {
             let rescue = open(fifo.path, O_RDWR | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
-            defer { if rescue >= 0 { close(rescue) } }
+            if rescue >= 0 { close(rescue) }
             XCTAssertGreaterThanOrEqual(rescue, 0, file: file, line: line)
             XCTAssertEqual(completed.wait(timeout: .now() + 1), .success, file: file, line: line)
         }

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -13,6 +13,10 @@ final class PowerHelperPlatformTests: XCTestCase {
         }
     }
 
+    func testBootSessionReaderCanBeConstructed() {
+        _ = SysctlBootSessionReader()
+    }
+
     func testBootSessionReaderReturnsStableCanonicalIdentifier() throws {
         let first = try SysctlBootSessionReader().currentBootSessionIdentifier()
         let repeated = try SysctlBootSessionReader().currentBootSessionIdentifier()

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -32,6 +32,35 @@ final class PowerHelperPlatformTests: XCTestCase {
         }
     }
 
+    func testRootCommandRunnerBoundsInheritedPipesAfterLeaderExit() throws {
+        let started = Date()
+        let result = try RootProcessCommandRunner(
+            timeout: 0.2, terminationGrace: 0.05
+        ).run(RootCommand(
+            executable: "/bin/sh",
+            arguments: ["-c", "(/bin/sleep 3; printf late) & printf ready"]))
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.5)
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.standardOutput, "ready")
+        XCTAssertTrue(result.standardOutputTruncated)
+        XCTAssertTrue(result.standardErrorTruncated)
+    }
+
+    func testRootCommandRunnerTimeoutIncludesPipeDescendants() {
+        let started = Date()
+        let runner = RootProcessCommandRunner(
+            timeout: 0.2, terminationGrace: 0.05)
+
+        XCTAssertThrowsError(try runner.run(RootCommand(
+            executable: "/bin/sh",
+            arguments: ["-c", "trap '' TERM; /bin/sleep 3 & wait"]))) { error in
+            XCTAssertEqual(error as? PowerHelperPlatformError,
+                           .commandTimedOut(executable: "/bin/sh"))
+        }
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.5)
+    }
+
     func testRootCommandRunnerDrainsButBoundsCapturedOutput() throws {
         let runner = RootProcessCommandRunner(
             timeout: 2, maximumOutputBytes: 1_024)

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -13,8 +13,13 @@ final class PowerHelperPlatformTests: XCTestCase {
         }
     }
 
-    func testBootSessionReaderCanBeConstructed() {
-        _ = SysctlBootSessionReader()
+    func testBootSessionReaderReturnsStableCanonicalIdentifier() throws {
+        let first = try SysctlBootSessionReader().currentBootSessionIdentifier()
+        let repeated = try SysctlBootSessionReader().currentBootSessionIdentifier()
+
+        let identifier = try XCTUnwrap(UUID(uuidString: first))
+        XCTAssertEqual(first, identifier.uuidString.lowercased())
+        XCTAssertEqual(repeated, first)
     }
 
     func testRootCommandRunnerTerminatesHungProcess() {

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -440,6 +440,7 @@ final class SessionEventsTests: XCTestCase {
 
         let first = expectation(description: "replacement observed")
         let second = expectation(description: "replacement rearmed")
+        let third = expectation(description: "append observed after registration")
         let lock = NSLock()
         nonisolated(unsafe) var deliveryCount = 0
         let queue = DispatchQueue(label: "detach-session-vnode-rearm-test")
@@ -450,6 +451,7 @@ final class SessionEventsTests: XCTestCase {
             }
             if count == 1 { first.fulfill() }
             if count == 2 { second.fulfill() }
+            if count == 3 { third.fulfill() }
         }
         monitor.update(paths: [
             "relative/transcript.jsonl",
@@ -459,17 +461,47 @@ final class SessionEventsTests: XCTestCase {
         queue.sync { monitor.update(paths: [transcript.path]) }
 
         try Data("replacement\n".utf8).write(to: transcript, options: .atomic)
-        wait(for: [first], timeout: 1)
-        Thread.sleep(forTimeInterval: 0.1)
+        wait(for: [first, second], timeout: 2, enforceOrder: true)
         let handle = try FileHandle(forWritingTo: transcript)
         try handle.seekToEnd()
         try handle.write(contentsOf: Data("append\n".utf8))
         try handle.synchronize()
         try handle.close()
 
-        wait(for: [second], timeout: 1)
+        wait(for: [third], timeout: 2)
         monitor.update(paths: [])
         monitor.stop()
+    }
+
+    func testTranscriptMonitorReportsWritesDuringReplacementRegistration() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "detach-session-vnode-gap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let transcript = root.appendingPathComponent("managed.jsonl")
+        try Data().write(to: transcript)
+        let refreshed = expectation(description: "replacement registration refreshes missed writes")
+        let queue = DispatchQueue(label: "detach-session-vnode-gap-test")
+        nonisolated(unsafe) var deliveryCount = 0
+        let monitor = SessionTranscriptFileMonitor(queue: queue) {
+            deliveryCount += 1
+            if deliveryCount == 1 {
+                // This callback still watches the old inode. Write the new
+                // file before the replacement source can be registered.
+                do {
+                    let handle = try FileHandle(forWritingTo: transcript)
+                    defer { try? handle.close() }
+                    try handle.seekToEnd()
+                    try handle.write(contentsOf: Data("gap append\n".utf8))
+                } catch { XCTFail("Could not append replacement fixture: \(error)") }
+            } else if deliveryCount == 2 {
+                refreshed.fulfill()
+            }
+        }
+        defer { monitor.stop() }
+        monitor.update(paths: [transcript.path])
+        try Data("replacement\n".utf8).write(to: transcript, options: .atomic)
+        wait(for: [refreshed], timeout: 2)
     }
 
     func testParentMonitorObservesProcessExit() throws {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -59,12 +59,14 @@ private actor DelayedCLI: DetachCLIRunning {
 
 private actor OverlappingStartCLI: DetachCLIRunning {
     private let listOutput: String
+    private let suspendsAfterFirstCall: Bool
     private var listCallCount = 0
     private var listContinuations: [Int: CheckedContinuation<CLIResult, Never>] = [:]
     private var listWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
-    init(listOutput: String) {
+    init(listOutput: String, suspendsAfterFirstCall: Bool = true) {
         self.listOutput = listOutput
+        self.suspendsAfterFirstCall = suspendsAfterFirstCall
     }
 
     func run(
@@ -78,6 +80,9 @@ private actor OverlappingStartCLI: DetachCLIRunning {
         let ready = listWaiters.filter { $0.0 <= call }
         listWaiters.removeAll { $0.0 <= call }
         ready.forEach { $0.1.resume() }
+        if call > 1, !suspendsAfterFirstCall {
+            return CLIResult(exitCode: 0, stdout: listOutput, stderr: "", timedOut: false)
+        }
         return await withCheckedContinuation { continuation in
             listContinuations[call] = continuation
         }
@@ -493,6 +498,64 @@ final class SessionStoreTests: XCTestCase {
         let finalCallCount = await cli.currentListCallCount
         XCTAssertEqual(finalCallCount, 2)
         XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
+    }
+
+    func testStopDiscardsQueuedRefreshesWithoutPublishingOrLaunchingAnotherList() async {
+        let cli = OverlappingStartCLI(listOutput: line, suspendsAfterFirstCall: false)
+        let store = SessionStore(cli: cli)
+        var snapshots: [[Session]] = []
+        store.onSnapshot = { snapshots.append($0) }
+        let first = Task { await store.refresh() }
+        await cli.waitForListCall(1)
+        let queued = expectation(description: "refresh queued")
+        let second = Task { @MainActor in
+            queued.fulfill()
+            return await store.refresh()
+        }
+        await fulfillment(of: [queued], timeout: 1)
+
+        store.stopObserving()
+        await cli.finishListCall(1)
+        _ = await first.value
+        let queuedResult = await second.value
+
+        let calls = await cli.currentListCallCount
+        XCTAssertEqual(calls, 1)
+        XCTAssertTrue(queuedResult.isEmpty)
+        XCTAssertTrue(snapshots.isEmpty)
+        XCTAssertTrue(store.sessions.isEmpty)
+        XCTAssertFalse(store.hasFreshSnapshot)
+
+        await store.refresh()
+        let callsAfterExplicitRefresh = await cli.currentListCallCount
+        XCTAssertEqual(callsAfterExplicitRefresh, 2)
+        XCTAssertEqual(store.sessions.first?.id, "detach-codex-p-1")
+    }
+
+    func testExplicitRefreshAfterStopWaitsForThePreviousReadAndPublishes() async {
+        let cli = OverlappingStartCLI(listOutput: line, suspendsAfterFirstCall: false)
+        let store = SessionStore(cli: cli)
+        let first = Task { await store.refresh() }
+        await cli.waitForListCall(1)
+        store.stopObserving()
+
+        let queued = expectation(description: "new lifetime refresh queued")
+        let second = Task { @MainActor in
+            queued.fulfill()
+            return await store.refresh()
+        }
+        await fulfillment(of: [queued], timeout: 1)
+        let callsBeforeCompletion = await cli.currentListCallCount
+        XCTAssertEqual(callsBeforeCompletion, 1)
+
+        await cli.finishListCall(1, output: "")
+        _ = await first.value
+        let fresh = await second.value
+        let calls = await cli.currentListCallCount
+        XCTAssertEqual(calls, 2)
+        XCTAssertEqual(fresh.first?.id, "detach-codex-p-1")
+        XCTAssertEqual(store.sessions, fresh)
+        XCTAssertTrue(store.hasFreshSnapshot)
     }
 
     func testStartDetachedKeepsFailuresAndTimeoutsInTheCaller() async {
@@ -952,6 +1015,75 @@ final class SessionStoreTests: XCTestCase {
 
         XCTAssertEqual(snapshotCount, 2)
         XCTAssertEqual(confirmationCalls, 1)
+    }
+
+    func testSnapshotBurstsKeepTheOriginalTransientConfirmationDeadline() async {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"hung""#))
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { delay in await probe.sleep(nanoseconds: delay) },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        await store.refresh()
+        await probe.waitForCallCount(1)
+        for _ in 0..<5 { await store.refresh() }
+        // A main-actor barrier lets any incorrectly restarted deadline enter
+        // the probe before the count is checked.
+        await Task { @MainActor in }.value
+        let calls = await probe.calls()
+        XCTAssertEqual(calls, 1)
+
+        let confirmed = expectation(description: "original deadline confirms")
+        store.onSnapshot = { _ in confirmed.fulfill() }
+        await probe.resumeSleepers()
+        await fulfillment(of: [confirmed], timeout: 1)
+        XCTAssertEqual(cli.calls.count, 7)
+        store.stopObserving()
+    }
+
+    func testNewTransientGetsItsOwnConfirmationAfterThePendingDeadline() async {
+        let cli = FakeCLI()
+        let hung = line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"hung""#)
+        let interrupted = hung.replacingOccurrences(of: "p-1", with: "p-2")
+            .replacingOccurrences(of: "hung", with: "interrupted")
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in await probe.sleep() },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        cli.responses["list --json"] = ok(hung)
+        await store.refresh()
+        await probe.waitForCallCount(1)
+
+        cli.responses["list --json"] = ok(hung + "\n" + interrupted)
+        await store.refresh()
+        let firstConfirmation = expectation(description: "first transition confirmed")
+        store.onSnapshot = { _ in firstConfirmation.fulfill() }
+        await probe.resumeSleepers()
+        await fulfillment(of: [firstConfirmation], timeout: 1)
+        await probe.waitForCallCount(2)
+
+        let secondConfirmation = expectation(description: "new transition confirmed")
+        store.onSnapshot = { _ in secondConfirmation.fulfill() }
+        await probe.resumeSleepers()
+        await fulfillment(of: [secondConfirmation], timeout: 1)
+        XCTAssertEqual(cli.calls.count, 4)
+
+        // A new observation lifetime must confirm again even if the same
+        // session names still report transient state.
+        store.stopObserving()
+        store.onSnapshot = nil
+        await store.refresh()
+        await probe.waitForCallCount(3)
+        store.stopObserving()
+        await probe.resumeSleepers()
     }
 
     func testDefaultConfirmationDelayPublishesTheFollowUpSnapshot() async {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -1086,6 +1086,100 @@ final class SessionStoreTests: XCTestCase {
         await probe.resumeSleepers()
     }
 
+    func testHungToInterruptedGetsARecheckAndFailureNotification() async {
+        let cli = FakeCLI()
+        let hung = line.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"hung""#)
+        let interrupted = hung.replacingOccurrences(of: "hung", with: "interrupted")
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in await probe.sleep() },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        defer { store.stopObserving() }
+        var detector = SessionTransitionDetector()
+        var transitions: [SessionTransition] = []
+        var snapshots = 0
+        let hungConfirmed = expectation(description: "hung rechecked")
+        let interruptionConfirmed = expectation(description: "interruption rechecked")
+        store.onSnapshot = { sessions in
+            transitions += detector.observe(sessions)
+            snapshots += 1
+            if snapshots == 3 { hungConfirmed.fulfill() }
+            if snapshots == 5 { interruptionConfirmed.fulfill() }
+        }
+        cli.responses["list --json"] = ok(line)
+        await store.refresh()
+        cli.responses["list --json"] = ok(hung)
+        await store.refresh()
+        await probe.waitForCallCount(1)
+        await probe.resumeSleepers()
+        await fulfillment(of: [hungConfirmed], timeout: 1)
+
+        cli.responses["list --json"] = ok(interrupted)
+        await store.refresh()
+        await Task { @MainActor in }.value
+        let calls = await probe.calls()
+        XCTAssertEqual(calls, 2)
+        await probe.resumeSleepers()
+        await fulfillment(of: [interruptionConfirmed], timeout: 1)
+        XCTAssertEqual(transitions.map(\.kind), [.failed])
+    }
+
+    func testReusedNameWithNewLifecycleGetsItsOwnTransientConfirmation() async {
+        let first = line.replacingOccurrences(
+            of: #""schema":1"#, with: #""schema":1,"lifecycle_id":"first""#)
+        let replacement = first.replacingOccurrences(
+            of: #""lifecycle_id":"first""#,
+            with: #""lifecycle_id":"replacement""#)
+        await assertReplacementGetsTransientConfirmation(first, replacement)
+    }
+
+    func testLegacyReusedNameWithNewCreationDateGetsTransientConfirmation() async {
+        let replacement = line.replacingOccurrences(
+            of: "2026-07-10T10:00:00Z", with: "2026-07-10T10:00:01Z")
+        await assertReplacementGetsTransientConfirmation(line, replacement)
+    }
+
+    private func assertReplacementGetsTransientConfirmation(
+        _ first: String, _ replacement: String
+    ) async {
+        let cli = FakeCLI()
+        let probe = ConfirmationSleepProbe()
+        let store = SessionStore(
+            cli: cli,
+            confirmationSleep: { _ in await probe.sleep() },
+            eventReadinessSleep: { try await Task.sleep(nanoseconds: $0) },
+            restartSleep: { _ in })
+        defer { store.stopObserving() }
+        var snapshots = 0
+        let firstConfirmed = expectation(description: "first lifecycle rechecked")
+        let replacementConfirmed = expectation(description: "replacement rechecked")
+        store.onSnapshot = { _ in
+            snapshots += 1
+            if snapshots == 2 { firstConfirmed.fulfill() }
+            if snapshots == 4 { replacementConfirmed.fulfill() }
+        }
+        cli.responses["list --json"] = ok(first.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"interrupted""#))
+        await store.refresh()
+        await probe.waitForCallCount(1)
+        await probe.resumeSleepers()
+        await fulfillment(of: [firstConfirmed], timeout: 1)
+        cli.responses["list --json"] = ok(replacement.replacingOccurrences(
+            of: #""effective_status":"running""#,
+            with: #""effective_status":"interrupted""#))
+        await store.refresh()
+        await Task { @MainActor in }.value
+        let calls = await probe.calls()
+        XCTAssertEqual(calls, 2)
+        await probe.resumeSleepers()
+        await fulfillment(of: [replacementConfirmed], timeout: 1)
+    }
+
     func testDefaultConfirmationDelayPublishesTheFollowUpSnapshot() async {
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line.replacingOccurrences(

--- a/docs/specs/app-setup.md
+++ b/docs/specs/app-setup.md
@@ -34,7 +34,9 @@ Bootstrap runs only from `/Applications`, not a DMG or App Translocation path.
 
 Settings → General owns both menu bar toggles. Settings → System keeps the only
 Mac Power status and approval controls. Settings follows the hosting screen;
-System scrolls. Temperature safety has its own warning shape and the
+System scrolls. A size or screen change moves the window inside the visible
+screen area. A window that already fits keeps its position.
+Temperature safety has its own warning shape and the
 text **Mac can sleep: temperature**.
 
 Settings → System owns the only **Mac Power** status and approval block. Helper

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -63,7 +63,9 @@ Detached live logs reread every 2 s. Cold attach uses one passive SwiftTerm
 overlay; cached bytes never enter the live buffer. Live switching keeps its PTY.
 tmux holds the frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
-action geometry. A cold passive screen leaves within one second.
+action geometry. The model and context gauge stay in the metadata row. They
+cannot reduce the title to zero width in a narrow window or with large text.
+A cold passive screen leaves within one second.
 New session accepts an optional printable UTF-8 name up to 100 bytes and
 rejects invalid input. Launch runs in Detach. Advanced holds the prompt
 below a fixed top. Titles use `display_name`, then the project or internal name.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -100,7 +100,8 @@ signed marker. UI smoke uses a stripped private copy below
 unsafe identity, build mismatch, or payload fails closed.
 
 Smoke restores focus and the pointer, then sends ordered AppKit events to
-controls. Slider changes use the native control's Accessibility increment
+controls. Each mouse click uses one event number for both events.
+Slider changes use the native control's Accessibility increment
 action. It covers all main surfaces, focus, session actions, and
 onboarding. Stop disconnects first. Stages have deadlines. Coverage isolates
 the normal bundle, instrumented copy, tests, binary, and profiles. The driver

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -87,7 +87,9 @@ Notifications are opt-in and deduplicated. Stop intent is not failure;
 `interrupted` and `hung` get one 350 ms recheck. Snapshot bursts do not restart
 that deadline. A new transition waits for the pending recheck, then gets its
 own deadline. Stable state cancels an obsolete recheck. Each observation
-lifetime confirms its own transitions. Ordered detection never waits for delivery.
+lifetime confirms its own transitions. Status and session lifecycle changes
+require a new confirmation, even when the session name stays the same.
+Ordered detection never waits for delivery.
 
 SwiftTerm 1.19.0 is pinned. The exact SwiftTerm shader bundle is shipped and
 verified.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -24,7 +24,9 @@ Protected counts working sessions. Allowed names all-waiting or an unprotected
 working session and never claims no sessions. Typed heartbeat and
 `detach watch --json` sources supply them. A schema-1 hint, activation, or
 `resync` starts a serialized `list --json`. Hints during a read share one ordered
-trailing read. No list timer runs. Dead or unready watchers and failed lists retry
+trailing read. Stop discards queued reads and prevents old results from updating
+the store. A new explicit read remains serialized with an active old read.
+No list timer runs. Dead or unready watchers and failed lists retry
 with 2–60 s backoff. Cold start waits 1 s for `ready`; a late `ready` repeats the
 snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
 checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
@@ -78,8 +80,10 @@ When a session leaves them, the earliest waiting session gets its number;
 extras stay unnumbered. The sidebar guide shows Command-N, Command-T,
 Command-comma, and terminal Command-F.
 Notifications are opt-in and deduplicated. Stop intent is not failure;
-`interrupted` and `hung` get one 350 ms recheck. Ordered detection never waits
-for delivery.
+`interrupted` and `hung` get one 350 ms recheck. Snapshot bursts do not restart
+that deadline. A new transition waits for the pending recheck, then gets its
+own deadline. Stable state cancels an obsolete recheck. Each observation
+lifetime confirms its own transitions. Ordered detection never waits for delivery.
 
 SwiftTerm 1.19.0 is pinned. The exact SwiftTerm shader bundle is shipped and
 verified.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -30,6 +30,8 @@ No list timer runs. Dead or unready watchers and failed lists retry
 with 2–60 s backoff. Cold start waits 1 s for `ready`; a late `ready` repeats the
 snapshot. UI never calls `pmset` or root XPC. The app, events, sessions,
 checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
+After a transcript file is replaced, registration of its new file observer
+emits a refresh hint. Writes before registration must not leave the UI stale.
 
 The dashboard separates identity, status, and Mac Power. Identity is a thin
 tmux-colored capsule. Status is a filled circle. Power uses a neutral surface

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -100,7 +100,8 @@ signed marker. UI smoke uses a stripped private copy below
 unsafe identity, build mismatch, or payload fails closed.
 
 Smoke restores focus and the pointer, then sends ordered AppKit events to
-controls. It covers all main surfaces, focus, session actions, and
+controls. Slider changes use the native control's Accessibility increment
+action. It covers all main surfaces, focus, session actions, and
 onboarding. Stop disconnects first. Stages have deadlines. Coverage isolates
 the normal bundle, instrumented copy, tests, binary, and profiles. The driver
 detects clipped controls before an action.

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -147,7 +147,9 @@ Hosted CI is the merge-readiness authority.
   exact head check. It then enables native auto-merge for that head and waits
   at most the merge deadline. It disables auto-merge on timeout. The command
   rejects a changed head, an invalid ruleset, and a repair attempt above the
-  policy maximum. It writes current-policy evidence under `app/build/`.
+  policy maximum. It validates the evidence path and creates its parent
+  before it calls GitHub. Invalid paths cannot trigger a merge. It writes
+  current-policy evidence under `app/build/`.
 - Weekly Dependabot checks pinned Actions and Swift packages. It groups each
   ecosystem into at most one pull request to protect the feedback queue. The
   bounded weekly/manual CodeQL workflow scans Actions on Linux and arm64 Swift

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -73,6 +73,8 @@ submitted unregister phase under the system and per-user transaction locks.
 Only a busy lifetime lock permits the prepare call. A replacement is not
 registered until the old lifetime lock is released or an exact absent-job
 callback provides the required completion barrier.
+Lifetime and system handoff probes reject special files without waiting for
+a FIFO writer. File validation precedes lock acquisition.
 
 An enabled registration with a matching bundled-definition digest is not
 enough to prove liveness. At startup, a missing or released lifetime lock that

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -74,7 +74,9 @@ Only a busy lifetime lock permits the prepare call. A replacement is not
 registered until the old lifetime lock is released or an exact absent-job
 callback provides the required completion barrier.
 Lifetime and system handoff probes reject special files without waiting for
-a FIFO writer. File validation precedes lock acquisition.
+a FIFO writer. File validation precedes lock acquisition. Activity and source
+handoff readers also reject special files without blocking and keep the
+session working.
 
 An enabled registration with a matching bundled-definition digest is not
 enough to prove liveness. At startup, a missing or released lifetime lock that

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -12,6 +12,12 @@ Power protection has two required layers and one observable combined state:
    It manages only the machine-wide closed-lid setting through absolute
    `/usr/bin/pmset` invocations and a renewable lease registry.
 
+Root commands use the same bounded process-group runner as CLI reads. Each
+command has a two-second default deadline and a one-second TERM grace.
+Dedicated readers bound each output stream. An inherited pipe cannot keep the
+helper waiting after command exit. Incomplete output cannot prove power state.
+The command environment keeps a fixed system PATH and the C locale.
+
 The wrapper must acquire both layers before provider launch. It watches a
 private, run-token-scoped activity file. Before it accepts `waiting`, it also
 validates a recorded inode/mtime/size snapshot and starts an event watcher on the

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -16,7 +16,8 @@ change real power state, upload assets, or claim publication.
 - Invoking `scripts/release-version X.Y.Z` authorizes its automated commit,
   tag, and publication steps. Push the release head to its unique
   `detach-release/vX.Y.Z` branch. `scripts/release-pr` creates or resumes one
-  exact pull request. The normal strict `quality-gates` job must pass before
+  exact pull request. It validates the evidence path before it creates or
+  merges a pull request. The normal strict `quality-gates` job must pass before
   bounded auto-merge. The final merge must have the tested source and release
   head as its ordered parents and the tested tree. Tag that merge, verify the
   remote `main` and tag, and remove only the matching temporary branch. No

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -6,7 +6,10 @@
 metadata, JSONL, health, reconcile, storage, emit, and event operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
 descriptors. It rejects unsafe directories and opens only owned regular files
-of at most 1 MiB with `O_NOFOLLOW`.
+of at most 1 MiB with `O_NOFOLLOW`. Storage metadata, checkpoint fallback
+metadata, and cached transcript validation use nonblocking file opens before
+they check the file type. This includes validation receipts. A FIFO cannot
+delay these reads while it waits for a writer.
 Integer conversion must not trap. Storage reports allocated and logical bytes,
 excludes provider storage, does not follow symlinks, and authorizes cleanup
 only after a complete scan with explicit `cleanup_eligible: true`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -138,8 +138,9 @@
   The smoke uses a stripped background-only copy, a fake CLI, and private
   HOME/preferences/state below `/private/tmp`; it cannot use the installed
   Detach or user session state. It temporarily activates the isolated app,
-  posts AppKit mouse events to measured SwiftUI controls, and restores the
-  prior application. The locator bridge has no application actions. Run the
+  posts AppKit mouse events to measured SwiftUI controls, uses native slider
+  increment actions, and restores the prior application. The locator bridge
+  has no application actions. Run the
   app build first. The UI smoke needs a logged-in WindowServer session but no
   Accessibility approval. Do not grant it broader filesystem or production
   payload access. Its fake CLI allowlist covers only the exact status and stop

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -51,7 +51,7 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
   if [ -f "$ROOT/fake/resumed" ]; then
     completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"running","created_at":"2026-07-22T07:00:00Z","agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"protected","health_actions":["attach","stop"]}'
   fi
-  recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","effective_status":"recoverable","created_at":"2026-07-22T07:40:00Z","finished_at":"2026-07-22T07:50:00Z","exit_status":1,"session_color":"#F97316","power_protection_state":"allowed","health_actions":["recover","delete"]}'
+  recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","model":"gpt-ui-fixture-long-model-name","context_used_tokens":185000,"context_window":200000,"effective_status":"recoverable","created_at":"2026-07-22T07:40:00Z","finished_at":"2026-07-22T07:50:00Z","exit_status":1,"session_color":"#F97316","power_protection_state":"allowed","health_actions":["recover","delete"]}'
   if [ -f "$ROOT/fake/recovered" ]; then
     recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","effective_status":"running","created_at":"2026-07-22T07:40:00Z","session_color":"#F97316","power_protection_state":"protected","health_actions":["attach","stop"]}'
   fi

--- a/tests/quality_merge_contract.py
+++ b/tests/quality_merge_contract.py
@@ -135,8 +135,10 @@ def invoke(
     mode: str = "success",
     repair: int = 0,
     policy: Path | None = None,
+    test_mode: bool = True,
+    output: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    output = root / f"{mode}-{repair}.json"
+    output = output or root / f"{mode}-{repair}.json"
     environment = os.environ.copy()
     environment.update(
         {
@@ -147,6 +149,9 @@ def invoke(
             "MERGE_STATE": str(root / f"state-{mode}-{repair}"),
         }
     )
+    if not test_mode:
+        environment.pop("DETACH_QUALITY_MERGE_TEST_MODE", None)
+        environment["PATH"] = str(fake.parent) + os.pathsep + environment.get("PATH", "")
     if policy is not None:
         environment["DETACH_QUALITY_POLICY"] = str(policy)
     return subprocess.run(
@@ -178,6 +183,29 @@ def main() -> None:
         root = Path(directory)
         fake = root / "gh"
         fake_gh(fake)
+
+        forbidden = invoke(root, fake, "forbidden-output", test_mode=False)
+        require_failure(forbidden, "merge evidence must use app/build/quality-merge.json")
+        assert not (root / "state-forbidden-output-0/calls.log").exists(), (
+            "invalid output reached GitHub before validation")
+
+        for mode in ["directory-output", "symlink-output", "dangling-output"]:
+            output = root / f"{mode}-0.json"
+            if mode == "directory-output":
+                output.mkdir()
+            else:
+                target = root / f"{mode}-target"
+                if mode == "symlink-output":
+                    target.write_text("preserve", encoding="utf-8")
+                output.symlink_to(target)
+            require_failure(invoke(root, fake, mode), "merge evidence output is unsafe")
+            assert not (root / f"state-{mode}-0/calls.log").exists()
+
+        parent_file = root / "parent-file"
+        parent_file.write_text("preserve", encoding="utf-8")
+        parent_result = invoke(root, fake, "parent-file", output=parent_file / "summary.json")
+        assert parent_result.returncode == 2, parent_result.stdout
+        assert not (root / "state-parent-file-0/calls.log").exists()
 
         result = invoke(root, fake)
         assert result.returncode == 0, result.stdout

--- a/tests/release_pr_contract.py
+++ b/tests/release_pr_contract.py
@@ -102,7 +102,9 @@ else:
     path.chmod(0o755)
 
 
-def invoke(root: Path, fake: Path, mode: str) -> subprocess.CompletedProcess[str]:
+def invoke(
+    root: Path, fake: Path, mode: str, *, test_mode: bool = True
+) -> subprocess.CompletedProcess[str]:
     output = root / f"{mode}.json"
     environment = os.environ.copy()
     environment.update(
@@ -116,6 +118,10 @@ def invoke(root: Path, fake: Path, mode: str) -> subprocess.CompletedProcess[str
             "RELEASE_PR_STATE": str(root / f"state-{mode}"),
         }
     )
+    if not test_mode:
+        environment.pop("DETACH_RELEASE_PR_TEST_MODE", None)
+        environment.pop("DETACH_QUALITY_MERGE_TEST_MODE", None)
+        environment["PATH"] = str(fake.parent) + os.pathsep + environment.get("PATH", "")
     return subprocess.run(
         [
             str(ROOT / "scripts/release-pr"),
@@ -140,6 +146,22 @@ def main() -> None:
         root = Path(directory)
         fake = root / "gh"
         fake_gh(fake)
+        forbidden = invoke(root, fake, "forbidden-output", test_mode=False)
+        assert forbidden.returncode == 2, forbidden.stdout
+        assert "release PR evidence must use app/build/release-pr.json" in forbidden.stdout
+        assert not (root / "state-forbidden-output/calls").exists()
+
+        for mode in ["directory-output", "dangling-output"]:
+            output = root / f"{mode}.json"
+            if mode == "directory-output":
+                output.mkdir()
+            else:
+                output.symlink_to(root / "absent-target")
+            invalid = invoke(root, fake, mode)
+            assert invalid.returncode == 2, invalid.stdout
+            assert "release PR evidence output is unsafe" in invalid.stdout
+            assert not (root / f"state-{mode}/calls").exists()
+
         success = invoke(root, fake, "success")
         assert success.returncode == 0, success.stdout
         summary = json.loads((root / "success.json").read_text(encoding="utf-8"))

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -323,6 +323,7 @@ run_app_scenario() {
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
       session-shortcut-selects-assigned-session|\
+      settings-text-growth-stays-on-screen|\
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
       new-session-advanced-keeps-top-edge|\
@@ -394,6 +395,7 @@ run_app_scenario main sessions 32 \
   settings-session-defaults-visible \
   settings-quick-chat-provider-persists \
   settings-quick-chat-folder-panel \
+  settings-text-growth-stays-on-screen \
   settings-window-stays-on-screen \
   settings-system-reveals-storage-and-installation \
   quick-chat-command-starts-session \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -318,6 +318,7 @@ run_app_scenario() {
       live-terminal-routes-control-v|\
       live-session-switch-reuses-synchronized-client|\
       non-live-session-switch-uses-warm-cache|\
+      session-title-survives-narrow-window-and-large-text|\
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
       session-shortcut-selects-assigned-session|\
@@ -364,6 +365,7 @@ run_app_scenario main sessions 32 \
   dashboard-accessible \
   sidebar-shortcut-guide-visible \
   non-live-session-switch-uses-warm-cache \
+  session-title-survives-narrow-window-and-large-text \
   recover-and-reconnect-run-in-app-with-terminal-fallback \
   sidebar-selects-completed-session \
   session-uuid-copies-from-text-side \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -323,9 +323,9 @@ run_app_scenario() {
       recover-and-reconnect-run-in-app-with-terminal-fallback|\
       resume-runs-in-app-with-terminal-fallback|\
       session-shortcut-selects-assigned-session|\
-      settings-text-growth-stays-on-screen|\
       settings-window-stays-on-screen|\
       settings-system-reveals-storage-and-installation|\
+      settings-text-growth-stays-on-screen|\
       new-session-advanced-keeps-top-edge|\
       new-session-starts-without-outer-terminal|\
       new-session-start-opens-embedded-terminal) ;;
@@ -395,9 +395,9 @@ run_app_scenario main sessions 32 \
   settings-session-defaults-visible \
   settings-quick-chat-provider-persists \
   settings-quick-chat-folder-panel \
-  settings-text-growth-stays-on-screen \
   settings-window-stays-on-screen \
   settings-system-reveals-storage-and-installation \
+  settings-text-growth-stays-on-screen \
   quick-chat-command-starts-session \
   session-shortcut-reopens-closed-main-window \
   installed-app-focus-restored

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -56,7 +56,8 @@ preserve_failure_diagnostics() {
   }
   mkdir -p "$ARTIFACT_DIR"
   chmod 0700 "$ARTIFACT_DIR"
-  for source in "$APP_LOG" "$RESULT" "$FAKE_DIR/invocations.log"; do
+  for source in "$TEST_ROOT"/app-*.log "$TEST_ROOT"/result-*.json \
+      "$FAKE_DIR/invocations.log"; do
     [ -f "$source" ] && [ ! -L "$source" ] || continue
     destination="$ARTIFACT_DIR/$(basename "$source")"
     install -m 0600 "$source" "$destination"
@@ -346,6 +347,7 @@ run_app_scenario() {
       settings-quick-chat-provider-persists) ;;
       settings-quick-chat-folder-panel) ;;
       quick-chat-command-starts-session) ;;
+      session-shortcut-reopens-closed-main-window) ;;
       *) printf 'UI e2e: unowned check: %s\n' "$check" >&2; exit 1 ;;
     esac
     if [ -n "${pass:-}" ]; then
@@ -395,6 +397,7 @@ run_app_scenario main sessions 32 \
   settings-window-stays-on-screen \
   settings-system-reveals-storage-and-installation \
   quick-chat-command-starts-session \
+  session-shortcut-reopens-closed-main-window \
   installed-app-focus-restored
 run_app_scenario onboarding-first-run empty 8 onboarding-first-run-completes
 run_app_scenario onboarding-provider empty 8 onboarding-detects-provider

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -57,7 +57,7 @@ preserve_failure_diagnostics() {
   mkdir -p "$ARTIFACT_DIR"
   chmod 0700 "$ARTIFACT_DIR"
   for source in "$TEST_ROOT"/app-*.log "$TEST_ROOT"/result-*.json \
-      "$FAKE_DIR/invocations.log"; do
+      "$TEST_ROOT"/window-*.png "$FAKE_DIR/invocations.log"; do
     [ -f "$source" ] && [ ! -L "$source" ] || continue
     destination="$ARTIFACT_DIR/$(basename "$source")"
     install -m 0600 "$source" "$destination"

--- a/tools/quality_merge.py
+++ b/tools/quality_merge.py
@@ -373,12 +373,16 @@ def wait_for_merge(
         sleep_until_next_poll(deadline, poll_seconds)
 
 
-def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+def prepare_summary_path(path: Path, test_mode: bool) -> None:
     if not test_mode and path.resolve() != DEFAULT_OUTPUT.resolve():
         raise MergeError("merge evidence must use app/build/quality-merge.json")
-    if path.exists() and (not path.is_file() or path.is_symlink()):
+    if path.is_symlink() or (path.exists() and not path.is_file()):
         raise MergeError("merge evidence output is unsafe")
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+    prepare_summary_path(path, test_mode)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
         temporary.write_text(
@@ -468,6 +472,8 @@ def main() -> int:
     args = parser().parse_args()
     try:
         policy = Policy(POLICY_FILE)
+        prepare_summary_path(
+            args.output, os.environ.get("DETACH_QUALITY_MERGE_TEST_MODE") == "1")
         summary = execute(args, policy)
         write_summary(
             args.output,

--- a/tools/release_pr.py
+++ b/tools/release_pr.py
@@ -149,12 +149,16 @@ def validate_completed_gate(
     return run["id"]
 
 
-def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+def prepare_summary_path(path: Path, test_mode: bool) -> None:
     if not test_mode and path.resolve() != DEFAULT_OUTPUT.resolve():
         raise ReleasePrError("release PR evidence must use app/build/release-pr.json")
-    if path.exists() and (not path.is_file() or path.is_symlink()):
+    if path.is_symlink() or (path.exists() and not path.is_file()):
         raise ReleasePrError("release PR evidence output is unsafe")
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_summary(path: Path, value: dict[str, Any], test_mode: bool) -> None:
+    prepare_summary_path(path, test_mode)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
         temporary.write_text(
@@ -242,6 +246,7 @@ def main() -> int:
     args = parser().parse_args()
     test_mode = os.environ.get("DETACH_RELEASE_PR_TEST_MODE") == "1"
     try:
+        prepare_summary_path(args.output, test_mode)
         summary = execute(args, Policy(POLICY_FILE))
         write_summary(args.output, summary, test_mode)
     except (ReleasePrError, MergeError, OSError, ValueError) as error:


### PR DESCRIPTION
Several edge cases can leave session state stale, hide a session title, move Settings off screen, or keep a helper operation waiting beyond its deadline.

- Retire queued refreshes with their observation lifetime. Preserve transient confirmation deadlines and distinguish status or lifecycle changes. Refresh after a replacement transcript observer is registered.
- Keep model and context metadata in the scrolling row so the session title stays visible. Keep Settings inside its hosting screen after text size or screen changes.
- Reject special files before reads of metadata, transcript validation, helper locks, and activity handoffs. Invalid activity keeps the session working.
- Bound root command output and owned descendants with the existing process runner.
- Validate PR evidence paths before creating or merging a remote pull request.

Regression tests reproduce these defects before their fixes. Native layout captures cover English and Russian, narrow detail views, and larger text. The packaged UI journey checks titles at the minimum window size, disconnected logs, reopening the main window, text-size Apply, and Settings growth at screen edges. The driver waits for panel closure, verifies native slider values, and sends matching mouse event pairs.

The [authoritative repository gate](https://github.com/iltsarev/detach/actions/runs/33934162162) passes for `e94d480d5bd95fb961e4302e0d00ef1bd5a03139`. All 1124 Swift tests complete with no failures and one release-only skip. All four packaged UI scenarios pass. Combined line coverage is 81.38% for UI and 96.25% for business code; changed executable Swift lines have 100% coverage. Codex, Claude, distribution, runtime, and hermetic release checks pass.

Focused local diagnostics and native layout checks pass. The full local run could not activate UI while the macOS session was locked, so local coverage and timing evaluation remain incomplete. Hosted CI supplies the readiness evidence. Hardware power and release checks were not run. This PR does not publish a release.
