### PR TITLE
Waive the closed-lid probe for detach-core hunks without power tokens

### DIFF
--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -36,7 +36,11 @@ change real power state, upload assets, or claim publication.
   mandatory for every release. `scripts/release-impact` compares the last
   published tag with the release source. It selects supervised closed-lid
   testing only for power, helper, watchdog, lease, assertion, or lid-probe
-  impact. An unknown product path selects the closed-lid gate. Test-only,
+  impact. An unknown product path selects the closed-lid gate. A policy
+  `release-scan` row refines one lid-gated path: a plain modification whose
+  diff hunks (changed lines and the enclosing function names) contain no
+  power token reports `lid_test_scan_waived` and does not select the probe.
+  Added, deleted, renamed, or copied files keep the gate. Test-only,
   documentation-only, release-orchestrator, and known unrelated product paths
   do not select it.
 - Notary credential preflight gives `notarytool` a private PTY and captures its

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -232,7 +232,10 @@ the signed candidate, runs the real power smoke, publishes, and independently
 lists, downloads, and hashes every remote asset. `scripts/release-impact` compares the
 last published tag with the release source. It selects the supervised
 closed-lid probe only for power, helper, watchdog, lease, assertion, or
-lid-probe impact. Unknown product paths select the closed-lid gate. Its private
+lid-probe impact. Unknown product paths select the closed-lid gate. The policy
+`release-scan` row for `bin/detach-core` waives the probe for a plain
+modification whose diff hunks mention no power token; the result records
+`lid_test_scan_waived`. Its private
 resume state and impact evidence live under ignored `app/build/`.
 The path result is fail-safe. For a false positive, a release operator can
 supply `DETACH_RELEASE_IMPACT_REVIEW` with an absolute path directly under

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -742,7 +742,7 @@
     "routed_spec_limit_bytes": 16384,
     "routed_spec_warning_bytes": 12288
   },
-  "policy": 57,
+  "policy": 58,
   "release_domains": [
     {
       "gates": "-",
@@ -768,6 +768,12 @@
       "gates": "lid",
       "id": "unknown",
       "unknown": true
+    }
+  ],
+  "release_scans": [
+    {
+      "path": "bin/detach-core",
+      "pattern": "power|lid|clamshell|sleep|assert|lease|watchdog|pmset|caffeinate|thermal|battery|idle|helper"
     }
   ],
   "required_suites": [

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	57
+policy	58
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime and session operations preserve exact ownership.
 spec	state	docs/specs/state.md	Typed state, storage, and change events remain safe and coherent.
@@ -71,6 +71,7 @@ release-domain	install	-	false
 release-domain	lid	lid	false
 release-domain	both	lid	false
 release-domain	unknown	lid	true
+release-scan	bin/detach-core	power|lid|clamshell|sleep|assert|lease|watchdog|pmset|caffeinate|thermal|battery|idle|helper
 coverage-exclusion	ui	app/Sources/DetachApp/UIE2E*.swift	SC-UI-DASHBOARD,SC-UI-SESSION-DETAIL,SC-UI-SESSION-DELETE,SC-UI-SESSION-STOP,SC-UI-NEW-SESSION,SC-UI-EMPTY,SC-UI-FAILURE,SC-UI-FOCUS,SC-UI-ONBOARD-FIRST-RUN,SC-UI-ONBOARD-PROVIDER,SC-UI-ONBOARD-APPROVAL,SC-UI-SETTINGS	The packaged real-control journeys own this test harness.
 coverage-exclusion	business	app/Sources/DetachKit/BoundedProcessRunner.swift	SC-POWER-UNIT	Process-group behavior uses bounded process integration evidence.
 coverage-exclusion	business	app/Sources/DetachKit/ClamshellLockRunner.swift	SC-POWER-UNIT	Platform lock behavior uses its dedicated process scenario.

--- a/scripts/release-impact
+++ b/scripts/release-impact
@@ -30,6 +30,8 @@ LID_TEST_REQUIRED=false
 UNKNOWN_IMPACT=false
 LID_REASONS=()
 UNKNOWN_REASONS=()
+SCAN_WAIVED=()
+MODIFIED_PATHS=""
 SEMANTIC_REVIEW_APPLIED=false
 LID_REVIEW_REASON=""
 
@@ -120,6 +122,40 @@ apply_semantic_review() {
   SEMANTIC_REVIEW_APPLIED=true
 }
 
+# A lid-gated path with a policy release-scan pattern keeps the closed-lid
+# probe only when its diff hunks mention a power token: changed lines or the
+# enclosing function names in the hunk headers. Only plain modifications are
+# scanned; added, deleted, renamed, or copied files keep the gate.
+apply_release_scans() {
+  local path pattern diff remaining=()
+  for path in "${LID_REASONS[@]-}"; do
+    [ -n "$path" ] || continue
+    pattern="$("$QUALITY_POLICY" release-scan "$path")" || \
+      die "cannot read the release scan for $path"
+    if [ "$pattern" = - ] || \
+        ! printf '%s' "$MODIFIED_PATHS" | grep -Fqx -- "$path"; then
+      remaining+=( "$path" )
+      continue
+    fi
+    diff="$(git -C "$ROOT" diff -U0 --no-color --no-ext-diff \
+      "$BASE_COMMIT" "$HEAD_COMMIT" -- "$path")" || die "cannot diff $path"
+    if [ -z "$diff" ] || printf '%s\n' "$diff" | awk '
+        /^@@/ { sub(/^@@[^@]*@@ ?/, ""); print; next }
+        /^(\+\+\+|---) / { next }
+        /^[-+]/ { print substr($0, 2) }
+      ' | grep -Eiq -- "$pattern"; then
+      remaining+=( "$path" )
+    else
+      SCAN_WAIVED+=( "$path" )
+    fi
+  done
+  LID_REASONS=( "${remaining[@]-}" )
+  LID_TEST_REQUIRED=false
+  for path in "${LID_REASONS[@]-}"; do
+    [ -z "$path" ] || LID_TEST_REQUIRED=true
+  done
+}
+
 classify_path() {
   local path="$1" status test_domain release_domain spec stages gates unknown
   local route_pattern route_priority capabilities journeys gate
@@ -144,6 +180,9 @@ classify_path() {
 while IFS= read -r -d '' status && IFS= read -r -d '' path; do
   classify_path "$path"
   case "$status" in
+    M) MODIFIED_PATHS="$MODIFIED_PATHS$path"$'\n' ;;
+  esac
+  case "$status" in
     R*|C*)
       IFS= read -r -d '' path || die 'malformed rename/copy entry from Git'
       classify_path "$path"
@@ -151,6 +190,7 @@ while IFS= read -r -d '' status && IFS= read -r -d '' path; do
   esac
 done < <(git -C "$ROOT" diff --name-status -z --find-renames "$BASE_COMMIT" "$HEAD_COMMIT")
 
+apply_release_scans
 apply_semantic_review
 
 printf 'schema\t2\n'
@@ -167,4 +207,7 @@ for path in "${LID_REASONS[@]-}"; do
 done
 for path in "${UNKNOWN_REASONS[@]-}"; do
   [ -z "$path" ] || printf 'unknown_reason\t%s\n' "$path"
+done
+for path in "${SCAN_WAIVED[@]-}"; do
+  [ -z "$path" ] || printf 'lid_test_scan_waived\t%s\n' "$path"
 done

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -4,6 +4,9 @@ set -euo pipefail
 set +x
 umask 077
 export LC_ALL=C
+# The owner runs this in a terminal for the closed-lid confirmation. No Git
+# or GitHub output may wait in a pager.
+export GIT_PAGER=cat PAGER=cat GH_PAGER=cat
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 APP_ROOT="$ROOT/app"

--- a/tests/quality-policy.sh
+++ b/tests/quality-policy.sh
@@ -42,6 +42,10 @@ policy_version="$("$ROOT/scripts/quality-policy" version)"
 [ "$("$ROOT/scripts/quality-policy" timeout app)" = 2400 ] || fail 'app timeout is not policy owned'
 [ -z "$("$ROOT/scripts/quality-policy" dependencies)" ] || \
   fail 'stage dependencies must not cascade beyond the routed plan'
+[ "$("$ROOT/scripts/quality-policy" release-scan bin/detach-core)" != - ] || \
+  fail 'bin/detach-core has no release scan pattern'
+[ "$("$ROOT/scripts/quality-policy" release-scan README.md)" = - ] || \
+  fail 'README.md must not have a release scan pattern'
 [ "$("$ROOT/scripts/quality-policy" critical | wc -l | tr -d ' ')" = 13 ] || \
   fail 'critical source inventory is incomplete'
 [ "$("$ROOT/scripts/quality-policy" suites | wc -l | tr -d ' ')" = 12 ] || \

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -249,6 +249,25 @@ class QualityGateContract(unittest.TestCase):
             with self.assertRaisesRegex(GateError, "hosted CI authority"):
                 exact_products_enabled()
 
+    def test_provider_stages_receive_the_exact_product_binding(self) -> None:
+        environment = {
+            "DETACH_QUALITY_GATE_TEST_MODE": "1",
+            "DETACH_QUALITY_EXACT_PRODUCTS": "1",
+            "DETACH_QUALITY_EXACT_APP": "1",
+        }
+        with patch.dict("os.environ", environment, clear=False):
+            gate = QualityGate(parse_options([]))
+            for stage in ("codex", "claude", "swift", "ui-e2e"):
+                self.assertEqual(
+                    gate.stage_environment(stage).get("DETACH_QUALITY_EXACT_PRODUCTS"), "1",
+                    stage,
+                )
+            for stage in ("static", "distribution", "tmux-runtime"):
+                self.assertNotIn(
+                    "DETACH_QUALITY_EXACT_PRODUCTS", gate.stage_environment(stage), stage
+                )
+            self.assertNotIn("DETACH_QUALITY_EXACT_APP", gate.stage_environment("codex"))
+
     def test_codex_parts_get_private_artifact_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/release-impact.sh
+++ b/tests/release-impact.sh
@@ -76,6 +76,58 @@ CORE_HEAD="$(commit_path bin/detach-core core)"
 "$REPO/scripts/release-impact" "$DMG_HEAD" "$CORE_HEAD" >"$TMP_ROOT/core.tsv"
 assert_value "$TMP_ROOT/core.tsv" lid_test_required true
 assert_value "$TMP_ROOT/core.tsv" unknown_impact false
+! grep -F 'lid_test_scan_waived' "$TMP_ROOT/core.tsv" >/dev/null
+
+# A plain modification of bin/detach-core is scanned. Hunks without a power
+# token waive the closed-lid probe and say so.
+CORE_SAFE_HEAD="$(commit_path bin/detach-core 'core resume companion directories')"
+"$REPO/scripts/release-impact" "$CORE_HEAD" "$CORE_SAFE_HEAD" >"$TMP_ROOT/core-safe.tsv"
+assert_value "$TMP_ROOT/core-safe.tsv" lid_test_required false
+assert_value "$TMP_ROOT/core-safe.tsv" unknown_impact false
+assert_value "$TMP_ROOT/core-safe.tsv" lid_test_scan_waived bin/detach-core
+! grep -F 'lid_test_reason' "$TMP_ROOT/core-safe.tsv" >/dev/null
+
+# A changed line that mentions a power token keeps the probe.
+CORE_POWER_HEAD="$(commit_path bin/detach-core 'core closed lid protection')"
+"$REPO/scripts/release-impact" "$CORE_SAFE_HEAD" "$CORE_POWER_HEAD" \
+  >"$TMP_ROOT/core-power.tsv"
+assert_value "$TMP_ROOT/core-power.tsv" lid_test_required true
+assert_value "$TMP_ROOT/core-power.tsv" lid_test_reason bin/detach-core
+! grep -F 'lid_test_scan_waived' "$TMP_ROOT/core-power.tsv" >/dev/null
+
+# A change inside a power function keeps the probe through the hunk header
+# even when the changed line itself has no token.
+printf '%s\n' 'power_refresh_state() {' '  local sample=1' '}' 'list_sessions() {' '  local rows=1' '}' \
+  >"$REPO/bin/detach-core"
+git -C "$REPO" add bin/detach-core
+git -C "$REPO" commit -qm 'core functions'
+CORE_FUNCTIONS_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+printf '%s\n' 'power_refresh_state() {' '  local sample=2' '}' 'list_sessions() {' '  local rows=1' '}' \
+  >"$REPO/bin/detach-core"
+git -C "$REPO" add bin/detach-core
+git -C "$REPO" commit -qm 'core power function body'
+CORE_CONTEXT_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+"$REPO/scripts/release-impact" "$CORE_FUNCTIONS_HEAD" "$CORE_CONTEXT_HEAD" \
+  >"$TMP_ROOT/core-context.tsv"
+assert_value "$TMP_ROOT/core-context.tsv" lid_test_required true
+printf '%s\n' 'power_refresh_state() {' '  local sample=2' '}' 'list_sessions() {' '  local rows=2' '}' \
+  >"$REPO/bin/detach-core"
+git -C "$REPO" add bin/detach-core
+git -C "$REPO" commit -qm 'core plain function body'
+CORE_PLAIN_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+"$REPO/scripts/release-impact" "$CORE_CONTEXT_HEAD" "$CORE_PLAIN_HEAD" \
+  >"$TMP_ROOT/core-plain.tsv"
+assert_value "$TMP_ROOT/core-plain.tsv" lid_test_required false
+assert_value "$TMP_ROOT/core-plain.tsv" lid_test_scan_waived bin/detach-core
+
+# Deleting the scanned file is not a modification and keeps the gate.
+git -C "$REPO" rm -q bin/detach-core
+git -C "$REPO" commit -qm 'core removed'
+CORE_REMOVED_HEAD="$(git -C "$REPO" rev-parse HEAD)"
+"$REPO/scripts/release-impact" "$CORE_PLAIN_HEAD" "$CORE_REMOVED_HEAD" \
+  >"$TMP_ROOT/core-removed.tsv"
+assert_value "$TMP_ROOT/core-removed.tsv" lid_test_required true
+CORE_HEAD="$(commit_path bin/detach-core core)"
 
 SHARED_POWER_HEAD="$(commit_path app/Sources/DetachKit/BoundedProcessRunner.swift runner)"
 "$REPO/scripts/release-impact" "$CORE_HEAD" "$SHARED_POWER_HEAD" \

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -22,6 +22,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
+grep -F 'export GIT_PAGER=cat PAGER=cat GH_PAGER=cat' \
+  "$ROOT/scripts/release-version" >/dev/null || {
+  printf 'release-version must disable pagers for terminal runs\n' >&2
+  exit 1
+}
+
 write_executable() {
   local path="$1"
   mkdir -p "$(dirname "$path")"

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1321,7 +1321,11 @@ class QualityGate:
         )
         if stage == "app" and exact_app:
             environment["DETACH_QUALITY_EXACT_APP"] = exact_app
-        if stage in ("swift", "app", "ui-e2e", "quality-contracts") and exact_products:
+        # Provider suites read tmux and detach-state from the exact runtime
+        # products when a hosted shard bound them.
+        if stage in (
+            "swift", "app", "ui-e2e", "quality-contracts", "codex", "claude"
+        ) and exact_products:
             environment["DETACH_QUALITY_EXACT_PRODUCTS"] = exact_products
         if not self.test_direct:
             environment["DETACH_RELEASE_TESTS_DETACHED"] = "1"

--- a/tools/quality_policy.py
+++ b/tools/quality_policy.py
@@ -117,6 +117,7 @@ class Policy:
         self.dependencies: list[tuple[str, str]] = []
         self.test_domains: dict[str, tuple[str, str]] = {}
         self.release_domains: dict[str, tuple[str, bool]] = {}
+        self.release_scans: dict[str, str] = {}
         self.coverage_exclusions: list[tuple[str, str, str, str]] = []
         self.coverage_regions: list[tuple[str, str, str, str, str]] = []
         self.routes: list[Route] = []
@@ -247,6 +248,22 @@ class Policy:
                     raise PolicyError(f"line {line_number}: unknown release gate")
                 self._unique(self.release_domains, name, "release domain", line_number)
                 self.release_domains[name] = (gates, self._boolean(raw_unknown, line_number))
+            elif kind == "release-scan":
+                # A lid-gated path whose diff hunks are scanned for power
+                # tokens before the closed-lid probe is selected. The path is
+                # exact, and the pattern is a case-insensitive extended regex.
+                self._expect_count(kind, values, 2, line_number)
+                path, pattern = values
+                if not ROUTE_PATTERN.fullmatch(path) or "*" in path or not pattern:
+                    raise PolicyError(f"line {line_number}: invalid release scan")
+                try:
+                    re.compile(pattern)
+                except re.error as error:
+                    raise PolicyError(
+                        f"line {line_number}: invalid release scan pattern: {error}"
+                    ) from error
+                self._unique(self.release_scans, path, "release scan", line_number)
+                self.release_scans[path] = pattern
             elif kind == "coverage-exclusion":
                 self._expect_count(kind, values, 4, line_number)
                 group, pattern, scenarios, summary = values
@@ -435,6 +452,10 @@ class Policy:
                 raise PolicyError(f"route references unknown release domain: {route.release_domain}")
             if route.spec not in registered_specs:
                 raise PolicyError(f"route references unknown spec: {route.spec}")
+        for path in self.release_scans:
+            classification = self.classify(path)
+            if classification.status == "unknown" or "lid" not in classification.release_gates.split(","):
+                raise PolicyError(f"release scan path has no lid gate: {path}")
         for source, requirement in self.critical:
             if requirement not in self.requirements:
                 raise PolicyError(f"critical source {source} references unknown requirement: {requirement}")
@@ -882,6 +903,10 @@ class Policy:
                 {"id": identifier, "gates": gates, "unknown": unknown}
                 for identifier, (gates, unknown) in self.release_domains.items()
             ],
+            "release_scans": [
+                {"path": path, "pattern": pattern}
+                for path, pattern in self.release_scans.items()
+            ],
             "coverage_exclusions": [
                 {
                     "group": group,
@@ -964,6 +989,7 @@ def usage(stream: object = sys.stdout) -> None:
        scripts/quality-policy dependencies
        scripts/quality-policy specs
        scripts/quality-policy classify PATH
+       scripts/quality-policy release-scan PATH
        scripts/quality-policy critical
        scripts/quality-policy requirements
        scripts/quality-policy capabilities
@@ -1030,6 +1056,9 @@ def main(arguments: list[str]) -> int:
     elif command == "classify":
         require_count(values, 1, "classify requires one path")
         print(policy.classify(values[0]).tsv())
+    elif command == "release-scan":
+        require_count(values, 1, "release-scan requires one path")
+        print(policy.release_scans.get(values[0], "-"))
     elif command == "critical":
         require_count(values, 0, "critical takes no arguments")
         for source, requirement in policy.critical:


### PR DESCRIPTION
## Why

Release 0.5.3 selected the supervised closed-lid probe because `bin/detach-core` changed, although the change only touched Claude transcript companions (the resume fix). The probe cost the owner two lid closures and about ten minutes of the release. A terminal run of `scripts/release-version` also stalled after the lid stage because `git diff --check` opened a pager. The first hosted run with a v2 product cache hit also exposed a defect from #212: the codex shard bound the exact products, but the gate did not forward that binding to provider stages.

## Contract delta

- ADDED: policy row `release-scan <path> <pattern>`; `scripts/quality-policy release-scan PATH` prints the pattern or `-`. The policy validates that the path is lid-gated and that the pattern compiles. Generated views include `release_scans` (policy 58).
- MODIFIED: `scripts/release-impact` scans a plain modification of a scanned path: changed lines and the enclosing function names from `git diff -U0` hunk headers. No power token → the path no longer selects the probe and the result records `lid_test_scan_waived <path>`. Added, deleted, renamed, or copied files, unknown paths, and any token match keep the gate. The owner review file still overrides.
- MODIFIED: `scripts/release-version` exports `GIT_PAGER=cat PAGER=cat GH_PAGER=cat`.
- FIXED: the gate forwards `DETACH_QUALITY_EXACT_PRODUCTS` to the codex and claude stages, so a provider shard with exact runtime products reads `tmux` and `detach-state` from the product root instead of failing on the absent packaged app.

On the real range v0.5.2..v0.5.3 the result is now `lid_test_required false` with `lid_test_scan_waived bin/detach-core`.

## Evidence

`tests/release-impact.sh` (new cases: waived modification, token on a changed line, token in the enclosing function, deletion keeps the gate), `tests/quality-policy.sh`, `tests/release-workflow.sh` (pager guard), `tests/quality-gate.sh`, `tests/quality_gate_contract.py` (stage binding contract), `tests/docs-contract.sh`, `tests/shell-safety.sh`, `scripts/quality-care evaluate` (9/9), `scripts/quality-policy generate --check`, `git diff --check` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
