### PR TITLE
Reuse hosted evidence in the pre-release gate

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -32,6 +32,10 @@ For a normal local change, `gate-contract` runs direct self-contracts only.
   selected by the accumulated diff from `<tag>`. It omits the recursive
   `scripts/release-version` test. Release mode without a base fails safe to the
   complete release plan.
+- `scripts/quality-gate --mode release --reuse-hosted <run-dir>` also reuses
+  every selected stage that digest-bound hosted evidence already proved for
+  the exact source tree. `scripts/quality-evidence fetch --commit <sha>`
+  downloads that evidence from the green `main` workflow run of the commit.
 - `scripts/quality-gate --resume <run-dir>` reuses compatible passed stages.
   `--resume latest` selects the newest compatible local run.
   `--resume auto` starts fresh when no compatible run exists. Releases use
@@ -109,6 +113,14 @@ Resume requires the same policy, authority, source commit, base commit, and
 input fingerprint. The old plan must contain every selected stage. Reused logs
 keep their duration and digest. The new manifest binds the parent manifest.
 Inherited wall time cannot become shorter.
+
+Hosted reuse is separate. Release mode may reuse a passed stage from a
+`ci-main` run that names the source commit, or from a promoted `ci-merge` run
+whose promotion record names the source commit and proves equal tested and
+merged trees. The evidence must have the current policy, a passed result, and
+matching environment, artifact, summary, and log digests. Each reused stage
+records the hosted run as its origin. Stages the hosted plan did not cover run
+on the release Mac.
 
 ## Automated stages and scheduling
 

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -44,6 +44,8 @@ Hosted CI is the merge-readiness authority.
   this group is merge-readiness evidence.
 - Resume evidence retains stage timing and digest-bound logs, binds its parent,
   and requires the same authority. Timing is telemetry, never a verdict.
+  Hosted reuse in release mode is separate: a passed `ci-main` or promoted
+  `ci-merge` stage counts only for the exact source tree it proved.
 - Quality policy files contain current version and state; Git is history.
   Runtime tools do not decode old policy schemas. A last-green metrics artifact
   can use an earlier policy number only with the current evidence schema,

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -77,8 +77,9 @@ change real power state, upload assets, or claim publication.
   signing, power, lid, and publication gate remains mandatory; no timing
   comparison can pass or fail a release.
 - The pre-release quality gate classifies the complete diff from the last
-  published tag to synchronized `main`. It runs that plan on the release Mac.
-  An empty or
+  published tag to synchronized `main`. It reuses the digest-bound hosted
+  evidence that proves the exact source tree and runs the remaining stages on
+  the release Mac. An empty or
   unknown diff selects the complete release plan. This selection does not omit
   later signing, notarization, hardware, artifact, or publication gates.
 - A resumed release automatically reuses digest-bound passed stages from the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,10 @@
 - Pull-request CI validates that machine plan and runs static contracts before
   optional metrics and Swift cache downloads. The final gate recomputes both,
   so the early pass is fail-fast diagnosis and not readiness evidence.
+- `scripts/quality-evidence fetch --repository OWNER/REPOSITORY --commit <sha>`
+  downloads the green `main` evidence that proves one commit into ignored
+  `app/build/quality-evidence/`. The release gate passes it as
+  `--reuse-hosted <run-dir>` and runs only the stages it does not prove.
 - `scripts/quality-cache-warm` builds the three isolated Swift products for a
   missing promoted-`main` cache key. It emits no gate evidence and never
   replaces a selected stage. `--dependencies-only` materializes the shared

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -742,7 +742,7 @@
     "routed_spec_limit_bytes": 16384,
     "routed_spec_warning_bytes": 12288
   },
-  "policy": 58,
+  "policy": 59,
   "release_domains": [
     {
       "gates": "-",
@@ -1057,6 +1057,20 @@
     },
     {
       "pattern": "tools/quality_baseline.py",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "scripts/quality-evidence",
+      "priority": 1000,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "policy"
+    },
+    {
+      "pattern": "tools/quality_evidence.py",
       "priority": 1000,
       "release_domain": "safe",
       "spec": "docs/specs/documentation.md",
@@ -2340,6 +2354,7 @@
         "scripts/quality-cache-warm",
         "scripts/quality-care",
         "scripts/quality-dashboard",
+        "scripts/quality-evidence",
         "scripts/quality-gate",
         "scripts/quality-history",
         "scripts/quality-merge",
@@ -2363,6 +2378,7 @@
         "tools/quality_cache_warm.py",
         "tools/quality_care.py",
         "tools/quality_dashboard.py",
+        "tools/quality_evidence.py",
         "tools/quality_gate.py",
         "tools/quality_history.py",
         "tools/quality_merge.py",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -36,6 +36,7 @@ It lists current specification ownership and verification links.
 - `scripts/quality-cache-warm`
 - `scripts/quality-care`
 - `scripts/quality-dashboard`
+- `scripts/quality-evidence`
 - `scripts/quality-gate`
 - `scripts/quality-history`
 - `scripts/quality-merge`
@@ -59,6 +60,7 @@ It lists current specification ownership and verification links.
 - `tools/quality_cache_warm.py`
 - `tools/quality_care.py`
 - `tools/quality_dashboard.py`
+- `tools/quality_evidence.py`
 - `tools/quality_gate.py`
 - `tools/quality_history.py`
 - `tools/quality_merge.py`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -1,5 +1,5 @@
 schema	1
-policy	58
+policy	59
 spec	documentation	docs/specs/documentation.md	Agent context, specifications, and quality automation stay synchronized.
 spec	runtime	docs/specs/runtime.md	Runtime and session operations preserve exact ownership.
 spec	state	docs/specs/state.md	Typed state, storage, and change events remain safe and coherent.
@@ -110,6 +110,8 @@ route	1000	scripts/quality-metrics	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_metrics.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-baseline	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_baseline.py	policy	safe	docs/specs/documentation.md
+route	1000	scripts/quality-evidence	policy	safe	docs/specs/documentation.md
+route	1000	tools/quality_evidence.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-promote	policy	safe	docs/specs/documentation.md
 route	1000	tools/quality_promote.py	policy	safe	docs/specs/documentation.md
 route	1000	scripts/quality-merge	policy	safe	docs/specs/documentation.md

--- a/scripts/quality-evidence
+++ b/scripts/quality-evidence
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality-evidence: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tools/quality_evidence.py" "$@"

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -505,15 +505,26 @@ file_line() {
 }
 
 run_full_tests() {
-  local impact_base="$1" baseline_root=""
+  local impact_base="$1" baseline_root="" hosted_root="" source_commit
+  local gate_args=(--mode release --base "$impact_base" --resume auto)
   note "running the impact-selected pre-release test suite from $impact_base"
   if [ "$TEST_MODE" != 1 ]; then
     baseline_root="$(DETACH_QUALITY_REPOSITORY="$REPOSITORY" \
       "$ROOT/scripts/quality-baseline")"
     export DETACH_QUALITY_BASELINE_ROOT="$baseline_root"
+    # Hosted CI already proved this exact tree for the stages of its merge
+    # plan. The gate reuses that digest-bound evidence and runs the rest.
+    source_commit="$(git -C "$ROOT" rev-parse HEAD)"
+    if hosted_root="$(DETACH_QUALITY_REPOSITORY="$REPOSITORY" \
+        "$ROOT/scripts/quality-evidence" fetch --repository "$REPOSITORY" \
+          --commit "$source_commit")"; then
+      note "reusing hosted evidence for $source_commit: $hosted_root"
+      gate_args+=(--reuse-hosted "$hosted_root")
+    else
+      note "no hosted evidence proves $source_commit; running every selected stage locally"
+    fi
   fi
-  "$ROOT/scripts/quality-gate" --mode release --base "$impact_base" \
-    --resume auto
+  "$ROOT/scripts/quality-gate" "${gate_args[@]}"
 }
 
 initialize_workflow() {

--- a/tests/quality-evidence.sh
+++ b/tests/quality-evidence.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+command -v python3 >/dev/null 2>&1 || {
+  printf 'quality evidence contracts: python3 is required\n' >&2
+  exit 2
+}
+exec python3 "$ROOT/tests/quality_evidence_contract.py"

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -664,6 +664,72 @@ reused_log_sha256="$(awk -F '\t' '$3 == "static" {print $7}' "$resumed_run/summa
 [ "$(shasum -a 256 "$resumed_run/$reused_log" | awk '{print $1}')" = "$reused_log_sha256" ]
 grep -F $'origin_run\n' "$resumed_run/summary.tsv" >/dev/null
 
+# Release mode reuses digest-bound hosted evidence for the exact source
+# commit. A ci-main run names the commit directly; a promoted ci-merge run
+# binds it through a promotion record with equal trees.
+setup_fixture hosted-reuse
+gate --mode repository >"$REPO/hosted-source.out"
+hosted_source="$(find "$RESULT_ROOT" -mindepth 1 -maxdepth 1 -type d -print | head -1)"
+mkdir -p "$REPO/hosted"
+cp -R "$hosted_source" "$REPO/hosted/"
+hosted_dir="$REPO/hosted/$(basename "$hosted_source")"
+rm -rf "$RESULT_ROOT"
+set_manifest_value "$hosted_dir/manifest.tsv" authority ci-main
+: >"$ACTION_LOG"
+gate --mode release --reuse-hosted "$hosted_dir" >"$REPO/hosted-reuse.out"
+grep -F "hosted evidence $(basename "$hosted_dir") proves static,gate-contract,swift,quality-contracts,app,ui-e2e,codex,claude,distribution,tmux-runtime,release-preflight,publish-preflight for" \
+  "$REPO/hosted-reuse.out" >/dev/null
+grep -F "reusing codex from hosted evidence $hosted_dir" "$REPO/hosted-reuse.out" >/dev/null
+grep -F "quality-gate: PASS policy=$POLICY_VERSION authority=release" \
+  "$REPO/hosted-reuse.out" >/dev/null
+[ ! -s "$ACTION_LOG" ]
+grep -F $'codex\treused\t' "$RESULT_ROOT"/*/summary.tsv >/dev/null
+grep -F "$(basename "$hosted_dir")" "$RESULT_ROOT"/*/summary.tsv >/dev/null
+grep -F $'resumed_from_run\t' "$RESULT_ROOT"/*/manifest.tsv | grep -qv "$(basename "$hosted_dir")"
+if gate --mode change --reuse-hosted "$hosted_dir" --plan >"$REPO/hosted-change.out" 2>&1; then
+  printf 'quality gate accepted hosted reuse outside release mode\n' >&2
+  exit 1
+fi
+grep -F -- '--reuse-hosted requires release mode' "$REPO/hosted-change.out" >/dev/null
+rm -rf "$RESULT_ROOT"
+printf 'tampered\n' >>"$hosted_dir/codex.log"
+if gate --mode release --reuse-hosted "$hosted_dir" >"$REPO/hosted-tampered.out" 2>&1; then
+  printf 'quality gate reused a tampered hosted log\n' >&2
+  exit 1
+fi
+grep -F 'log digest does not match: codex' "$REPO/hosted-tampered.out" >/dev/null
+sed -i '' '$d' "$hosted_dir/codex.log"
+rm -rf "$RESULT_ROOT"
+git -C "$REPO" commit -q --allow-empty -m 'same tree, new commit'
+if gate --mode release --reuse-hosted "$hosted_dir" >"$REPO/hosted-unbound.out" 2>&1; then
+  printf 'quality gate reused hosted evidence for another commit\n' >&2
+  exit 1
+fi
+grep -F 'hosted evidence is not bound to the source commit' "$REPO/hosted-unbound.out" >/dev/null
+rm -rf "$RESULT_ROOT"
+set_manifest_value "$hosted_dir/manifest.tsv" authority ci-merge
+hosted_tree="$(git -C "$REPO" rev-parse HEAD^{tree})"
+printf '%s\n' \
+  $'schema\t1' $'authority\tci-main' $'result\tpassed' \
+  "repository	example/detach" \
+  "main_commit	$(git -C "$REPO" rev-parse HEAD)" \
+  "main_tree	$hosted_tree" \
+  "tested_commit	$BASE" \
+  "tested_tree	$hosted_tree" \
+  "source_manifest_sha256	$(shasum -a 256 "$hosted_dir/manifest.tsv" | awk '{print $1}')" \
+  >"$hosted_dir/promotion.tsv"
+: >"$ACTION_LOG"
+gate --mode release --reuse-hosted "$hosted_dir" >"$REPO/hosted-promoted.out"
+grep -F "reusing claude from hosted evidence" "$REPO/hosted-promoted.out" >/dev/null
+[ ! -s "$ACTION_LOG" ]
+rm -rf "$RESULT_ROOT"
+if DETACH_QUALITY_REPOSITORY=other/detach gate --mode release --reuse-hosted "$hosted_dir" \
+    >"$REPO/hosted-repository.out" 2>&1; then
+  printf 'quality gate reused hosted evidence from another repository\n' >&2
+  exit 1
+fi
+grep -F 'hosted promotion names another repository' "$REPO/hosted-repository.out" >/dev/null
+
 setup_fixture stale-resume
 if FAIL_STAGES=swift gate --mode repository >"$REPO/stale-first.out" 2>&1; then
   exit 1

--- a/tests/quality_evidence_contract.py
+++ b/tests/quality_evidence_contract.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Contract tests for hosted quality evidence retrieval."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts/quality-evidence"
+
+FAKE_GH = '''#!/usr/bin/env python3
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+
+arguments = sys.argv[1:]
+mode = os.environ.get("FAKE_GH_MODE", "direct")
+commit = os.environ["FAKE_GH_COMMIT"]
+tree = os.environ["FAKE_GH_TREE"]
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+if arguments[0] == "api" and "workflows/quality-gates.yml/runs" in arguments[1]:
+    if mode == "no-runs":
+        print(json.dumps({"workflow_runs": []}))
+    else:
+        assert f"head_sha={commit}" in arguments[1]
+        print(json.dumps({"workflow_runs": [{"id": 321}]}))
+elif arguments[0] == "api" and "/artifacts" in arguments[1]:
+    print(json.dumps({"artifacts": [{"expired": False, "name": "quality-gate-evidence-321-1"}]}))
+elif arguments[:2] == ["run", "download"]:
+    run = Path(arguments[arguments.index("--dir") + 1]) / "20260905T120000Z-1"
+    run.mkdir()
+    (run / "codex.log").write_text("codex passed\\n")
+    (run / "environment.tsv").write_text("schema\\t1\\ngithub_actions\\ttrue\\n")
+    (run / "artifacts.tsv").write_text("schema\\t1\\n")
+    direct = mode in ("direct", "tampered", "failed")
+    tested = commit if direct else "b" * 40
+    summary = (
+        "policy\\tmode\\tstage\\tstatus\\tduration_seconds\\tlog\\tlog_sha256\\torigin_run\\n"
+        f"59\\timpact\\tcodex\\tpassed\\t10\\tcodex.log\\t{digest(run / 'codex.log')}\\t-\\n"
+    )
+    (run / "summary.tsv").write_text(summary)
+    authority = "ci-main" if direct else "ci-merge"
+    result = "failed" if mode == "failed" else "passed"
+    manifest = "\\n".join(
+        [
+            "schema\\t4", "policy\\t59", "mode\\timpact", f"authority\\t{authority}",
+            f"source_commit\\t{tested}", "base_commit\\t" + "c" * 40,
+            "stages\\tcodex", f"result\\t{result}",
+            f"environment_sha256\\t{digest(run / 'environment.tsv')}",
+            f"artifacts_sha256\\t{digest(run / 'artifacts.tsv')}",
+            f"summary_sha256\\t{digest(run / 'summary.tsv')}",
+        ]
+    ) + "\\n"
+    (run / "manifest.tsv").write_text(manifest)
+    if mode in ("promoted", "wrong-tree", "wrong-repository"):
+        main_tree = "d" * 40 if mode == "wrong-tree" else tree
+        repository = "other/repository" if mode == "wrong-repository" else "owner/repository"
+        (run / "promotion.tsv").write_text(
+            "\\n".join(
+                [
+                    "schema\\t1", "authority\\tci-main", "result\\tpassed",
+                    f"repository\\t{repository}", f"main_commit\\t{commit}",
+                    f"main_tree\\t{main_tree}", f"tested_commit\\t{tested}",
+                    f"tested_tree\\t{main_tree}",
+                    f"source_manifest_sha256\\t{digest(run / 'manifest.tsv')}",
+                ]
+            ) + "\\n"
+        )
+    if mode == "tampered":
+        with (run / "summary.tsv").open("a") as handle:
+            handle.write("59\\timpact\\tclaude\\tpassed\\t1\\tcodex.log\\t-\\t-\\n")
+else:
+    raise SystemExit(3)
+'''
+
+
+def git(*arguments: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(ROOT), *arguments],
+        stdout=subprocess.PIPE, text=True, check=True,
+    ).stdout.strip()
+
+
+def invoke(
+    fake_gh: Path, output_root: Path, commit: str, tree: str, *, mode: str, expected: int = 0
+) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "DETACH_QUALITY_EVIDENCE_GH": str(fake_gh),
+            "DETACH_QUALITY_EVIDENCE_TEST_MODE": "1",
+            "FAKE_GH_MODE": mode,
+            "FAKE_GH_COMMIT": commit,
+            "FAKE_GH_TREE": tree,
+        }
+    )
+    result = subprocess.run(
+        [
+            str(SCRIPT), "fetch", "--repository", "owner/repository",
+            "--commit", commit, "--output-root", str(output_root),
+        ],
+        cwd=ROOT, env=environment, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+    )
+    if result.returncode != expected:
+        raise AssertionError(
+            f"unexpected exit {result.returncode}, expected {expected}\n{result.stdout}")
+    return result
+
+
+def require(result: subprocess.CompletedProcess[str], value: str) -> None:
+    if value not in result.stdout:
+        raise AssertionError(f"missing diagnostic {value!r}:\n{result.stdout}")
+
+
+def main() -> int:
+    commit = git("rev-parse", "HEAD")
+    tree = git("rev-parse", "HEAD^{tree}")
+    with tempfile.TemporaryDirectory(prefix="detach-quality-evidence-") as raw:
+        root = Path(raw)
+        fake_gh = root / "fake-gh"
+        fake_gh.write_text(FAKE_GH, encoding="utf-8")
+        fake_gh.chmod(0o755)
+
+        direct = invoke(fake_gh, root / "direct", commit, tree, mode="direct")
+        run_dir = Path(direct.stdout.strip())
+        if run_dir != root / "direct/321/20260905T120000Z-1" or not (run_dir / "manifest.tsv").is_file():
+            raise AssertionError("direct ci-main evidence was not fetched deterministically")
+        cached = invoke(fake_gh, root / "direct", commit, tree, mode="direct")
+        if Path(cached.stdout.strip()) != run_dir:
+            raise AssertionError("cached evidence changed the selected run")
+
+        promoted = invoke(fake_gh, root / "promoted", commit, tree, mode="promoted")
+        if not Path(promoted.stdout.strip()).joinpath("promotion.tsv").is_file():
+            raise AssertionError("promoted evidence was not fetched")
+
+        wrong_tree = invoke(
+            fake_gh, root / "wrong-tree", commit, tree, mode="wrong-tree", expected=2)
+        require(wrong_tree, "promotion main_tree does not bind the commit")
+        wrong_repository = invoke(
+            fake_gh, root / "wrong-repository", commit, tree,
+            mode="wrong-repository", expected=2)
+        require(wrong_repository, "promotion names another repository")
+        unbound = invoke(fake_gh, root / "unbound", commit, tree, mode="unbound", expected=2)
+        require(unbound, "run is not bound to the commit")
+        failed = invoke(fake_gh, root / "failed", commit, tree, mode="failed", expected=2)
+        require(failed, "run did not pass")
+        tampered = invoke(
+            fake_gh, root / "tampered", commit, tree, mode="tampered", expected=2)
+        require(tampered, "summary.tsv digest does not match the manifest")
+        missing = invoke(fake_gh, root / "no-runs", commit, tree, mode="no-runs", expected=2)
+        require(missing, "no successful main quality run")
+        bad_commit = subprocess.run(
+            [str(SCRIPT), "fetch", "--repository", "owner/repository", "--commit", "HEAD",
+             "--output-root", str(root / "bad")],
+            cwd=ROOT, env={**os.environ, "DETACH_QUALITY_EVIDENCE_TEST_MODE": "1",
+                           "DETACH_QUALITY_EVIDENCE_GH": str(fake_gh)},
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
+        )
+        if bad_commit.returncode != 2 or "full lowercase SHA-1" not in bad_commit.stdout:
+            raise AssertionError(f"symbolic commit was accepted:\n{bad_commit.stdout}")
+    print("Quality evidence contracts passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/shell-safety.sh
+++ b/tests/shell-safety.sh
@@ -16,7 +16,7 @@ failures=0
 while IFS= read -r -d '' file; do
   case "$file" in
     tests/shell-safety-contract.sh) continue ;;
-    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/quality-promote|scripts/quality-history|scripts/quality-care|scripts/quality-merge|scripts/release-version|scripts/release-impact|scripts/release-lid-probe|scripts/release-pr|scripts/release-sbom) ;;
+    *.sh|bin/detach|bin/detach-core|scripts/quality-gate|scripts/quality-scenarios|scripts/quality-policy|scripts/quality-metrics|scripts/quality-mutation|scripts/quality-baseline|scripts/quality-evidence|scripts/quality-promote|scripts/quality-history|scripts/quality-care|scripts/quality-merge|scripts/release-version|scripts/release-impact|scripts/release-lid-probe|scripts/release-pr|scripts/release-sbom) ;;
     *) continue ;;
   esac
   [ -f "$ROOT/$file" ] || continue

--- a/tools/quality_evidence.py
+++ b/tools/quality_evidence.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Fetch the hosted quality evidence that proves one exact source commit."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import NoReturn, Optional
+
+from quality_baseline import BaselineError, document, evidence_artifact, gh, successful_runs
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "app/build/quality-evidence"
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+
+
+class EvidenceError(Exception):
+    """Hosted evidence is unavailable or does not prove the commit."""
+
+
+def fail(message: str) -> NoReturn:
+    print(f"quality-evidence: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tsv_values(path: Path) -> dict[str, Optional[str]]:
+    values: dict[str, Optional[str]] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        fields = line.split("\t")
+        if len(fields) != 2:
+            raise EvidenceError(f"{path.name} has a malformed record")
+        key, value = fields
+        values[key] = None if key in values else value
+    return values
+
+
+def commit_tree(commit: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "rev-parse", f"{commit}^{{tree}}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise EvidenceError(f"cannot resolve the tree of {commit}")
+    return result.stdout.strip()
+
+
+def binding_error(run_dir: Path, commit: str, repository: str) -> Optional[str]:
+    """Return why the run does not prove the commit, or None when it does."""
+    manifest = run_dir / "manifest.tsv"
+    for name in ("manifest.tsv", "summary.tsv", "environment.tsv", "artifacts.tsv"):
+        path = run_dir / name
+        if not path.is_file() or path.is_symlink():
+            return f"{name} is missing or unsafe"
+    values = tsv_values(manifest)
+    if values.get("schema") != "4":
+        return "manifest schema is unsupported"
+    if values.get("result") != "passed":
+        return "run did not pass"
+    authority = values.get("authority")
+    if authority not in ("ci-merge", "ci-main"):
+        return "authority is not hosted"
+    for name, key in (
+        ("environment.tsv", "environment_sha256"),
+        ("artifacts.tsv", "artifacts_sha256"),
+        ("summary.tsv", "summary_sha256"),
+    ):
+        if sha256_file(run_dir / name) != values.get(key):
+            return f"{name} digest does not match the manifest"
+    tested = values.get("source_commit") or ""
+    if authority == "ci-main" and tested == commit:
+        return None
+    promotion = run_dir / "promotion.tsv"
+    if not promotion.is_file() or promotion.is_symlink():
+        return "run is not bound to the commit"
+    record = tsv_values(promotion)
+    tree = commit_tree(commit)
+    expected = {
+        "schema": "1",
+        "authority": "ci-main",
+        "result": "passed",
+        "main_commit": commit,
+        "tested_commit": tested,
+        "source_manifest_sha256": sha256_file(manifest),
+        "main_tree": tree,
+        "tested_tree": tree,
+    }
+    for key, value in expected.items():
+        if not value or record.get(key) != value:
+            return f"promotion {key} does not bind the commit"
+    if repository and record.get("repository") != repository:
+        return "promotion names another repository"
+    return None
+
+
+def fetch(
+    repository: str,
+    commit: str,
+    output_root: Path,
+    executable: str,
+    *,
+    test_mode: bool,
+) -> Path:
+    if not REPOSITORY.fullmatch(repository):
+        raise EvidenceError("repository must identify owner/repository")
+    if not COMMIT.fullmatch(commit):
+        raise EvidenceError("commit must be a full lowercase SHA-1")
+    if not test_mode and output_root.resolve() != DEFAULT_OUTPUT.resolve():
+        raise EvidenceError("evidence output must use app/build/quality-evidence")
+    if output_root.exists() and (not output_root.is_dir() or output_root.is_symlink()):
+        raise EvidenceError("evidence output is unsafe")
+    output_root.mkdir(parents=True, exist_ok=True)
+    run_ids = successful_runs(document(
+        gh(
+            executable,
+            [
+                "api",
+                f"repos/{repository}/actions/workflows/quality-gates.yml/runs"
+                f"?branch=main&status=success&event=push&head_sha={commit}&per_page=5",
+            ],
+        ),
+        "workflow run",
+    ))
+    reasons: list[str] = []
+    for run_id in run_ids:
+        destination = output_root / str(run_id)
+        if destination.exists():
+            if not destination.is_dir() or destination.is_symlink():
+                raise EvidenceError(f"evidence destination is unsafe: {destination}")
+        else:
+            artifact = evidence_artifact(document(
+                gh(executable, ["api", f"repos/{repository}/actions/runs/{run_id}/artifacts"]),
+                "artifact",
+            ), run_id)
+            destination.mkdir()
+            try:
+                gh(
+                    executable,
+                    [
+                        "run", "download", str(run_id), "--repo", repository,
+                        "--name", artifact, "--dir", str(destination),
+                    ],
+                )
+            except Exception:
+                shutil.rmtree(destination, ignore_errors=True)
+                raise
+        manifests = [
+            path for path in destination.glob("*/manifest.tsv")
+            if path.is_file() and not path.is_symlink()
+        ]
+        if len(manifests) != 1:
+            raise EvidenceError("downloaded evidence has no unique quality manifest")
+        run_dir = manifests[0].parent
+        reason = binding_error(run_dir, commit, repository)
+        if reason is None:
+            print(run_dir)
+            return run_dir
+        reasons.append(f"run {run_id}: {reason}")
+    raise EvidenceError(
+        f"no hosted quality evidence proves {commit}: " + "; ".join(reasons)
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subcommands = result.add_subparsers(dest="command", required=True)
+    fetch_parser = subcommands.add_parser("fetch")
+    fetch_parser.add_argument(
+        "--repository",
+        default=os.environ.get("DETACH_QUALITY_REPOSITORY", os.environ.get("GITHUB_REPOSITORY", "")),
+    )
+    fetch_parser.add_argument("--commit", required=True)
+    fetch_parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=Path(os.environ.get("DETACH_QUALITY_EVIDENCE_OUTPUT", DEFAULT_OUTPUT)),
+    )
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    test_mode = os.environ.get("DETACH_QUALITY_EVIDENCE_TEST_MODE") == "1"
+    executable = (
+        os.environ.get("DETACH_QUALITY_EVIDENCE_GH", "gh") if test_mode else "gh"
+    )
+    fetch(
+        arguments.repository,
+        arguments.commit,
+        arguments.output_root,
+        executable,
+        test_mode=test_mode,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (EvidenceError, BaselineError, OSError) as error:
+        fail(str(error))

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -203,6 +203,7 @@ class Options:
     explain: bool
     resume: str
     keep_going: bool
+    reuse_hosted: str
     list_stages: bool
     stage: str
     shard: str
@@ -352,6 +353,7 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--explain", action="store_true")
     result.add_argument("--resume", default="")
     result.add_argument("--keep-going", action="store_true")
+    result.add_argument("--reuse-hosted", default="")
     result.add_argument("--list-stages", action="store_true")
     result.add_argument("--stage", default="")
     result.add_argument("--shard", default="")
@@ -368,6 +370,7 @@ def parse_options(arguments: list[str]) -> Options:
         explain=values.explain,
         resume=values.resume,
         keep_going=values.keep_going,
+        reuse_hosted=values.reuse_hosted,
         list_stages=values.list_stages,
         stage=values.stage,
         shard=values.shard,
@@ -420,6 +423,8 @@ class QualityGate:
         self.failure_count = 0
         self.prior_manifest: dict[str, str | None] = {}
         self.prior_results: dict[str, StageResult] = {}
+        self.hosted_dir: Path | None = None
+        self.hosted_results: dict[str, StageResult] = {}
         self.scenario_records: list[dict[str, object]] = []
 
     def validate_options(self) -> None:
@@ -465,6 +470,11 @@ class QualityGate:
         else:
             raise GateError(f"invalid quality authority: {self.authority}")
 
+        if self.options.reuse_hosted:
+            if self.options.mode != "release":
+                raise GateError("--reuse-hosted requires release mode")
+            if self.options.stage or self.options.shard:
+                raise GateError("--reuse-hosted cannot be combined with --stage or --shard")
         if self.options.output_format not in ("text", "json"):
             raise GateError(f"invalid format: {self.options.output_format}")
         if self.options.stage and (
@@ -1094,43 +1104,7 @@ class QualityGate:
             raise GateError("resume environment digest does not match its manifest")
         if sha256_file(resume / "artifacts.tsv") != values.get("artifacts_sha256"):
             raise GateError("resume artifact inventory digest does not match its manifest")
-        artifact_lines = (resume / "artifacts.tsv").read_text(encoding="utf-8").splitlines()
-        if not artifact_lines or artifact_lines[0] != "schema\t1":
-            raise GateError("resume artifact inventory schema is invalid")
-        for line in artifact_lines[1:]:
-            fields = line.split("\t")
-            if len(fields) != 3 or fields[0] != "file":
-                raise GateError("resume artifact inventory contains an unknown record")
-            _, relative, expected_digest = fields
-            if (
-                relative.startswith("/")
-                or relative.startswith("../")
-                or "/../" in relative
-                or "\n" in relative
-                or "\t" in relative
-            ):
-                raise GateError("resume artifact inventory path is unsafe")
-            if not (
-                relative == "quality-metrics.json"
-                or relative == "quality-metrics-swift.json"
-                or relative == "coverage-opportunities.json"
-                or relative == "spec-sizes.json"
-                or relative == "scenarios.jsonl"
-                or relative == "scenarios.junit.xml"
-                or relative == "repair-bundle.json"
-                or relative.startswith("stage-scenarios/")
-                or relative.startswith("ui-e2e-artifacts/")
-                or relative.startswith("codex-artifacts/")
-                or relative.startswith("claude-artifacts/")
-            ):
-                raise GateError("resume artifact inventory path is unapproved")
-            if not DIGEST.fullmatch(expected_digest):
-                raise GateError("resume artifact inventory digest is invalid")
-            artifact = resume / relative
-            if not artifact.is_file() or artifact.is_symlink():
-                raise GateError("resume diagnostic artifact is missing or unsafe")
-            if sha256_file(artifact) != expected_digest:
-                raise GateError("resume diagnostic artifact digest does not match")
+        self.validate_artifact_inventory(resume, "resume")
         timing_wall = values.get("timing_wall_seconds")
         if timing_wall is None or not NONNEGATIVE_INTEGER.fullmatch(timing_wall):
             raise GateError("resume evidence timing wall duration is invalid")
@@ -1196,6 +1170,133 @@ class QualityGate:
             resume / "summary.tsv", prior_stages, prior_mode
         )
 
+    def validate_artifact_inventory(self, root: Path, label: str) -> None:
+        artifact_lines = (root / "artifacts.tsv").read_text(encoding="utf-8").splitlines()
+        if not artifact_lines or artifact_lines[0] != "schema\t1":
+            raise GateError(f"{label} artifact inventory schema is invalid")
+        for line in artifact_lines[1:]:
+            fields = line.split("\t")
+            if len(fields) != 3 or fields[0] != "file":
+                raise GateError(f"{label} artifact inventory contains an unknown record")
+            _, relative, expected_digest = fields
+            if (
+                relative.startswith("/")
+                or relative.startswith("../")
+                or "/../" in relative
+                or "\n" in relative
+                or "\t" in relative
+            ):
+                raise GateError(f"{label} artifact inventory path is unsafe")
+            if not (
+                relative == "quality-metrics.json"
+                or relative == "quality-metrics-swift.json"
+                or relative == "coverage-opportunities.json"
+                or relative == "spec-sizes.json"
+                or relative == "scenarios.jsonl"
+                or relative == "scenarios.junit.xml"
+                or relative == "repair-bundle.json"
+                or relative.startswith("stage-scenarios/")
+                or relative.startswith("ui-e2e-artifacts/")
+                or relative.startswith("codex-artifacts/")
+                or relative.startswith("claude-artifacts/")
+            ):
+                raise GateError(f"{label} artifact inventory path is unapproved")
+            if not DIGEST.fullmatch(expected_digest):
+                raise GateError(f"{label} artifact inventory digest is invalid")
+            artifact = root / relative
+            if not artifact.is_file() or artifact.is_symlink():
+                raise GateError(f"{label} diagnostic artifact is missing or unsafe")
+            if sha256_file(artifact) != expected_digest:
+                raise GateError(f"{label} diagnostic artifact digest does not match")
+
+    def validate_hosted_reuse(self) -> None:
+        """Bind hosted ci-main evidence to the exact source commit before reuse.
+
+        Release mode may reuse a stage that hosted CI already proved for the
+        same tree. The evidence must be digest-bound, must have passed, and
+        must name this commit directly (ci-main) or through a promotion
+        record whose tested and merged trees are equal.
+        """
+        if not self.options.reuse_hosted:
+            return
+        hosted = Path(self.options.reuse_hosted).absolute()
+        if not hosted.is_dir() or hosted.is_symlink():
+            raise GateError("hosted evidence path must be a non-symlink run directory")
+        for name in ("manifest.tsv", "summary.tsv", "environment.tsv", "artifacts.tsv"):
+            path = hosted / name
+            if not path.is_file() or path.is_symlink():
+                raise GateError(f"hosted evidence {name} is missing or unsafe")
+        values = self.manifest_values(hosted / "manifest.tsv")
+        if values.get("schema") != "4":
+            raise GateError("hosted evidence schema is unsupported")
+        if values.get("policy") != str(self.policy_version):
+            raise GateError("hosted evidence uses another policy version")
+        if values.get("result") != "passed":
+            raise GateError("hosted evidence did not pass")
+        if values.get("mode") not in ("impact", "repository"):
+            raise GateError("hosted evidence mode is not a hosted plan")
+        authority = values.get("authority")
+        if authority not in ("ci-merge", "ci-main"):
+            raise GateError("hosted evidence authority is not hosted")
+        for name, key in (
+            ("environment.tsv", "environment_sha256"),
+            ("artifacts.tsv", "artifacts_sha256"),
+            ("summary.tsv", "summary_sha256"),
+        ):
+            if sha256_file(hosted / name) != values.get(key):
+                raise GateError(f"hosted evidence {name} digest does not match its manifest")
+        self.validate_artifact_inventory(hosted, "hosted evidence")
+        tested_commit = values.get("source_commit") or ""
+        if not (authority == "ci-main" and tested_commit == self.source_commit):
+            self.validate_hosted_promotion(hosted, values)
+        results = self.parse_summary(
+            hosted / "summary.tsv", values.get("stages") or "", values.get("mode") or ""
+        )
+        self.hosted_results = {
+            stage: result for stage, result in results.items() if result.status == "passed"
+        }
+        self.hosted_dir = hosted
+        proven = [
+            stage
+            for stage in self.selected
+            if stage in self.hosted_results and stage not in self.prior_results
+        ]
+        print(
+            f"quality-gate: hosted evidence {hosted.name} proves "
+            f"{','.join(proven) if proven else 'no selected stage'} for {self.source_commit}"
+        )
+
+    def validate_hosted_promotion(self, hosted: Path, values: dict[str, str | None]) -> None:
+        promotion = hosted / "promotion.tsv"
+        if not promotion.is_file() or promotion.is_symlink():
+            raise GateError("hosted evidence is not bound to the source commit")
+        record = self.manifest_values(promotion)
+        tree = git_text(["rev-parse", f"{self.source_commit}^{{tree}}"])
+        checks = (
+            ("schema", "1", "hosted promotion schema is unsupported"),
+            ("authority", "ci-main", "hosted promotion authority is not ci-main"),
+            ("result", "passed", "hosted promotion did not pass"),
+            ("main_commit", self.source_commit, "hosted promotion names another main commit"),
+            (
+                "tested_commit",
+                values.get("source_commit") or "",
+                "hosted promotion names another tested commit",
+            ),
+            (
+                "source_manifest_sha256",
+                sha256_file(hosted / "manifest.tsv"),
+                "hosted promotion does not bind this manifest",
+            ),
+            ("main_tree", tree, "hosted promotion tree does not match the source tree"),
+            ("tested_tree", tree, "hosted promotion tested tree does not match the source tree"),
+        )
+        for key, expected, message in checks:
+            if not expected or record.get(key) != expected:
+                raise GateError(message)
+        repository = os.environ.get("DETACH_QUALITY_REPOSITORY", "")
+        if repository and record.get("repository") != repository:
+            raise GateError("hosted promotion names another repository")
+
     def stage_result_path(self, stage: str) -> Path:
         return self.run_dir / f".stage-{stage}.result"
 
@@ -1240,13 +1341,30 @@ class QualityGate:
             ),
         )
 
+    def reuse_source(self, stage: str) -> tuple[Path, StageResult] | None:
+        prior = self.prior_results.get(stage)
+        if (
+            prior is not None
+            and prior.status in ("passed", "reused")
+            and self.resume_dir is not None
+        ):
+            return self.resume_dir, prior
+        hosted = self.hosted_results.get(stage)
+        if hosted is not None and self.hosted_dir is not None:
+            return self.hosted_dir, hosted
+        return None
+
     def reusable(self, stage: str) -> bool:
-        result = self.prior_results.get(stage)
+        source = self.reuse_source(stage)
+        if source is None:
+            return False
         if stage == "ui-e2e" and "quality-contracts" in self.selected:
-            metrics = self.prior_results.get("quality-contracts")
-            if metrics is None or metrics.status not in ("passed", "reused"):
+            # The UI profile only counts with the metrics that merged it, so
+            # both must come from the same evidence.
+            metrics = self.reuse_source("quality-contracts")
+            if metrics is None or metrics[0] != source[0]:
                 return False
-        return result is not None and result.status in ("passed", "reused")
+        return True
 
     def prerequisite_failed(self, stage: str) -> bool:
         prerequisites = EXECUTION_PREREQUISITES.get(stage)
@@ -1335,24 +1453,26 @@ class QualityGate:
         if stage not in self.selected or stage in self.results or stage in self.active:
             return
         if self.reusable(stage):
-            assert self.resume_dir is not None
-            prior = self.prior_results[stage]
-            print(f"quality-gate: reusing {stage} from matching evidence {self.resume_dir}")
-            origin = prior.origin_run if prior.origin_run != "-" else self.resume_dir.name
+            source = self.reuse_source(stage)
+            assert source is not None
+            source_dir, prior = source
+            kind = "hosted" if source_dir == self.hosted_dir else "matching"
+            print(f"quality-gate: reusing {stage} from {kind} evidence {source_dir}")
+            origin = prior.origin_run if prior.origin_run != "-" else source_dir.name
             reused_log = "-"
             if prior.log != "-":
                 reused_log = f"{stage}.reused.log"
-                shutil.copyfile(self.resume_dir / prior.log, self.run_dir / reused_log)
+                shutil.copyfile(source_dir / prior.log, self.run_dir / reused_log)
                 (self.run_dir / reused_log).chmod(0o600)
             if stage == "quality-contracts":
-                metrics = self.resume_dir / "quality-metrics.json"
+                metrics = source_dir / "quality-metrics.json"
                 if not metrics.is_file() or metrics.is_symlink():
                     raise GateError(
                         "reused quality-contracts evidence has no safe quality metrics"
                     )
                 shutil.copyfile(metrics, self.run_dir / "quality-metrics.json")
                 (self.run_dir / "quality-metrics.json").chmod(0o600)
-                swift_metrics = self.resume_dir / "quality-metrics-swift.json"
+                swift_metrics = source_dir / "quality-metrics-swift.json"
                 if swift_metrics.exists():
                     if not swift_metrics.is_file() or swift_metrics.is_symlink():
                         raise GateError(
@@ -1362,7 +1482,7 @@ class QualityGate:
                         swift_metrics, self.run_dir / "quality-metrics-swift.json"
                     )
                     (self.run_dir / "quality-metrics-swift.json").chmod(0o600)
-                opportunities = self.resume_dir / "coverage-opportunities.json"
+                opportunities = source_dir / "coverage-opportunities.json"
                 if not opportunities.is_file() or opportunities.is_symlink():
                     raise GateError(
                         "reused quality-contracts evidence has no safe coverage opportunities"
@@ -1374,7 +1494,7 @@ class QualityGate:
             self.record_result(
                 stage,
                 StageResult("reused", prior.duration, reused_log, 0, origin),
-                scenario_source=self.resume_dir / "stage-scenarios" / f"{stage}.jsonl",
+                scenario_source=source_dir / "stage-scenarios" / f"{stage}.jsonl",
             )
             return
         if self.prerequisite_failed(stage):
@@ -1749,6 +1869,7 @@ class QualityGate:
             return 0
         self.prepare_evidence()
         self.validate_resume()
+        self.validate_hosted_reuse()
         self.write_manifest("running")
 
         def signal_handler(_signum: int, _frame: object) -> None:
@@ -2154,6 +2275,7 @@ def run_static_stage(root: Path, run_dir: Path, mode: str, resolved_base: str) -
         "scripts/quality-metrics",
         "scripts/quality-mutation",
         "scripts/quality-baseline",
+        "scripts/quality-evidence",
         "scripts/quality-promote",
         "scripts/quality-history",
         "scripts/quality-care",
@@ -2239,6 +2361,12 @@ def gate_contract_definitions(
             [str(root / "tests/quality-baseline.sh")],
             {},
             "Quality baseline contracts passed",
+        ),
+        (
+            "quality-evidence.log",
+            [str(root / "tests/quality-evidence.sh")],
+            {},
+            "Quality evidence contracts passed",
         ),
         (
             "quality-promote.log",


### PR DESCRIPTION
## Why

The pre-release gate repeated every stage of the accumulated diff on the release Mac although hosted CI had already proved the exact tree. Release 0.5.3 spent 4m48s there, mostly in the codex and claude suites.

## Contract delta

- ADDED: `scripts/quality-evidence fetch --repository OWNER/REPOSITORY --commit <sha>` downloads the green `main` quality-gates evidence for one commit into ignored `app/build/quality-evidence/` and prints the run directory. It accepts a `ci-main` run that names the commit or a promoted `ci-merge` run whose promotion record names the commit and proves equal tested and merged trees; digests, result, and repository are checked.
- ADDED: `scripts/quality-gate --mode release --reuse-hosted <run-dir>` binds that evidence fail closed (current policy, passed result, hosted authority, environment/artifact/summary digests, per-stage log digests, commit or promotion binding) and reuses every selected stage it proved. Each reused stage records the hosted run as its origin. Stages the hosted plan did not cover run locally. Local `--resume` continues to work alongside; ui-e2e and quality-contracts must come from the same evidence.
- MODIFIED: `scripts/release-version` fetches the evidence for HEAD before the gate and passes it; when none proves the commit it runs every selected stage as before.
- Policy 59 registers the new tool and test paths.

On this Mac, `scripts/quality-evidence fetch` for the current `main` returns the promoted evidence of the release merge. For a release cut right after a product PR whose plan covered the provider suites, the pre-release gate drops from about five minutes to the stages that plan did not prove.

## Evidence

`tests/quality-evidence.sh` (direct, promoted, wrong tree, wrong repository, unbound, failed, tampered, no runs, symbolic commit), `tests/quality-gate.sh` (hosted reuse: full reuse, change-mode rejection, tampered log, unbound commit, promotion path, foreign repository), `tests/quality_gate_contract.py`, `tests/release-workflow.sh`, `tests/docs-contract.sh`, `tests/shell-safety.sh`, `scripts/quality-care evaluate` (9/9), `scripts/quality-policy generate --check`, `git diff --check` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
