### PR TITLE
Approve the shard binding table in hosted evidence inventories

### DIFF
--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -675,6 +675,13 @@ cp -R "$hosted_source" "$REPO/hosted/"
 hosted_dir="$REPO/hosted/$(basename "$hosted_source")"
 rm -rf "$RESULT_ROOT"
 set_manifest_value "$hosted_dir/manifest.tsv" authority ci-main
+# Aggregated hosted runs inventory their shard binding table too.
+printf 'schema\t1\nshard\tstatic\n' >"$hosted_dir/shards.tsv"
+printf 'file\tshards.tsv\t%s\n' \
+  "$(shasum -a 256 "$hosted_dir/shards.tsv" | awk '{print $1}')" \
+  >>"$hosted_dir/artifacts.tsv"
+set_manifest_value "$hosted_dir/manifest.tsv" artifacts_sha256 \
+  "$(shasum -a 256 "$hosted_dir/artifacts.tsv" | awk '{print $1}')"
 : >"$ACTION_LOG"
 gate --mode release --reuse-hosted "$hosted_dir" >"$REPO/hosted-reuse.out"
 grep -F "hosted evidence $(basename "$hosted_dir") proves static,gate-contract,swift,quality-contracts,app,ui-e2e,codex,claude,distribution,tmux-runtime,release-preflight,publish-preflight for" \

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -1192,6 +1192,7 @@ class QualityGate:
                 or relative == "quality-metrics-swift.json"
                 or relative == "coverage-opportunities.json"
                 or relative == "spec-sizes.json"
+                or relative == "shards.tsv"
                 or relative == "scenarios.jsonl"
                 or relative == "scenarios.junit.xml"
                 or relative == "repair-bundle.json"


### PR DESCRIPTION
## Why

The first real use of `--reuse-hosted` against the promoted evidence of the current `main` failed with `hosted evidence artifact inventory path is unapproved`. Aggregated hosted runs inventory `shards.tsv`; the hosted reuse validator inherited the resume allowlist, which never sees aggregated runs.

## Contract delta

- MODIFIED: the artifact inventory allowlist used by resume and hosted reuse includes `shards.tsv`.
- The hosted reuse contract in `tests/quality-gate.sh` inventories a shard binding table.

## Evidence

- From a detached checkout of `main` (b7f18eb) with this fix: `scripts/quality-gate --mode release --base v0.5.3 --reuse-hosted <fetched run>` passes in 1 s with all twelve release stages reused from the promoted evidence; the same gate ran 4m48s during the 0.5.3 release.
- `tests/quality-gate.sh`, `tests/quality_gate_contract.py`, `git diff --check` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
