### PR TITLE
Fix embedded terminal copy and plain link clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,17 @@ The embedded terminal keeps the shortcuts that matter:
 | Open the standard New session sheet | `Cmd-N` |
 | Start a Quick chat immediately | `Cmd-T` |
 | Switch to a numbered Working or Answer ready session | `Cmd-1` … `Cmd-9` |
+| Copy selected text | `Cmd-C` |
+| Open a link | Click the link |
 | Paste text | `Cmd-V` |
 | Give Codex or Claude Code an image from the clipboard | `Ctrl-V` |
 | Interrupt a command or close a provider overlay | `Ctrl-C` |
 | Find terminal output | `Cmd-F` |
 | Replace an exited terminal client without restarting the agent | **Reconnect** |
+
+With managed mouse input, tmux copies the selection when you release the
+mouse button. `Cmd-C` keeps that copy when there is no native selection.
+Links show an underline on hover. Click an underlined link to open it.
 
 Settings → General selects the provider and parent folder for Quick chat. The
 default is `/tmp`. Each `Cmd-T` creates a private

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -272,9 +272,10 @@ final class SessionTerminalScreenCache {
     }
 }
 
-final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
+class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     var onDroppedPaths: ((String) -> Void)?
     var onFirstVisibleFrame: (() -> Void)?
+    private var didDragPointer = false
     private var didConfigureEventDrivenRenderer = false
     private var retainedScreenView: NSView?
     private var frameReadinessCheck: DispatchWorkItem?
@@ -288,6 +289,42 @@ final class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         registerForDraggedTypes([.fileURL])
+    }
+
+    override func copy(_ sender: Any) {
+        // tmux copies its own mouse selection on release. It is not a
+        // SwiftTerm selection, so an empty native copy must preserve it.
+        SessionAttachClipboard.write(
+            selection.getSelectedText(), to: .general)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        didDragPointer = false
+        super.mouseDown(with: event)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        didDragPointer = true
+        super.mouseDragged(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        // SwiftTerm does not mark drags forwarded to tmux as selection drags.
+        // Disable link activation for this release, but let its normal mouse
+        // handler finish the gesture and send the release to tmux.
+        guard didDragPointer, let release = NSEvent.mouseEvent(
+            with: event.type, location: event.locationInWindow,
+            modifierFlags: event.modifierFlags.subtracting(.command),
+            timestamp: event.timestamp, windowNumber: event.windowNumber,
+            context: nil, eventNumber: event.eventNumber,
+            clickCount: event.clickCount, pressure: event.pressure) else {
+            super.mouseUp(with: event)
+            return
+        }
+        let mode = linkHighlightMode
+        linkHighlightMode = .hoverWithModifier
+        defer { linkHighlightMode = mode }
+        super.mouseUp(with: release)
     }
 
     override func viewDidMoveToWindow() {
@@ -654,6 +691,7 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
         view.font = Self.terminalFont(pointSize: fontPointSize)
         view.nativeBackgroundColor = ANSIParser.terminalBackground
         view.nativeForegroundColor = NSColor(white: 0.85, alpha: 1)
+        view.linkHighlightMode = .hover
         view.setAccessibilityIdentifier("session-preview-terminal")
         view.setAccessibilityLabel(L10n.string("Live session terminal"))
         view.setAccessibilityElement(true)
@@ -679,6 +717,7 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
 enum SessionAttachClipboard {
     @discardableResult
     static func write(_ text: String, to pasteboard: NSPasteboard) -> String {
+        guard !text.isEmpty else { return text }
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
         return text

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -6,6 +6,21 @@ import SwiftTerm
 import DetachKit
 @testable import DetachApp
 
+private final class MouseRecordingTerminalView: SessionAttachLocalProcessTerminalView {
+    var sent: [UInt8] = []
+    var opened: [String] = []
+
+    override func send(source: TerminalView, data: ArraySlice<UInt8>) {
+        sent.append(contentsOf: data)
+    }
+
+    override func requestOpenLink(
+        source: TerminalView, link: String, params: [String: String]
+    ) {
+        opened.append(link)
+    }
+}
+
 private final class SilentDetachCLI: DetachCLIRunning, @unchecked Sendable {
     func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
         CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
@@ -971,6 +986,124 @@ final class SessionAttachTerminalTests: XCTestCase {
             SessionAttachClipboard.write("selected text", to: pasteboard),
             "selected text")
         XCTAssertEqual(pasteboard.string(forType: .string), "selected text")
+    }
+
+    func testEmptyNativeCopyPreservesClipboardContentsAndChangeCount() {
+        let pasteboard = NSPasteboard.withUniqueName()
+        defer { pasteboard.releaseGlobally() }
+        pasteboard.setString("tmux selection", forType: .string)
+        let changeCount = pasteboard.changeCount
+
+        XCTAssertEqual(SessionAttachClipboard.write("", to: pasteboard), "")
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "tmux selection")
+        XCTAssertEqual(pasteboard.changeCount, changeCount)
+    }
+
+    @MainActor
+    func testCommandCCopiesNativeSelectionAndPreservesTmuxCopy() throws {
+        let pasteboard = NSPasteboard.general
+        let savedItems = (pasteboard.pasteboardItems ?? []).map { item in
+            let saved = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    saved.setData(data, forType: type)
+                }
+            }
+            return saved
+        }
+        defer {
+            pasteboard.clearContents()
+            pasteboard.writeObjects(savedItems)
+        }
+        let terminal = SessionAttachLocalProcessTerminalView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+        let coordinator = SessionAttachTerminalView.Coordinator(
+            controller: SessionAttachController(invocation: Self.invocation()),
+            session: try XCTUnwrap(Self.session()),
+            screenCache: SessionTerminalScreenCache(),
+            onTerminated: { _ in })
+        let commandC = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: .command,
+            timestamp: 0, windowNumber: 0, context: nil,
+            characters: "с", charactersIgnoringModifiers: "с",
+            isARepeat: false, keyCode: 8))
+        func copy() {
+            XCTAssertNil(coordinator.routeKeyboardEvent(
+                commandC, window: nil, firstResponder: terminal, in: terminal,
+                send: { _ in XCTFail("Command-C must not reach the provider") }))
+        }
+
+        // tmux owns the visible selection and copies it on mouse release.
+        terminal.feed(text: "\u{1B}[?1000h\u{1B}[?1006houtput")
+        pasteboard.clearContents()
+        pasteboard.setString("tmux selection", forType: .string)
+        XCTAssertEqual(terminal.selection.getSelectedText(), "")
+        let changeCount = pasteboard.changeCount
+        copy()
+        XCTAssertEqual(pasteboard.string(forType: .string), "tmux selection")
+        XCTAssertEqual(pasteboard.changeCount, changeCount)
+
+        terminal.selectAll(nil)
+        let selected = terminal.selection.getSelectedText()
+        XCTAssertTrue(selected.contains("output"))
+        copy()
+        XCTAssertEqual(pasteboard.string(forType: .string), selected)
+    }
+
+    @MainActor
+    func testPlainClicksOpenExplicitAndDetectedLinksButDragsDoNot() throws {
+        for mouseReporting in [false, true] {
+            for output in [
+                "https://example.com/path",
+                "\u{1B}]8;;https://example.com/path\u{07}Open link\u{1B}]8;;\u{07}",
+            ] {
+                let terminal = MouseRecordingTerminalView(
+                    frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+                let controller = SessionAttachController(invocation: Self.invocation())
+                controller.configure(terminal, fontPointSize: 13)
+                let window = NSWindow(
+                    contentRect: terminal.frame, styleMask: .borderless,
+                    backing: .buffered, defer: false)
+                window.contentView = terminal
+                terminal.feed(text: mouseReporting
+                    ? "\u{1B}[?1000h\u{1B}[?1006h" + output : output)
+                func event(
+                    _ type: NSEvent.EventType, x: CGFloat = 10,
+                    modifiers: NSEvent.ModifierFlags = []
+                ) throws -> NSEvent {
+                    try XCTUnwrap(NSEvent.mouseEvent(
+                        with: type,
+                        location: NSPoint(x: x, y: terminal.frame.height - 5),
+                        modifierFlags: modifiers, timestamp: 0,
+                        windowNumber: window.windowNumber, context: nil,
+                        eventNumber: 1, clickCount: 1, pressure: 1))
+                }
+
+                terminal.mouseDown(with: try event(.leftMouseDown))
+                terminal.mouseUp(with: try event(.leftMouseUp))
+                XCTAssertEqual(terminal.opened, ["https://example.com/path"])
+
+                terminal.opened.removeAll()
+                for modifiers: NSEvent.ModifierFlags in [[], .command] {
+                    terminal.mouseDown(with: try event(.leftMouseDown, modifiers: modifiers))
+                    terminal.mouseDragged(with: try event(.leftMouseDragged, x: 30, modifiers: modifiers))
+                    terminal.mouseDragged(with: try event(.leftMouseDragged, x: 60, modifiers: modifiers))
+                    terminal.sent.removeAll()
+                    terminal.mouseUp(with: try event(.leftMouseUp, x: 60, modifiers: modifiers))
+                    XCTAssertTrue(terminal.opened.isEmpty)
+                    if mouseReporting {
+                        let release = String(decoding: terminal.sent, as: UTF8.self)
+                        XCTAssertTrue(release.hasPrefix("\u{1B}[<0;"), release)
+                        XCTAssertTrue(release.hasSuffix("m"), release)
+                    }
+                }
+
+                terminal.mouseDown(with: try event(.leftMouseDown))
+                terminal.mouseUp(with: try event(.leftMouseUp))
+                XCTAssertEqual(terminal.opened, ["https://example.com/path"])
+            }
+        }
     }
 
     func testDroppedFileURLsBecomeShellSafeAbsolutePaths() throws {

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -50,7 +50,10 @@ tmux client. Closing the view ends the client.
 Terminal I/O is event-driven. CoreGraphics repaints on changes and uses a
 steady cursor. No terminal poller or frame loop runs. `Command-C/V/F` provide
 native copy, paste, and find. `Ctrl-C` and `Ctrl-V` reach providers as
-conventional control bytes. A Finder drop sends shell-safe paths without
+conventional control bytes. An empty native selection cannot clear the
+clipboard; tmux copies its mouse selection on release. Explicit and detected
+links show an underline on hover and open on a plain click. A selection drag
+does not open a link. A Finder drop sends shell-safe paths without
 reading files. Live views move Mac Power to metadata. An exited client offers
 Reconnect.
 


### PR DESCRIPTION
Command-C cleared the clipboard after a tmux mouse selection because SwiftTerm had no native selection. Empty native copies now preserve the clipboard, while native selections still copy normally. Explicit hyperlinks and detected URLs now open with a plain click and show an underline on hover.

Dragging across a link does not open it. Mouse release still reaches tmux, including when Command is held. README and the app specification describe these behaviors.

Validation: 48 focused terminal tests passed. The impact-selected local quality gate passed static checks, Swift tests, app validation, UI smoke, and quality contracts. The first sandboxed run could not access macOS GUI services; `--resume latest` passed with GUI access and reused successful stages. Regression tests cover Cyrillic Command-C, native and tmux clipboard behavior, OSC 8 and detected links, and mouse-release delivery after drags. No release or hardware power checks were run.
