### PR TITLE
Resume Claude sessions that only have startup companions

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -3187,7 +3187,6 @@ claude_provider_entry_for_id_exists() {
   local configured_home
   local home
   local projects
-  local short_id
   local candidate
   local config
 
@@ -3200,15 +3199,14 @@ claude_provider_entry_for_id_exists() {
   if [ -e "$projects" ] || [ -L "$projects" ]; then
     [ -d "$projects" ] && [ ! -L "$projects" ] || return 2
   fi
-  short_id="${id:0:8}"
+  # Only transcript evidence proves that Claude bound conversation state to
+  # this UUID. Claude creates companion directories such as
+  # session-env/<uuid> and tasks/session-<short> at startup, before any
+  # transcript exists, and reuses them on a later --session-id launch. They
+  # must not block a metadata-only resume.
   for candidate in \
     "$projects"/*/"$id.jsonl" \
-    "$projects"/*/"$id" \
-    "$home/file-history/$id" \
-    "$home/session-env/$id" \
-    "$home/tasks/$id" \
-    "$home/tasks/session-$short_id" \
-    "$home/teams/session-$short_id"; do
+    "$projects"/*/"$id"; do
     if [ -e "$candidate" ] || [ -L "$candidate" ]; then
       return 0
     fi

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -151,7 +151,9 @@ the original copy tables immediately.
 
 Claude gets a wrapper-owned UUID via `--session-id`. Resume uses `--resume` with
 a valid transcript or matching checkpoint. It uses `--session-id` only if both
-are absent. A present invalid transcript fails closed. Codex binds identity
+are absent. A present invalid transcript fails closed. Startup companions such
+as `session-env/<uuid>` or `tasks/session-<short>` are not transcript evidence
+and do not block that path. Codex binds identity
 after launch by matching the run-token originator in rollout files and SQLite;
 an ambiguous first binding fails. If the provider switches to another run-owned
 user thread (for example `/clear`), discovery rebinds identity, transcript, and

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -1484,6 +1484,43 @@ grep -Fx -- "$empty_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 "$SCRIPT" claude stop "$empty_label"
 export CLAUDE_CONFIG_DIR="$claude_config_dir_with_history"
 
+# Claude creates session-env/<uuid> and tasks/session-<short> at startup,
+# before it writes any transcript. These startup companions must not block a
+# metadata-only Resume inside the populated Claude home.
+rm -rf \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id.jsonl" \
+  "$CLAUDE_CONFIG_DIR/projects/fake/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/file-history/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/session-env/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/session-${empty_id:0:8}" \
+  "$CLAUDE_CONFIG_DIR/teams/session-${empty_id:0:8}"
+rm -f \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session.tar" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
+rm -rf \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-file-history" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/claude-session-env"
+"$STATE_HELPER" meta patch "$empty_meta" --null transcript_path --null last_checkpoint_at
+cp -p "$empty_meta" \
+  "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/meta.json"
+mkdir -p \
+  "$CLAUDE_CONFIG_DIR/session-env/$empty_id" \
+  "$CLAUDE_CONFIG_DIR/tasks/session-${empty_id:0:8}"
+reset_fake_claude_ready
+: >"$FAKE_CLAUDE_ARGS_FILE"
+if ! "$SCRIPT" resume --detach "$empty_id"; then
+  printf 'metadata-only Resume rejected Claude startup companions\n' >&2
+  exit 1
+fi
+wait_for_fake_claude_ready
+grep -Fx -- '--session-id' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+! grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+grep -Fx -- "$empty_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
+"$STATE_HELPER" meta matches "$empty_meta" claude "$empty_id"
+"$SCRIPT" claude stop "$empty_label"
+
 # If a later metadata-only Resume fails before readiness, Recover must still
 # select checkpoint A and launch its UUID with --session-id. No transcript or
 # provider payload exists yet for that generation.


### PR DESCRIPTION
## Contract delta

- MODIFIED: metadata-only Claude Resume no longer fails when Claude left startup companions (`session-env/<uuid>`, `tasks/session-<short>`) without a transcript. Only transcript evidence (`projects/*/<uuid>.jsonl`, `projects/*/<uuid>`) or a team config naming the UUID as lead blocks the `--session-id` path.
- UNCHANGED: a present invalid transcript still fails closed; unsafe team configs still fail closed.

## Root cause

The app showed `Claude session '<uuid>' changed while preparing resume` for a session that showed the welcome screen and was stopped. On this machine 22 session-env directories exist without a transcript, 8 of them next to a `tasks/session-<short>` directory, so the startup companions are normal Claude behavior and not evidence of a changed session.

## Evidence

- `tests/run-claude.sh` gains a scenario that keeps the startup companions in the populated Claude home and requires Resume to launch with `--session-id`. It fails on the previous `bin/detach-core` with the exact production message and passes with the fix.
- `tests/shell-safety.sh`, `tests/docs-contract.sh`, and `git diff --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
