### PR TITLE
Bind exact runtime products in hosted provider shards

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -88,15 +88,6 @@ jobs:
         run: |
           baseline_root="$(scripts/quality-baseline --profile '${{ matrix.coverage_profile }}')"
           printf 'DETACH_QUALITY_BASELINE_ROOT=%s\n' "$baseline_root" >>"$GITHUB_ENV"
-      - name: Restore exact packaged test app
-        id: app-cache
-        if: matrix.needs_app
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            app/build/Detach.app
-            app/.build/tmux-runtime/arm64/product
-          key: detach-app-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Restore exact executable quality products
         id: product-cache
         if: matrix.needs_cache
@@ -108,10 +99,21 @@ jobs:
             app/.build/quality-swift-tests/arm64-apple-macosx/debug/Sparkle.framework
             app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp
             app/.build/quality-ui-release/arm64-apple-macosx/release/Sparkle.framework
-          key: detach-quality-products-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
+            app/.build/quality-runtime/tmux
+            app/.build/quality-runtime/detach-state
+          key: detach-quality-products-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
+      - name: Restore exact packaged test app
+        id: app-cache
+        if: matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true')
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            app/build/Detach.app
+            app/.build/tmux-runtime/arm64/product
+          key: detach-app-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Resources/**/*', 'app/scripts/make-app.sh', 'app/scripts/bundle-modes.sh', 'app/scripts/verify-app.sh', 'bin/detach', 'bin/detach-core', 'scripts/install.sh', 'scripts/build-tmux.sh', 'VERSION', 'BUILD') }}
       - name: Restore exact Swift and tmux inputs
         id: swift-cache
-        if: (matrix.needs_cache && steps.product-cache.outputs.cache-hit != 'true') || (matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true')
+        if: (matrix.needs_cache && steps.product-cache.outputs.cache-hit != 'true') || ((matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true')) && steps.app-cache.outputs.cache-hit != 'true')
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -131,12 +133,12 @@ jobs:
           python3 tools/quality_products.py verify
           printf 'DETACH_QUALITY_EXACT_PRODUCTS=1\n' >>"$GITHUB_ENV"
       - name: Verify and bind exact packaged test app
-        if: matrix.needs_app && steps.app-cache.outputs.cache-hit == 'true'
+        if: (matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true')) && steps.app-cache.outputs.cache-hit == 'true'
         run: |
           app/scripts/verify-app.sh
           printf 'DETACH_QUALITY_EXACT_APP=1\n' >>"$GITHUB_ENV"
       - name: Build and bind exact packaged test app
-        if: matrix.needs_app && steps.app-cache.outputs.cache-hit != 'true'
+        if: (matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true')) && steps.app-cache.outputs.cache-hit != 'true'
         env:
           DETACH_QUALITY_APP_SCRATCH: 1
         run: |
@@ -241,7 +243,9 @@ jobs:
             app/.build/quality-swift-tests/arm64-apple-macosx/debug/Sparkle.framework
             app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp
             app/.build/quality-ui-release/arm64-apple-macosx/release/Sparkle.framework
-          key: detach-quality-products-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
+            app/.build/quality-runtime/tmux
+            app/.build/quality-runtime/detach-state
+          key: detach-quality-products-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
       - name: Restore Swift and tmux caches
         id: swift-cache
         if: github.event_name != 'pull_request' && (steps.product-cache.outputs.cache-hit != 'true' || steps.app-cache.outputs.cache-hit != 'true')
@@ -318,7 +322,9 @@ jobs:
             app/.build/quality-swift-tests/arm64-apple-macosx/debug/Sparkle.framework
             app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp
             app/.build/quality-ui-release/arm64-apple-macosx/release/Sparkle.framework
-          key: detach-quality-products-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
+            app/.build/quality-runtime/tmux
+            app/.build/quality-runtime/detach-state
+          key: detach-quality-products-v2-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-${{ hashFiles('app/Package.swift', 'app/Package.resolved', 'app/Sources/**/*.swift', 'app/Tests/**/*.swift', 'app/Resources/DetachWatchdog-Info.plist', 'tools/quality_cache_warm.py', 'tools/quality_products.py', 'VERSION', 'BUILD') }}
       - name: Publish gate summary
         if: always()
         shell: bash

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -176,8 +176,12 @@ compiler, package, sources, tests, build scripts, and version metadata. A
 promoted `main` run warms only a missing exact product and emits no gate
 evidence. The packaged UI test uses a
 stripped process-private app, fake CLI, and private state. Provider tests use
-private state and socket roots plus the newly bundled `tmux` and
-`detach-state`. Each provider part has private state, socket, log, and failure
+private state and socket roots plus the bundled `tmux` and `detach-state`. A
+hosted provider shard binds the exact runtime products that the last green
+`main` published when the product cache has them, so a change that touches
+only the shell CLI does not rebuild the app in every shard. Without them the
+shard verifies or builds the packaged app first. Each provider part has
+private state, socket, log, and failure
 artifact roots. Parts run concurrently. The bounded large-host Codex lane
 starts the longest measured independent parts first, and still runs every
 part. Smaller hosts use three Codex parts and two Claude parts; larger hosts

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,9 @@
 - `scripts/quality-cache-warm` builds the three isolated Swift products for a
   missing promoted-`main` cache key. It emits no gate evidence and never
   replaces a selected stage. `--dependencies-only` materializes the shared
-  cache once before parallel builds.
+  cache once before parallel builds. `tools/quality_products.py publish`
+  also stages the bundled `tmux` and `detach-state` as exact runtime
+  products; a hosted provider shard that binds them skips the app build.
 - `scripts/quality-scenarios rerun SC-ID` runs the owning diagnostic stage for
   an instrumented scenario, or its direct policy command otherwise. The stage
   process deadline bounds both forms. The helper has 30 seconds for evidence

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -99,10 +99,15 @@ if [ "$app_bind_line" -le "$app_build_line" ]; then
   printf 'quality workflow bound a fresh app before its build completed\n' >&2
   exit 1
 fi
-grep -F 'key: detach-quality-products-v1-' \
+grep -F 'key: detach-quality-products-v2-' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'app/.build/quality-products-v1.json' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+grep -F 'app/.build/quality-runtime/detach-state' \
+  "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
+printf '%s\n' "$quality_shards_job" | grep -F \
+  "if: matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true')" \
+  >/dev/null
 grep -F 'python3 tools/quality_products.py verify' \
   "$ROOT/.github/workflows/quality-gates.yml" >/dev/null
 grep -F 'DETACH_QUALITY_EXACT_PRODUCTS=1' \

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import sys
 import tempfile
@@ -35,10 +36,33 @@ from quality_gate import (  # noqa: E402
     split_swift_build_jobs,
     ui_coverage_binary,
 )
+from quality_gate import provider_runtime_payload  # noqa: E402
 from quality_policy import POLICY_FILE, Policy  # noqa: E402
 
 
 class QualityGateContract(unittest.TestCase):
+    def test_provider_payload_follows_exact_product_binding(self) -> None:
+        root = Path("/repo")
+        with patch.dict("os.environ", {}, clear=False):
+            for name in (
+                "DETACH_QUALITY_EXACT_PRODUCTS",
+                "GITHUB_ACTIONS",
+                "DETACH_QUALITY_GATE_AUTHORITY",
+            ):
+                os.environ.pop(name, None)
+            self.assertEqual(
+                provider_runtime_payload(root),
+                root / "app/build/Detach.app/Contents/Resources/DetachCLI",
+            )
+            os.environ["DETACH_QUALITY_EXACT_PRODUCTS"] = "1"
+            with self.assertRaisesRegex(GateError, "hosted CI authority"):
+                provider_runtime_payload(root)
+            os.environ["GITHUB_ACTIONS"] = "true"
+            os.environ["DETACH_QUALITY_GATE_AUTHORITY"] = "ci-shard"
+            self.assertEqual(
+                provider_runtime_payload(root), root / "app/.build/quality-runtime"
+            )
+
     def test_relative_result_root_becomes_absolute_evidence(self) -> None:
         relative = Path("app/build/relative-quality-evidence")
         with patch.dict(

--- a/tests/quality_products_contract.py
+++ b/tests/quality_products_contract.py
@@ -40,6 +40,7 @@ class QualityProductsContract(unittest.TestCase):
                 (("tests", Path("products/tests")), ("ui", Path("products/ui"))),
             ),
             patch.object(quality_products, "EXECUTABLE_PATHS", ()),
+            patch("quality_products.stage_runtime_products", return_value=None),
             patch("quality_products.source_fingerprint", return_value="a" * 64),
             patch(
                 "quality_products.toolchain_document",
@@ -57,7 +58,7 @@ class QualityProductsContract(unittest.TestCase):
             root = Path(temporary)
             self.fixture(root)
             patches = self.context()
-            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
                 self.assertEqual(quality_products.publish(root), 0)
                 self.assertEqual(quality_products.verify(root), 0)
                 manifest = json.loads(
@@ -79,7 +80,7 @@ class QualityProductsContract(unittest.TestCase):
             outside.write_text("outside\n", encoding="utf-8")
             (root / "products/tests/escape").symlink_to("../../outside")
             patches = self.context()
-            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
                 with self.assertRaisesRegex(
                     quality_products.ProductError, "symlink escapes"
                 ):
@@ -92,9 +93,28 @@ class QualityProductsContract(unittest.TestCase):
             (root / "products/manifest-target").write_text("{}\n", encoding="utf-8")
             (root / "products/manifest.json").symlink_to("manifest-target")
             patches = self.context()
-            with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
                 with self.assertRaisesRegex(quality_products.ProductError, "symlink"):
                     quality_products.publish(root)
+
+    def test_runtime_products_are_staged_from_the_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / quality_products.RUNTIME_SOURCE
+            source.mkdir(parents=True)
+            for name in quality_products.RUNTIME_PRODUCTS:
+                (source / name).write_text(f"{name}\n", encoding="utf-8")
+                (source / name).chmod(0o755)
+            quality_products.stage_runtime_products(root)
+            for name in quality_products.RUNTIME_PRODUCTS:
+                staged = root / quality_products.RUNTIME_PRODUCT_ROOT / name
+                self.assertEqual(staged.read_text(encoding="utf-8"), f"{name}\n")
+                self.assertTrue(os.access(staged, os.X_OK))
+            (source / "tmux").unlink()
+            with self.assertRaisesRegex(
+                quality_products.ProductError, "missing or unsafe: tmux"
+            ):
+                quality_products.stage_runtime_products(root)
 
     def test_exact_coverage_inputs_fail_closed(self) -> None:
         environment = os.environ.copy()

--- a/tests/quality_shard_contract.py
+++ b/tests/quality_shard_contract.py
@@ -41,6 +41,7 @@ class QualityShardContract(unittest.TestCase):
                     "level": 0,
                     "needs_app": False,
                     "needs_cache": False,
+                    "needs_runtime": False,
                     "needs_metrics": False,
                     "coverage_profile": "",
                 }
@@ -84,9 +85,12 @@ class QualityShardContract(unittest.TestCase):
         )
         self.assertTrue(contracts["needs_app"])
         self.assertFalse(contracts["needs_cache"])
+        self.assertFalse(contracts["needs_runtime"])
         codex = shard_for({"stages": stages}, "codex")
-        self.assertTrue(codex["needs_app"])
-        self.assertFalse(codex["needs_cache"])
+        self.assertFalse(codex["needs_app"])
+        self.assertTrue(codex["needs_cache"])
+        self.assertTrue(codex["needs_runtime"])
+        self.assertFalse(build["needs_runtime"])
 
     def test_swift_only_metrics_shard_selects_swift_profile(self) -> None:
         build = shard_for(

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1821,6 +1821,20 @@ def child_run(arguments: list[str], *, cwd: Path = ROOT, env: dict[str, str] | N
     return process.returncode
 
 
+RUNTIME_PRODUCT_ROOT = Path("app/.build/quality-runtime")
+
+
+def provider_runtime_payload(root: Path) -> Path:
+    """Return the directory that holds tmux and detach-state for provider suites.
+
+    Hosted shards that bind exact products from the last green main use the
+    published runtime products. Everything else uses the freshly verified app.
+    """
+    if exact_products_enabled():
+        return root / RUNTIME_PRODUCT_ROOT
+    return root / "app/build/Detach.app/Contents/Resources/DetachCLI"
+
+
 def exact_products_enabled() -> bool:
     value = os.environ.get("DETACH_QUALITY_EXACT_PRODUCTS", "")
     if value not in ("", "1"):
@@ -2727,16 +2741,22 @@ def run_stage_worker(stage: str) -> int:
                 print("quality-gate: UI e2e emitted no coverage profile", file=sys.stderr)
                 return 2
         return status
-    payload = root / "app/build/Detach.app/Contents/Resources/DetachCLI"
+    payload = provider_runtime_payload(root)
     tmux = payload / "tmux"
     state = payload / "detach-state"
     if stage in ("codex", "claude"):
-        if not tmux.is_file() or not os.access(tmux, os.X_OK):
-            print(f"quality-gate: {stage} gate requires the app stage bundled tmux", file=sys.stderr)
-            return 2
-        if not state.is_file() or not os.access(state, os.X_OK):
+        print(f"quality-gate: {stage} runtime payload {payload}", file=sys.stderr)
+        if not tmux.is_file() or tmux.is_symlink() or not os.access(tmux, os.X_OK):
             print(
-                f"quality-gate: {stage} gate requires the app stage bundled state helper",
+                f"quality-gate: {stage} gate requires bundled tmux from the app stage "
+                "or exact runtime products",
+                file=sys.stderr,
+            )
+            return 2
+        if not state.is_file() or state.is_symlink() or not os.access(state, os.X_OK):
+            print(
+                f"quality-gate: {stage} gate requires the bundled state helper from the "
+                "app stage or exact runtime products",
                 file=sys.stderr,
             )
             return 2

--- a/tools/quality_products.py
+++ b/tools/quality_products.py
@@ -17,6 +17,12 @@ from quality_cache_warm import product_fingerprint, product_inputs
 
 ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_RELATIVE = Path("app/.build/quality-products-v1.json")
+# The provider integrations need only the bundled tmux and detach-state. A
+# green main publishes both as exact runtime products so a pull request that
+# changes only the shell CLI does not rebuild the whole app in every shard.
+RUNTIME_PRODUCT_ROOT = Path("app/.build/quality-runtime")
+RUNTIME_SOURCE = Path("app/build/Detach.app/Contents/Resources/DetachCLI")
+RUNTIME_PRODUCTS = ("tmux", "detach-state")
 PRODUCT_PATHS = (
     (
         "swift-tests",
@@ -45,6 +51,8 @@ PRODUCT_PATHS = (
             "Sparkle.framework"
         ),
     ),
+    ("runtime-tmux", RUNTIME_PRODUCT_ROOT / "tmux"),
+    ("runtime-state", RUNTIME_PRODUCT_ROOT / "detach-state"),
 )
 EXECUTABLE_PATHS = (
     Path(
@@ -52,6 +60,8 @@ EXECUTABLE_PATHS = (
         "DetachAppPackageTests.xctest/Contents/MacOS/DetachAppPackageTests"
     ),
     Path("app/.build/quality-ui-release/arm64-apple-macosx/release/DetachApp"),
+    RUNTIME_PRODUCT_ROOT / "tmux",
+    RUNTIME_PRODUCT_ROOT / "detach-state",
 )
 
 
@@ -176,8 +186,29 @@ def manifest_path(root: Path) -> Path:
     return root / MANIFEST_RELATIVE
 
 
+def stage_runtime_products(root: Path) -> None:
+    """Copy the verified bundle's tmux and detach-state into the product root."""
+    source_root = root / RUNTIME_SOURCE
+    destination_root = root / RUNTIME_PRODUCT_ROOT
+    if destination_root.is_symlink():
+        raise ProductError("runtime product root is a symlink")
+    destination_root.mkdir(parents=True, exist_ok=True)
+    for name in RUNTIME_PRODUCTS:
+        source = source_root / name
+        if not source.is_file() or source.is_symlink() or not os.access(source, os.X_OK):
+            raise ProductError(f"bundled runtime product is missing or unsafe: {name}")
+        destination = destination_root / name
+        if destination.is_symlink():
+            raise ProductError(f"runtime product is a symlink: {name}")
+        temporary = destination_root / f".{name}.{os.getpid()}"
+        temporary.write_bytes(source.read_bytes())
+        temporary.chmod(0o755)
+        os.replace(temporary, destination)
+
+
 def publish(root: Path) -> int:
     root = root.resolve()
+    stage_runtime_products(root)
     validate_executables(root)
     document = {
         "schema": 1,

--- a/tools/quality_shard.py
+++ b/tools/quality_shard.py
@@ -126,8 +126,12 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
             raise ShardError(f"planned stage has more than one shard: {sorted(overlap)[0]}")
         owned.update(stages)
         remaining.difference_update(stages)
-        needs_app = bool({"app", "codex", "claude", "tmux-runtime"} & set(stages))
-        needs_cache = bool({"swift", "app", "ui-e2e"} & set(stages))
+        # Provider suites need only tmux and detach-state. They bind the exact
+        # runtime products from the last green main when the cache has them
+        # and fall back to the packaged app otherwise.
+        needs_runtime = bool({"codex", "claude"} & set(stages))
+        needs_app = bool({"app", "tmux-runtime"} & set(stages))
+        needs_cache = bool({"swift", "app", "ui-e2e"} & set(stages)) or needs_runtime
         needs_metrics = "quality-contracts" in stages
         shards.append(
             {
@@ -136,6 +140,7 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
                 "level": level,
                 "needs_app": needs_app,
                 "needs_cache": needs_cache,
+                "needs_runtime": needs_runtime,
                 "needs_metrics": needs_metrics,
                 "coverage_profile": (
                     "combined" if needs_metrics and "ui-e2e" in stages


### PR DESCRIPTION
## Why

A pull request that touches only `bin/detach-core` misses the packaged app cache in every shard because the key hashes `bin/detach` and `bin/detach-core`. On PR #208 the codex shard spent 175 s compiling Swift and 3 minutes in total rebuilding the app before its 5.5-minute suite, although the provider suites need only the bundled `tmux` and `detach-state`, which do not depend on the shell CLI.

## Contract delta

- ADDED: `tools/quality_products.py publish` stages the verified bundle's `tmux` and `detach-state` as exact runtime products under `app/.build/quality-runtime` and inventories them in the product manifest. `verify` checks them like the other executables (digest, arm64, no symlinks).
- MODIFIED: shard planning marks codex and claude shards `needs_runtime` and `needs_cache` instead of `needs_app`. The workflow restores the product cache first; a provider shard with exact products binds `DETACH_QUALITY_EXACT_PRODUCTS=1` and skips the app restore and build. Without them it verifies or builds the packaged app as before. `tmux-runtime` keeps the packaged app.
- MODIFIED: the gate's provider workers read `tmux` and `detach-state` from the runtime product root when exact products are bound, otherwise from the packaged app, and log which payload they use.
- MODIFIED: product cache key `detach-quality-products-v1` → `v2` because its paths changed. The first hosted run after merge misses the product cache and rebuilds the app; the main push then publishes the runtime products.

## Evidence

- `tests/quality_shard_contract.py`, `tests/quality_products_contract.py` (new staging contract), `tests/quality_gate_contract.py` (new payload-binding contract), `tests/quality_cache_warm_contract.py`, `tests/quality-gate.sh` (workflow structure and distributed shard contracts), `tests/docs-contract.sh`, `tests/shell-safety.sh`, `git diff --check` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
