### PR TITLE
NO-TICKET: Claude Code и Codex могут работать вместе в одном проекте

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ Settings → General selects the provider and parent folder for Quick chat. The
 default is `/tmp`. Each `Cmd-T` creates a private
 `detach-chat-<uuid>` project inside that folder, so another Quick chat can
 start while earlier chats are still running. The same settings page selects
-the default folder for the standard project chooser. Quick chat uses the
-normal managed session lifecycle. Detach does not automatically delete its
-project files, state, or provider transcripts.
+the default folder for the standard project chooser. It also has an opt-in
+agent collaboration setting described below. Quick chat uses the normal
+managed session lifecycle. Detach does not automatically delete its project
+files, state, or provider transcripts.
 
 Detach shows each assigned session shortcut beside its name. The number stays
 with the session while it is in Working or Answer ready. Detach reuses the
@@ -248,9 +249,12 @@ These actions solve different problems:
 managed run.**
 
 Recovery validates identity, paths, and provider data before it writes. It
-never rolls repository files back. A shared project lock also prevents two
-Detach-managed agents, including agents from different providers, from writing
-the same worktree at the same time.
+never rolls repository files back. By default, a shared project lock prevents
+two Detach-managed agents from writing the same worktree at the same time.
+Settings → General can opt into one live Codex and one live Claude Code session
+per project. Nested directories share their nearest Git root; outside Git, only
+the exact working directory is shared. Starts remain serialized, but later file
+edits do not: coordinate the agents and review overlapping changes carefully.
 
 ## Reliability that distinguishes slow from broken
 
@@ -510,6 +514,7 @@ detach reconcile --dry-run --json
 | `detach config tmux-style [detach\|inherit]` | Use the Detach identity bar or your tmux theme. |
 | `detach config tmux-mouse [on\|off]` | Toggle managed scrolling, selection, and copy-mode type-through. |
 | `detach config tmux-extended-keys [on\|off]` | Toggle Shift+Return multiline input in managed sessions. |
+| `detach config parallel-providers [on\|off]` | Opt into one Codex and one Claude Code session in the same project. |
 | `detach doctor [--json]` | Verify the app-installed runtime, provider CLIs, helper, and monitor. |
 | `detach repair` | Reinstall the pristine immutable CLI payload from Detach.app. |
 | `detach uninstall [--keep-state\|--purge-state]` | Remove Detach components and choose whether checkpoints stay. |

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "Try again" = "Try again";
 "Couldn't read the tmux setting: %@" = "Couldn't read the tmux setting: %@";
 "Couldn't save the tmux setting: %@" = "Couldn't save the tmux setting: %@";
+"Couldn't read the parallel agents setting: %@" = "Couldn't read the parallel agents setting: %@";
+"Couldn't save the parallel agents setting: %@" = "Couldn't save the parallel agents setting: %@";
 
 /* App and shared UI */
 "%@ build %@" = "%@ build %@";
@@ -61,10 +63,13 @@
 "<empty>" = "<empty>";
 "Add %@ to PATH" = "Add %@ to PATH";
 "Agent response is ready" = "Agent response is ready";
+"Agent collaboration" = "Agent collaboration";
 "Advanced" = "Advanced";
 "All detach sessions from both providers are on the left" = "All detach sessions from both providers are on the left";
 "All interactive actions will open in %@." = "All interactive actions will open in %@.";
 "Allow notifications" = "Allow notifications";
+"Allow Claude and Codex in the same project" = "Allow Claude and Codex in the same project";
+"Allows one Claude Code and one Codex session to run in the same project. Nested folders share their nearest Git root; outside Git, Detach matches the exact working folder. The agents can edit the same files at the same time, so coordinate their work carefully." = "Allows one Claude Code and one Codex session to run in the same project. Nested folders share their nearest Git root; outside Git, Detach matches the exact working folder. The agents can edit the same files at the same time, so coordinate their work carefully.";
 "App and CLI Version" = "App and CLI Version";
 "Application Location" = "Application Location";
 "Automatic updates are unavailable" = "Automatic updates are unavailable";
@@ -216,6 +221,7 @@
 "detach config timed out" = "detach config timed out";
 "detach is unavailable" = "detach is unavailable";
 "detach returned an unsupported tmux style: %@" = "detach returned an unsupported tmux style: %@";
+"detach returned an unsupported parallel-providers setting: %@" = "detach returned an unsupported parallel-providers setting: %@";
 "exit %d" = "exit %d";
 "lockf" = "lockf";
 "macOS did not finish registering the watchdog." = "macOS did not finish registering the watchdog.";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "Try again" = "Повторить";
 "Couldn't read the tmux setting: %@" = "Не удалось прочитать настройку tmux: %@";
 "Couldn't save the tmux setting: %@" = "Не удалось сохранить настройку tmux: %@";
+"Couldn't read the parallel agents setting: %@" = "Не удалось прочитать настройку параллельных агентов: %@";
+"Couldn't save the parallel agents setting: %@" = "Не удалось сохранить настройку параллельных агентов: %@";
 
 /* App and shared UI */
 "%@ build %@" = "%@ (сборка %@)";
@@ -61,10 +63,13 @@
 "<empty>" = "<пусто>";
 "Add %@ to PATH" = "Добавьте %@ в PATH";
 "Agent response is ready" = "Ответ агента готов";
+"Agent collaboration" = "Совместная работа агентов";
 "Advanced" = "Дополнительно";
 "All detach sessions from both providers are on the left" = "Слева — все detach-сессии обоих провайдеров";
 "All interactive actions will open in %@." = "Все интерактивные действия будут открываться в %@.";
 "Allow notifications" = "Разрешить уведомления";
+"Allow Claude and Codex in the same project" = "Разрешить Claude и Codex работать в одном проекте";
+"Allows one Claude Code and one Codex session to run in the same project. Nested folders share their nearest Git root; outside Git, Detach matches the exact working folder. The agents can edit the same files at the same time, so coordinate their work carefully." = "Разрешает одновременно запустить одну сессию Claude Code и одну сессию Codex в одном проекте. Вложенные каталоги относятся к ближайшему корню Git, а вне Git Detach сравнивает точный рабочий каталог. Агенты могут одновременно менять одни и те же файлы, поэтому координируйте их работу.";
 "App and CLI Version" = "Версия приложения и CLI";
 "Application Location" = "Расположение приложения";
 "Automatic updates are unavailable" = "Автообновления недоступны";
@@ -216,6 +221,7 @@
 "detach config timed out" = "Истекло время ожидания detach config";
 "detach is unavailable" = "detach недоступен";
 "detach returned an unsupported tmux style: %@" = "detach вернул неподдерживаемый стиль tmux: %@";
+"detach returned an unsupported parallel-providers setting: %@" = "detach вернул неподдерживаемую настройку parallel-providers: %@";
 "exit %d" = "код выхода %d";
 "lockf" = "lockf";
 "macOS did not finish registering the watchdog." = "macOS не завершила регистрацию фоновой службы.";

--- a/app/Sources/DetachApp/ParallelProvidersSettingsController.swift
+++ b/app/Sources/DetachApp/ParallelProvidersSettingsController.swift
@@ -1,0 +1,68 @@
+import DetachKit
+import Foundation
+
+/// Loads and persists the opt-in project collaboration setting for Settings → General.
+@MainActor
+final class ParallelProvidersSettingsController: ObservableObject {
+    @Published private(set) var setting: ParallelProviders?
+    @Published private(set) var isUpdating = false
+    @Published private(set) var errorMessage: String?
+
+    private let makeClient: (String) -> ParallelProvidersClient
+    private var activePath: String?
+
+    init(
+        makeClient: @escaping (String) -> ParallelProvidersClient = { path in
+            ParallelProvidersClient(
+                cli: ProcessDetachCLI(executable: URL(fileURLWithPath: path)))
+        }
+    ) {
+        self.makeClient = makeClient
+    }
+
+    var isEnabled: Bool { setting?.isEnabled ?? false }
+
+    func load(detachPath: String) async {
+        activePath = detachPath
+        isUpdating = true
+        errorMessage = nil
+        defer {
+            if activePath == detachPath {
+                isUpdating = false
+            }
+        }
+        do {
+            let value = try await makeClient(detachPath).loadSetting()
+            guard !Task.isCancelled, activePath == detachPath else { return }
+            setting = value
+        } catch {
+            guard !Task.isCancelled, activePath == detachPath else { return }
+            setting = nil
+            errorMessage = L10n.format(
+                "Couldn't read the parallel agents setting: %@",
+                error.localizedDescription)
+        }
+    }
+
+    func save(_ newValue: ParallelProviders, detachPath: String) async {
+        guard !isUpdating, let previous = setting, newValue != previous else { return }
+        activePath = detachPath
+        setting = newValue
+        isUpdating = true
+        errorMessage = nil
+        defer {
+            if activePath == detachPath {
+                isUpdating = false
+            }
+        }
+        do {
+            try await makeClient(detachPath).setSetting(newValue)
+        } catch {
+            guard !Task.isCancelled, activePath == detachPath else { return }
+            setting = previous
+            errorMessage = L10n.format(
+                "Couldn't save the parallel agents setting: %@",
+                error.localizedDescription)
+        }
+    }
+}

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -173,7 +173,7 @@ private extension SettingsDestination {
     /// the selected tab like classic AppKit preference panes.
     var baseHeight: CGFloat {
         switch self {
-        case .general: 620
+        case .general: 680
         case .terminal: 460
         case .notifications: 350
         case .system: 780
@@ -229,6 +229,7 @@ struct SettingsView: View {
     @State private var isUpdatingTmuxStyle = false
     @State private var tmuxStyleError: String?
     @StateObject private var extendedKeys = TmuxExtendedKeysSettingsController()
+    @StateObject private var parallelProviders = ParallelProvidersSettingsController()
     @State private var fontSizeDraft: AppFontSizeDraft?
     @State private var selectedStorageSessionIDs = Set<String>()
     @State private var pendingStorageCleanup: [StorageSession] = []
@@ -336,6 +337,7 @@ struct SettingsView: View {
                 executable: URL(fileURLWithPath: activeDetachPath)))
             await loadTmuxStyle()
             await extendedKeys.load(detachPath: activeDetachPath)
+            await parallelProviders.load(detachPath: activeDetachPath)
         }
         .task(id: navigation.selectedTab) {
 // quality-coverage:begin system-heartbeat
@@ -374,6 +376,9 @@ struct SettingsView: View {
                 await installation.refreshContext()
                 if !isUpdatingTmuxStyle {
                     await loadTmuxStyle()
+                }
+                if !parallelProviders.isUpdating {
+                    await parallelProviders.load(detachPath: activeDetachPath)
                 }
                 if navigation.selectedTab == .system {
                     await storageStore.refresh()
@@ -562,6 +567,48 @@ struct SettingsView: View {
                 Text(L10n.string(
                     "⌘N opens New session. ⌘T starts Quick chat immediately."))
                     .settingsMessage()
+            }
+            Section(L10n.string("Agent collaboration")) {
+                Toggle(
+                    L10n.string("Allow Claude and Codex in the same project"),
+                    isOn: Binding(
+                        get: { parallelProviders.isEnabled },
+                        set: { newValue in
+                            Task {
+                                await parallelProviders.save(
+                                    newValue ? .on : .off,
+                                    detachPath: activeDetachPath)
+                            }
+                        }))
+                    .disabled(
+                        parallelProviders.setting == nil
+                            || parallelProviders.isUpdating)
+                    .accessibilityIdentifier("settings-parallel-providers")
+
+                if parallelProviders.isUpdating && parallelProviders.setting == nil {
+                    HStack(spacing: 7) {
+                        ProgressView().controlSize(.small)
+                        Text(L10n.string("Reading the setting from detach…"))
+                    }
+                    .settingsMessage()
+                } else {
+                    Text(L10n.string(
+                        "Allows one Claude Code and one Codex session to run in the same project. Nested folders share their nearest Git root; outside Git, Detach matches the exact working folder. The agents can edit the same files at the same time, so coordinate their work carefully."))
+                        .settingsMessage()
+                }
+
+                if let parallelProvidersError = parallelProviders.errorMessage {
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(parallelProvidersError).settingsMessage(color: .red)
+                        Spacer(minLength: 8)
+                        Button(L10n.string("Try again")) {
+                            Task {
+                                await parallelProviders.load(detachPath: activeDetachPath)
+                            }
+                        }
+                        .disabled(parallelProviders.isUpdating)
+                    }
+                }
             }
             Section(L10n.string("Menu Bar")) {
                 Toggle(

--- a/app/Sources/DetachKit/ParallelProvidersClient.swift
+++ b/app/Sources/DetachKit/ParallelProvidersClient.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum ParallelProviders: String, Equatable, Sendable, CaseIterable {
+    /// Allow one Codex and one Claude Code session in the same canonical project.
+    case on
+    /// Keep the default single managed writer for each canonical project.
+    case off
+
+    public var isEnabled: Bool { self == .on }
+}
+
+public enum ParallelProvidersClientError: LocalizedError, Equatable {
+    case timedOut
+    case commandFailed(String)
+    case invalidResponse(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .timedOut:
+            L10n.string("detach config timed out")
+        case .commandFailed(let message):
+            message
+        case .invalidResponse(let value):
+            L10n.format(
+                "detach returned an unsupported parallel-providers setting: %@",
+                value.isEmpty ? L10n.string("<empty>") : value)
+        }
+    }
+}
+
+/// Typed access to the CLI-backed cross-provider project concurrency setting.
+public struct ParallelProvidersClient: Sendable {
+    private let cli: any DetachCLIRunning
+
+    public init(cli: any DetachCLIRunning) {
+        self.cli = cli
+    }
+
+    public func loadSetting() async throws -> ParallelProviders {
+        let result = try await cli.run(arguments: ["config", "parallel-providers"], timeout: 5)
+        try validate(result)
+        let value = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let setting = ParallelProviders(rawValue: value) else {
+            throw ParallelProvidersClientError.invalidResponse(value)
+        }
+        return setting
+    }
+
+    public func setSetting(_ setting: ParallelProviders) async throws {
+        let result = try await cli.run(
+            arguments: ["config", "parallel-providers", setting.rawValue],
+            timeout: 5)
+        try validate(result)
+    }
+
+    private func validate(_ result: CLIResult) throws {
+        if result.timedOut {
+            throw ParallelProvidersClientError.timedOut
+        }
+        guard result.exitCode == 0 else {
+            let stderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw ParallelProvidersClientError.commandFailed(
+                stderr.isEmpty
+                    ? L10n.format("detach config exited with status %d", result.exitCode)
+                    : stderr)
+        }
+    }
+}

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -692,9 +692,34 @@ public final class SessionStore {
     }
 
     private static func canonicalProjectPath(_ path: String) -> String {
-        URL(fileURLWithPath: path, isDirectory: true)
+        let resolved = URL(fileURLWithPath: path, isDirectory: true)
             .resolvingSymlinksInPath()
-            .standardizedFileURL.path
+            .standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+            atPath: resolved.path,
+            isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return resolved.path
+        }
+
+        var candidate = resolved
+        while true {
+            let marker = candidate.appendingPathComponent(".git")
+            if let values = try? marker.resourceValues(forKeys: [
+                .isDirectoryKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+            ]),
+               values.isSymbolicLink != true,
+               values.isDirectory == true || values.isRegularFile == true {
+                return candidate.path
+            }
+            let parent = candidate.deletingLastPathComponent()
+            guard parent.path != candidate.path else { break }
+            candidate = parent
+        }
+        return resolved.path
     }
 
     /// Deletes every selected finished session and reports failures without

--- a/app/Tests/DetachAppTests/ParallelProvidersSettingsControllerTests.swift
+++ b/app/Tests/DetachAppTests/ParallelProvidersSettingsControllerTests.swift
@@ -1,0 +1,121 @@
+import DetachKit
+import Foundation
+import XCTest
+@testable import DetachApp
+
+private final class ParallelProvidersScriptedCLI: DetachCLIRunning, @unchecked Sendable {
+    var responses: [String: Result<CLIResult, Error>] = [:]
+    private(set) var calls: [[String]] = []
+
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        calls.append(arguments)
+        let key = arguments.joined(separator: " ")
+        if let response = responses[key] {
+            return try response.get()
+        }
+        return CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
+    }
+}
+
+@MainActor
+final class ParallelProvidersSettingsControllerTests: XCTestCase {
+    private func controller(
+        _ cli: ParallelProvidersScriptedCLI
+    ) -> ParallelProvidersSettingsController {
+        ParallelProvidersSettingsController(
+            makeClient: { _ in ParallelProvidersClient(cli: cli) })
+    }
+
+    func testLoadPublishesSettingAndClearsUpdating() async {
+        let cli = ParallelProvidersScriptedCLI()
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 0, stdout: "off\n", stderr: "", timedOut: false))
+        let sut = controller(cli)
+
+        await sut.load(detachPath: "/opt/detach")
+
+        XCTAssertEqual(sut.setting, .off)
+        XCTAssertFalse(sut.isEnabled)
+        XCTAssertFalse(sut.isUpdating)
+        XCTAssertNil(sut.errorMessage)
+        XCTAssertEqual(cli.calls, [["config", "parallel-providers"]])
+    }
+
+    func testLoadFailureReportsErrorAndClearsSetting() async {
+        let cli = ParallelProvidersScriptedCLI()
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 3, stdout: "", stderr: "boom\n", timedOut: false))
+        let sut = controller(cli)
+
+        await sut.load(detachPath: "/opt/detach")
+
+        XCTAssertNil(sut.setting)
+        XCTAssertEqual(
+            sut.errorMessage,
+            L10n.format("Couldn't read the parallel agents setting: %@", "boom"))
+    }
+
+    func testSaveSendsSetterAndKeepsValue() async {
+        let cli = ParallelProvidersScriptedCLI()
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 0, stdout: "off\n", stderr: "", timedOut: false))
+        let sut = controller(cli)
+        await sut.load(detachPath: "/opt/detach")
+
+        await sut.save(.on, detachPath: "/opt/detach")
+
+        XCTAssertEqual(sut.setting, .on)
+        XCTAssertTrue(sut.isEnabled)
+        XCTAssertNil(sut.errorMessage)
+        XCTAssertEqual(cli.calls.last, ["config", "parallel-providers", "on"])
+    }
+
+    func testSaveFailureRollsBackToPreviousValue() async {
+        let cli = ParallelProvidersScriptedCLI()
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 0, stdout: "on\n", stderr: "", timedOut: false))
+        cli.responses["config parallel-providers off"] = .success(CLIResult(
+            exitCode: 5, stdout: "", stderr: "locked\n", timedOut: false))
+        let sut = controller(cli)
+        await sut.load(detachPath: "/opt/detach")
+
+        await sut.save(.off, detachPath: "/opt/detach")
+
+        XCTAssertEqual(sut.setting, .on)
+        XCTAssertEqual(
+            sut.errorMessage,
+            L10n.format("Couldn't save the parallel agents setting: %@", "locked"))
+    }
+
+    func testDefaultClientReadsThroughARealDetachExecutable() async throws {
+        let script = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fake-detach-\(UUID().uuidString)")
+        try "#!/bin/sh\nprintf 'off\\n'\n".write(
+            to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: script.path)
+        defer { try? FileManager.default.removeItem(at: script) }
+
+        let sut = ParallelProvidersSettingsController()
+        await sut.load(detachPath: script.path)
+
+        XCTAssertEqual(sut.setting, .off)
+        XCTAssertNil(sut.errorMessage)
+    }
+
+    func testSaveIgnoresNoOpAndUnloadedState() async {
+        let cli = ParallelProvidersScriptedCLI()
+        let sut = controller(cli)
+
+        await sut.save(.on, detachPath: "/opt/detach")
+        XCTAssertTrue(cli.calls.isEmpty)
+
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 0, stdout: "on\n", stderr: "", timedOut: false))
+        await sut.load(detachPath: "/opt/detach")
+        let callsAfterLoad = cli.calls.count
+
+        await sut.save(.on, detachPath: "/opt/detach")
+        XCTAssertEqual(cli.calls.count, callsAfterLoad)
+    }
+}

--- a/app/Tests/DetachKitTests/ParallelProvidersClientTests.swift
+++ b/app/Tests/DetachKitTests/ParallelProvidersClientTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+@testable import DetachKit
+
+final class ParallelProvidersClientTests: XCTestCase {
+    func testErrorDescriptionsCoverTimeoutCommandAndEmptyResponse() {
+        XCTAssertEqual(
+            ParallelProvidersClientError.timedOut.errorDescription,
+            L10n.string("detach config timed out"))
+        XCTAssertEqual(
+            ParallelProvidersClientError.commandFailed("denied").errorDescription,
+            "denied")
+        XCTAssertEqual(
+            ParallelProvidersClientError.invalidResponse("").errorDescription,
+            L10n.format(
+                "detach returned an unsupported parallel-providers setting: %@",
+                L10n.string("<empty>")))
+        XCTAssertEqual(
+            ParallelProvidersClientError.invalidResponse("always").errorDescription,
+            L10n.format(
+                "detach returned an unsupported parallel-providers setting: %@",
+                "always"))
+    }
+
+    func testLoadsSettingThroughConfigGetter() async throws {
+        let cli = FakeCLI()
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 0, stdout: "off\n", stderr: "", timedOut: false))
+
+        let setting = try await ParallelProvidersClient(cli: cli).loadSetting()
+
+        XCTAssertEqual(setting, .off)
+        XCTAssertFalse(setting.isEnabled)
+        XCTAssertEqual(cli.calls, [["config", "parallel-providers"]])
+    }
+
+    func testSavesSettingThroughConfigSetter() async throws {
+        let cli = FakeCLI()
+
+        try await ParallelProvidersClient(cli: cli).setSetting(.on)
+
+        XCTAssertEqual(cli.calls, [["config", "parallel-providers", "on"]])
+    }
+
+    func testRejectsUnsupportedGetterOutput() async {
+        let cli = FakeCLI()
+        cli.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 0, stdout: "always\n", stderr: "", timedOut: false))
+
+        do {
+            _ = try await ParallelProvidersClient(cli: cli).loadSetting()
+            XCTFail("expected invalid response")
+        } catch {
+            XCTAssertEqual(
+                error as? ParallelProvidersClientError,
+                .invalidResponse("always"))
+        }
+    }
+
+    func testReportsCLIErrorTimeoutAndMissingStderr() async {
+        let failing = FakeCLI()
+        failing.responses["config parallel-providers off"] = .success(CLIResult(
+            exitCode: 2, stdout: "", stderr: "config is read-only\n", timedOut: false))
+        do {
+            try await ParallelProvidersClient(cli: failing).setSetting(.off)
+            XCTFail("expected command failure")
+        } catch {
+            XCTAssertEqual(
+                error as? ParallelProvidersClientError,
+                .commandFailed("config is read-only"))
+        }
+
+        let timedOut = FakeCLI()
+        timedOut.responses["config parallel-providers"] = .success(CLIResult(
+            exitCode: 15, stdout: "", stderr: "", timedOut: true))
+        do {
+            _ = try await ParallelProvidersClient(cli: timedOut).loadSetting()
+            XCTFail("expected timeout")
+        } catch {
+            XCTAssertEqual(error as? ParallelProvidersClientError, .timedOut)
+        }
+
+        let missingStderr = FakeCLI()
+        missingStderr.responses["config parallel-providers on"] = .success(CLIResult(
+            exitCode: 23, stdout: "", stderr: " \n", timedOut: false))
+        do {
+            try await ParallelProvidersClient(cli: missingStderr).setSetting(.on)
+            XCTFail("expected command failure")
+        } catch {
+            XCTAssertEqual(
+                error as? ParallelProvidersClientError,
+                .commandFailed(L10n.format("detach config exited with status %d", 23)))
+        }
+    }
+}

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -647,6 +647,69 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertNil(result.message)
     }
 
+    func testStartDetachedMatchesRuntimeCanonicalGitRootFromNestedDirectory() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-project-\(UUID().uuidString)", isDirectory: true)
+        let nested = root.appendingPathComponent("Sources/Nested", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: nested,
+            withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: "/tmp/p",
+            with: root.path))
+        let store = SessionStore(cli: cli)
+
+        let result = await store.startDetached(
+            provider: .codex,
+            projectDirectory: nested,
+            name: nil,
+            prompt: nil)
+
+        XCTAssertEqual(result.sessionID, "detach-codex-p-1")
+        XCTAssertNil(result.message)
+        XCTAssertEqual(cli.calls, [["codex", "--detach"], ["list", "--json"]])
+    }
+
+    func testStartDetachedUsesNearestGitFileMarkerForAWorktree() async throws {
+        let outer = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-outer-\(UUID().uuidString)", isDirectory: true)
+        let worktree = outer.appendingPathComponent("Worktrees/feature", isDirectory: true)
+        let nested = worktree.appendingPathComponent("Sources/Nested", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: outer.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: nested,
+            withIntermediateDirectories: true)
+        try "gitdir: /tmp/detach-test-worktree\n".write(
+            to: worktree.appendingPathComponent(".git"),
+            atomically: true,
+            encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: outer) }
+
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(
+            of: "/tmp/p",
+            with: worktree.path))
+        let store = SessionStore(cli: cli)
+
+        let result = await store.startDetached(
+            provider: .codex,
+            projectDirectory: nested,
+            name: nil,
+            prompt: nil)
+
+        XCTAssertEqual(result.sessionID, "detach-codex-p-1")
+        XCTAssertNil(result.message)
+        XCTAssertEqual(cli.calls, [["codex", "--detach"], ["list", "--json"]])
+    }
+
     func testPrepareResumeStartsDetachedThenRefreshes() async throws {
         let cli = FakeCLI()
         let stopped = line.replacingOccurrences(

--- a/bin/detach
+++ b/bin/detach
@@ -31,6 +31,7 @@ usage() {
     '  detach config tmux-style [detach|inherit]' \
     '  detach config tmux-mouse [on|off]' \
     '  detach config tmux-extended-keys [on|off]' \
+    '  detach config parallel-providers [on|off]' \
     '  detach doctor [--json]' \
     '  detach repair' \
     '  detach uninstall [--keep-state|--purge-state]' \

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -104,6 +104,8 @@ CONFIG_TMUX_MOUSE="$(config_value TMUX_MOUSE 2>/dev/null || true)"
 case "$CONFIG_TMUX_MOUSE" in 0|1|'') ;; *) CONFIG_TMUX_MOUSE="" ;; esac
 CONFIG_TMUX_EXTENDED_KEYS="$(config_value TMUX_EXTENDED_KEYS 2>/dev/null || true)"
 case "$CONFIG_TMUX_EXTENDED_KEYS" in 0|1|'') ;; *) CONFIG_TMUX_EXTENDED_KEYS="" ;; esac
+CONFIG_PARALLEL_PROVIDERS="$(config_value PARALLEL_PROVIDERS 2>/dev/null || true)"
+case "$CONFIG_PARALLEL_PROVIDERS" in 0|1|'') ;; *) CONFIG_PARALLEL_PROVIDERS="" ;; esac
 CODEX_STATE_ROOT="${DETACH_CODEX_STATE_ROOT:-$STATE_BASE_ROOT/codex}"
 CLAUDE_STATE_ROOT="${DETACH_CLAUDE_STATE_ROOT:-$STATE_BASE_ROOT/claude}"
 CODEX_SESSIONS_ROOT="$CODEX_STATE_ROOT/sessions"
@@ -136,6 +138,11 @@ TMUX_EXTENDED_KEYS_ENABLED="${DETACH_TMUX_EXTENDED_KEYS:-${CONFIG_TMUX_EXTENDED_
 case "$TMUX_EXTENDED_KEYS_ENABLED" in
   0|1) ;;
   *) die "DETACH_TMUX_EXTENDED_KEYS must be 0 or 1" ;;
+esac
+PARALLEL_PROVIDERS_ENABLED="${DETACH_PARALLEL_PROVIDERS:-${CONFIG_PARALLEL_PROVIDERS:-0}}"
+case "$PARALLEL_PROVIDERS_ENABLED" in
+  0|1) ;;
+  *) die "DETACH_PARALLEL_PROVIDERS must be 0 or 1" ;;
 esac
 DEFAULT_TMUX_SOCKET_PATH="$INSTALL_STATE_ROOT/tmux/tmux.sock"
 TMUX_SOCKET_PATH="${DETACH_TMUX_SOCKET_PATH:-$DEFAULT_TMUX_SOCKET_PATH}"
@@ -177,6 +184,7 @@ usage() {
     "  $PROGRAM config tmux-style [detach|inherit]" \
     "  $PROGRAM config tmux-mouse [on|off]" \
     "  $PROGRAM config tmux-extended-keys [on|off]" \
+    "  $PROGRAM config parallel-providers [on|off]" \
     "  $PROGRAM status [NAME]" \
     "  $PROGRAM logs [--ansi] [NAME]" \
     "  $PROGRAM stop [NAME]" \
@@ -1711,7 +1719,10 @@ write_config_key_locked() {
   local line
   local found=0
 
-  case "$key" in TMUX_STYLE|TMUX_MOUSE|TMUX_EXTENDED_KEYS) ;; *) die "invalid internal config key" ;; esac
+  case "$key" in
+    TMUX_STYLE|TMUX_MOUSE|TMUX_EXTENDED_KEYS|PARALLEL_PROVIDERS) ;;
+    *) die "invalid internal config key" ;;
+  esac
   case "$value" in 0|1) ;; *) die "invalid internal config value" ;; esac
   ensure_config_root
   if [ -e "$CONFIG_FILE" ] || [ -L "$CONFIG_FILE" ]; then
@@ -1839,6 +1850,25 @@ config_tmux_extended_keys() {
     *) die "tmux extended keys must be 'on' or 'off'" ;;
   esac
   write_config_key_under_lock TMUX_EXTENDED_KEYS "$value" "tmux extended keys"
+}
+
+config_parallel_providers() {
+  local requested="${1:-}"
+  local value
+
+  if [ "$#" -eq 0 ]; then
+    if [ "$PARALLEL_PROVIDERS_ENABLED" = "1" ]; then printf 'on\n'; else printf 'off\n'; fi
+    return 0
+  fi
+  [ "$#" -eq 1 ] || die "config parallel-providers accepts at most one value"
+  [ "${DETACH_PARALLEL_PROVIDERS+x}" != "x" ] || \
+    die "cannot change parallel providers while DETACH_PARALLEL_PROVIDERS overrides the config"
+  case "$requested" in
+    on) value=1 ;;
+    off) value=0 ;;
+    *) die "parallel providers must be 'on' or 'off'" ;;
+  esac
+  write_config_key_under_lock PARALLEL_PROVIDERS "$value" "parallel providers"
 }
 
 attach_session() {
@@ -6149,11 +6179,23 @@ running_session_for_project() {
   local cwd="$1"
   local excluded_session="${2:-}"
   local candidate
+  local candidate_provider
 
   while IFS= read -r candidate; do
     [ -n "$candidate" ] || continue
     [ "$candidate" = "$excluded_session" ] && continue
     tmux_is_any_managed "$candidate" || continue
+    if [ "$PARALLEL_PROVIDERS_ENABLED" = "1" ]; then
+      # Opt-in collaboration permits one session from each provider in the
+      # same canonical repository. Only a well-formed tag for the other known
+      # provider is exempt; missing or foreign identity still fails closed.
+      candidate_provider="$(tmux_option "$candidate" '@detach_provider')"
+      case "$candidate_provider" in
+        "$PROVIDER") ;;
+        codex|claude) continue ;;
+        *) ;;
+      esac
+    fi
     tmux_session_running "$candidate" || continue
     [ "$(tmux_option "$candidate" '@detach_cwd')" = "$cwd" ] || continue
     printf '%s\n' "$candidate"
@@ -8086,6 +8128,10 @@ main() {
       tmux-extended-keys)
         shift
         config_tmux_extended_keys "$@"
+        ;;
+      parallel-providers)
+        shift
+        config_parallel_providers "$@"
         ;;
       *) die "unknown config key: ${1:-missing}" ;;
     esac

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -80,7 +80,13 @@ Command-N opens New session. Its chooser starts at the default project or the
 selection's parent. Command-T starts the chosen provider in a private 0700
 `detach-chat-<UUID>` below its folder (`/tmp` default). An event
 selects an unambiguous `starting` session before readiness, without polling.
-Invalid folders block launch.
+Invalid folders block launch. General settings expose the CLI-backed,
+default-off `parallel-providers` option. When enabled, one Claude Code and one
+Codex session may share a canonical project directory; the UI warns that their
+file edits are not isolated. Session matching resolves the same nearest real
+`.git` ancestor as the runtime, or the exact working directory outside Git, so
+a launch chosen from a nested repository directory selects the new session
+emitted for the repository root.
 Command-1 through Command-9 open main and select numbered Working or Answer
 ready sessions. Numbers appear in rows and stay stable across both sections.
 When a session leaves them, the earliest waiting session gets its number;

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -55,6 +55,12 @@ worst hold.
 
 `start` takes a cross-provider project lock, creates a safe identifier, sets
 window `remain-on-exit` off and the provider pane on, then launches `__worker`.
+The lock always serializes lifecycle transitions. Project occupancy defaults
+to one live managed writer across providers. The opt-in `parallel-providers`
+setting permits one known Codex and one known Claude session in the same
+canonical project. A project is the nearest real Git root, or the exact working
+directory outside Git. A second session from either provider and a missing or
+unknown provider identity still fail closed.
 Splits close on exit; logs and status remain. The first unnamed history is
 `detach-<provider>-<project-slug>-<project-hash>`; successors add a monotonic
 `-r<12-hex>` and store the base as `default_session_base`. Explicit names are
@@ -81,11 +87,13 @@ The retained provider pane, metadata, and checkpoints remain available.
 Ctrl-C that leaves the provider running does not detach its clients.
 
 Default starts form a provider/project history series. A fresh start refuses a
-live member or second writer; otherwise it allocates a successor without
-reusing saved state. No-`NAME` commands select the live member, then the highest
-suffix. Older `session_name` values stay addressable; their metadata, logs,
-and checkpoints remain until Delete or typed storage cleanup. Explicit names
-stay deterministic and obey the same project lock and cleanup policy.
+live member or conflicting writer; otherwise it allocates a successor without
+reusing saved state. With `parallel-providers` off, every live provider in the
+project conflicts. With it on, only the same provider conflicts. No-`NAME`
+commands select the live member, then the highest suffix. Older `session_name`
+values stay addressable; their metadata, logs, and checkpoints remain until
+Delete or typed storage cleanup. Explicit names stay deterministic and obey the
+same project lock and cleanup policy.
 
 The worker starts checkpoint and power-status loops, then runs the provider only
 through:

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -522,12 +522,95 @@ mkdir -p "$TMP_ROOT/unrelated-tmux-tmpdir"
 TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
   "$SCRIPT" list | grep -F 'claude' | grep -F "$session" | grep -F "$session_id" >/dev/null
 
-# Exercise cross-provider routing while the fake Claude worker is definitely
-# live; the later metadata and checkpoint assertions intentionally do more IO.
-if "$SCRIPT" codex --name cross-provider --detach -- 'must not run beside Claude'; then
-  printf 'Codex unexpectedly started beside a running Claude task\n' >&2
+# Exercise cross-provider project occupancy while the fake Claude worker is
+# definitely live. Safe mode remains the default, so Codex is rejected even
+# when it starts from a nested directory canonicalized to this repository.
+parallel_codex_name=parallel-provider
+parallel_codex_session=detach-codex-parallel-provider
+if (cd "$ROOT/app" && \
+    "$SCRIPT" codex --name "$parallel_codex_name" --detach -- \
+      'must not run beside Claude by default'); then
+  printf 'Codex unexpectedly started beside a running Claude task by default\n' >&2
   exit 1
 fi
+
+# The opt-in permits exactly the other provider in the same canonical project.
+# Startup remains serialized by the shared project/install locks; only the
+# long-running occupancy rule becomes provider-specific.
+parallel_codex_release="$TMP_ROOT/parallel-codex-release"
+claude_power_args_snapshot="$TMP_ROOT/claude-power-args-before-parallel.txt"
+cp "$FAKE_POWER_ARGS_FILE" "$claude_power_args_snapshot"
+export FAKE_CODEX_RELEASE_FILE="$parallel_codex_release"
+export FAKE_CODEX_EXIT=0
+"$SCRIPT" config parallel-providers on
+[ "$("$SCRIPT" config parallel-providers)" = on ]
+
+# A managed-looking session with missing or unknown provider identity remains
+# a conservative conflict instead of becoming an opt-in bypass.
+unknown_provider_session=detach-unknown-provider
+unknown_provider_pane="$(tmux -L "$SOCKET" new-session -d -P -F '#{pane_id}' \
+  -s "$unknown_provider_session" -n unknown)"
+tmux -L "$SOCKET" set-option -q -t "=$unknown_provider_session:" @detach 1
+tmux -L "$SOCKET" set-option -q -t "=$unknown_provider_session:" \
+  @detach_provider unknown
+tmux -L "$SOCKET" set-option -q -t "=$unknown_provider_session:" \
+  @detach_cwd "$ROOT"
+tmux -L "$SOCKET" set-option -q -t "=$unknown_provider_session:" \
+  @detach_pane_id "$unknown_provider_pane"
+if (cd "$ROOT/app" && \
+    "$SCRIPT" codex --name malformed-provider-bypass --detach -- \
+      'must fail closed'); then
+  printf 'Codex unexpectedly bypassed an unknown managed provider identity\n' >&2
+  exit 1
+fi
+tmux -L "$SOCKET" set-option -qu -t "=$unknown_provider_session:" \
+  @detach_provider
+if (cd "$ROOT/app" && \
+    "$SCRIPT" codex --name missing-provider-bypass --detach -- \
+      'must also fail closed'); then
+  printf 'Codex unexpectedly bypassed a missing managed provider identity\n' >&2
+  exit 1
+fi
+tmux -L "$SOCKET" kill-session -t "=$unknown_provider_session"
+
+(cd "$ROOT/app" && \
+  "$SCRIPT" codex --name "$parallel_codex_name" --detach -- \
+    'coordinate with Claude')
+wait_for_tmux_option "$parallel_codex_session" @detach_status running
+[ "$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$parallel_codex_session:" @detach_provider)" = codex ]
+[ "$(tmux -L "$SOCKET" show-options -qv \
+  -t "=$parallel_codex_session:" @detach_cwd)" = "$ROOT" ]
+parallel_list="$("$SCRIPT" list --json)"
+printf '%s\n' "$parallel_list" | grep -F "\"session_name\":\"$human_session\"" >/dev/null
+printf '%s\n' "$parallel_list" | \
+  grep -F "\"session_name\":\"$parallel_codex_session\"" >/dev/null
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "=$parallel_codex_session:" '#{pane_dead}')" = 0 ]
+[ "$(tmux -L "$SOCKET" display-message -p \
+  -t "=$human_session:" '#{pane_dead}')" = 0 ]
+
+# Enabling collaboration never permits a second session from the same
+# provider, including another launch from a nested directory.
+if (cd "$ROOT/app" && \
+    "$SCRIPT" claude --name second-claude --detach -- \
+      'must not run beside the existing Claude'); then
+  printf 'a second Claude unexpectedly started in one project\n' >&2
+  exit 1
+fi
+if (cd "$ROOT/app" && \
+    "$SCRIPT" codex --name second-codex --detach -- \
+      'must not run beside the existing Codex'); then
+  printf 'a second Codex unexpectedly started in one project\n' >&2
+  exit 1
+fi
+"$SCRIPT" codex stop "$parallel_codex_name"
+"$SCRIPT" codex delete --force "$parallel_codex_name"
+cp "$claude_power_args_snapshot" "$FAKE_POWER_ARGS_FILE"
+unset FAKE_CODEX_RELEASE_FILE FAKE_CODEX_EXIT
+"$SCRIPT" config parallel-providers off
+[ "$("$SCRIPT" config parallel-providers)" = off ]
+
 "$STATE_HELPER" meta matches "$meta" claude "$session_id"
 test_sqlite "$CODEX_HOME/state_5.sqlite" \
   'CREATE TABLE IF NOT EXISTS threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, created_at_ms INTEGER, updated_at_ms INTEGER, source TEXT, thread_source TEXT, cwd TEXT);'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -942,6 +942,26 @@ if DETACH_TMUX_STYLE=0 "$SCRIPT" config tmux-style detach >/dev/null 2>&1; then
   exit 1
 fi
 
+# Cross-provider collaboration is an explicit opt-in. The shared config
+# round-trips without disturbing older keys, and an environment override owns
+# the effective value without being persisted.
+[ "$("$SCRIPT" config parallel-providers)" = "off" ]
+"$SCRIPT" config parallel-providers on
+[ "$("$SCRIPT" config parallel-providers)" = "on" ]
+grep -Fx CUSTOM_SETTING=kept "$DETACH_CONFIG_ROOT/config" >/dev/null
+if "$SCRIPT" config parallel-providers always >/dev/null 2>&1; then
+  printf 'config unexpectedly accepted an unsupported parallel-providers value\n' >&2
+  exit 1
+fi
+[ "$(DETACH_PARALLEL_PROVIDERS=0 "$SCRIPT" config parallel-providers)" = "off" ]
+if DETACH_PARALLEL_PROVIDERS=0 \
+     "$SCRIPT" config parallel-providers on >/dev/null 2>&1; then
+  printf 'config unexpectedly changed a value owned by DETACH_PARALLEL_PROVIDERS\n' >&2
+  exit 1
+fi
+"$SCRIPT" config parallel-providers off
+[ "$("$SCRIPT" config parallel-providers)" = "off" ]
+
 # Pre-feature managed sessions have no styling ownership marker and must not
 # be modified when the shared setting changes.
 legacy_session="detach-codex-legacy-style"


### PR DESCRIPTION
NO-TICKET: Claude Code и Codex могут работать вместе в одном проекте

Режим потенциально полезен, но пока остаётся под вопросом: после запуска Claude Code и Codex могут одновременно менять одни и те же файлы. Поэтому он выключен по умолчанию и включается явно.

- добавить глобальную настройку `parallel-providers` в CLI и Settings → General
- разрешить по одной активной сессии Codex и Claude Code в каноническом проекте
- продолжать блокировать второй запуск того же провайдера и сессии без распознанного провайдера
- определять проект по ближайшему физическому Git-корню, а вне Git — по точному рабочему каталогу
- предупредить об одновременной неизолированной правке файлов в интерфейсе и документации
- покрыть настройку, канонизацию проекта и межпровайдерную занятость тестами

Проверено: `swift test --package-path app --filter 'ParallelProviders|SessionStoreTests'` — 75/75; `DETACH_CODEX_TEST_PART=configuration tests/run.sh` — PASS; `DETACH_CLAUDE_TEST_PART=lifecycle tests/run-claude.sh` — PASS; `scripts/quality-gate --stage static` — PASS; `git diff --check origin/main` — PASS; ручная проверка сборки 905 — PASS.
