### PR TITLE
Fix Claude answers that stay in Working after completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ A compact guide below the session list keeps `Cmd-N`, `Cmd-T`, `Cmd-,`, and
 
 Sessions that wait for your reply move into **Answer ready**, before agents
 that are still working. Detach reads structured provider lifecycle records for
-this signal. It does not guess from terminal text. Mid-turn permission prompts
-are not currently part of the signal.
+this signal. A completed Claude text answer enters **Answer ready** even when
+Claude omits its turn-duration record. Detach does not guess from terminal
+text. Mid-turn permission prompts are not currently part of the signal.
 
 The optional menu bar companion shows:
 

--- a/app/Sources/DetachKit/DetachState.swift
+++ b/app/Sources/DetachKit/DetachState.swift
@@ -738,8 +738,29 @@ public enum TranscriptDocument {
         }
 
         if type == "system", record["subtype"] as? String == "turn_duration" {
-            if result.pendingToolUseID == nil {
+            if result.pendingToolUseID == nil, result.agentTurnState != .waiting {
                 result.agentTurnState = .waiting
+                result.agentTurnID = turnID
+            }
+            return
+        }
+
+        if type == "assistant",
+           !isJSONTrue(record["isMeta"]),
+           message?["role"] as? String == "assistant",
+           result.pendingToolUseID == nil {
+            if message?["stop_reason"] as? String == "end_turn",
+               hasFinalText(message?["content"]) {
+                // Claude can omit turn_duration. Keep one notification identity
+                // across final text fragments and a later duration record.
+                if result.agentTurnState != .waiting {
+                    result.agentTurnState = .waiting
+                    result.agentTurnID = turnID
+                }
+            } else if message?["stop_reason"] as? String == "tool_use" {
+                // A tool continuation can follow a completed answer without a
+                // new plain user record (for example, after a Stop hook).
+                result.agentTurnState = .working
                 result.agentTurnID = turnID
             }
             return
@@ -779,6 +800,16 @@ public enum TranscriptDocument {
             }
             return identifier
         }.first
+    }
+
+    private static func hasFinalText(_ value: Any?) -> Bool {
+        guard let content = value as? [[String: Any]],
+              !content.contains(where: { $0["type"] as? String == "tool_use" })
+        else { return false }
+        return content.contains {
+            $0["type"] as? String == "text"
+                && ($0["text"] as? String)?.isEmpty == false
+        }
     }
 
     private static func toolResultStatus(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -987,7 +987,7 @@ public enum DetachStateCommand {
     }
 
     private struct TranscriptSummaryReceipt: Codable {
-        static let currentSchema = 3
+        static let currentSchema = 4
         private static let overlapByteCount: UInt64 = 64 * 1_024
 
         var schema: Int

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -1015,7 +1015,7 @@ final class DetachStateCommandTests: XCTestCase {
         let migratedReceipt = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(contentsOf: receipt))
                 as? [String: Any])
-        XCTAssertEqual(migratedReceipt["schema"] as? Int, 3)
+        XCTAssertEqual(migratedReceipt["schema"] as? Int, 4)
 
         let unrelatedToolResult = Data("""
 
@@ -1068,6 +1068,56 @@ final class DetachStateCommandTests: XCTestCase {
             separator: 0, omittingEmptySubsequences: false
         ).dropLast().map { String(decoding: $0, as: UTF8.self) }
         XCTAssertEqual(Array(workingValues[28..<30]), ["working", "answer-user"])
+    }
+
+    func testMetaSnapshotsReclassifyCachedClaudeEndTurnWithoutTranscriptChange() throws {
+        let root = temporaryDirectory.appendingPathComponent("completed-sessions")
+        let session = root.appendingPathComponent("detach-claude-completed")
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+        let transcript = temporaryDirectory.appendingPathComponent("completed.jsonl")
+        try Data("""
+        {"type":"user","uuid":"request","message":{"role":"user","content":"go"}}
+        {"type":"assistant","uuid":"answer","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"Done."}]}}
+
+        """.utf8).write(to: transcript)
+        try JSONSerialization.data(withJSONObject: [
+            "schema": 1, "session_name": "detach-claude-completed",
+            "project_dir": "/tmp/project", "status": "running",
+            "transcript_path": transcript.path,
+        ]).write(to: session.appendingPathComponent("meta.json"))
+
+        func turnFields() throws -> [String] {
+            let output = try DetachStateCommand.run(arguments: [
+                "meta", "snapshots", root.path, "--with-transcript-summary",
+            ])
+            let values = output.split(separator: 0, omittingEmptySubsequences: false)
+                .dropLast().map { String(decoding: $0, as: UTF8.self) }
+            return Array(values[28..<30])
+        }
+        XCTAssertEqual(try turnFields(), ["waiting", "answer"])
+        let receipt = session.appendingPathComponent(".transcript-summary-cache.json")
+        var legacy = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: receipt)) as? [String: Any])
+        // Keep the exact transcript identity, as an installed schema-3 helper
+        // does when it ignores end_turn and caches the preceding request.
+        legacy["schema"] = 3
+        legacy["agentTurnState"] = "working"
+        legacy["agentTurnID"] = "request"
+        try JSONSerialization.data(withJSONObject: legacy).write(to: receipt)
+
+        XCTAssertEqual(try turnFields(), ["waiting", "answer"])
+        XCTAssertEqual(try turnFields(), ["waiting", "answer"])
+        let updated = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: receipt)) as? [String: Any])
+        XCTAssertEqual(updated["schema"] as? Int, 4)
+
+        let handle = try FileHandle(forWritingTo: transcript)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data("""
+        {"type":"system","subtype":"turn_duration","uuid":"duration"}
+        """.utf8))
+        try handle.close()
+        XCTAssertEqual(try turnFields(), ["waiting", "answer"])
     }
 
     func testMetaSnapshotsFailClosedForNonFileTranscripts() throws {

--- a/app/Tests/DetachKitTests/DetachStateTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateTests.swift
@@ -547,6 +547,89 @@ final class DetachStateTests: XCTestCase {
                 agentTurnID: "real-user"))
     }
 
+    func testClaudeSummaryCompletesFinalTextWithoutTurnDuration() {
+        let thinking = Data("""
+        {"type":"user","uuid":"request","message":{"role":"user","content":"go"}}
+        {"type":"assistant","uuid":"thinking","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"thinking","thinking":"done"}]}}
+        """.utf8)
+        let working = TranscriptDocument.summary(ofTail: thinking, provider: .claude)
+        XCTAssertEqual(working.agentTurnState, .working)
+
+        let answer = Data("""
+        {"type":"assistant","uuid":"answer","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"Done."}]}}
+        """.utf8)
+        let waiting = TranscriptDocument.summary(
+            ofTail: answer, provider: .claude, startingFrom: working)
+        XCTAssertEqual(waiting.agentTurnState, .waiting)
+        XCTAssertEqual(waiting.agentTurnID, "answer")
+        // A cold bounded tail can contain only the final answer.
+        XCTAssertEqual(
+            TranscriptDocument.summary(ofTail: answer, provider: .claude), waiting)
+
+        let trailing = Data("""
+        {"type":"assistant","uuid":"answer-fragment","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"More detail."}]}}
+        {"type":"system","subtype":"turn_duration","uuid":"duration"}
+        """.utf8)
+        XCTAssertEqual(
+            TranscriptDocument.summary(
+                ofTail: trailing, provider: .claude, startingFrom: waiting), waiting)
+    }
+
+    func testClaudeSummaryRejectsUnprovenFinalAnswers() throws {
+        let unsupported: [[String: Any]] = [
+            ["isSidechain": true], ["isMeta": true], ["uuid": ""],
+            ["message": ["role": "user"]],
+            ["message": ["stop_reason": "max_tokens"]],
+            ["message": ["stop_reason": NSNull()]],
+            ["message": ["content": NSNull()]],
+            ["message": ["content": [["type": "text", "text": ""]]]],
+            ["message": ["content": [["type": "text", "text": "Done"],
+                                      ["type": "tool_use", "name": "Bash"]]]],
+        ]
+        for overrides in unsupported {
+            var message: [String: Any] = [
+                "role": "assistant", "stop_reason": "end_turn",
+                "content": [["type": "text", "text": "Done"]],
+            ]
+            message.merge(overrides["message"] as? [String: Any] ?? [:]) { _, new in new }
+            var record: [String: Any] = ["type": "assistant", "uuid": "answer"]
+            record.merge(overrides) { _, new in new }
+            record["message"] = message
+            let summary = TranscriptDocument.summary(
+                ofTail: try JSONSerialization.data(withJSONObject: record),
+                provider: .claude,
+                startingFrom: TranscriptSummary(
+                    agentTurnState: .working, agentTurnID: "request"))
+            XCTAssertEqual(summary.agentTurnState, .working, "\(overrides)")
+            XCTAssertEqual(summary.agentTurnID, "request", "\(overrides)")
+        }
+    }
+
+    func testClaudeSummaryResumesAfterFinalAnswer() {
+        let waiting = TranscriptSummary(agentTurnState: .waiting, agentTurnID: "answer")
+        let continuations = [
+            """
+            {"type":"user","uuid":"next","message":{"role":"user","content":"continue"}}
+            """,
+            """
+            {"type":"assistant","uuid":"next","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"Bash","id":"tool"}]}}
+            """,
+        ]
+        for continuation in continuations {
+            let working = TranscriptDocument.summary(
+                ofTail: Data(continuation.utf8), provider: .claude, startingFrom: waiting)
+            XCTAssertEqual(working.agentTurnState, .working)
+            XCTAssertEqual(working.agentTurnID, "next")
+            let answer = Data("""
+            {"type":"assistant","uuid":"next-answer","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"Done again."}]}}
+            """.utf8)
+            let completed = TranscriptDocument.summary(
+                ofTail: answer, provider: .claude, startingFrom: working)
+            XCTAssertEqual(completed.agentTurnState, .waiting)
+            XCTAssertEqual(completed.agentTurnID, "next-answer")
+        }
+    }
+
     func testClaudeSummaryTracksAskUserQuestionUntilItsMatchingResult() {
         let contradictoryTail = Data("""
         {"type":"user","uuid":"real-user","message":{"role":"user","content":"go"}}
@@ -569,6 +652,9 @@ final class DetachStateTests: XCTestCase {
         {"type":"assistant","uuid":"ask-record","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"AskUserQuestion","id":"ask-1"}]}}
         {"type":"user","uuid":"unrelated-result","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"bash-1"}]}}
         {"type":"user","uuid":"plain-user","message":{"role":"user","content":"this must not clear a pending tool result"}}
+        {"type":"assistant","uuid":"final-text","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"Choose an option."}]}}
+        {"type":"system","subtype":"turn_duration","uuid":"duration"}
+        {"type":"assistant","uuid":"other-tool","message":{"role":"assistant","stop_reason":"tool_use","content":[{"type":"tool_use","name":"Bash","id":"bash-2"}]}}
         """.utf8)
 
         XCTAssertEqual(

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -79,4 +79,10 @@ an unseen oversized gap clears waiting to prevent stale Answer ready. A
 main-chain Claude `AskUserQuestion` with `stop_reason: tool_use` and a tool ID
 means waiting; only its matching user tool result restores working. Reducer
 changes invalidate old receipts so unchanged prompts are reclassified.
+A main-chain Claude assistant record with `stop_reason: end_turn` and nonempty
+text also means waiting. Thinking-only, metadata, and tool-use blocks do not
+prove a completed answer. Repeated final text and a later `turn_duration` keep
+the waiting turn ID. A new user request or an assistant `tool_use` continuation
+restores working. A pending `AskUserQuestion` still requires its matching
+result. Schema-4 summary receipts invalidate earlier cached turn states.
 Typed cleanup uses `cleanup_eligible`.

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -618,21 +618,25 @@ wait_for_file_text "$power_activity" waiting
 printf '{"type":"user","isSidechain":false,"isMeta":false,"sessionId":"%s","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"ask-tool"}]},"uuid":"tool-result-event","timestamp":"2099-01-01T00:02:00.000Z"}\n' \
   "$session_id" >>"$transcript"
 wait_for_file_text "$power_activity" working
-printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1"},"uuid":"assistant-chunk-1","timestamp":"2099-01-01T00:03:00.000Z"}\n' \
+printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1","content":[{"type":"thinking","thinking":"Ready to answer."}]},"uuid":"assistant-chunk-1","timestamp":"2099-01-01T00:03:00.000Z"}\n' \
   "$session_id" >>"$transcript"
-printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1"},"uuid":"assistant-chunk-2","timestamp":"2099-01-01T00:03:01.000Z"}\n' \
+json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
+assert_json_field agent_turn_state working
+printf '{"type":"assistant","isSidechain":false,"sessionId":"%s","message":{"role":"assistant","stop_reason":"end_turn","id":"message-1","content":[{"type":"text","text":"Done."}]},"uuid":"assistant-chunk-2","timestamp":"2099-01-01T00:03:01.000Z"}\n' \
   "$session_id" >>"$transcript"
 json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin display_name)" = \
   "$human_label" ]
-[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "working" ]
-[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "tool-result-event" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "waiting" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "assistant-chunk-2" ]
+wait_for_file_text "$power_activity" waiting
+[ -s "$power_activity_source" ]
 printf '{"type":"system","subtype":"turn_duration","isSidechain":false,"sessionId":"%s","uuid":"turn-duration-1","timestamp":"2099-01-01T00:03:02.000Z"}\n' \
   "$session_id" >>"$transcript"
 json_line="$("$SCRIPT" list --json | grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin effective_status)" = "running" ]
 [ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_state)" = "waiting" ]
-[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "turn-duration-1" ]
+[ "$(printf '%s' "$json_line" | "$STATE_HELPER" meta get /dev/stdin agent_turn_id)" = "assistant-chunk-2" ]
 wait_for_file_text "$power_activity" waiting
 [ -s "$power_activity_source" ]
 printf '{"type":"user","isSidechain":false,"isMeta":false,"sessionId":"%s","message":{"role":"user","content":"continue"},"uuid":"turn-after-idle","timestamp":"2099-01-01T00:03:03.000Z"}\n' \


### PR DESCRIPTION
## Contract delta

A completed Claude answer could stay in Working when the transcript ended with `stop_reason: end_turn` and omitted `turn_duration`. It now enters Answer ready through the shared typed summary used by the app and power worker.

- MODIFIED `README.md`: completed Claude text answers do not require a turn-duration record.
- ADDED `docs/specs/state.md`: accept main-chain final text, preserve one waiting identity across completion fragments, return to working on a user request or tool continuation, and invalidate summary receipts before schema 4.

## Durable decisions

Require nonempty assistant text and reject contradictory tool blocks. Thinking fragments, sidechains, and metadata do not prove an answer. A pending AskUserQuestion still requires its matching tool result. Repeated completion records keep the waiting ID to prevent duplicate notifications. No installed runtime or provider data is changed.

## Acceptance evidence

- Swift suite: 1,134 tests, one skipped, zero failures. Covers completion without duration, unsupported records, continuation, pending questions, and unchanged-transcript cache migration.
- Claude integration passed: list JSON and the power activity file become waiting before any turn-duration record.
- Direct read-only comparison on the reported transcript: the new helper reports waiting where the installed helper cannot detect completion.
- Local impact-selected quality gate: DIAGNOSTIC PASS (policy 59). Static contracts, Swift, coverage contracts, packaged app, UI smoke, and both provider integrations passed.
- Hosted pull-request `quality-gates`: authoritative PASS on [run 34054400640](https://github.com/iltsarev/detach/actions/runs/34054400640), attempt 1. Real power and release-only checks were not run.
