### PR TITLE
Make native file event coverage deterministic

### DIFF
--- a/app/Sources/DetachKit/SessionEvents.swift
+++ b/app/Sources/DetachKit/SessionEvents.swift
@@ -381,7 +381,7 @@ final class SessionTranscriptFileMonitor: @unchecked Sendable {
     }
 }
 
-private func sessionFSEventsCallback(
+func sessionFSEventsCallback(
     _: ConstFSEventStreamRef,
     info: UnsafeMutableRawPointer?,
     count: Int,

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -121,6 +121,7 @@ final class SessionEventsTests: XCTestCase {
             queue: queue,
             output: pipe.fileHandleForWriting)
         let paths = [configuration.signalPath] as CFArray
+        let unrelatedPaths = [configuration.stateRoot + "/unrelated.json"] as CFArray
         var flag: FSEventStreamEventFlags = 0
 
         let delivery = withUnsafePointer(to: &flag) { flags in
@@ -139,9 +140,41 @@ final class SessionEventsTests: XCTestCase {
         XCTAssertEqual(
             delivery?.batch,
             SessionFileEventBatch(paths: [configuration.signalPath], flags: [0]))
+        let callback: FSEventStreamCallback = sessionFSEventsCallback
+        let stream = try XCTUnwrap(FSEventStreamCreate(
+            nil,
+            callback,
+            nil,
+            paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0,
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagUseCFTypes)))
+        defer { FSEventStreamRelease(stream) }
+        var eventID: FSEventStreamEventId = 1
         queue.sync {
-            if let delivery {
-                delivery.watcher.receive(delivery.batch)
+            withUnsafePointer(to: &flag) { flags in
+                withUnsafePointer(to: &eventID) { eventIDs in
+                    callback(
+                        stream, nil, 1,
+                        Unmanaged.passUnretained(paths).toOpaque(),
+                        flags, eventIDs)
+                    callback(
+                        stream,
+                        Unmanaged.passUnretained(watcher).toOpaque(),
+                        1,
+                        Unmanaged.passUnretained(unrelatedPaths).toOpaque(),
+                        flags, eventIDs)
+                    var descriptor = pollfd(
+                        fd: pipe.fileHandleForReading.fileDescriptor,
+                        events: Int16(POLLIN), revents: 0)
+                    XCTAssertEqual(Darwin.poll(&descriptor, 1, 0), 0)
+                    callback(
+                        stream,
+                        Unmanaged.passUnretained(watcher).toOpaque(),
+                        1,
+                        Unmanaged.passUnretained(paths).toOpaque(),
+                        flags, eventIDs)
+                }
             }
         }
 

--- a/app/Tests/DetachKitTests/SessionEventsTests.swift
+++ b/app/Tests/DetachKitTests/SessionEventsTests.swift
@@ -122,6 +122,7 @@ final class SessionEventsTests: XCTestCase {
             output: pipe.fileHandleForWriting)
         let paths = [configuration.signalPath] as CFArray
         let unrelatedPaths = [configuration.stateRoot + "/unrelated.json"] as CFArray
+        let emptyPaths = [] as CFArray
         var flag: FSEventStreamEventFlags = 0
 
         let delivery = withUnsafePointer(to: &flag) { flags in
@@ -163,6 +164,12 @@ final class SessionEventsTests: XCTestCase {
                         Unmanaged.passUnretained(watcher).toOpaque(),
                         1,
                         Unmanaged.passUnretained(unrelatedPaths).toOpaque(),
+                        flags, eventIDs)
+                    callback(
+                        stream,
+                        Unmanaged.passUnretained(watcher).toOpaque(),
+                        0,
+                        Unmanaged.passUnretained(emptyPaths).toOpaque(),
                         flags, eventIDs)
                     var descriptor = pollfd(
                         fd: pipe.fileHandleForReading.fileDescriptor,


### PR DESCRIPTION
Release coverage depended on whether macOS delivered a directory event before the Swift tests ended. The existing callback test decoded a batch and called the watcher separately, so the callback and ignored-event path could stay untested even when the test passed.

Call the actual FSEventStreamCallback pointer with a real unstarted stream. Verify that a missing context, an unrelated file, and an empty batch emit no bytes, then require the lifecycle event to emit its typed hint. Make the callback internal so the existing test can exercise this boundary. Keep the baseline test identity.

Validation: disabling callback forwarding makes the test fail on the missing hint. All Swift tests pass after restoration. The local diagnostic passes in 24 seconds; business coverage rises from 9955/10354 to 9967/10354, meeting the green-main baseline. No coverage threshold changes.

The [authoritative repository gate](https://github.com/iltsarev/detach/actions/runs/33953643728) passes for `26a63983c98a37854c4ea7244506ec246ba654e4`, including all four UI scenarios and provider integrations. Combined coverage is 81.38% for UI and 96.26% for business code.
