### PR TITLE
Restore logs and terminal return after session exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,9 @@ palette slot. Detach never edits the global tmux configuration.
 Shells in user-created split panes close normally on `Ctrl-D` or exit. Only the
 managed Codex or Claude pane is retained after completion so that Detach can
 preserve output and exit status.
+When the provider exits, including after `Ctrl-C`, the external terminal returns
+to its original shell. A `Ctrl-C` that only interrupts work keeps the connection
+while the provider remains running. Logs and checkpoints stay available.
 
 Inside managed tmux, the mouse wheel scrolls one line at a time. Mouse selection
 copies to the macOS clipboard and keeps the highlight and scroll position. When

--- a/app/Sources/DetachApp/QuickChat.swift
+++ b/app/Sources/DetachApp/QuickChat.swift
@@ -70,6 +70,14 @@ enum QuickChatLaunch {
         onSessionAvailable: (@MainActor (String) -> Void)? = nil,
         createProjectDirectory: (URL, FileManager) throws -> URL = {
             try QuickChatProjectDirectory.create(inside: $0, fileManager: $1)
+        },
+        waitForSession: @escaping @MainActor @Sendable (
+            SessionStore, Provider, URL, Set<String>
+        ) async -> String? = { store, provider, directory, existingIDs in
+            await store.waitForSession(
+                provider: provider,
+                projectDirectory: directory,
+                excluding: existingIDs)
         }
     ) async -> SessionStartResult {
         guard let directory = DirectoryPreference.existingDirectoryURL(
@@ -106,10 +114,8 @@ enum QuickChatLaunch {
                     prompt: nil))
             }
             group.addTask {
-                .session(await store.waitForSession(
-                    provider: provider,
-                    projectDirectory: projectDirectory,
-                    excluding: existingIDs))
+                .session(await waitForSession(
+                    store, provider, projectDirectory, existingIDs))
             }
 
             var selectedEarly = false

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -134,40 +134,6 @@ struct SessionDetailView: View {
             attachRequested = false
             preparingAction = nil
         }
-        .task(id: logTaskID) {
-            guard !showsEmbeddedTerminal else {
-                logPoller = nil
-                logPollerSessionID = nil
-                return
-            }
-            let poller = cachedLog
-                ?? (logPollerSessionID == session.id ? logPoller : nil)
-                ?? LogPoller(
-                    cli: ProcessDetachCLI(executable: URL(fileURLWithPath: detachPath)),
-                    provider: session.provider,
-                    sessionName: session.sessionName)
-            if cachedLog == nil, logPoller !== poller {
-                logPoller = poller
-                logPollerSessionID = session.id
-            }
-            // The cache follows typed lifecycle revisions. An unchanged
-            // non-live tail is immutable, so revisiting it needs no process.
-            if cachedLog?.hasLoaded == true { return }
-            await poller.fetchOnce()
-            guard session.isLive else { return }
-            // Pane output of a disconnected live session has no event source.
-            // Follow it only while this surface is visible; selection changes
-            // and the embedded terminal cancel this task.
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(
-                        nanoseconds: SessionDetailLogRefresh.liveFallbackIntervalNanoseconds)
-                } catch {
-                    return
-                }
-                await poller.fetchOnce()
-            }
-        }
         .alert(L10n.string("Something went wrong"), isPresented: .init(
             get: { actionError != nil }, set: { if !$0 { actionError = nil } })) {
             Button(L10n.string("OK"), role: .cancel) {}
@@ -391,6 +357,37 @@ struct SessionDetailView: View {
             cachedLogIdentity: cachedLog.map(ObjectIdentifier.init))
     }
 
+    private func refreshVisibleLog() async {
+        guard !Task.isCancelled else { return }
+        let poller = cachedLog
+            ?? (logPollerSessionID == session.id ? logPoller : nil)
+            ?? LogPoller(
+                cli: ProcessDetachCLI(executable: URL(fileURLWithPath: detachPath)),
+                provider: session.provider,
+                sessionName: session.sessionName)
+        if cachedLog == nil, logPoller !== poller {
+            logPoller = poller
+            logPollerSessionID = session.id
+        }
+        // The cache follows typed lifecycle revisions. An unchanged
+        // non-live tail is immutable, so revisiting it needs no process.
+        if cachedLog?.hasLoaded == true { return }
+        await poller.fetchOnce()
+        guard session.isLive else { return }
+        // Pane output of a disconnected live session has no event source.
+        // Follow it only while this surface is visible; selection changes
+        // and the embedded terminal cancel this task.
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(
+                    nanoseconds: SessionDetailLogRefresh.liveFallbackIntervalNanoseconds)
+            } catch {
+                return
+            }
+            await poller.fetchOnce()
+        }
+    }
+
     private var logView: some View {
         ZStack {
             VStack(spacing: 0) {
@@ -416,6 +413,7 @@ struct SessionDetailView: View {
                 } else {
                     LogTextView(text: logContent)
                         .frame(maxHeight: .infinity)
+                        .task(id: logTaskID) { await refreshVisibleLog() }
                         .onAppear {
                             // makeNSView applies and lays out cached text before
                             // it returns. Keep the passive outgoing frame for one

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -328,7 +328,7 @@ struct SessionDetailView: View {
         .foregroundColor: NSColor(white: 0.85, alpha: 1),
     ]
 
-    var logContent: NSAttributedString {
+    private var logContent: NSAttributedString {
         let visiblePoller = cachedLog
             ?? (logPollerSessionID == session.id ? logPoller : nil)
         if let error = visiblePoller?.errorText {
@@ -357,7 +357,7 @@ struct SessionDetailView: View {
             cachedLogIdentity: cachedLog.map(ObjectIdentifier.init))
     }
 
-    func refreshVisibleLog() async {
+    private func refreshVisibleLog() async {
         guard !Task.isCancelled else { return }
         let poller = cachedLog
             ?? (logPollerSessionID == session.id ? logPoller : nil)
@@ -387,6 +387,12 @@ struct SessionDetailView: View {
             await poller.fetchOnce()
         }
     }
+
+#if DEBUG
+    var logContentForTesting: NSAttributedString { logContent }
+
+    func refreshVisibleLogForTesting() async { await refreshVisibleLog() }
+#endif
 
     private var logView: some View {
         ZStack {

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -357,7 +357,12 @@ struct SessionDetailView: View {
             cachedLogIdentity: cachedLog.map(ObjectIdentifier.init))
     }
 
-    private func refreshVisibleLog() async {
+    private func refreshVisibleLog(
+        waitForNextRead: @MainActor @Sendable () async throws -> Void = {
+            try await Task.sleep(
+                nanoseconds: SessionDetailLogRefresh.liveFallbackIntervalNanoseconds)
+        }
+    ) async {
         guard !Task.isCancelled else { return }
         let poller = cachedLog
             ?? (logPollerSessionID == session.id ? logPoller : nil)
@@ -379,8 +384,7 @@ struct SessionDetailView: View {
         // and the embedded terminal cancel this task.
         while !Task.isCancelled {
             do {
-                try await Task.sleep(
-                    nanoseconds: SessionDetailLogRefresh.liveFallbackIntervalNanoseconds)
+                try await waitForNextRead()
             } catch {
                 return
             }
@@ -392,6 +396,10 @@ struct SessionDetailView: View {
     var logContentForTesting: NSAttributedString { logContent }
 
     func refreshVisibleLogForTesting() async { await refreshVisibleLog() }
+
+    func refreshVisibleLogForTesting(
+        waitForNextRead: @MainActor @Sendable () async throws -> Void
+    ) async { await refreshVisibleLog(waitForNextRead: waitForNextRead) }
 #endif
 
     private var logView: some View {

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -328,9 +328,9 @@ struct SessionDetailView: View {
         .foregroundColor: NSColor(white: 0.85, alpha: 1),
     ]
 
-    private var logContent: NSAttributedString {
-        let sessionPoller = logPollerSessionID == session.id ? logPoller : nil
-        let visiblePoller = cachedLog ?? sessionPoller
+    var logContent: NSAttributedString {
+        let visiblePoller = cachedLog
+            ?? (logPollerSessionID == session.id ? logPoller : nil)
         if let error = visiblePoller?.errorText {
             var attributes = Self.placeholderAttributes
             attributes[.foregroundColor] = NSColor.systemOrange
@@ -357,7 +357,7 @@ struct SessionDetailView: View {
             cachedLogIdentity: cachedLog.map(ObjectIdentifier.init))
     }
 
-    private func refreshVisibleLog() async {
+    func refreshVisibleLog() async {
         guard !Task.isCancelled else { return }
         let poller = cachedLog
             ?? (logPollerSessionID == session.id ? logPoller : nil)

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -341,6 +341,9 @@ enum UIE2ETestDriver {
                 recoverButton, name: "in-app recover action")
             try requireSemanticControl(
                 recoverFallback, name: "external recover fallback")
+            let logFailure = configuration.root.appendingPathComponent(
+                "fake/disconnected-log-failure")
+            try Data().write(to: logFailure, options: .atomic)
             try await clickUntil(
                 recoverButton,
                 name: "in-app recover action",
@@ -363,17 +366,16 @@ enum UIE2ETestDriver {
             guard label(reconnectButton) == L10n.string("Reconnect") else {
                 throw Failure(message: "exited attach client does not offer Reconnect")
             }
-            try await waitUntil("disconnected session log is readable") {
+            try await waitUntil("disconnected session log shows a read failure") {
+                guard let scrollView = find(identifier: "session-preview-log") as? NSScrollView,
+                      let textView = scrollView.documentView as? NSTextView else { return false }
+                return textView.string.contains("UI fixture log read failed")
+            }
+            try FileManager.default.removeItem(at: logFailure)
+            try await waitUntil("disconnected session log recovers after read failure") {
                 guard let scrollView = find(identifier: "session-preview-log") as? NSScrollView,
                       let textView = scrollView.documentView as? NSTextView else { return false }
                 return textView.string.contains("UI fixture log for \(recoverableID)")
-            }
-            try Data().write(to: configuration.root.appendingPathComponent(
-                "fake/disconnected-log-updated"), options: .atomic)
-            try await waitUntil("disconnected session log follows new output") {
-                guard let scrollView = find(identifier: "session-preview-log") as? NSScrollView,
-                      let textView = scrollView.documentView as? NSTextView else { return false }
-                return textView.string.contains("Updated UI fixture log for \(recoverableID)")
             }
             try await clickUntil(
                 reconnectButton,

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -368,6 +368,13 @@ enum UIE2ETestDriver {
                       let textView = scrollView.documentView as? NSTextView else { return false }
                 return textView.string.contains("UI fixture log for \(recoverableID)")
             }
+            try Data().write(to: configuration.root.appendingPathComponent(
+                "fake/disconnected-log-updated"), options: .atomic)
+            try await waitUntil("disconnected session log follows new output") {
+                guard let scrollView = find(identifier: "session-preview-log") as? NSScrollView,
+                      let textView = scrollView.documentView as? NSTextView else { return false }
+                return textView.string.contains("Updated UI fixture log for \(recoverableID)")
+            }
             try await clickUntil(
                 reconnectButton,
                 name: "in-app reconnect action",

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -205,6 +205,35 @@ final class QuickChatTests: XCTestCase {
         XCTAssertEqual(listCallCount, 2)
     }
 
+    func testQuickChatSelectsCompletedLaunchWhenObservationEndsWithoutASession() async throws {
+        let directory = try XCTUnwrap(
+            DirectoryPreference.existingDirectoryURL(path: "/tmp"))
+        let sessionID = "detach-codex-tmp-1"
+        let cli = QuickChatRecordingCLI()
+        cli.responses["list --json"] = CLIResult(
+            exitCode: 0,
+            stdout: #"{"schema":1,"provider":"codex","session_name":"\#(sessionID)","name":"tmp-1","effective_status":"running","project_dir":"\#(directory.path)"}"#,
+            stderr: "",
+            timedOut: false)
+        var selectedIDs: [String] = []
+
+        let result = await QuickChatLaunch.start(
+            store: SessionStore(cli: cli),
+            providerRawValue: Provider.codex.rawValue,
+            directoryPath: directory.path,
+            onSessionAvailable: { selectedIDs.append($0) },
+            createProjectDirectory: { directory, _ in directory },
+            waitForSession: { _, _, _, _ in nil })
+
+        XCTAssertEqual(result.sessionID, sessionID)
+        XCTAssertNil(result.message)
+        XCTAssertEqual(selectedIDs, [sessionID])
+        XCTAssertEqual(cli.calls.map(\.arguments), [
+            ["codex", "--detach"],
+            ["list", "--json"],
+        ])
+    }
+
     func testQuickChatRejectsAnUnavailableFolderWithoutCallingTheCLI() async {
         let cli = QuickChatRecordingCLI()
         let missing = "/tmp/detach-missing-\(UUID().uuidString)"

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -12,6 +12,21 @@ private final class SilentDetachCLI: DetachCLIRunning, @unchecked Sendable {
     }
 }
 
+private actor DetailLogSequenceCLI: DetachCLIRunning {
+    private var responses: [CLIResult]
+    private(set) var callCount = 0
+
+    init(responses: [CLIResult]) { self.responses = responses }
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        callCount += 1
+        guard !responses.isEmpty else {
+            return CLIResult(exitCode: 1, stdout: "", stderr: "unexpected read", timedOut: false)
+        }
+        return responses.removeFirst()
+    }
+}
+
 private actor TerminalScreenPrefetchCLI: DetachCLIRunning {
     private(set) var calls: [[String]] = []
     private var activeCalls = 0
@@ -379,6 +394,67 @@ final class SessionAttachTerminalTests: XCTestCase {
             detachPath: "/tmp/detach",
             terminalScreens: SessionTerminalScreenCache(),
             cachedLog: cache.poller(for: session)).body
+    }
+
+    @MainActor
+    func testDetailLogReplacesReadErrorWithSuccessfulStyledOutput() async throws {
+        let session = try XCTUnwrap(Self.session(status: "stopped"))
+        let cli = DetailLogSequenceCLI(responses: [
+            CLIResult(exitCode: 1, stdout: "", stderr: "Log read failed\n", timedOut: false),
+            CLIResult(exitCode: 0, stdout: "\u{001B}[32mRestored log\u{001B}[0m", stderr: "", timedOut: false),
+        ])
+        let poller = LogPoller(
+            cli: cli, provider: session.provider, sessionName: session.sessionName)
+        let view = SessionDetailView(
+            session: session,
+            store: SessionStore(cli: SilentDetachCLI()),
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: poller)
+
+        XCTAssertEqual(view.logContent.string, "…")
+        await poller.fetchOnce()
+        XCTAssertEqual(view.logContent.string, "⚠︎ Log read failed")
+        XCTAssertEqual(
+            view.logContent.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
+            NSColor.systemOrange)
+
+        await poller.fetchOnce()
+        XCTAssertEqual(view.logContent.string, "Restored log")
+        XCTAssertEqual(view.logContent, poller.attributed)
+        XCTAssertNotEqual(
+            view.logContent.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
+            NSColor.systemOrange)
+    }
+
+    @MainActor
+    func testRetiredLogTaskCannotReadAndWarmLogDoesNotReread() async throws {
+        let session = try XCTUnwrap(Self.session(status: "stopped"))
+        let cli = DetailLogSequenceCLI(responses: [
+            CLIResult(exitCode: 0, stdout: "Ready log", stderr: "", timedOut: false),
+        ])
+        let poller = LogPoller(
+            cli: cli, provider: session.provider, sessionName: session.sessionName)
+        let view = SessionDetailView(
+            session: session,
+            store: SessionStore(cli: SilentDetachCLI()),
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: poller)
+
+        let retired = Task { @MainActor in await view.refreshVisibleLog() }
+        retired.cancel()
+        await retired.value
+        let retiredCalls = await cli.callCount
+        XCTAssertEqual(retiredCalls, 0)
+        XCTAssertFalse(poller.hasLoaded)
+
+        await view.refreshVisibleLog()
+        XCTAssertEqual(view.logContent.string, "Ready log")
+        await view.refreshVisibleLog()
+        let loadedCalls = await cli.callCount
+        XCTAssertEqual(loadedCalls, 1)
+        XCTAssertEqual(view.logContent.string, "Ready log")
     }
 
     func testDetachedLiveLogRefreshKeysOnSessionAndCacheIdentity() throws {

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -412,18 +412,18 @@ final class SessionAttachTerminalTests: XCTestCase {
             terminalScreens: SessionTerminalScreenCache(),
             cachedLog: poller)
 
-        XCTAssertEqual(view.logContent.string, "…")
+        XCTAssertEqual(view.logContentForTesting.string, "…")
         await poller.fetchOnce()
-        XCTAssertEqual(view.logContent.string, "⚠︎ Log read failed")
+        XCTAssertEqual(view.logContentForTesting.string, "⚠︎ Log read failed")
         XCTAssertEqual(
-            view.logContent.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
+            view.logContentForTesting.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
             NSColor.systemOrange)
 
         await poller.fetchOnce()
-        XCTAssertEqual(view.logContent.string, "Restored log")
-        XCTAssertEqual(view.logContent, poller.attributed)
+        XCTAssertEqual(view.logContentForTesting.string, "Restored log")
+        XCTAssertEqual(view.logContentForTesting, poller.attributed)
         XCTAssertNotEqual(
-            view.logContent.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
+            view.logContentForTesting.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
             NSColor.systemOrange)
     }
 
@@ -442,19 +442,19 @@ final class SessionAttachTerminalTests: XCTestCase {
             terminalScreens: SessionTerminalScreenCache(),
             cachedLog: poller)
 
-        let retired = Task { @MainActor in await view.refreshVisibleLog() }
+        let retired = Task { @MainActor in await view.refreshVisibleLogForTesting() }
         retired.cancel()
         await retired.value
         let retiredCalls = await cli.callCount
         XCTAssertEqual(retiredCalls, 0)
         XCTAssertFalse(poller.hasLoaded)
 
-        await view.refreshVisibleLog()
-        XCTAssertEqual(view.logContent.string, "Ready log")
-        await view.refreshVisibleLog()
+        await view.refreshVisibleLogForTesting()
+        XCTAssertEqual(view.logContentForTesting.string, "Ready log")
+        await view.refreshVisibleLogForTesting()
         let loadedCalls = await cli.callCount
         XCTAssertEqual(loadedCalls, 1)
-        XCTAssertEqual(view.logContent.string, "Ready log")
+        XCTAssertEqual(view.logContentForTesting.string, "Ready log")
     }
 
     func testDetachedLiveLogRefreshKeysOnSessionAndCacheIdentity() throws {

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -14,12 +14,17 @@ private final class SilentDetachCLI: DetachCLIRunning, @unchecked Sendable {
 
 private actor DetailLogSequenceCLI: DetachCLIRunning {
     private var responses: [CLIResult]
+    private let cancelDuringRead: Bool
     private(set) var callCount = 0
 
-    init(responses: [CLIResult]) { self.responses = responses }
+    init(responses: [CLIResult], cancelDuringRead: Bool = false) {
+        self.responses = responses
+        self.cancelDuringRead = cancelDuringRead
+    }
 
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
         callCount += 1
+        if cancelDuringRead { withUnsafeCurrentTask { $0?.cancel() } }
         guard !responses.isEmpty else {
             return CLIResult(exitCode: 1, stdout: "", stderr: "unexpected read", timedOut: false)
         }
@@ -425,6 +430,71 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertNotEqual(
             view.logContentForTesting.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor,
             NSColor.systemOrange)
+    }
+
+    @MainActor
+    func testLiveDetailLogRefreshRecoversBeforeCancelledWaitStopsReads() async throws {
+        let session = try XCTUnwrap(Self.session(status: "running"))
+        let cli = DetailLogSequenceCLI(responses: [
+            CLIResult(exitCode: 1, stdout: "", stderr: "Log read failed\n", timedOut: false),
+            CLIResult(exitCode: 0, stdout: "\u{001B}[32mRestored log\u{001B}[0m", stderr: "", timedOut: false),
+        ])
+        let poller = LogPoller(
+            cli: cli, provider: session.provider, sessionName: session.sessionName)
+        let view = SessionDetailView(
+            session: session,
+            store: SessionStore(cli: SilentDetachCLI()),
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: poller)
+        var waitCount = 0
+
+        await view.refreshVisibleLogForTesting {
+            waitCount += 1
+            if waitCount == 1 {
+                XCTAssertEqual(view.logContentForTesting.string, "⚠︎ Log read failed")
+                return
+            }
+            XCTAssertEqual(view.logContentForTesting.string, "Restored log")
+            throw CancellationError()
+        }
+
+        let calls = await cli.callCount
+        XCTAssertEqual(waitCount, 2)
+        XCTAssertEqual(calls, 2)
+        XCTAssertEqual(view.logContentForTesting, poller.attributed)
+        XCTAssertNil(poller.errorText)
+    }
+
+    @MainActor
+    func testDetailLogCancelledDuringReadCannotScheduleAnotherRefresh() async throws {
+        let session = try XCTUnwrap(Self.session(status: "running"))
+        let cli = DetailLogSequenceCLI(
+            responses: [
+                CLIResult(exitCode: 0, stdout: "Last log", stderr: "", timedOut: false),
+            ],
+            cancelDuringRead: true)
+        let poller = LogPoller(
+            cli: cli, provider: session.provider, sessionName: session.sessionName)
+        let view = SessionDetailView(
+            session: session,
+            store: SessionStore(cli: SilentDetachCLI()),
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: poller)
+
+        let read = Task { @MainActor in
+            await view.refreshVisibleLogForTesting {
+                XCTFail("A cancelled read cannot schedule a refresh wait")
+                throw CancellationError()
+            }
+        }
+        await read.value
+
+        let calls = await cli.callCount
+        XCTAssertTrue(read.isCancelled)
+        XCTAssertEqual(calls, 1)
+        XCTAssertEqual(view.logContentForTesting.string, "Last log")
     }
 
     @MainActor

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -14,17 +14,17 @@ private final class SilentDetachCLI: DetachCLIRunning, @unchecked Sendable {
 
 private actor DetailLogSequenceCLI: DetachCLIRunning {
     private var responses: [CLIResult]
-    private let cancelDuringRead: Bool
+    private let cancelDuringRead: Int?
     private(set) var callCount = 0
 
-    init(responses: [CLIResult], cancelDuringRead: Bool = false) {
+    init(responses: [CLIResult], cancelDuringRead: Int? = nil) {
         self.responses = responses
         self.cancelDuringRead = cancelDuringRead
     }
 
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
         callCount += 1
-        if cancelDuringRead { withUnsafeCurrentTask { $0?.cancel() } }
+        if cancelDuringRead == callCount { withUnsafeCurrentTask { $0?.cancel() } }
         guard !responses.isEmpty else {
             return CLIResult(exitCode: 1, stdout: "", stderr: "unexpected read", timedOut: false)
         }
@@ -473,7 +473,7 @@ final class SessionAttachTerminalTests: XCTestCase {
             responses: [
                 CLIResult(exitCode: 0, stdout: "Last log", stderr: "", timedOut: false),
             ],
-            cancelDuringRead: true)
+            cancelDuringRead: 1)
         let poller = LogPoller(
             cli: cli, provider: session.provider, sessionName: session.sessionName)
         let view = SessionDetailView(
@@ -495,6 +495,33 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertTrue(read.isCancelled)
         XCTAssertEqual(calls, 1)
         XCTAssertEqual(view.logContentForTesting.string, "Last log")
+    }
+
+    @MainActor
+    func testLiveDetailLogDefaultWaitRefreshesBeforeReadCancellation() async throws {
+        let session = try XCTUnwrap(Self.session(status: "running"))
+        let cli = DetailLogSequenceCLI(
+            responses: [
+                CLIResult(exitCode: 0, stdout: "Initial log", stderr: "", timedOut: false),
+                CLIResult(exitCode: 0, stdout: "Updated log", stderr: "", timedOut: false),
+            ],
+            cancelDuringRead: 2)
+        let poller = LogPoller(
+            cli: cli, provider: session.provider, sessionName: session.sessionName)
+        let view = SessionDetailView(
+            session: session,
+            store: SessionStore(cli: SilentDetachCLI()),
+            detachPath: "/tmp/detach",
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: poller)
+
+        let refresh = Task { @MainActor in await view.refreshVisibleLogForTesting() }
+        await refresh.value
+
+        let calls = await cli.callCount
+        XCTAssertTrue(refresh.isCancelled)
+        XCTAssertEqual(calls, 2)
+        XCTAssertEqual(view.logContentForTesting.string, "Updated log")
     }
 
     @MainActor

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -2015,6 +2015,22 @@ install_session_event_hook() {
     error "warning: could not install the tmux pane-died hook for this session"
 }
 
+install_session_completion_hook() {
+  local session="$1" pane_id="$2" run_token="$3"
+  local session_id condition command
+
+  [[ "$pane_id" =~ ^%[0-9]+$ ]] || return 1
+  [[ "$run_token" =~ ^[a-zA-Z0-9_-]+$ ]] || return 1
+  session_id="$("${TMUX_CMD[@]}" display-message -p -t "$pane_id" '#{session_id}')" || \
+    return 1
+  [[ "$session_id" =~ ^\$[0-9]+$ ]] || return 1
+  # Use tmux's event queue and immutable pane/session IDs. A dead user split
+  # or an old run must never disconnect clients of the current provider run.
+  condition="#{&&:#{==:#{hook_pane},$pane_id},#{&&:#{pane_dead},#{&&:#{==:#{@detach_pane_id},$pane_id},#{==:#{@detach_run_token},$run_token}}}}"
+  command="if-shell -F -t $pane_id '$condition' { detach-client -s '$session_id' }"
+  "${TMUX_CMD[@]}" set-hook -t "=$session:" 'pane-died[1]' "$command"
+}
+
 state_update_meta_for_run() {
   local session="$1"
   local run_token="$2"
@@ -6059,6 +6075,8 @@ start_tmux_session() {
   "${TMUX_CMD[@]}" set-option -q -w -t "$pane_id" remain-on-exit off
   "${TMUX_CMD[@]}" set-option -q -p -t "$pane_id" remain-on-exit on
   install_session_event_hook "$session"
+  install_session_completion_hook "$session" "$pane_id" "$run_token" || \
+    die "could not configure terminal return after provider exit"
   "${TMUX_CMD[@]}" set-option -q -t "=$session:" history-limit "$HISTORY_LIMIT"
   tmux_configure_server || \
     error "warning: could not configure Detach server input options for this session"

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -67,6 +67,7 @@ Detached live logs reread every 2 s. Cold attach uses one passive SwiftTerm
 overlay; cached bytes never enter the live buffer. Live switching keeps its PTY.
 The visible log view owns its read task. A terminal handoff cannot clear the
 reader of a returned log view. The returned view shows and refreshes its log.
+A failed read shows the error. The next successful read replaces it.
 tmux holds the frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
 action geometry. The model and context gauge stay in the metadata row. They

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -65,6 +65,8 @@ a revision. Bursts keep active reads. The lifecycle ID blocks cache
 inheritance after name reuse; older rows use creation and provider identity.
 Detached live logs reread every 2 s. Cold attach uses one passive SwiftTerm
 overlay; cached bytes never enter the live buffer. Live switching keeps its PTY.
+The visible log view owns its read task. A terminal handoff cannot clear the
+reader of a returned log view. The returned view shows and refreshes its log.
 tmux holds the frame until a synchronized redraw.
 Metadata stays in one scrolling row. Selection keeps header, terminal, and
 action geometry. The model and context gauge stay in the metadata row. They

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -73,6 +73,13 @@ canonical project beneath the cleanup trap.
 
 Tmux environment arguments stay in memory; credentials never touch disk.
 
+When the provider pane dies, tmux detaches its clients. External terminals
+return to their original shell.
+The completion hook requires the exact pane ID and run token. It targets the
+original tmux session ID. A dead user split cannot disconnect those clients.
+The retained provider pane, metadata, and checkpoints remain available.
+Ctrl-C that leaves the provider running does not detach its clients.
+
 Default starts form a provider/project history series. A fresh start refuses a
 live member or second writer; otherwise it allocates a successor without
 reusing saved state. No-`NAME` commands select the live member, then the highest

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -100,11 +100,11 @@ if [ "$#" -eq 4 ] && [ "$2" = logs ] && [ "$3" = --ansi ]; then
       : >"$ROOT/fake/recoverable-log-refresh-delayed"
       sleep 0.25
     fi
-    if [ -f "$ROOT/fake/disconnected-log-updated" ]; then
-      printf '\033[32mUpdated UI fixture log for %s\033[0m\n' "$4"
-    else
-      printf '\033[32mUI fixture log for %s\033[0m\n' "$4"
+    if [ -f "$ROOT/fake/disconnected-log-failure" ]; then
+      printf 'UI fixture log read failed\n' >&2
+      exit 1
     fi
+    printf '\033[32mUI fixture log for %s\033[0m\n' "$4"
     : >"$ROOT/fake/recoverable-log-ready"
     exit 0
   fi

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -100,7 +100,11 @@ if [ "$#" -eq 4 ] && [ "$2" = logs ] && [ "$3" = --ansi ]; then
       : >"$ROOT/fake/recoverable-log-refresh-delayed"
       sleep 0.25
     fi
-    printf '\033[32mUI fixture log for %s\033[0m\n' "$4"
+    if [ -f "$ROOT/fake/disconnected-log-updated" ]; then
+      printf '\033[32mUpdated UI fixture log for %s\033[0m\n' "$4"
+    else
+      printf '\033[32mUI fixture log for %s\033[0m\n' "$4"
+    fi
     : >"$ROOT/fake/recoverable-log-ready"
     exit 0
   fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1640,6 +1640,103 @@ grep -Fx "release --session $SESSION --run-token $stopped_run_token" \
   "$FAKE_POWER_RELEASES_FILE" >/dev/null
 codex_scenario_event pass SC-SESSION-STOP-CODEX
 
+# Ctrl+C that ends the provider must return the attached terminal to its
+# original shell. Keep the dead provider pane available for retained logs.
+interrupt_session=detach-codex-interrupt-terminal
+interrupt_project="$TMP_ROOT/interrupt-project"
+interrupt_returned="$TMP_ROOT/interrupt-terminal-returned"
+interrupt_usable="$TMP_ROOT/interrupt-terminal-usable"
+mkdir -p "$interrupt_project"
+(
+  cd "$interrupt_project"
+  FAKE_CODEX_RELEASE_FILE="$TMP_ROOT/interrupt-provider-release" \
+    FAKE_CODEX_FOREIGN_FIRST=0 FAKE_CODEX_INIT_DELAY=0 \
+    run_codex --name interrupt-terminal --detach >/dev/null
+)
+interrupt_pane="$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$interrupt_session:" @detach_pane_id)"
+interrupt_host="$(tmux -L "$OUTER_SOCKET" new-session -d -P \
+  -F '#{pane_id}' -s interrupt-host -x 120 -y 30)"
+printf -v interrupt_command \
+  'env -u TMUX -u TMUX_PANE %q codex attach interrupt-terminal; printf returned >%q' \
+  "$DETACH" "$interrupt_returned"
+tmux -L "$OUTER_SOCKET" send-keys -l -t "$interrupt_host" -- "$interrupt_command"
+tmux -L "$OUTER_SOCKET" send-keys -t "$interrupt_host" C-m
+attempts=0
+while ! tmux -L "$SOCKET" list-clients -F '#{client_session}' | \
+    grep -Fx "$interrupt_session" >/dev/null && [ "$attempts" -lt 100 ]; do
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+tmux -L "$SOCKET" list-clients -F '#{client_session}' | \
+  grep -Fx "$interrupt_session" >/dev/null
+# A user split can retain its own dead process. Its death must leave the
+# provider client attached, and an unrelated client must survive completion.
+interrupt_split="$(tmux -L "$SOCKET" split-window -d -P -F '#{pane_id}' \
+  -t "$interrupt_pane" /bin/sleep 60)"
+tmux -L "$SOCKET" set-option -p -t "$interrupt_split" remain-on-exit on
+tmux -L "$SOCKET" respawn-pane -k -t "$interrupt_split" /usr/bin/true
+attempts=0
+while [ "$(tmux -L "$SOCKET" display-message -p -t "$interrupt_split" '#{pane_dead}')" != 1 ] && \
+    [ "$attempts" -lt 50 ]; do
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+[ "$(tmux -L "$SOCKET" display-message -p -t "$interrupt_split" '#{pane_dead}')" = 1 ]
+tmux -L "$SOCKET" list-clients -F '#{client_session}' | \
+  grep -Fx "$interrupt_session" >/dev/null
+[ ! -f "$interrupt_returned" ]
+tmux -L "$SOCKET" new-session -d -s completion-unrelated
+interrupt_other_host="$(tmux -L "$OUTER_SOCKET" split-window -d -P \
+  -F '#{pane_id}' -t "$interrupt_host")"
+printf -v interrupt_command \
+  'env -u TMUX -u TMUX_PANE %q -S %q attach-session -t "=completion-unrelated"' \
+  "$TMUX_TEST_BIN" "$SOCKET_PATH"
+tmux -L "$OUTER_SOCKET" send-keys -l -t "$interrupt_other_host" -- "$interrupt_command"
+tmux -L "$OUTER_SOCKET" send-keys -t "$interrupt_other_host" C-m
+attempts=0
+while ! tmux -L "$SOCKET" list-clients -F '#{client_session}' | \
+    grep -Fx completion-unrelated >/dev/null && [ "$attempts" -lt 100 ]; do
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+tmux -L "$SOCKET" list-clients -F '#{client_session}' | \
+  grep -Fx completion-unrelated >/dev/null || {
+    printf 'unrelated terminal client did not attach\n' >&2
+    tmux -L "$OUTER_SOCKET" capture-pane -p -t "$interrupt_other_host" >&2
+    exit 1
+  }
+tmux -L "$OUTER_SOCKET" send-keys -t "$interrupt_host" C-c
+attempts=0
+while [ ! -f "$interrupt_returned" ] && [ "$attempts" -lt 160 ]; do
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+[ -f "$interrupt_returned" ] || {
+  printf 'Ctrl+C left the terminal attached after provider exit\n' >&2
+  exit 1
+}
+[ "$(tmux -L "$SOCKET" display-message -p -t "$interrupt_pane" '#{pane_dead}')" = 1 ]
+tmux -L "$SOCKET" list-clients -F '#{client_session}' | \
+  grep -Fx completion-unrelated >/dev/null || {
+    printf 'provider completion disconnected an unrelated client\n' >&2
+    tmux -L "$SOCKET" list-clients -F '#{client_session}' >&2
+    exit 1
+  }
+run_codex logs interrupt-terminal | grep -F 'fake Codex started' >/dev/null
+printf -v interrupt_command 'printf usable >%q' "$interrupt_usable"
+tmux -L "$OUTER_SOCKET" send-keys -l -t "$interrupt_host" -- "$interrupt_command"
+tmux -L "$OUTER_SOCKET" send-keys -t "$interrupt_host" C-m
+attempts=0
+while [ ! -f "$interrupt_usable" ] && [ "$attempts" -lt 50 ]; do
+  attempts=$((attempts + 1))
+  sleep 0.1
+done
+[ -f "$interrupt_usable" ]
+run_codex delete --force interrupt-terminal >/dev/null
+tmux -L "$OUTER_SOCKET" kill-server >/dev/null 2>&1 || true
+tmux -L "$SOCKET" kill-session -t =completion-unrelated
+
 if [ "$CODEX_TEST_PART" = lifecycle ]; then
   run_codex delete --force integration
 fi


### PR DESCRIPTION
When a provider exits after Ctrl+C, an external terminal can remain attached to its retained dead tmux pane. When an embedded attach client exits, the app can also remain on a log placeholder. Return external terminals to their original shell and keep the visible app log updating.

A native tmux completion hook requires the exact dead provider pane, stored pane ID, and run token. It detaches clients only from the original tmux session ID. Logs and checkpoints remain available. A dead user split does not disconnect the provider client, and unrelated clients stay attached. Ctrl+C that leaves the provider running keeps its attachment. README and the runtime specification record the contract.

The visible app log owns its read task and retains its reader across terminal handoffs. Tests cover failed reads followed by styled output, cancellation before and during a read, cancellation of a refresh wait, the actual default refresh interval, and immutable warm-cache reuse. Private product helpers have DEBUG-only test accessors. Quick Chat also has a deterministic completed-launch fallback test when its early observer returns no session.

Validation: all functional stages of the selected local diagnostic passed against the measured green-main baseline: 1130 Swift tests (one release-only signed-fixture skip), four native UI scenarios, Codex and Claude lifecycle suites, distribution, tmux, static checks, and coverage contracts. UI coverage is 81.39%, business coverage 96.26%, and changed Swift lines 100%. Only the pre-existing local provider timing ceilings failed: Codex 164/110 seconds and Claude 152/60 seconds. The owner authorized a timing-only exception for release 0.5.2; no policy or functional check was relaxed.

The real PTY Ctrl+C regression fails on the original core and passes with the fix. It verifies a second command in the same original shell, retained output, a dead user split, and an unrelated attached client. Existing negative probes detect missing log cancellation admission and a persistent log-read error. The authoritative quality-gates job must pass on this final head before merge.
