### PR TITLE
Preserve Unicode clipboard text and paste from tmux copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ The embedded terminal keeps the shortcuts that matter:
 With managed mouse input, tmux copies the selection when you release the
 mouse button. `Cmd-C` keeps that copy when there is no native selection.
 Links show an underline on hover. Click an underlined link to open it.
+Copies preserve Unicode text. `Cmd-V` leaves managed copy mode and inserts
+the text at the live prompt, including line breaks.
 
 Settings → General selects the provider and parent folder for Quick chat. The
 default is `/tmp`. Each `Cmd-T` creates a private
@@ -581,7 +583,9 @@ Inside managed tmux, the mouse wheel scrolls one line at a time. Mouse selection
 copies to the macOS clipboard and keeps the highlight and scroll position. When
 managed mouse input is on, an ASCII or Cyrillic printable key, Space, Enter, or
 Backspace leaves copy mode and sends that key to the live prompt. Arrows, page
-navigation, Escape, and control chords keep their copy-mode behavior. Use
+navigation, Escape, and bound control chords keep their copy-mode behavior.
+Other unbound input, including bracketed paste, returns to the live prompt.
+Use
 `detach config tmux-mouse off` to restore the original copy-mode key tables and
 return mouse handling to the terminal emulator. In Terminal.app, Option-drag
 also bypasses tmux selection.

--- a/app/Sources/DetachKit/SessionAttach.swift
+++ b/app/Sources/DetachKit/SessionAttach.swift
@@ -54,6 +54,16 @@ public struct SessionAttachInvocation: Equatable, Sendable {
         if env["LANG"] == nil || env["LANG"]?.isEmpty == true {
             env["LANG"] = "en_US.UTF-8"
         }
+        // SwiftTerm always consumes UTF-8. A GUI launch can inherit LC_ALL=C,
+        // which takes precedence over LANG and makes tmux render for a
+        // non-UTF-8 client. Limit this correction to the attach client.
+        let characterLocale = ["LC_ALL", "LC_CTYPE", "LANG"]
+            .compactMap { env[$0] }.first { !$0.isEmpty } ?? ""
+        let normalizedLocale = characterLocale.uppercased()
+            .replacingOccurrences(of: "-", with: "")
+        if !normalizedLocale.contains("UTF8") {
+            env["LC_ALL"] = "en_US.UTF-8"
+        }
         return env.keys.sorted().map { key in
             "\(key)=\(env[key] ?? "")"
         }

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -1016,7 +1016,7 @@ final class SessionAttachTerminalTests: XCTestCase {
             pasteboard.clearContents()
             pasteboard.writeObjects(savedItems)
         }
-        let terminal = SessionAttachLocalProcessTerminalView(
+        let terminal = MouseRecordingTerminalView(
             frame: NSRect(x: 0, y: 0, width: 640, height: 360))
         let coordinator = SessionAttachTerminalView.Coordinator(
             controller: SessionAttachController(invocation: Self.invocation()),
@@ -1049,6 +1049,25 @@ final class SessionAttachTerminalTests: XCTestCase {
         XCTAssertTrue(selected.contains("output"))
         copy()
         XCTAssertEqual(pasteboard.string(forType: .string), selected)
+
+        let commandV = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: .command,
+            timestamp: 0, windowNumber: 0, context: nil,
+            characters: "м", charactersIgnoringModifiers: "м",
+            isARepeat: false, keyCode: 9))
+        let text = "Привет, мир! Ёж 🦔\n第二行"
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+        terminal.feed(text: "\u{1B}[?2004h")
+        for enhancement in ["", "\u{1B}[>1u"] {
+            terminal.feed(text: enhancement)
+            terminal.sent.removeAll()
+            XCTAssertNil(coordinator.routeKeyboardEvent(
+                commandV, window: nil, firstResponder: terminal, in: terminal,
+                send: { _ in XCTFail("Command-V must use native paste") }))
+            XCTAssertEqual(terminal.sent,
+                Array(("\u{1B}[200~" + text + "\u{1B}[201~").utf8))
+        }
     }
 
     @MainActor

--- a/app/Tests/DetachKitTests/SessionAttachTests.swift
+++ b/app/Tests/DetachKitTests/SessionAttachTests.swift
@@ -52,6 +52,26 @@ final class SessionAttachTests: XCTestCase {
             ])
     }
 
+    func testAttachClientAlwaysUsesUTF8DespiteInheritedCLocale() {
+        for base in [
+            ["LANG": "C"],
+            ["LANG": "ru_RU.UTF-8", "LC_ALL": "C"],
+            ["LANG": "ru_RU.UTF-8", "LC_CTYPE": "C", "LC_ALL": ""],
+        ] {
+            XCTAssertTrue(SessionAttachInvocation.environment(from: base)
+                .contains("LC_ALL=en_US.UTF-8"))
+        }
+        for base in [
+            ["LANG": "C", "LC_ALL": "ru_RU.UTF-8"],
+            ["LANG": "C", "LC_CTYPE": "en_US.utf8"],
+        ] {
+            let environment = SessionAttachInvocation.environment(from: base)
+            for (key, value) in base {
+                XCTAssertTrue(environment.contains("\(key)=\(value)"))
+            }
+        }
+    }
+
     func testClientSwitchBindsExactPIDSourceAndTargetProvider() {
         XCTAssertEqual(
             SessionClientSwitchInvocation.arguments(

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -1617,6 +1617,11 @@ tmux_emit_type_through_config() {
       "$table" "$fallback_table"
     printf 'bind-key -T %s BSpace if-shell -F "#{==:#{@detach_copy_type_through},1}" "send-keys -X cancel ; send-keys" "switch-client -T %s ; send-keys -K"\n' \
       "$table" "$fallback_table"
+    # PasteStart has no named binding in the pinned tmux. Any catches it
+    # before tmux drops paste bytes in copy-mode. Keep the original key event
+    # so the provider receives its bracketed-paste start as well as its text.
+    printf 'bind-key -T %s Any if-shell -F "#{==:#{@detach_copy_type_through},1}" "send-keys -X cancel ; send-keys" "switch-client -T %s ; send-keys -K"\n' \
+      "$table" "$fallback_table"
   done
 }
 
@@ -1624,9 +1629,12 @@ tmux_bind_copy_type_through() {
   local cfg initialized
 
   initialized="$("${TMUX_CMD[@]}" show-options -sqv @detach_copy_type_through_initialized 2>/dev/null || true)"
-  [ "$initialized" != "1" ] || return 0
-  tmux_clone_key_table copy-mode detach-copy-mode-original || return 1
-  tmux_clone_key_table copy-mode-vi detach-copy-mode-vi-original || return 1
+  [ "$initialized" != "2" ] || return 0
+  # Upgrade live version-1 tables without overwriting their original bindings.
+  if [ "$initialized" != "1" ]; then
+    tmux_clone_key_table copy-mode detach-copy-mode-original || return 1
+    tmux_clone_key_table copy-mode-vi detach-copy-mode-vi-original || return 1
+  fi
   cfg="$(mktemp "${TMPDIR:-/tmp}/detach-copy-binds.XXXXXX")" || return 1
   if ! tmux_emit_type_through_config >"$cfg"; then
     rm -f "$cfg"
@@ -1637,7 +1645,7 @@ tmux_bind_copy_type_through() {
     return 1
   fi
   rm -f "$cfg"
-  "${TMUX_CMD[@]}" set-option -q -s @detach_copy_type_through_initialized 1
+  "${TMUX_CMD[@]}" set-option -q -s @detach_copy_type_through_initialized 2
 }
 
 # One-line wheel steps in copy mode, mouse selections that land in the macOS
@@ -1647,7 +1655,7 @@ tmux_bind_copy_type_through() {
 tmux_configure_copy_input() {
   local table
 
-  "${TMUX_CMD[@]}" set-option -q -s copy-command '/usr/bin/pbcopy' || return 1
+  "${TMUX_CMD[@]}" set-option -q -s copy-command 'LC_ALL=en_US.UTF-8 /usr/bin/pbcopy' || return 1
   "${TMUX_CMD[@]}" set-option -q -s set-clipboard on || return 1
   for table in copy-mode copy-mode-vi; do
     "${TMUX_CMD[@]}" bind-key -T "$table" WheelUpPane send-keys -X -N 1 scroll-up || return 1
@@ -1859,6 +1867,8 @@ attach_session() {
     error "warning: could not configure the terminal title for this session"
   tmux_configure_server || \
     error "warning: could not configure Detach server input options for this session"
+  tmux_apply_mouse_input "$session" || \
+    error "warning: could not configure Detach mouse input for this session"
   if [ -n "$INSIDE_TMUX" ]; then
     current_socket="${INSIDE_TMUX%%,*}"
     target_socket="$("${TMUX_CMD[@]}" display-message -p -t "=$session:" '#{socket_path}' 2>/dev/null)" || \

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -57,6 +57,10 @@ does not open a link. A Finder drop sends shell-safe paths without
 reading files. Live views move Mac Power to metadata. An exited client offers
 Reconnect.
 
+The embedded attach client always uses a UTF-8 character locale. A conflicting
+inherited locale cannot change how tmux encodes its output. Native paste sends
+Unicode text and line breaks with the provider's bracketed paste framing.
+
 Cold start paints at most 128 rows and 1 MiB from private preferences. Cached
 rows grant no action, ownership, PID, cleanup, or power claim until a fresh
 list arrives. A failed refresh keeps them visible but not authoritative. Only

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -140,7 +140,11 @@ secondary.
 Managed input changes only the private server. `tmux-mouse` defaults on: wheel
 steps are one line; selection copies without clearing, exiting, or snapping;
 click clears it. ASCII/Cyrillic text, Space, Enter, and BSpace exit
-copy-mode and reach the pane while navigation/control keys stay. Off restores
+copy-mode and reach the pane while bound navigation/control keys stay.
+Unbound input, including bracketed paste, also leaves managed copy mode.
+Paste preserves its UTF-8 bytes and the provider's paste framing. The copy
+command reads UTF-8 regardless of the server locale. Attach updates older
+managed input bindings without replacing their saved original tables. Off restores
 the original copy tables immediately.
 
 `tmux-extended-keys` defaults on and maps recognized `S-Enter` to stable

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1169,7 +1169,7 @@ tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" status-right | \
 # the macOS clipboard through the Detach-owned server's copy-command.
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" mouse)" = "on" ]
 [ "$(tmux -L "$SOCKET" show-options -qv -t "=$SESSION:" @detach_copy_type_through)" = "1" ]
-[ "$(tmux -L "$SOCKET" show-options -sqv copy-command)" = "/usr/bin/pbcopy" ]
+[ "$(tmux -L "$SOCKET" show-options -sqv copy-command)" = "LC_ALL=en_US.UTF-8 /usr/bin/pbcopy" ]
 tmux -L "$SOCKET" list-keys -T copy-mode | grep -F 'WheelUpPane' | \
   grep -F 'scroll-up' >/dev/null
 # Selections copy through the clipboard but keep the highlight and stay in
@@ -1240,7 +1240,126 @@ tmux -L "$SOCKET" new-session -d -s "$shift_return_session" \
 # Re-run the server configuration through a real attach. Attaching without a
 # controlling terminal fails after tmux_configure_server has already run, so the
 # terminal-features must still appear exactly once.
+original_copy_keys="$(tmux -L "$SOCKET" list-keys -T detach-copy-mode-original)"
+tmux -L "$SOCKET" set-option -s @detach_copy_type_through_initialized 1
+tmux -L "$SOCKET" set-option -s copy-command /usr/bin/pbcopy
+tmux -L "$SOCKET" unbind-key -T copy-mode Any
+tmux -L "$SOCKET" unbind-key -T copy-mode-vi Any
 run_codex attach integration </dev/null >/dev/null 2>&1 || true
+[ "$(tmux -L "$SOCKET" show-options -sqv @detach_copy_type_through_initialized)" = 2 ]
+[ "$(tmux -L "$SOCKET" list-keys -T detach-copy-mode-original)" = "$original_copy_keys" ]
+python3 - "$TMUX_TEST_BIN" "$SOCKET_PATH" "$TMP_ROOT" <<'PY_TERMINAL_PASTE'
+#!/usr/bin/env python3
+"""Exercise managed tmux clipboard and paste through a real terminal client."""
+
+import os
+from pathlib import Path
+import pty
+import shlex
+import subprocess
+import sys
+import time
+
+
+def wait_for(predicate):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("terminal clipboard condition did not become true")
+
+
+def main():
+    tmux, socket, directory = sys.argv[1:]
+    root = Path(directory)
+    utf8 = dict(os.environ, LC_ALL="en_US.UTF-8", TERM="xterm-256color")
+
+    def tm(*args):
+        return subprocess.check_output([tmux, "-S", socket, *args], env=utf8)
+
+    def read_clipboard():
+        return subprocess.check_output(
+            ["/usr/bin/pbpaste", "-pboard", "find"], env=utf8)
+
+    saved = read_clipboard()
+    sample = "Привет, мир! Ёж 🦔 第二行".encode()
+    copy_command = tm("show-options", "-sqv", "copy-command").decode().strip()
+    reader = root / "paste-reader.py"
+    reader.write_text(
+        "import os,sys,tty\n"
+        "tty.setraw(0)\n"
+        "output=open(sys.argv[1],'wb',buffering=0)\n"
+        "os.write(1, bytes.fromhex(sys.argv[2]))\n"
+        "while True: output.write(os.read(0,4096))\n")
+    try:
+        for key_mode in ["emacs", "vi"]:
+            for enabled in [False, True]:
+                name = f"detach-paste-{key_mode}-{int(enabled)}"
+                output = root / f"{name}.bytes"
+                child = None
+                master = None
+                try:
+                    banner = b"\x1b[?2004h" + sample + b"\r\n"
+                    tm("new-session", "-d", "-s", name, shlex.join([
+                        "/usr/bin/python3", str(reader), str(output), banner.hex()]))
+                    tm("set-option", "-t", name, "mode-keys", key_mode)
+                    tm("set-option", "-t", name, "@detach_copy_type_through",
+                       str(int(enabled)))
+                    master, slave = pty.openpty()
+                    child = subprocess.Popen(
+                        [tmux, "-S", socket, "attach-session", "-t", name],
+                        stdin=slave, stdout=slave, stderr=slave,
+                        env=utf8, start_new_session=True)
+                    os.close(slave)
+                    wait_for(lambda: sample in tm("capture-pane", "-p", "-t", name))
+                    wait_for(lambda: name.encode() in tm(
+                        "list-clients", "-F", "#{client_session}"))
+                    tm("copy-mode", "-t", name)
+                    tm("send-keys", "-t", name, "-X", "cursor-up")
+                    tm("send-keys", "-t", name, "-X", "select-line")
+                    # Use the configured command under a C locale on the find
+                    # board, leaving the user's general clipboard untouched.
+                    tm("set-environment", "-t", name, "LC_ALL", "C")
+                    tm("send-keys", "-t", name, "-X", "copy-pipe-no-clear",
+                       copy_command + " -pboard find")
+                    wait_for(lambda: read_clipboard().rstrip(b"\n") == sample)
+                    assert tm("display-message", "-p", "-t", name,
+                              "#{pane_in_mode}").strip() == b"1"
+                    # Bound navigation must keep copy mode active.
+                    os.write(master, b"\x1b[A")
+                    time.sleep(0.05)
+                    assert tm("display-message", "-p", "-t", name,
+                              "#{pane_in_mode}").strip() == b"1"
+                    payload = read_clipboard().rstrip(b"\n") + b"\nsecond line"
+                    framed = b"\x1b[200~" + payload + b"\x1b[201~"
+                    os.write(master, framed)
+                    if enabled:
+                        wait_for(lambda: output.read_bytes() == framed)
+                        assert tm("display-message", "-p", "-t", name,
+                                  "#{pane_in_mode}").strip() == b"0"
+                        os.write(master, framed)
+                        wait_for(lambda: output.read_bytes() == framed * 2)
+                    else:
+                        time.sleep(0.15)
+                        assert output.read_bytes() == b""
+                        assert tm("display-message", "-p", "-t", name,
+                                  "#{pane_in_mode}").strip() == b"1"
+                finally:
+                    tm("kill-session", "-t", name)
+                    if child is not None:
+                        child.wait(timeout=3)
+                    if master is not None:
+                        os.close(master)
+    finally:
+        subprocess.run(["/usr/bin/pbcopy", "-pboard", "find"],
+                       input=saved, env=utf8, check=True)
+    print("UTF-8 clipboard and bracketed paste round trips passed")
+
+
+if __name__ == "__main__":
+    main()
+PY_TERMINAL_PASTE
 [ "$(tmux -L "$SOCKET" show-options -sv terminal-features | grep -Fxc -- '*:extkeys')" = "1" ]
 [ "$(tmux -L "$SOCKET" show-options -sv terminal-features | grep -Fxc -- '*:hyperlinks')" = "1" ]
 grep -Fx -- 'run' "$FAKE_POWER_ARGS_FILE" >/dev/null


### PR DESCRIPTION
Copying non-ASCII terminal output could corrupt the macOS clipboard when the tmux server inherited a C locale. Command-V then lost bracketed paste while the pane remained in copy mode. Clipboard copies now explicitly use UTF-8, and unbound managed copy-mode input exits that mode while preserving the original event and paste framing. Existing navigation and control bindings keep their behavior.

Attach upgrades version-1 input bindings without replacing saved original tables. The embedded UTF-8 client also corrects conflicting inherited character locales. README and runtime/app specifications describe the resulting behavior.

Regression evidence includes real tmux and macOS clipboard round trips with Cyrillic, emoji, multiline text, C locale, emacs/vi tables, managed input enabled/disabled, navigation, and existing binding migration. AppKit tests exercise Cyrillic Command-V and exact paste bytes with normal and enhanced keyboard modes. All 54 focused Swift tests and the configuration/lifecycle suites passed. The impact-selected local gate passed static checks, Swift tests, app validation, UI smoke, quality contracts, Codex, Claude, and distribution. No release or hardware power checks were run.
