### PR TITLE
NO-TICKET: Встроенный терминал использует всю ширину окна при запуске и после изменения размера

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Start, Resume, and Recover run inside Detach and do not require an outer
 terminal. The selected external terminal remains available as a fallback for
 Attach, Resume, and Recover.
 
+New session and Quick chat pass the main terminal width before the provider
+starts, including when the session list is empty. They measure the main detail
+area with the terminal font, not the New session sheet. The detached start uses
+24 rows until attachment supplies the visible height. Resizing the window then
+uses the normal terminal and tmux size updates.
+
 Resume and Recover show the new terminal as soon as the session can accept an
 attachment. Startup checks continue, and Detach reports any startup error.
 With the current CLI, the provider receives the visible terminal size before

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ area with the terminal font, not the New session sheet. The detached start uses
 24 rows until attachment supplies the visible height. Resizing the window then
 uses the normal terminal and tmux size updates.
 
+With both an embedded and an external client attached, tmux uses the size of
+the last active client (`window-size latest`). Input in the embedded terminal
+restores its width. Closing the external client also restores the embedded
+size. Closing both clients leaves the managed provider running.
+
 Resume and Recover show the new terminal as soon as the session can accept an
 attachment. Startup checks continue, and Detach reports any startup error.
 With the current CLI, the provider receives the visible terminal size before

--- a/app/Sources/DetachApp/DetachApp.swift
+++ b/app/Sources/DetachApp/DetachApp.swift
@@ -108,7 +108,7 @@ struct UIE2EConfiguration: Sendable {
         }
         let scenario = environment["DETACH_UI_E2E_SCENARIO"] ?? "main"
         guard [
-            "main", "failure", "settings", "onboarding-first-run",
+            "main", "failure", "settings", "terminal-width", "onboarding-first-run",
             "onboarding-provider", "onboarding-approval",
         ].contains(scenario) else {
             try fail("DETACH_UI_E2E_SCENARIO is unsupported")

--- a/app/Sources/DetachApp/NewSessionSheet.swift
+++ b/app/Sources/DetachApp/NewSessionSheet.swift
@@ -8,6 +8,7 @@ struct NewSessionSheet: View {
     let store: SessionStore
     @Binding var selectedID: String?
     let projectPickerRoot: URL
+    let terminalSize: SessionTerminalSize?
 
     @State private var projectDir: URL?
     @State private var provider: Provider = .claude
@@ -25,10 +26,12 @@ struct NewSessionSheet: View {
         showsAdvanced: Bool = false,
         initialProjectDir: URL? = nil,
         initialLaunchFailure: String? = nil,
+        terminalSize: SessionTerminalSize? = nil,
         projectPickerRoot: URL = FileManager.default.homeDirectoryForCurrentUser
     ) {
         self.store = store
         self.projectPickerRoot = projectPickerRoot
+        self.terminalSize = terminalSize
         _selectedID = selectedID
         _name = State(initialValue: initialName)
         _showAdvanced = State(initialValue: showsAdvanced)
@@ -327,7 +330,8 @@ struct NewSessionSheet: View {
             provider: provider,
             projectDirectory: projectDir,
             name: normalizedName,
-            prompt: NewSessionLaunch.trimmedPrompt(prompt))
+            prompt: NewSessionLaunch.trimmedPrompt(prompt),
+            terminalSize: terminalSize)
         launchFailure = nil
         if let message = result.message {
             launchFailure = message

--- a/app/Sources/DetachApp/QuickChat.swift
+++ b/app/Sources/DetachApp/QuickChat.swift
@@ -67,6 +67,7 @@ enum QuickChatLaunch {
         providerRawValue: String,
         directoryPath: String,
         fileManager: FileManager = .default,
+        terminalSize: SessionTerminalSize? = nil,
         onSessionAvailable: (@MainActor (String) -> Void)? = nil,
         createProjectDirectory: (URL, FileManager) throws -> URL = {
             try QuickChatProjectDirectory.create(inside: $0, fileManager: $1)
@@ -101,7 +102,8 @@ enum QuickChatLaunch {
                 provider: provider,
                 projectDirectory: projectDirectory,
                 name: nil,
-                prompt: nil)
+                prompt: nil,
+                terminalSize: terminalSize)
         }
 
         let existingIDs = existingSessionIDs(in: store.sessions)
@@ -111,7 +113,8 @@ enum QuickChatLaunch {
                     provider: provider,
                     projectDirectory: projectDirectory,
                     name: nil,
-                    prompt: nil))
+                    prompt: nil,
+                    terminalSize: terminalSize))
             }
             group.addTask {
                 .session(await waitForSession(

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -37,6 +37,8 @@ struct RootView: View {
     @ObservedObject var settingsNavigation: SettingsNavigation
 
     @State private var selectedID: String?
+    @State private var detailWidth: CGFloat = 0
+    @State private var initialTerminalSize: SessionTerminalSize?
     @State private var shortcutAssignments: [SessionShortcutAssignment] = []
     @State private var initialSetupComplete = false
 
@@ -64,27 +66,40 @@ struct RootView: View {
                             store: store,
                             selectedID: $selectedID,
                             navigation: navigation,
-                            shortcutAssignments: shortcutAssignments)
+                            shortcutAssignments: shortcutAssignments,
+                            initialTerminalSize: initialTerminalSize)
                     } detail: {
-                        if store.sessions.isEmpty && store.state == .ok {
-                            EmptySessionsView()
-                        } else if let session = selectedSession {
-                            SessionDetailSwitcher(
-                                session: session,
-                                store: store,
-                                detachPath: detachPath,
-                                sessionLogSnapshots: sessionLogSnapshots,
-                                terminalScreens: terminalScreens)
-                        } else {
-                            ContentUnavailableView {
-                                Label {
-                                    Text(L10n.string("Select a session"))
-                                } icon: {
-                                    Image(systemName: "terminal").foregroundStyle(Brand.gradient)
+                        Group {
+                            if store.sessions.isEmpty && store.state == .ok {
+                                EmptySessionsView()
+                            } else if let session = selectedSession {
+                                SessionDetailSwitcher(
+                                    session: session,
+                                    store: store,
+                                    detachPath: detachPath,
+                                    sessionLogSnapshots: sessionLogSnapshots,
+                                    terminalScreens: terminalScreens)
+                            } else {
+                                ContentUnavailableView {
+                                    Label {
+                                        Text(L10n.string("Select a session"))
+                                    } icon: {
+                                        Image(systemName: "terminal").foregroundStyle(Brand.gradient)
+                                    }
+                                } description: {
+                                    Text(L10n.string("All detach sessions from both providers are on the left"))
                                 }
-                            } description: {
-                                Text(L10n.string("All detach sessions from both providers are on the left"))
                             }
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .onGeometryChange(for: CGFloat.self) { $0.size.width } action: {
+                            detailWidth = $0
+                            initialTerminalSize = SessionAttachController.initialStartSize(
+                                detailWidth: $0, fontPointSize: fontPointSize)
+                        }
+                        .onChange(of: fontPointSize) { _, size in
+                            initialTerminalSize = SessionAttachController.initialStartSize(
+                                detailWidth: detailWidth, fontPointSize: size)
                         }
                     }
 

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -701,6 +701,17 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
         return SessionTerminalSize(columns: view.terminal.cols, rows: view.terminal.rows)
     }
 
+    // Новый detail ещё не существует: ширину берём из основной области,
+    // высоту до подключения оставляем стандартной для detached tmux.
+    @MainActor
+    static func initialStartSize(detailWidth: CGFloat, fontPointSize: CGFloat) -> SessionTerminalSize? {
+        let width = detailWidth - 2 * SessionDetailLayout.contentInset
+        guard let measured = initialSize(
+            surfaceSize: CGSize(width: width, height: 100),
+            fontPointSize: AppFontSize.clamped(fontPointSize)) else { return nil }
+        return SessionTerminalSize(columns: measured.columns, rows: 24)
+    }
+
     static func terminate(process: LocalProcess, timeout: TimeInterval = 1) {
         let pid = process.shellPid
         process.terminate()
@@ -1045,4 +1056,8 @@ struct SessionAttachTerminalView: NSViewRepresentable {
             }
         }
     }
+}
+
+enum SessionDetailLayout {
+    static let contentInset: CGFloat = 16
 }

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -202,6 +202,7 @@ struct SessionDetailView: View {
                     .appFont(.title2, weight: .bold)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .layoutPriority(1)
                     .help(session.displayTitle)
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -123,7 +123,7 @@ struct SessionDetailView: View {
             logView.layoutPriority(1)
             actionBar
         }
-        .padding(16)
+        .padding(SessionDetailLayout.contentInset)
         .onChange(of: session.id) { _, _ in
             interactionGeneration = UUID()
             logPoller = nil

--- a/app/Sources/DetachApp/SidebarView.swift
+++ b/app/Sources/DetachApp/SidebarView.swift
@@ -52,6 +52,7 @@ struct SidebarView: View {
     @Binding var selectedID: String?
     @ObservedObject var navigation: MainNavigation
     let shortcutAssignments: [SessionShortcutAssignment]
+    var initialTerminalSize: SessionTerminalSize? = nil
     @AppStorage(AppSettings.defaultProjectsDirectoryKey, store: AppSettings.defaults)
     private var defaultProjectsDirectoryPath =
         AppSettings.defaultProjectsDirectoryPath
@@ -160,6 +161,7 @@ struct SidebarView: View {
                 store: store,
                 selectedID: $selectedID,
                 initialProjectDir: uiE2EInitialProjectDirectory,
+                terminalSize: initialTerminalSize,
                 projectPickerRoot: DirectoryPreference.configuredOrFallback(
                     path: defaultProjectsDirectoryPath,
                     fallback: FileManager.default.homeDirectoryForCurrentUser)
@@ -194,8 +196,10 @@ struct SidebarView: View {
         }
         .onChange(of: navigation.quickChatRequestID, initial: true) { _, requestID in
             guard requestID != nil else { return }
-            navigation.quickChatRequestID = nil
-            startQuickChat()
+            startRequestedQuickChat()
+        }
+        .onChange(of: initialTerminalSize) { _, _ in
+            startRequestedQuickChat()
         }
         .onChange(of: deletableFinishedSessions.map(\.id)) { _, currentIDs in
             let state = FinishedSelectionReconciliation.resolve(
@@ -462,6 +466,13 @@ struct SidebarView: View {
         }
     }
 
+    private func startRequestedQuickChat() {
+        // После открытия окна запрос может прийти раньше измерения detail.
+        guard navigation.quickChatRequestID != nil, initialTerminalSize != nil else { return }
+        navigation.quickChatRequestID = nil
+        startQuickChat()
+    }
+
     private func startQuickChat() {
         guard !isStartingQuickChat else { return }
         isStartingQuickChat = true
@@ -471,6 +482,7 @@ struct SidebarView: View {
                 store: store,
                 providerRawValue: quickChatProvider,
                 directoryPath: quickChatDirectoryPath,
+                terminalSize: initialTerminalSize,
                 onSessionAvailable: { sessionID in
                     selectedID = sessionID
                 })

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -325,6 +325,81 @@ enum UIE2ETestDriver {
                 throw Failure(message: "Quick Chat reused stale width after resize")
             }
             checks.append("quick-chat-uses-visible-width")
+
+            // Проверить первые кадры существующих lifecycle-действий отдельно
+            // от общей UI-проверки и её несвязанных контролов.
+            let recoveredID = "detach-codex-ui-recoverable"
+            let resumedID = "detach-claude-ui-completed"
+            try Data().write(to: configuration.root.appendingPathComponent("fake/reconnect-ready"))
+            func select(_ id: String) async throws {
+                _ = try await clickUntilElement(
+                    try await element(identifier: "session-row-\(id)"),
+                    name: "terminal lifecycle row", resultIdentifier: "session-detail-\(id)")
+            }
+            func waitForFrame(_ id: String) async throws {
+                try await waitUntil("first visible frame for \(id)") {
+                    guard let terminal = find(identifier: "session-preview-terminal")
+                        as? LocalProcessTerminalView else { return false }
+                    return String(decoding: terminal.terminal.getBufferAsData(), as: UTF8.self)
+                        .contains(id)
+                }
+            }
+            try await select(recoveredID)
+            try await clickMeasuredControl(identifier: "session-action-recover-in-app", name: "Recover")
+            try await waitForFrame(recoveredID)
+            _ = try assertWidth("recover-terminal-size")
+            checks.append("terminal-recover-first-frame-uses-visible-width")
+
+            try await select(resumedID)
+            try await clickMeasuredControl(identifier: "session-action-resume-in-app", name: "Resume")
+            try await waitForFrame(resumedID)
+            _ = try assertWidth("resume-terminal-size")
+            guard !FileManager.default.fileExists(atPath: configuration.root
+                .appendingPathComponent("fake/resume-completed").path) else {
+                throw Failure(message: "Resume did not attach before readiness completed")
+            }
+            try Data().write(to: configuration.root.appendingPathComponent("fake/release-resume"))
+            checks.append("terminal-resume-first-frame-uses-visible-width")
+
+            guard let original = find(identifier: "session-preview-terminal")
+                as? LocalProcessTerminalView else { throw Failure(message: "live terminal missing") }
+            let pid = original.process.shellPid
+            let invocations = configuration.root.appendingPathComponent("fake/invocations.log")
+            func attachCount() throws -> Int {
+                try String(contentsOf: invocations, encoding: .utf8).split(separator: "\n")
+                    .filter { $0.contains(" attach --terminal-features sync ") }.count
+            }
+            let countBefore = try attachCount()
+            let holdSwitch = configuration.root.appendingPathComponent("fake/hold-client-switch")
+            let requested = configuration.root.appendingPathComponent("fake/client-switch-requested")
+            if FileManager.default.fileExists(atPath: requested.path) {
+                try FileManager.default.removeItem(at: requested)
+            }
+            try Data().write(to: holdSwitch)
+            try await select(recoveredID)
+            try await waitUntil("delayed client switch is in flight") {
+                FileManager.default.fileExists(atPath: requested.path)
+            }
+            // Вернуться до завершения первого switch; поздний ответ не должен
+            // отменить последнее выбранное назначение или создать второй PTY.
+            try await select(resumedID)
+            try FileManager.default.removeItem(at: holdSwitch)
+            try await waitUntil("latest selection wins after both switches") {
+                let lines = (try? String(contentsOf: invocations, encoding: .utf8)) ?? ""
+                let expected = "client switch --pid \(pid) --from \(recoveredID) --to \(resumedID) --provider claude"
+                let current = try? String(contentsOf: configuration.root
+                    .appendingPathComponent("fake/attach-client-current"), encoding: .utf8)
+                return lines.contains(expected)
+                    && current?.trimmingCharacters(in: .whitespacesAndNewlines) == resumedID
+                    && find(identifier: "session-detail-\(resumedID)") != nil
+            }
+            try await waitForFrame(resumedID)
+            guard let final = find(identifier: "session-preview-terminal") as? LocalProcessTerminalView,
+                  final === original, final.process.shellPid == pid,
+                  try attachCount() == countBefore else {
+                throw Failure(message: "superseded selection replaced the existing PTY")
+            }
+            checks.append("terminal-late-switch-keeps-latest-selection-and-pty")
             try await restoreFocus(to: previousFrontmost, policy: previousPolicy)
             return Report(schema: 1, passed: true, checks: checks, error: nil,
                           accessibilityTree: snapshots())
@@ -501,6 +576,19 @@ enum UIE2ETestDriver {
             let pasteboardSnapshot = captureGeneralPasteboard()
             defer { restoreGeneralPasteboard(pasteboardSnapshot) }
             let pasteboardGeneration = NSPasteboard.general.changeCount
+            guard let uuidView = elements().compactMap({ $0 as? UIE2EGeometryView })
+                .first(where: { $0.identifierValue == "session-uuid-chip" }) else {
+                throw Failure(message: "UUID chip has no measured view")
+            }
+            // Показать кнопку в горизонтальной ленте перед настоящим кликом.
+            uuidView.scrollToVisible(uuidView.bounds)
+            if let scroll = uuidView.enclosingScrollView {
+                scroll.reflectScrolledClipView(scroll.contentView)
+            }
+            try await waitUntil("UUID chip is visible for copying") {
+                uuidView.publishFrame()
+                return uuidView.visibleRect.contains(uuidView.bounds)
+            }
             try await clickMeasuredControl(
                 identifier: "session-uuid-chip",
                 name: "session UUID chip text",
@@ -816,7 +904,7 @@ enum UIE2ETestDriver {
             bulkDeleteButton = try await element(identifier: "finished-delete-button")
             try requireSemanticControl(bulkDeleteButton, name: "bulk delete action")
             let confirmDelete = try await clickUntilSheetButton(
-                bulkDeleteButton, name: "bulk delete action", label: "Delete")
+                bulkDeleteButton, name: "bulk delete action", label: L10n.string("Delete"))
             try requireSemanticControl(confirmDelete, name: "delete confirmation")
             try await clickUntil(
                 confirmDelete,

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -231,6 +231,8 @@ enum UIE2ETestDriver {
             cursorRestorePoint = nil
         }
         switch configuration.scenario {
+        case "terminal-width":
+            return await runTerminalWidthScenario(configuration: configuration, store: store)
         case "onboarding-first-run":
             return await runOnboardingFirstRun(
                 configuration: configuration,
@@ -251,6 +253,85 @@ enum UIE2ETestDriver {
                 store: store,
                 sessionLogSnapshots: sessionLogSnapshots,
                 shortcuts: shortcuts)
+        }
+    }
+
+    private static func runTerminalWidthScenario(
+        configuration: UIE2EConfiguration,
+        store: SessionStore
+    ) async -> Report {
+        var checks: [String] = []
+        let previousFrontmost = NSWorkspace.shared.frontmostApplication
+        let previousPolicy = NSApp.activationPolicy()
+        do {
+            guard let window = NSApp.windows.first(where: { $0.identifier?.rawValue == "main" }),
+                  NSApp.setActivationPolicy(.regular) else {
+                throw Failure(message: "terminal width test window is unavailable")
+            }
+            window.setContentSize(CGSize(width: 1100, height: 700))
+            try await activate(window)
+            guard store.sessions.isEmpty, store.state == .ok else {
+                throw Failure(message: "width scenario must start with an empty fresh session list")
+            }
+            try Data().write(to: configuration.root.appendingPathComponent(
+                "fake/enable-new-session-project"))
+            try await keyPress("n", keyCode: 45, modifiers: [.command])
+            try await waitUntil("Start from empty dashboard") {
+                find(identifier: "new-session-launch").map(isEnabled) == true
+            }
+            try await clickMeasuredControl(identifier: "new-session-launch", name: "start wide session")
+            try await waitUntil("new terminal attached") {
+                FileManager.default.fileExists(atPath: configuration.root
+                    .appendingPathComponent("fake/new-session-attach-ready").path)
+                    && find(identifier: "session-preview-terminal") is LocalProcessTerminalView
+            }
+            func assertWidth(_ filename: String) throws -> Int {
+                let hint = try String(contentsOf: configuration.root.appendingPathComponent(
+                    "fake/" + filename), encoding: .utf8)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let terminal = find(identifier: "session-preview-terminal") as? LocalProcessTerminalView,
+                      let columns = hint.split(separator: "x").first.flatMap({ Int($0) }),
+                      columns == terminal.terminal.cols, columns > 80 else {
+                    throw Failure(message: "startup width differs from visible grid: \(hint)")
+                }
+                var actual = winsize()
+                guard ioctl(terminal.process.childfd, TIOCGWINSZ, &actual) == 0,
+                      Int(actual.ws_col) == columns else {
+                    throw Failure(message: "PTY width differs from visible terminal columns")
+                }
+                trace("startup width \(hint) matches visible grid")
+                return columns
+            }
+            let initialColumns = try assertWidth("new-session-terminal-size")
+            checks.append("terminal-start-uses-visible-width")
+            window.setContentSize(CGSize(width: 1400, height: 800))
+            try await waitUntil("terminal grows after resize") {
+                guard let terminal = find(identifier: "session-preview-terminal") as? LocalProcessTerminalView
+                else { return false }
+                var actual = winsize()
+                return terminal.terminal.cols > initialColumns
+                    && ioctl(terminal.process.childfd, TIOCGWINSZ, &actual) == 0
+                    && Int(actual.ws_col) == terminal.terminal.cols
+            }
+            checks.append("terminal-resize-updates-grid")
+            AppSettings.defaults.set("codex", forKey: AppSettings.quickChatProviderKey)
+            try await keyPress("t", keyCode: 17, modifiers: [.command])
+            try await waitUntil("quick chat attached") {
+                FileManager.default.fileExists(atPath: configuration.root
+                    .appendingPathComponent("fake/quick-session-ready").path)
+            }
+            let quickColumns = try assertWidth("quick-chat-terminal-size")
+            guard quickColumns > initialColumns else {
+                throw Failure(message: "Quick Chat reused stale width after resize")
+            }
+            checks.append("quick-chat-uses-visible-width")
+            try await restoreFocus(to: previousFrontmost, policy: previousPolicy)
+            return Report(schema: 1, passed: true, checks: checks, error: nil,
+                          accessibilityTree: snapshots())
+        } catch {
+            try? await restoreFocus(to: previousFrontmost, policy: previousPolicy)
+            return Report(schema: 1, passed: false, checks: checks,
+                          error: error.localizedDescription, accessibilityTree: snapshots())
         }
     }
 

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -595,7 +595,8 @@ public final class SessionStore {
         provider: Provider,
         projectDirectory: URL,
         name: String?,
-        prompt: String?
+        prompt: String?,
+        terminalSize: SessionTerminalSize? = nil
     ) async -> SessionStartResult {
         let existingIDs = Set(sessions.map(\.id))
         var arguments = [provider.rawValue]
@@ -608,10 +609,21 @@ public final class SessionStore {
         }
 
         do {
-            let result = try await cli.run(
-                arguments: arguments,
+            var result = try await cli.run(
+                arguments: terminalSize.map {
+                    $0.arguments + [provider.rawValue, "start"] + arguments.dropFirst()
+                } ?? arguments,
                 timeout: 120,
                 currentDirectoryURL: projectDirectory)
+            // Повтор допустим только после отказа старого CLI до запуска.
+            if terminalSize != nil, result.exitCode == 1, !result.timedOut,
+               result.stdout.isEmpty,
+               result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "detach: unknown command: --terminal-size" {
+                result = try await cli.run(
+                    arguments: arguments, timeout: 120,
+                    currentDirectoryURL: projectDirectory)
+            }
             guard !result.timedOut else {
                 await refresh()
                 return SessionStartResult(

--- a/app/Tests/DetachAppTests/QuickChatTests.swift
+++ b/app/Tests/DetachAppTests/QuickChatTests.swift
@@ -70,6 +70,22 @@ final class QuickChatTests: XCTestCase {
         XCTAssertTrue(project.lastPathComponent.hasPrefix("detach-chat-"))
     }
 
+    func testQuickChatPassesWidthWithAndWithoutEarlySelection() async {
+        for earlySelection in [false, true] {
+            let cli = QuickChatRecordingCLI()
+            var selection: (@MainActor (String) -> Void)?
+            if earlySelection { selection = { (_: String) in } }
+            _ = await QuickChatLaunch.start(
+                store: SessionStore(cli: cli), providerRawValue: "codex", directoryPath: "/tmp",
+                terminalSize: SessionTerminalSize(columns: 137, rows: 24),
+                onSessionAvailable: selection,
+                createProjectDirectory: { directory, _ in directory },
+                waitForSession: { _, _, _, _ in nil })
+            XCTAssertEqual(cli.calls.first?.arguments,
+                           ["--terminal-size", "137x24", "codex", "start", "--detach"])
+        }
+    }
+
     func testQuickChatUsesConfiguredProviderAndWorkingDirectory() async {
         let directory = try! XCTUnwrap(
             DirectoryPreference.existingDirectoryURL(path: "/tmp"))

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -333,6 +333,26 @@ final class SessionAttachTerminalTests: XCTestCase {
     }
 
     @MainActor
+    func testStartWidthMatchesTerminalAcrossWindowSizesAndFonts() throws {
+        for detailWidth: CGFloat in [720, 1100, 1500] {
+            for fontSize: CGFloat in [1, 11, 13, 14.6, 18, 100] {
+                let terminal = LocalProcessTerminalView(frame: NSRect(
+                    x: 0, y: 0,
+                    width: detailWidth - 2 * SessionDetailLayout.contentInset,
+                    height: 400))
+                terminal.font = SessionAttachController.terminalFont(
+                    pointSize: AppFontSize.clamped(fontSize))
+                let hint = try XCTUnwrap(SessionAttachController.initialStartSize(
+                    detailWidth: detailWidth, fontPointSize: fontSize))
+                XCTAssertEqual(hint.columns, terminal.terminal.cols)
+                XCTAssertEqual(hint.rows, 24)
+                if detailWidth >= 1500 { XCTAssertGreaterThan(hint.columns, 80) }
+            }
+        }
+        XCTAssertNil(SessionAttachController.initialStartSize(detailWidth: 0, fontPointSize: 13))
+    }
+
+    @MainActor
     func testCoordinatorOwnsThePublicAttachInvocation() throws {
         let session = try XCTUnwrap(Self.session())
         let view = SessionAttachTerminalView(

--- a/app/Tests/DetachAppTests/UIE2EConfigurationTests.swift
+++ b/app/Tests/DetachAppTests/UIE2EConfigurationTests.swift
@@ -38,7 +38,7 @@ final class UIE2EConfigurationTests: XCTestCase {
     func testAcceptsOnlyKnownScenarios() throws {
         try withFixture { fixture in
             for scenario in [
-                "main", "failure", "settings", "onboarding-first-run",
+                "main", "failure", "settings", "terminal-width", "onboarding-first-run",
                 "onboarding-provider", "onboarding-approval",
             ] {
                 var environment = fixture.environment

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -424,6 +424,42 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertTrue(cli.calls.contains(["codex", "delete", "--force", "detach-codex-p-1"]))
     }
 
+    func testStartDetachedPassesWidthBeforeProviderLaunch() async {
+        for provider in [Provider.codex, .claude] {
+            let cli = FakeCLI()
+            let store = SessionStore(cli: cli)
+            _ = await store.startDetached(
+                provider: provider,
+                projectDirectory: URL(fileURLWithPath: "/tmp/p"),
+                name: "wide", prompt: "first output",
+                terminalSize: SessionTerminalSize(columns: 137, rows: 47))
+            XCTAssertEqual(cli.calls.first, [
+                "--terminal-size", "137x47", provider.rawValue, "start",
+                "--name", "wide", "--detach", "--", "first output",
+            ])
+        }
+    }
+
+    func testStartSizeRetriesOnlyBeforeAnOlderFrontendDispatches() async {
+        for (stderr, stdout, timedOut, retries) in [
+            ("detach: unknown command: --terminal-size\n", "", false, true),
+            ("provider startup failed", "", false, false),
+            ("detach: unknown command: --terminal-size", "Started", false, false),
+            ("detach: unknown command: --terminal-size", "", true, false),
+        ] {
+            let cli = FakeCLI()
+            cli.responses["--terminal-size 137x47 codex start --detach"] = .success(CLIResult(
+                exitCode: 1, stdout: stdout, stderr: stderr, timedOut: timedOut))
+            let result = await SessionStore(cli: cli).startDetached(
+                provider: .codex, projectDirectory: URL(fileURLWithPath: "/tmp/p"),
+                name: nil, prompt: nil,
+                terminalSize: SessionTerminalSize(columns: 137, rows: 47))
+            XCTAssertEqual(cli.calls.filter { $0 == ["codex", "--detach"] }.count,
+                           retries ? 1 : 0)
+            XCTAssertEqual(result.message == nil, retries)
+        }
+    }
+
     func testStartDetachedUsesProjectAndSelectsTheNewTypedSession() async {
         let cli = FakeCLI()
         cli.responses["list --json"] = ok(line)

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -69,6 +69,11 @@ A Quick chat requested while the window opens waits for that measurement.
 A new run uses 24 rows until attachment supplies the actual height. No lifecycle
 lock waits for a UI client. Normal terminal resize and tmux client selection
 continue to control the attached size.
+With concurrent embedded and external clients, `window-size latest` selects
+the last active client's size. Input in either client selects its width.
+Closing the external client restores the embedded size. Closing both clients
+preserves the managed provider. The public attach regression uses two real
+PTYs and checks resize, client removal, and provider survival.
 Resume and Recover pass the visible terminal size before the provider starts.
 The app measures this size with the terminal font and SwiftTerm layout. This
 prevents initial output from wrapping at the default detached window width.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -61,6 +61,14 @@ before the command completes. The lifecycle ID must change, or a legacy row
 must have a later creation time. An old or unidentified run waits for command
 completion. An exited early client does not reconnect during preparation.
 The preparation command still reports readiness failures.
+New session and Quick chat pass the initial width through the same public
+`--terminal-size` prefix. The main detail area owns the width measurement,
+including its shared content inset and terminal font. The sheet does not own
+this measurement. An empty session list still measures the main detail area.
+A Quick chat requested while the window opens waits for that measurement.
+A new run uses 24 rows until attachment supplies the actual height. No lifecycle
+lock waits for a UI client. Normal terminal resize and tmux client selection
+continue to control the attached size.
 Resume and Recover pass the visible terminal size before the provider starts.
 The app measures this size with the terminal font and SwiftTerm layout. This
 prevents initial output from wrapping at the default detached window width.

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -18,10 +18,17 @@ esac
 
 printf '%s\n' "$*" >>"$INVOCATIONS"
 
+initial_terminal_size=""
 if [ "${1:-}" = --terminal-size ]; then
   [[ "${2:-}" =~ ^[1-9][0-9]{0,2}x[1-9][0-9]{0,2}$ ]] || exit 90
   printf '%s\n' "$2" >"$ROOT/fake/initial-terminal-size"
+  initial_terminal_size="$2"
   shift 2
+  case "${1:-}:${2:-}" in
+    codex:start|claude:start) set -- "$1" "${@:3}" ;;
+    codex:recover|claude:resume) ;;
+    *) printf 'unsupported sized startup fixture\n' >&2; exit 90 ;;
+  esac
 fi
 
 if [ "$#" -eq 2 ] && [ "$1" = watch ] && [ "$2" = --json ]; then
@@ -295,7 +302,9 @@ if [ "$#" -eq 2 ] && [ "$1" = claude ] && [ "$2" = --detach ]; then
     printf 'new session started outside its selected project\n' >&2
     exit 65
   }
+  printf '%s\n' "$initial_terminal_size" >"$ROOT/fake/new-session-terminal-size"
   : >"$ROOT/fake/new-session-started"
+  [ "$(<"$STATE")" != empty ] || printf 'sessions\n' >"$STATE"
   printf '%s\n' "$*" >>"$ACTIONS"
   exit 0
 fi
@@ -311,6 +320,7 @@ if [ "$#" -eq 2 ] && [ "$1" = codex ] && [ "$2" = --detach ]; then
     exit 65
   }
   printf '%s\n' "$quick_cwd" >"$ROOT/fake/quick-chat-cwd"
+  printf '%s\n' "$initial_terminal_size" >"$ROOT/fake/quick-chat-terminal-size"
   : >"$ROOT/fake/quick-chat-started"
   printf '%s\n' "$*" >>"$ACTIONS"
   exit 0

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -147,6 +147,12 @@ if [ "$#" -eq 10 ] && [ "$1" = client ] && [ "$2" = switch ] \
     ;;
   esac
   : >"$ROOT/fake/client-switch-requested"
+  attempts=0
+  while [ -f "$ROOT/fake/hold-client-switch" ] && [ "$attempts" -lt 200 ]; do
+    attempts=$((attempts + 1))
+    sleep 0.01
+  done
+  [ ! -f "$ROOT/fake/hold-client-switch" ] || exit 75
   # Keep the old complete terminal frame visible while the command is in
   # flight. A private FIFO models tmux socket delivery without cross-process
   # signals that the packaged app sandbox can reject.
@@ -258,6 +264,7 @@ fi
 
 if [ "$#" -eq 4 ] && [ "$1" = codex ] && [ "$2" = recover ] \
     && [ "$3" = --detach ] && [ "$4" = detach-codex-ui-recoverable ]; then
+  printf '%s\n' "$initial_terminal_size" >"$ROOT/fake/recover-terminal-size"
   : >"$ROOT/fake/recovered"
   printf '%s\n' "$*" >>"$ACTIONS"
   exit 0
@@ -276,6 +283,7 @@ fi
 if [ "$#" -eq 6 ] && [ "$1" = claude ] && [ "$2" = resume ] \
     && [ "$3" = --name ] && [ "$4" = detach-claude-ui-completed ] \
     && [ "$5" = --detach ] && [ "$6" = a9f58f1d-1234-5678-9abc-def012342ed9 ]; then
+  printf '%s\n' "$initial_terminal_size" >"$ROOT/fake/resume-terminal-size"
   : >"$ROOT/fake/resumed"
   printf '%s\n' "$*" >>"$ACTIONS"
   attempts=0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1497,6 +1497,10 @@ tmux -L "$SOCKET" has-session -t "=$SESSION"
 tmux -L "$OUTER_SOCKET" has-session -t "=$outer_session"
 tmux -L "$OUTER_SOCKET" kill-server >/dev/null 2>&1 || true
 
+# Два public attach на разных PTY проверяют window-size latest и закрытие UI.
+python3 "$ROOT/tests/terminal_client_geometry.py" \
+  "$TMUX_TEST_BIN" "$SOCKET_PATH" "$DETACH" "$SESSION"
+
 # SwiftTerm closes the in-app attach client with SIGTERM. Attach through the
 # public CLI on a real PTY, terminate that client, and prove the managed
 # session, worker, and provider survive. A second tmux server owns the test

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1911,11 +1911,12 @@ printf '{damaged rollout\n' >"$resume_rollout"
 export FAKE_CODEX_SLEEP=20
 export FAKE_CODEX_EXIT=0
 export FAKE_CODEX_FOREIGN_FIRST=0
-if ! run_codex recover --detach integration; then
+if ! "$DETACH" --terminal-size 151x39 codex recover --detach integration; then
   printf 'recover command returned a failure after starting the session\n' >&2
   exit 1
 fi
 wait_for_file_text "$FAKE_CODEX_ARGS_FILE" resume
+[ "$(awk '{print $1, $2}' "$FAKE_CODEX_ARGS_FILE.terminal-size")" = '39 151' ]
 require_file_line "$FAKE_CODEX_ARGS_FILE" resume
 require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
 # A new run under the same name starts without the previous Stop intent.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1104,7 +1104,9 @@ if codex_part_selected lifecycle; then
   codex_scenario_event begin SC-SESSION-STOP-CODEX
   codex_scenario_event begin SC-SESSION-DELETE-CODEX
   COLORTERM=ambient-is-not-a-capability \
-    LC_ALL=C run_codex --name integration --detach -- "$literal_prompt"
+    LC_ALL=C "$DETACH" --terminal-size 137x47 codex start --name integration --detach -- "$literal_prompt"
+# Провайдер записывает размер до первого вывода и до подключения клиента.
+[ "$(awk '{print $1, $2}' "$FAKE_CODEX_ARGS_FILE.terminal-size")" = '47 137' ]
 
 wait_for_tmux_option "$SESSION" @detach_status running
 wait_for_tmux_option "$SESSION" set-titles on

--- a/tests/terminal_client_geometry.py
+++ b/tests/terminal_client_geometry.py
@@ -73,12 +73,15 @@ def main():
         process, fd = client
         process.terminate()
         try:
+            # tmux пишет финальную очистку терминала при выходе. Как SwiftTerm,
+            # продолжаем читать PTY, иначе tty drain может задержать завершение.
+            wait_for('attach exits after TERM', lambda: process.poll() is not None)
+        finally:
+            os.close(fd)
+            if process.poll() is None:
+                process.kill()
             process.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=3)
-        os.close(fd)
-        clients.remove(client)
+            clients.remove(client)
 
     try:
         policy = tm('show-options', '-A', '-wv', '-t', session, 'window-size')

--- a/tests/terminal_client_geometry.py
+++ b/tests/terminal_client_geometry.py
@@ -81,7 +81,8 @@ def main():
         clients.remove(client)
 
     try:
-        assert tm('show-options', '-wv', '-t', session, 'window-size') == 'latest'
+        policy = tm('show-options', '-A', '-wv', '-t', session, 'window-size')
+        assert policy == 'latest', repr(policy)
         provider = tm('display-message', '-p', '-t', session, '#{pane_pid}')
         embedded = attach(132, 42, True)
         wait_for('embedded width', lambda: width_is(132))

--- a/tests/terminal_client_geometry.py
+++ b/tests/terminal_client_geometry.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Размер управляемого окна при двух клиентах public attach на реальных PTY."""
+import fcntl
+import os
+import pty
+import select
+import signal
+import struct
+import subprocess
+import sys
+import termios
+import time
+
+
+def main():
+    tmux, socket, cli, session = sys.argv[1:]
+    clients = []
+
+    def tm(*args):
+        return subprocess.check_output([tmux, '-S', socket, *args], timeout=3).decode().strip()
+
+    def drain():
+        descriptors = [fd for process, fd in clients if process.poll() is None]
+        for fd in select.select(descriptors, [], [], 0.01)[0]:
+            try:
+                os.read(fd, 65536)
+            except OSError:
+                pass
+
+    def wait_for(description, predicate):
+        deadline = time.monotonic() + 4
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            drain()
+        raise AssertionError(description + ': ' + tm('list-clients', '-F',
+            '#{client_pid}|#{client_session}|#{client_width}x#{client_height}')
+            + '; pane=' + tm('display-message', '-p', '-t', session, '#{pane_width}x#{pane_height}'))
+
+    def resize(client, columns, rows):
+        process, fd = client
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack('HHHH', rows, columns, 0, 0))
+        os.kill(process.pid, signal.SIGWINCH)
+
+    def attach(columns, rows, embedded):
+        master, slave = pty.openpty()
+        fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack('HHHH', rows, columns, 0, 0))
+        args = [cli, 'codex', 'attach']
+        if embedded:
+            args += ['--terminal-features', 'sync']
+        args += [session]
+        environment = dict(os.environ, TERM='xterm-256color', LC_ALL='en_US.UTF-8')
+        environment.pop('TMUX', None)
+        process = subprocess.Popen(args, stdin=slave, stdout=slave, stderr=slave,
+                                   env=environment, start_new_session=True)
+        os.close(slave)
+        client = (process, master)
+        clients.append(client)
+        wait_for('public attach registered', lambda: str(process.pid) in tm(
+            'list-clients', '-F', '#{client_pid}').splitlines())
+        return client
+
+    def width_is(columns):
+        return tm('display-message', '-p', '-t', session, '#{pane_width}') == str(columns)
+
+    def activate(client, columns):
+        # latest — последний активный клиент, а не минимальный размер обоих.
+        os.write(client[1], b'x')
+        wait_for('active client sets width ' + str(columns), lambda: width_is(columns))
+        print('Активный клиент задаёт ширину', columns, flush=True)
+
+    def close(client):
+        process, fd = client
+        process.terminate()
+        try:
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=3)
+        os.close(fd)
+        clients.remove(client)
+
+    try:
+        assert tm('show-options', '-wv', '-t', session, 'window-size') == 'latest'
+        provider = tm('display-message', '-p', '-t', session, '#{pane_pid}')
+        embedded = attach(132, 42, True)
+        wait_for('embedded width', lambda: width_is(132))
+        external = attach(78, 28, False)
+        activate(external, 78)
+        activate(embedded, 132)
+        resize(embedded, 154, 46)
+        activate(embedded, 154)
+        activate(external, 78)
+        close(external)
+        wait_for('external close restores embedded width', lambda: width_is(154))
+        close(embedded)
+        assert tm('display-message', '-p', '-t', session, '#{pane_pid}') == provider
+        assert tm('display-message', '-p', '-t', session, '#{pane_dead}') == '0'
+        assert not tm('list-clients', '-t', session, '-F', '#{client_pid}')
+        print('Два клиента, resize и закрытие обоих: PASS; provider pane сохранился', flush=True)
+    finally:
+        for client in clients[:]:
+            close(client)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -66,6 +66,8 @@ for invocation in \
   '--terminal-size 137x47 claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9' \
   'claude attach --terminal-features sync detach-claude-ui-completed' \
   'claude --detach' \
+  '--terminal-size 137x24 claude start --detach' \
+  '--terminal-size 137x24 codex start --detach' \
   'claude attach --terminal-features sync detach-claude-ui-new' \
   'codex stop detach-codex-ui-running' \
   'storage --json' \
@@ -78,6 +80,9 @@ for invocation in \
   '--terminal-size 0x47 codex recover --detach detach-codex-ui-recoverable' \
   '--terminal-size 1000x47 codex recover --detach detach-codex-ui-recoverable' \
   '--terminal-size 137x47 codex stop detach-codex-ui-running' \
+  '--terminal-size 0x24 codex start --detach' \
+  '--terminal-size 137x24 codex --detach' \
+  '--terminal-size 137x24 claude start --detach -- unexpected' \
   'config tmux-style detach' \
   'config tmux-extended-keys on' \
   'storage cleanup --dry-run --json' \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -18,6 +18,8 @@ approved_invocation() {
   if [[ "$invocation" =~ ^--terminal-size\ [1-9][0-9]{0,2}x[1-9][0-9]{0,2}\ (.*)$ ]]; then
     invocation="${BASH_REMATCH[1]}"
     case "$invocation" in
+      'claude start --detach') invocation='claude --detach' ;;
+      'codex start --detach') invocation='codex --detach' ;;
       'codex recover --detach detach-codex-ui-recoverable'|\
       'claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9') ;;
       *) return 1 ;;
@@ -476,6 +478,13 @@ run_app_scenario() {
     exit 1
   fi
 
+  while IFS= read -r invocation; do
+    approved_invocation "$invocation" || {
+      printf 'UI e2e %s: unapproved fixture invocation: %s\n' "$scenario" "$invocation" >&2
+      exit 1
+    }
+  done <"$FAKE_DIR/invocations.log"
+
   for check in "$@"; do
     actual="$(plutil -extract "checks.$check_index" raw -o - "$RESULT")"
     [ "$actual" = "$check" ] || {
@@ -484,6 +493,8 @@ run_app_scenario() {
       exit 1
     }
     case "$check" in
+      terminal-start-uses-visible-width|terminal-resize-updates-grid|\
+      quick-chat-uses-visible-width|\
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
       finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
       live-session-hosts-attach-client|\
@@ -538,6 +549,11 @@ run_app_scenario() {
   printf 'UI e2e: %s passed in %ss (attempt %s)\n' "$scenario" \
     "$((SECONDS - scenario_started))" "$attempt"
 }
+
+run_app_scenario terminal-width empty 10 \
+  terminal-start-uses-visible-width \
+  terminal-resize-updates-grid \
+  quick-chat-uses-visible-width
 
 run_app_scenario main sessions 32 \
   background-app-starts-without-focus \
@@ -602,9 +618,9 @@ running_attach_count="$(grep -Fxc \
   "$TEST_ROOT/invocations-main.log" || true)"
 switch_count="$(grep -Fc 'client switch --pid ' \
   "$TEST_ROOT/invocations-main.log" || true)"
-claude_start_count="$(grep -Fxc 'claude --detach' \
+claude_start_count="$(grep -Ec '^(claude --detach|--terminal-size [1-9][0-9]{0,2}x[1-9][0-9]{0,2} claude start --detach)$' \
   "$TEST_ROOT/invocations-main.log" || true)"
-codex_start_count="$(grep -Fxc 'codex --detach' \
+codex_start_count="$(grep -Ec '^(codex --detach|--terminal-size [1-9][0-9]{0,2}x[1-9][0-9]{0,2} codex start --detach)$' \
   "$TEST_ROOT/invocations-main.log" || true)"
 quick_attach_count="$(grep -Fxc \
   'codex attach --terminal-features sync detach-codex-ui-quick' \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -494,6 +494,8 @@ run_app_scenario() {
     }
     case "$check" in
       terminal-start-uses-visible-width|terminal-resize-updates-grid|\
+      terminal-recover-first-frame-uses-visible-width|terminal-resume-first-frame-uses-visible-width|\
+      terminal-late-switch-keeps-latest-selection-and-pty|\
       quick-chat-uses-visible-width|\
       background-app-starts-without-focus|disconnected-stop-blocks-action|\
       finished-selection-clears-scrollbar|session-uuid-copies-from-text-side|\
@@ -550,10 +552,13 @@ run_app_scenario() {
     "$((SECONDS - scenario_started))" "$attempt"
 }
 
-run_app_scenario terminal-width empty 10 \
+run_app_scenario terminal-width empty 20 \
   terminal-start-uses-visible-width \
   terminal-resize-updates-grid \
-  quick-chat-uses-visible-width
+  quick-chat-uses-visible-width \
+  terminal-recover-first-frame-uses-visible-width \
+  terminal-resume-first-frame-uses-visible-width \
+  terminal-late-switch-keeps-latest-selection-and-pty
 
 run_app_scenario main sessions 32 \
   background-app-starts-without-focus \


### PR DESCRIPTION
NO-TICKET: Встроенный терминал использует всю ширину окна при запуске и после изменения размера

- запускать PTY после стабилизации ненулевой сетки SwiftTerm, чтобы первый вывод получил видимую ширину
- ждать два стабильных замера геометрии tmux-клиента приложения перед запуском провайдера
- переводить окно tmux в `window-size latest` при подключении и переключении живых сессий
- выбирать starting-сессию до готовности провайдера и один раз обновлять состояние через 250 мс
- сохранять один PTY при переключении между живыми сессиями
- не применять запоздалый ответ от предыдущего переключения
- покрыть начальную ширину, изменение размера и переключение клиента модульными, интеграционными и UI-сценариями

Проверено: `swift test --package-path app --filter 'QuickChatTests|SessionAttachTerminalTests|UIE2EConfigurationTests|DetachCLITests|SessionAttachTests|SessionStoreTests'` — 174/174; `DETACH_CODEX_TEST_PART=lifecycle tests/run.sh` — PASS; `scripts/quality-gate --stage static` — PASS; `git diff --check origin/main` — PASS; ручная проверка сборки 906 — PASS.
