### PR TITLE
Classify UI smoke environment denials and retry silent launches

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -149,7 +149,10 @@ the same bundle and does not build it again. A failed build cannot create this
 binding. Only the private UI copy gets the instrumented executable.
 The short packaged UI lane runs after the verified app and before the
 CPU-intensive provider, runtime, and gate-contract lanes. This prevents
-WindowServer event delivery from competing with those workers. After the UI and metric phases,
+WindowServer event delivery from competing with those workers. The UI smoke
+probes the console session first. An agent sandbox, SSH session, login window,
+or locked screen is an environment denial that the gate records as
+`environment-failed`, never as a product failure. After the UI and metric phases,
 the scheduler starts ready process-heavy stages in descending policy timing
 order. It admits at most two process-heavy top-level lanes. One separate lane
 runs short runtime and release preflights during gate-contract. Distribution
@@ -186,7 +189,10 @@ or ambient helpers. Distribution runs its runtime and shell-profile contracts
 concurrently in separate private temporary homes.
 
 There are no quarantined tests. A future quarantine needs an owner, reason, and
-expiry. It cannot remove release evidence.
+expiry. It cannot remove release evidence. The packaged UI journeys are the
+only retry layer: a scenario whose app never reports a result gets exactly one
+retry from its starting state inside the stage budget, and the stage log
+records the retry. A reported failure never retries.
 
 ## Impact and user journeys
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -190,9 +190,11 @@ concurrently in separate private temporary homes.
 
 There are no quarantined tests. A future quarantine needs an owner, reason, and
 expiry. It cannot remove release evidence. The packaged UI journeys are the
-only retry layer: a scenario whose app never reports a result gets exactly one
-retry from its starting state inside the stage budget, and the stage log
-records the retry. A reported failure never retries.
+only retry layer: every scenario and every attempt starts from a clean
+private state with no app state, fake CLI markers, attach client, or
+persisted defaults; a scenario whose app never reports a result, or reports
+a timeout, gets exactly one retry inside the stage budget, and the stage log
+records the retry. A reported assertion failure never retries.
 
 ## Impact and user journeys
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -137,9 +137,12 @@
   Accessibility approval. Before it launches the app it probes the console
   session. An agent sandbox, an SSH session, the login window, or a locked
   screen produces `UI e2e: environment denied`, exit 2, and the gate records
-  `environment-failed` instead of a product failure. A scenario whose app
-  never reports a result gets one retry from its starting state; the log
-  records `e2e retry 1 of 1`. A reported failure never retries. Do not grant
+  `environment-failed` instead of a product failure. Every scenario and
+  attempt starts from a clean private state, and the smoke deletes the test
+  copy's preference domains through cfprefsd at the end. A scenario whose
+  app never reports a result, or reports a timeout, gets one retry; the log
+  records `e2e retry 1 of 1`. A reported assertion failure never retries.
+  Do not grant
   it broader filesystem or production
   payload access. Its fake CLI allowlist covers only the exact status and stop
   flow and the completed-session forced delete asserted by the smoke. The

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -134,7 +134,13 @@
   increment actions, and restores the prior application. The locator bridge
   has no application actions. Run the
   app build first. The UI smoke needs a logged-in WindowServer session but no
-  Accessibility approval. Do not grant it broader filesystem or production
+  Accessibility approval. Before it launches the app it probes the console
+  session. An agent sandbox, an SSH session, the login window, or a locked
+  screen produces `UI e2e: environment denied`, exit 2, and the gate records
+  `environment-failed` instead of a product failure. A scenario whose app
+  never reports a result gets one retry from its starting state; the log
+  records `e2e retry 1 of 1`. A reported failure never retries. Do not grant
+  it broader filesystem or production
   payload access. Its fake CLI allowlist covers only the exact status and stop
   flow and the completed-session forced delete asserted by the smoke. The
   same run disconnects Stop, proves that no action occurs, reconnects it, and

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -742,7 +742,7 @@
     "routed_spec_limit_bytes": 16384,
     "routed_spec_warning_bytes": 12288
   },
-  "policy": 56,
+  "policy": 57,
   "release_domains": [
     {
       "gates": "-",
@@ -3223,7 +3223,7 @@
       "name": "ui-e2e",
       "order": 60,
       "release": true,
-      "timeout_seconds": 55
+      "timeout_seconds": 130
     },
     {
       "name": "codex",

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	56
+policy	57
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime and session operations preserve exact ownership.
 spec	state	docs/specs/state.md	Typed state, storage, and change events remain safe and coherent.
@@ -21,7 +21,7 @@ stage	20	gate-contract	300	true
 stage	30	swift	1200	true
 stage	40	quality-contracts	1200	true
 stage	50	app	2400	true
-stage	60	ui-e2e	55	true
+stage	60	ui-e2e	130	true
 stage	70	codex	1200	true
 stage	80	claude	1200	true
 stage	90	distribution	1200	true

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -139,7 +139,16 @@ if [ "$#" -eq 10 ] && [ "$1" = client ] && [ "$2" = switch ] \
     printf 'fake attached client control channel is missing\n' >&2
     exit 65
   }
-  printf '%s\n' "$8" >"$ROOT/fake/attach-client-control"
+  # A dead attach client leaves its FIFO behind. Refuse instead of blocking
+  # forever on a write that nothing will read.
+  attach_pid="$(<"$ROOT/fake/attach-client-pid")" 2>/dev/null || attach_pid=""
+  [ -n "$attach_pid" ] && kill -0 "$attach_pid" 2>/dev/null || {
+    printf 'fake attached client is not running\n' >&2
+    exit 65
+  }
+  exec 3<>"$ROOT/fake/attach-client-control"
+  printf '%s\n' "$8" >&3
+  exec 3>&-
   attempts=0
   while [ "$attempts" -lt 50 ] \
       && [ "$(<"$ROOT/fake/attach-client-current")" != "$8" ]; do

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -692,6 +692,17 @@ fi
 grep -F $'codex\tenvironment-failed' "$RESULT_ROOT"/*/summary.tsv >/dev/null
 grep -F 'codex environment-failed' "$REPO/environment-failure.out" >/dev/null
 grep -F '<failure message="environment-failed">' "$RESULT_ROOT"/*/junit.xml >/dev/null
+
+setup_fixture ui-environment-denial
+printf '#!/bin/bash\nprintf "UI e2e: environment denied: no interactive GUI session (no-session)\\n" >&2\nexit 2\n' \
+  >"$REPO/tests/quality-gate-fixtures/ui-e2e"
+chmod 0755 "$REPO/tests/quality-gate-fixtures/ui-e2e"
+if gate --mode repository >"$REPO/ui-environment-denial.out" 2>&1; then
+  printf 'quality gate accepted a UI smoke without a GUI session\n' >&2
+  exit 1
+fi
+grep -F $'ui-e2e\tenvironment-failed' "$RESULT_ROOT"/*/summary.tsv >/dev/null
+grep -F 'ui-e2e environment-failed' "$REPO/ui-environment-denial.out" >/dev/null
 fi
 
 if [ "$CONTRACT_SHARD" = all ] || [ "$CONTRACT_SHARD" = execution ] || \

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -27,6 +27,14 @@ run_validation() {
 
 run_validation "$APP"
 
+if DETACH_TEST_APP="$APP" DETACH_UI_E2E_GUI_PROBE_RESULT=no-session \
+    "$ROOT/tests/ui-e2e.sh" >"$TMP_ROOT/no-gui-session.log" 2>&1; then
+  printf 'UI e2e ran without an interactive GUI session\n' >&2
+  exit 1
+fi
+grep -F 'UI e2e: environment denied: no interactive GUI session (no-session)' \
+  "$TMP_ROOT/no-gui-session.log" >/dev/null
+
 if DETACH_TEST_APP="$APP" DETACH_UI_E2E_VALIDATE_ONLY=1 \
     DETACH_UI_E2E_COVERAGE_BINARY="$TMP_ROOT/missing-coverage-binary" \
     "$ROOT/tests/ui-e2e.sh" >"$TMP_ROOT/missing-coverage.log" 2>&1; then

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -10,6 +10,7 @@ ARTIFACT_DIR="${DETACH_UI_E2E_ARTIFACT_DIR:-}"
 COVERAGE_BINARY="${DETACH_UI_E2E_COVERAGE_BINARY:-}"
 TEST_ROOT=""
 APP_PID=""
+FAKE_CLI=""
 
 approved_invocation() {
   case "$1" in
@@ -57,6 +58,7 @@ preserve_failure_diagnostics() {
   mkdir -p "$ARTIFACT_DIR"
   chmod 0700 "$ARTIFACT_DIR"
   for source in "$TEST_ROOT"/app-*.log "$TEST_ROOT"/result-*.json \
+      "$TEST_ROOT"/sample-*.txt \
       "$TEST_ROOT"/window-*.png "$FAKE_DIR/invocations.log"; do
     [ -f "$source" ] && [ ! -L "$source" ] || continue
     destination="$ARTIFACT_DIR/$(basename "$source")"
@@ -73,12 +75,22 @@ preserve_failure_diagnostics() {
   printf 'UI e2e diagnostics preserved at %s\n' "$ARTIFACT_DIR" >&2
 }
 
+# The app spawns the fake CLI (`watch --json`, attach clients). When the app
+# exits, those children survive as orphans and keep polling the fixture.
+# Stop every process that still runs the private fake CLI.
+stop_fixture_processes() {
+  [ -n "$FAKE_CLI" ] || return 0
+  pkill -TERM -f "^/bin/bash $FAKE_CLI " 2>/dev/null || true
+  pkill -TERM -f "^$FAKE_CLI " 2>/dev/null || true
+}
+
 cleanup() {
   local status="${1:-0}"
   if [ -n "$APP_PID" ] && kill -0 "$APP_PID" 2>/dev/null; then
     kill -TERM "$APP_PID" 2>/dev/null || true
     wait "$APP_PID" 2>/dev/null || true
   fi
+  stop_fixture_processes
   preserve_failure_diagnostics "$status"
   if [ "$KEEP" = 1 ] && [ -n "$TEST_ROOT" ]; then
     printf 'UI e2e fixture kept at %s\n' "$TEST_ROOT" >&2
@@ -141,6 +153,78 @@ fi
 
 [ "$VALIDATE_ONLY" = 0 ] || exit 0
 
+# The smoke drives a real window. Without an interactive console session
+# (agent sandbox, SSH, login window, locked screen) AppKit registration
+# aborts or activation never completes. Report that as an environment denial
+# so the gate records environment-failed instead of a product failure.
+gui_session_state() {
+  if [ -n "${DETACH_UI_E2E_GUI_PROBE_RESULT:-}" ]; then
+    printf '%s\n' "$DETACH_UI_E2E_GUI_PROBE_RESULT"
+    return 0
+  fi
+  python3 - <<'PY'
+import ctypes
+import ctypes.util
+import sys
+
+core_graphics = ctypes.CDLL(ctypes.util.find_library("CoreGraphics"))
+core_foundation = ctypes.CDLL(ctypes.util.find_library("CoreFoundation"))
+core_graphics.CGSessionCopyCurrentDictionary.restype = ctypes.c_void_p
+core_foundation.CFStringCreateWithCString.restype = ctypes.c_void_p
+core_foundation.CFStringCreateWithCString.argtypes = [
+    ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint32]
+core_foundation.CFDictionaryGetValue.restype = ctypes.c_void_p
+core_foundation.CFDictionaryGetValue.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+core_foundation.CFGetTypeID.restype = ctypes.c_ulong
+core_foundation.CFGetTypeID.argtypes = [ctypes.c_void_p]
+core_foundation.CFBooleanGetTypeID.restype = ctypes.c_ulong
+core_foundation.CFNumberGetTypeID.restype = ctypes.c_ulong
+core_foundation.CFBooleanGetValue.restype = ctypes.c_bool
+core_foundation.CFBooleanGetValue.argtypes = [ctypes.c_void_p]
+core_foundation.CFNumberGetValue.restype = ctypes.c_bool
+core_foundation.CFNumberGetValue.argtypes = [
+    ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+UTF8 = 0x08000100
+SINT64 = 4
+
+
+def flag(dictionary, key):
+    name = core_foundation.CFStringCreateWithCString(None, key.encode(), UTF8)
+    value = core_foundation.CFDictionaryGetValue(dictionary, name)
+    if not value:
+        return None
+    type_id = core_foundation.CFGetTypeID(value)
+    if type_id == core_foundation.CFBooleanGetTypeID():
+        return bool(core_foundation.CFBooleanGetValue(value))
+    if type_id == core_foundation.CFNumberGetTypeID():
+        out = ctypes.c_int64(0)
+        core_foundation.CFNumberGetValue(value, SINT64, ctypes.byref(out))
+        return out.value != 0
+    return None
+
+
+session = core_graphics.CGSessionCopyCurrentDictionary()
+if not session:
+    print("no-session")
+elif flag(session, "kCGSSessionOnConsoleKey") is not True:
+    print("off-console")
+elif flag(session, "kCGSessionLoginDoneKey") is False:
+    print("login-incomplete")
+elif flag(session, "CGSSessionScreenIsLocked") is True:
+    print("locked")
+else:
+    print("ok")
+sys.exit(0)
+PY
+}
+
+gui_state="$(gui_session_state 2>/dev/null)" || gui_state="probe-failed"
+if [ "$gui_state" != ok ]; then
+  printf 'UI e2e: environment denied: no interactive GUI session (%s)\n' \
+    "$gui_state" >&2
+  exit 2
+fi
+
 TEST_ROOT="$(mktemp -d /private/tmp/detach-ui-e2e.XXXXXX)"
 TEST_APP="$TEST_ROOT/Detach-UI-E2E.app"
 TEST_HOME="$TEST_ROOT/home"
@@ -151,7 +235,7 @@ RESULT="$TEST_ROOT/result.json"
 BREACH="$TEST_ROOT/production-cli-breach"
 APP_LOG="$TEST_ROOT/app.log"
 IDENTIFIER="dev.tsarev.detach.ui-e2e.$$"
-UI_E2E_DEADLINE=$((SECONDS + 50))
+UI_E2E_DEADLINE=$((SECONDS + 120))
 
 mkdir -p "$TEST_HOME/.local/bin" "$TEST_HOME/Library/Preferences" \
   "$TEST_ROOT/state" "$TEST_ROOT/power" "$TEST_ROOT/project" "$FAKE_DIR"
@@ -212,13 +296,30 @@ chmod 0755 "$TEST_HOME/.local/bin/detach"
   SC-UI-ONBOARD-APPROVAL \
   SC-UI-SETTINGS
 
+# The packaged journeys are the e2e layer. A scenario whose app never reports
+# a result (launch stalled, process killed at the deadline) gets exactly one
+# retry from the state it started with. A reported failure never retries.
+snapshot_scenario_state() {
+  rm -rf "$TEST_ROOT/snapshot"
+  mkdir -p "$TEST_ROOT/snapshot"
+  cp -cR "$TEST_HOME" "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR" \
+    "$TEST_ROOT/snapshot/"
+}
+
+restore_scenario_state() {
+  rm -rf "$TEST_HOME" "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
+  cp -cR "$TEST_ROOT/snapshot/home" "$TEST_HOME"
+  cp -cR "$TEST_ROOT/snapshot/state" "$TEST_ROOT/state"
+  cp -cR "$TEST_ROOT/snapshot/power" "$TEST_ROOT/power"
+  cp -cR "$TEST_ROOT/snapshot/fake" "$FAKE_DIR"
+}
+
 run_app_scenario() {
   local scenario="$1" fixture="$2" scenario_budget="$3"
   local app_status check_index=0 actual check scenario_deadline driver_budget pass
-  local passed_scenarios=()
+  local passed_scenarios=() attempt=1
   local scenario_started="$SECONDS"
   shift 3
-  scenario_deadline=$((SECONDS + scenario_budget))
   driver_budget=$((scenario_budget - 3))
   [ "$driver_budget" -ge 1 ] || {
     printf 'UI e2e: %s process budget leaves no driver deadline\n' "$scenario" >&2
@@ -232,7 +333,10 @@ run_app_scenario() {
       "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
       >"$TEST_ROOT/power/watchdog-status.json"
   fi
+  snapshot_scenario_state
 
+  while :; do
+  scenario_deadline=$((SECONDS + scenario_budget))
   HOME="$TEST_HOME" \
   CFFIXED_USER_HOME="$TEST_HOME" \
   XDG_STATE_HOME="$TEST_ROOT/state" \
@@ -249,24 +353,45 @@ run_app_scenario() {
     "$TEST_APP/Contents/MacOS/Detach" >"$APP_LOG" 2>&1 &
   APP_PID=$!
 
+  sampled=0
   while [ "$SECONDS" -lt "$scenario_deadline" ] \
       && [ "$SECONDS" -lt "$UI_E2E_DEADLINE" ]; do
     [ ! -f "$RESULT" ] || break
     if ! kill -0 "$APP_PID" 2>/dev/null; then break; fi
+    # A launch that stays silent for four seconds is stalled before the
+    # driver. Sample it once so the preserved diagnostics show where.
+    if [ "$sampled" -eq 0 ] && [ "$((scenario_deadline - SECONDS))" -le "$((scenario_budget - 4))" ] \
+        && [ ! -s "$APP_LOG" ]; then
+      sampled=1
+      sample "$APP_PID" 2 -file "$TEST_ROOT/sample-$scenario-$attempt.txt" \
+        >/dev/null 2>&1 &
+    fi
     sleep 0.05
   done
-  if [ ! -f "$RESULT" ]; then
-    kill -TERM "$APP_PID" 2>/dev/null || true
-    set +e
-    wait "$APP_PID"
-    app_status=$?
-    set -e
-    APP_PID=""
-    printf 'UI e2e: %s produced no result within its %ss budget (status %s)\n' \
-      "$scenario" "$scenario_budget" "$app_status" >&2
-    sed -n '1,240p' "$APP_LOG" >&2
-    exit 1
+  if [ -f "$RESULT" ]; then
+    break
   fi
+  kill -TERM "$APP_PID" 2>/dev/null || true
+  set +e
+  wait "$APP_PID"
+  app_status=$?
+  set -e
+  APP_PID=""
+  if [ "$attempt" -eq 1 ] && \
+      [ $((SECONDS + scenario_budget)) -le "$UI_E2E_DEADLINE" ]; then
+    printf 'UI e2e: %s produced no result within its %ss budget (status %s); e2e retry 1 of 1\n' \
+      "$scenario" "$scenario_budget" "$app_status" >&2
+    mv -f "$APP_LOG" "$TEST_ROOT/app-$scenario-attempt1.log"
+    stop_fixture_processes
+    restore_scenario_state
+    attempt=2
+    continue
+  fi
+  printf 'UI e2e: %s produced no result within its %ss budget (status %s)\n' \
+    "$scenario" "$scenario_budget" "$app_status" >&2
+  sed -n '1,240p' "$APP_LOG" >&2
+  exit 1
+  done
   for _ in $(seq 1 10); do
     if ! kill -0 "$APP_PID" 2>/dev/null; then break; fi
     [ "$SECONDS" -lt "$UI_E2E_DEADLINE" ] || break
@@ -360,7 +485,9 @@ run_app_scenario() {
   if [ "${#passed_scenarios[@]}" -gt 0 ]; then
     "$ROOT/scripts/quality-scenarios" event pass "${passed_scenarios[@]}"
   fi
-  printf 'UI e2e: %s passed in %ss\n' "$scenario" "$((SECONDS - scenario_started))"
+  stop_fixture_processes
+  printf 'UI e2e: %s passed in %ss (attempt %s)\n' "$scenario" \
+    "$((SECONDS - scenario_started))" "$attempt"
 }
 
 run_app_scenario main sessions 32 \
@@ -401,9 +528,9 @@ run_app_scenario main sessions 32 \
   quick-chat-command-starts-session \
   session-shortcut-reopens-closed-main-window \
   installed-app-focus-restored
-run_app_scenario onboarding-first-run empty 8 onboarding-first-run-completes
-run_app_scenario onboarding-provider empty 8 onboarding-detects-provider
-run_app_scenario onboarding-approval empty 8 onboarding-explains-approval
+run_app_scenario onboarding-first-run empty 15 onboarding-first-run-completes
+run_app_scenario onboarding-provider empty 15 onboarding-detects-provider
+run_app_scenario onboarding-approval empty 15 onboarding-explains-approval
 
 [ -s "$FAKE_DIR/invocations.log" ]
 while IFS= read -r invocation; do

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -11,6 +11,7 @@ COVERAGE_BINARY="${DETACH_UI_E2E_COVERAGE_BINARY:-}"
 TEST_ROOT=""
 APP_PID=""
 FAKE_CLI=""
+IDENTIFIER=""
 
 approved_invocation() {
   case "$1" in
@@ -49,7 +50,11 @@ fi
 
 preserve_failure_diagnostics() {
   local status="$1" source destination
-  [ "$status" -ne 0 ] && [ -n "$ARTIFACT_DIR" ] && [ -n "$TEST_ROOT" ] || return 0
+  [ -n "$ARTIFACT_DIR" ] && [ -n "$TEST_ROOT" ] || return 0
+  # A passed run that needed a retry still preserves its stall samples.
+  if [ "$status" -eq 0 ] && ! ls "$TEST_ROOT"/sample-*.txt >/dev/null 2>&1; then
+    return 0
+  fi
   case "$ARTIFACT_DIR" in /*) ;; *) printf 'UI e2e artifact directory must be absolute\n' >&2; return 0 ;; esac
   [ ! -e "$ARTIFACT_DIR" ] || [ -d "$ARTIFACT_DIR" ] && [ ! -L "$ARTIFACT_DIR" ] || {
     printf 'UI e2e artifact directory is unsafe\n' >&2
@@ -58,7 +63,7 @@ preserve_failure_diagnostics() {
   mkdir -p "$ARTIFACT_DIR"
   chmod 0700 "$ARTIFACT_DIR"
   for source in "$TEST_ROOT"/app-*.log "$TEST_ROOT"/result-*.json \
-      "$TEST_ROOT"/sample-*.txt \
+      "$TEST_ROOT"/sample-*.txt "$TEST_ROOT"/invocations-*.log \
       "$TEST_ROOT"/window-*.png "$FAKE_DIR/invocations.log"; do
     [ -f "$source" ] && [ ! -L "$source" ] || continue
     destination="$ARTIFACT_DIR/$(basename "$source")"
@@ -73,6 +78,19 @@ preserve_failure_diagnostics() {
   } >"$ARTIFACT_DIR/diagnostics.tsv"
   chmod 0600 "$ARTIFACT_DIR/diagnostics.tsv"
   printf 'UI e2e diagnostics preserved at %s\n' "$ARTIFACT_DIR" >&2
+}
+
+# cfprefsd keys preferences by user, not by HOME, so the test copy writes its
+# defaults into the real preference folder under its private identifier.
+forget_test_app_preferences() {
+  local domain preferences="$HOME/Library/Preferences"
+  [ -n "$IDENTIFIER" ] || return 0
+  # Delete through cfprefsd so a cached domain is not flushed back to disk
+  # after the files are gone.
+  for domain in "$IDENTIFIER" "$IDENTIFIER.preferences"; do
+    defaults delete "$domain" >/dev/null 2>&1 || true
+    rm -f "$preferences/$domain.plist"
+  done
 }
 
 # The app spawns the fake CLI (`watch --json`, attach clients). When the app
@@ -91,6 +109,7 @@ cleanup() {
     wait "$APP_PID" 2>/dev/null || true
   fi
   stop_fixture_processes
+  forget_test_app_preferences
   preserve_failure_diagnostics "$status"
   if [ "$KEEP" = 1 ] && [ -n "$TEST_ROOT" ]; then
     printf 'UI e2e fixture kept at %s\n' "$TEST_ROOT" >&2
@@ -296,24 +315,30 @@ chmod 0755 "$TEST_HOME/.local/bin/detach"
   SC-UI-ONBOARD-APPROVAL \
   SC-UI-SETTINGS
 
+# Every scenario and every attempt starts from the same clean state: no
+# app state, no fake CLI markers, no attach client, no persisted defaults.
+# A previous scenario's persisted terminal or selection otherwise makes the
+# next launch reconnect to a dead attach client and stall before the driver.
+prepare_scenario_state() {
+  local scenario="$1" fixture="$2"
+  stop_fixture_processes
+  forget_test_app_preferences
+  rm -rf "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
+  mkdir -p "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
+  install -m 0755 "$ROOT/tests/fake-ui-cli" "$FAKE_CLI"
+  printf '%s\n' "$fixture" >"$FIXTURE_STATE"
+  if [ "$scenario" = onboarding-first-run ]; then
+    printf '{"schema":1,"state":"ok","power_state":"protected","checked_at":"%s","thermal_state":"nominal","thermal_safety_active":false,"exit_status":0}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      >"$TEST_ROOT/power/watchdog-status.json"
+  fi
+}
+
 # The packaged journeys are the e2e layer. A scenario whose app never reports
-# a result (launch stalled, process killed at the deadline) gets exactly one
-# retry from the state it started with. A reported failure never retries.
-snapshot_scenario_state() {
-  rm -rf "$TEST_ROOT/snapshot"
-  mkdir -p "$TEST_ROOT/snapshot"
-  cp -cR "$TEST_HOME" "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR" \
-    "$TEST_ROOT/snapshot/"
-}
-
-restore_scenario_state() {
-  rm -rf "$TEST_HOME" "$TEST_ROOT/state" "$TEST_ROOT/power" "$FAKE_DIR"
-  cp -cR "$TEST_ROOT/snapshot/home" "$TEST_HOME"
-  cp -cR "$TEST_ROOT/snapshot/state" "$TEST_ROOT/state"
-  cp -cR "$TEST_ROOT/snapshot/power" "$TEST_ROOT/power"
-  cp -cR "$TEST_ROOT/snapshot/fake" "$FAKE_DIR"
-}
-
+# a result (launch stalled, process killed at the deadline) or whose report
+# is a timeout ("scenario budget expired", "timed out waiting") gets exactly
+# one retry from the same clean state. A reported assertion failure never
+# retries.
 run_app_scenario() {
   local scenario="$1" fixture="$2" scenario_budget="$3"
   local app_status check_index=0 actual check scenario_deadline driver_budget pass
@@ -327,15 +352,9 @@ run_app_scenario() {
   }
   RESULT="$TEST_ROOT/result-$scenario.json"
   APP_LOG="$TEST_ROOT/app-$scenario.log"
-  printf '%s\n' "$fixture" >"$FIXTURE_STATE"
-  if [ "$scenario" = onboarding-first-run ]; then
-    printf '{"schema":1,"state":"ok","power_state":"protected","checked_at":"%s","thermal_state":"nominal","thermal_safety_active":false,"exit_status":0}\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      >"$TEST_ROOT/power/watchdog-status.json"
-  fi
-  snapshot_scenario_state
 
   while :; do
+  prepare_scenario_state "$scenario" "$fixture"
   scenario_deadline=$((SECONDS + scenario_budget))
   HOME="$TEST_HOME" \
   CFFIXED_USER_HOME="$TEST_HOME" \
@@ -369,6 +388,27 @@ run_app_scenario() {
     sleep 0.05
   done
   if [ -f "$RESULT" ]; then
+    if [ "$attempt" -eq 1 ] && [ "$(plutil -extract passed raw -o - "$RESULT" 2>/dev/null)" != true ] \
+        && [ $((SECONDS + scenario_budget)) -le "$UI_E2E_DEADLINE" ]; then
+      case "$(plutil -extract error raw -o - "$RESULT" 2>/dev/null || true)" in
+        'scenario budget expired'*|'timed out waiting'*)
+          printf 'UI e2e: %s reported a timeout: %s; e2e retry 1 of 1\n' \
+            "$scenario" "$(plutil -extract error raw -o - "$RESULT" 2>/dev/null || true)" >&2
+          for _ in $(seq 1 10); do
+            if ! kill -0 "$APP_PID" 2>/dev/null; then break; fi
+            sleep 0.05
+          done
+          kill -TERM "$APP_PID" 2>/dev/null || true
+          wait "$APP_PID" 2>/dev/null || true
+          APP_PID=""
+          mv -f "$APP_LOG" "$TEST_ROOT/app-$scenario-attempt1.log"
+          mv -f "$RESULT" "$TEST_ROOT/result-$scenario-attempt1.json"
+          cp -f "$FAKE_DIR/invocations.log" "$TEST_ROOT/invocations-$scenario-attempt1.log" 2>/dev/null || true
+          attempt=2
+          continue
+          ;;
+      esac
+    fi
     break
   fi
   kill -TERM "$APP_PID" 2>/dev/null || true
@@ -382,8 +422,7 @@ run_app_scenario() {
     printf 'UI e2e: %s produced no result within its %ss budget (status %s); e2e retry 1 of 1\n' \
       "$scenario" "$scenario_budget" "$app_status" >&2
     mv -f "$APP_LOG" "$TEST_ROOT/app-$scenario-attempt1.log"
-    stop_fixture_processes
-    restore_scenario_state
+    cp -f "$FAKE_DIR/invocations.log" "$TEST_ROOT/invocations-$scenario-attempt1.log" 2>/dev/null || true
     attempt=2
     continue
   fi
@@ -485,6 +524,7 @@ run_app_scenario() {
   if [ "${#passed_scenarios[@]}" -gt 0 ]; then
     "$ROOT/scripts/quality-scenarios" event pass "${passed_scenarios[@]}"
   fi
+  cp -f "$FAKE_DIR/invocations.log" "$TEST_ROOT/invocations-$scenario.log" 2>/dev/null || true
   stop_fixture_processes
   printf 'UI e2e: %s passed in %ss (attempt %s)\n' "$scenario" \
     "$((SECONDS - scenario_started))" "$attempt"
@@ -541,32 +581,34 @@ while IFS= read -r invocation; do
   fi
 done <"$FAKE_DIR/invocations.log"
 
+# Every scenario starts clean, so the main journey's records live in its
+# preserved per-scenario copy.
 recover_count="$(grep -Fxc 'codex recover --detach detach-codex-ui-recoverable' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 recover_attach_count="$(grep -Fxc \
   'codex attach --terminal-features sync detach-codex-ui-recoverable' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 running_attach_count="$(grep -Fxc \
   'codex attach --terminal-features sync detach-codex-ui-running' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 switch_count="$(grep -Fc 'client switch --pid ' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 claude_start_count="$(grep -Fxc 'claude --detach' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 codex_start_count="$(grep -Fxc 'codex --detach' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 quick_attach_count="$(grep -Fxc \
   'codex attach --terminal-features sync detach-codex-ui-quick' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 new_attach_count="$(grep -Fxc \
   'claude attach --terminal-features sync detach-claude-ui-new' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 quick_switch_count="$(grep -Fc \
   ' --to detach-codex-ui-quick --provider codex' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 new_switch_count="$(grep -Fc \
   ' --to detach-claude-ui-new --provider claude' \
-  "$FAKE_DIR/invocations.log" || true)"
+  "$TEST_ROOT/invocations-main.log" || true)"
 if [ "$recover_count" -lt 1 ] || [ "$recover_attach_count" -lt 2 ] \
     || [ "$switch_count" -lt 3 ] \
     || [ "$claude_start_count" -ne 1 ] || [ "$codex_start_count" -ne 1 ] \

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1435,7 +1435,8 @@ class QualityGate:
             )
             if re.search(
                 r"error creating .+\.sock \(Operation not permitted\)|"
-                r"sandbox\S* denied|deny\(1\)",
+                r"sandbox\S* denied|deny\(1\)|"
+                r"UI e2e: environment denied",
                 log,
             ):
                 result = "environment-failed"


### PR DESCRIPTION
## Why

`ui-e2e` failed 202 of 343 retained local runs. The preserved logs, crash reports, and process samples show three classes:

- 47 `Abort trap: 6` failures, all with `managed_sandbox_declared=true`: `HIServices _RegisterApplication` aborts when the process has no GUI session.
- 70 `timed out waiting for test app activation`: no interactive console session (agent sandbox or locked screen). `CGSessionCopyCurrentDictionary()` returns NULL inside the sandbox and reports `CGSSessionScreenIsLocked` when the screen is locked.
- Silent onboarding launches: the next app instance inherited the main journey's persisted terminal and selection, reconnected to a dead attach client through `client switch`, and the fake CLI blocked on a FIFO write that nothing read. The driver never started.

## Contract delta

- ADDED: the UI smoke probes the console session before it launches the app. No session, off-console, incomplete login, or a locked screen prints `UI e2e: environment denied: no interactive GUI session (<reason>)`, exits 2, and the gate records `environment-failed`, never a product failure.
- ADDED: every scenario and every attempt starts from a clean private state: fresh app state, fresh fake CLI directory, no attach client, no persisted defaults. The fake `client switch` refuses a dead attach client and never blocks on its control FIFO.
- ADDED: the packaged journeys are the only retry layer. A scenario whose app never reports a result, or reports a timeout, gets exactly one retry inside the stage budget; the log records `e2e retry 1 of 1`. A reported assertion failure never retries.
- ADDED: the smoke deletes the test copy's two preference domains through cfprefsd at the end. Every earlier run leaked two files into the real preference folder (1778 stale files on the reference Mac, now removed).
- MODIFIED: onboarding scenario budgets 8 → 15 s; UI stage deadline 55 → 130 s (policy 57). Timing is telemetry, so these are safety bounds only.
- ADDED: a launch silent for four seconds is sampled into the preserved diagnostics; a retried pass keeps its samples and fake CLI records; orphaned fake CLI watchers are stopped after each scenario and at cleanup.

## Evidence

- Sandboxed run: `UI e2e: environment denied: no interactive GUI session (no-session)`, exit 2. Locked screen: `(locked)`, exit 2.
- Eight consecutive local runs on the owner's Mac after the isolation fix pass in 19 to 20 s with zero retries, no orphaned watchers, and no leaked preferences. Before the fix, 3 of 7 runs needed a retry and one failed twice.
- `tests/ui-e2e-contract.sh`, `tests/quality-gate.sh` (with the new environment-denial fixture), `tests/quality-policy.sh`, `tests/docs-contract.sh`, `tests/shell-safety.sh`, `scripts/quality-care evaluate` (9/9), `git diff --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
