### PR TITLE
Fix terminal attach startup and retained session health

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,12 @@ Attach, Resume, and Recover.
 The live terminal processes PTY input and output as events. Its stable
 CoreGraphics renderer repaints only when content changes. A steady cursor
 avoids an idle redraw timer. Switching between live sessions keeps the same
-terminal and PTY. tmux synchronized output replaces the complete frame at once.
+terminal and PTY. The first attach waits for the visible terminal size. A
+selection change during attachment waits for the tmux client to become ready.
+tmux synchronized output replaces the complete frame at once.
 
 Detach preloads the last text screen for up to nine live sessions in a small
-bounded burst. A cold attachment can show that text until its first frame. It
+bounded burst. A cold attachment can show that text for up to one second. It
 does not keep hidden PTYs alive or use raster snapshots during live switching.
 
 Detach preloads recent non-live session logs in a bounded startup burst. This

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -331,9 +331,39 @@ class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         super.viewDidMoveToWindow()
         guard window != nil else { return }
         configureRealtimeRendererIfNeeded()
+        scheduleSizedStart()
         DispatchQueue.main.async { [weak self] in
             guard let self, let window = self.window else { return }
             window.makeFirstResponder(self)
+        }
+    }
+
+    private var pendingStart: (() -> Void)?
+    private var startScheduled = false
+    private var retainedScreenDeadline: DispatchWorkItem?
+
+    func startWhenSized(_ start: @escaping () -> Void) {
+        pendingStart = start
+        scheduleSizedStart()
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        scheduleSizedStart()
+    }
+
+    private func scheduleSizedStart() {
+        guard pendingStart != nil, !startScheduled,
+              window != nil, bounds.width > 0, bounds.height > 0 else { return }
+        startScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.startScheduled = false
+            guard self.window != nil,
+                  self.bounds.width > 0, self.bounds.height > 0 else { return }
+            let start = self.pendingStart
+            self.pendingStart = nil
+            start?()
         }
     }
 
@@ -352,6 +382,11 @@ class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
         overlay.autoresizingMask = [.width, .height]
         addSubview(overlay, positioned: .above, relativeTo: nil)
         retainedScreenView = overlay
+        let deadline = DispatchWorkItem { [weak self] in
+            self?.removeRetainedScreen()
+        }
+        retainedScreenDeadline = deadline
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: deadline)
     }
 
     override func dataReceived(slice: ArraySlice<UInt8>) {
@@ -376,17 +411,24 @@ class SessionAttachLocalProcessTerminalView: LocalProcessTerminalView {
     }
 
     func removeRetainedScreen() {
+        retainedScreenDeadline?.cancel()
+        retainedScreenDeadline = nil
+        needsDisplay = true
         retainedScreenView?.removeFromSuperview()
         retainedScreenView = nil
     }
 
     func stopFrameObservation() {
+        pendingStart = nil
+        retainedScreenDeadline?.cancel()
+        retainedScreenDeadline = nil
         frameReadinessCheck?.cancel()
         frameReadinessCheck = nil
         onFirstVisibleFrame = nil
     }
 
     var isRetainingScreen: Bool { retainedScreenView != nil }
+    var hasFirstVisibleFrame: Bool { didReportFirstVisibleFrame }
 
     static func hasVisibleContent(in terminal: Terminal) -> Bool {
         (0..<terminal.rows).contains { row in
@@ -706,6 +748,17 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
     }
 
     func start(on view: LocalProcessTerminalView) {
+        if let terminal = view as? SessionAttachLocalProcessTerminalView {
+            terminal.startWhenSized { [weak self, weak view] in
+                guard let self, let view else { return }
+                self.startSizedProcess(on: view)
+            }
+        } else {
+            startSizedProcess(on: view)
+        }
+    }
+
+    private func startSizedProcess(on view: LocalProcessTerminalView) {
         view.startProcess(
             executable: invocation.executable,
             args: invocation.arguments,
@@ -837,6 +890,11 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         ) {
             attachedView = view
             desiredSession = target
+            guard view.process.running || view.process.shellPid > 0 else { return }
+            // The child PID initially belongs to the public attach CLI. Wait
+            // for its tmux frame before requesting an exact-client switch.
+            if let terminal = view as? SessionAttachLocalProcessTerminalView,
+               !terminal.hasFirstVisibleFrame { return }
             guard target.id != session.id, switchTask == nil else { return }
             switchTask = Task { @MainActor [weak self, weak view] in
                 await self?.drainSwitches(in: view)
@@ -903,6 +961,7 @@ struct SessionAttachTerminalView: NSViewRepresentable {
         func reportFirstVisibleFrame(from view: LocalProcessTerminalView) {
             captureScreen(from: view)
             onFirstVisibleFrame()
+            requestSession(desiredSession, in: view)
         }
 
         func installKeyboardMonitor(for view: LocalProcessTerminalView) {

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -424,6 +424,7 @@ public enum DetachStateCommand {
         let allowed = required.union(processInspection).union([
             "--stop-requested", "--lifecycle-phase", "--uncommitted-replacement",
             "--runtime-quiescent",
+            "--runtime-ready-at",
         ])
         var values: [String: String] = [:]
         var index = 0
@@ -483,7 +484,10 @@ public enum DetachStateCommand {
                 tmuxState: tmux,
                 workerPID: workerPID,
                 providerPID: providerPID,
-                panePID: panePID)
+                panePID: panePID,
+                runtimeReadyAt: values["--runtime-ready-at"].flatMap {
+                    ISO8601DateFormatter().date(from: $0)
+                })
             worker = processHealth.worker
             providerProcess = processHealth.provider
         } else if !processInspection.isDisjoint(with: values.keys) {

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -75,6 +75,7 @@ struct SessionProcessHealth: Equatable, Sendable {
 struct SessionProcessIdentity: Equatable, Sendable {
     var parentPID: pid_t
     var userID: uid_t
+    var startedAtSeconds: UInt64? = nil
 }
 
 enum ExactProcessState: String, Equatable, Sendable {
@@ -150,7 +151,8 @@ private func liveProcessIdentity(_ pid: pid_t) -> SessionProcessIdentity? {
         expected) == expected else { return nil }
     return SessionProcessIdentity(
         parentPID: pid_t(information.pbi_ppid),
-        userID: uid_t(information.pbi_uid))
+        userID: uid_t(information.pbi_uid),
+        startedAtSeconds: information.pbi_start_tvsec)
 }
 
 /// Reads only the process identities named by one health record. The result is
@@ -164,6 +166,7 @@ enum SessionProcessHealthInspector {
         workerPID rawWorkerPID: String,
         providerPID rawProviderPID: String,
         panePID rawPanePID: String,
+        runtimeReadyAt: Date? = nil,
         userID: uid_t = geteuid(),
         lookup: Lookup = liveProcessIdentity
     ) -> SessionProcessHealth {
@@ -173,7 +176,16 @@ enum SessionProcessHealthInspector {
         var identities: [pid_t: SessionProcessIdentity?] = [:]
         func identity(_ pid: pid_t) -> SessionProcessIdentity? {
             if let cached = identities[pid] { return cached }
-            let value = lookup(pid)
+            var value = lookup(pid)
+            // Readiness is published only after both recorded processes exist.
+            // A later process start proves PID reuse, even for the same UID.
+            // Compare whole seconds because metadata has second precision.
+            if (pid == workerPID || pid == providerPID),
+               let started = value?.startedAtSeconds,
+               let ready = runtimeReadyAt,
+               Double(started) > floor(ready.timeIntervalSince1970) {
+                value = nil
+            }
             identities[pid] = .some(value)
             return value
         }

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -417,6 +417,42 @@ final class SessionAttachTerminalTests: XCTestCase {
     }
 
     @MainActor
+    func testSelectionDuringSlowAttachWaitsForClientFrameAndKeepsLatestTarget() async throws {
+        let source = try XCTUnwrap(Self.session(name: "detach-codex-source"))
+        let skipped = try XCTUnwrap(Self.session(name: "detach-codex-skipped"))
+        let target = try XCTUnwrap(Self.session(name: "detach-codex-target"))
+        let terminal = SessionAttachLocalProcessTerminalView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+        let controller = SessionAttachController(invocation: Self.invocation())
+        controller.configure(terminal, fontPointSize: 13)
+        // A running child is initially the attach wrapper, not a registered
+        // tmux client. Let startup exceed the CLI's client lookup retry bound.
+        terminal.startProcess(executable: "/bin/sleep", args: ["5"])
+        defer { controller.terminateClient() }
+        let cli = RecordingSessionSwitchCLI()
+        let coordinator = SessionAttachTerminalView.Coordinator(
+            controller: controller, session: source,
+            screenCache: SessionTerminalScreenCache(),
+            onTerminated: { _ in }, onSwitchFailed: { XCTFail($0) },
+            switchCLI: cli)
+        terminal.onFirstVisibleFrame = { [weak terminal, weak coordinator] in
+            guard let terminal else { return }
+            coordinator?.reportFirstVisibleFrame(from: terminal)
+        }
+        coordinator.requestSession(skipped, in: terminal)
+        coordinator.requestSession(target, in: terminal)
+        try await Task.sleep(nanoseconds: 600_000_000)
+        let earlyCalls = await cli.recordedCalls()
+        XCTAssertTrue(earlyCalls.isEmpty)
+        terminal.dataReceived(slice: Array("attached tmux frame".utf8)[...])
+        await waitUntilAsync { coordinator.session.id == target.id }
+        let calls = await cli.recordedCalls()
+        XCTAssertEqual(calls, [SessionClientSwitchInvocation.arguments(
+            clientPID: terminal.process.shellPid, from: source, to: target)])
+        coordinator.cancelSwitch()
+    }
+
+    @MainActor
     func testDetailLogReplacesReadErrorWithSuccessfulStyledOutput() async throws {
         let session = try XCTUnwrap(Self.session(status: "stopped"))
         let cli = DetailLogSequenceCLI(responses: [
@@ -1244,6 +1280,57 @@ final class SessionAttachTerminalTests: XCTestCase {
         terminal.dataReceived(slice: Array("more output".utf8)[...])
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.12))
         XCTAssertEqual(visibleFrameCount, 1)
+    }
+
+    @MainActor
+    func testAttachStartsWithVisibleGeometryAndCancelledHostNeverStarts() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-sized-attach-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let record = root.appendingPathComponent("size")
+        let executable = root.appendingPathComponent("detach")
+        try "#!/bin/sh\nstty size > '\(record.path)'\nexec /bin/cat\n"
+            .write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755],
+                                             ofItemAtPath: executable.path)
+        let controller = SessionAttachController(invocation: SessionAttachInvocation(
+            detachPath: executable.path, session: try XCTUnwrap(Self.session()),
+            baseEnvironment: ["PATH": "/bin:/usr/bin"]))
+        let terminal = SessionAttachLocalProcessTerminalView(frame: .zero)
+        controller.configure(terminal, fontPointSize: 13)
+        controller.start()
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertFalse(terminal.process.running)
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+                              styleMask: .borderless, backing: .buffered, defer: false)
+        window.isReleasedWhenClosed = false
+        defer { controller.terminateClient(); window.close() }
+        window.contentView = terminal
+        terminal.setFrameSize(NSSize(width: 900, height: 600))
+        try waitUntil { FileManager.default.fileExists(atPath: record.path) }
+        let actual = try String(contentsOf: record, encoding: .utf8)
+            .split(whereSeparator: \.isWhitespace).compactMap { Int($0) }
+        XCTAssertEqual(actual, [terminal.terminal.rows, terminal.terminal.cols])
+        XCTAssertGreaterThan(terminal.terminal.rows, 24)
+
+        let cancelled = SessionAttachLocalProcessTerminalView(frame: .zero)
+        var starts = 0
+        cancelled.startWhenSized { starts += 1 }
+        cancelled.stopFrameObservation()
+        window.contentView = cancelled
+        cancelled.setFrameSize(NSSize(width: 900, height: 600))
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+        XCTAssertEqual(starts, 0)
+    }
+
+    @MainActor
+    func testSilentAttachCannotKeepAStaleScreenOverLiveInput() throws {
+        let terminal = SessionAttachLocalProcessTerminalView(
+            frame: NSRect(x: 0, y: 0, width: 640, height: 360))
+        terminal.retainScreen(Data("stale snapshot".utf8), fontPointSize: 13)
+        try waitUntil(timeout: 1.3) { !terminal.isRetainingScreen }
+        XCTAssertNil(terminal.terminal.getBufferAsData().range(of: Data("stale snapshot".utf8)))
     }
 
     func testDroppedPathNeverInsertsAControlCharacter() {

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -1951,6 +1951,28 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testHealthInspectionRejectsPIDReusedAfterReadinessButKeepsUnknownTime() throws {
+        let pid = String(ProcessInfo.processInfo.processIdentifier)
+        let arguments = [
+            "health", "evaluate", "--metadata-valid", "true",
+            "--runtime-identity-expected", "true", "--meta-status", "stopped",
+            "--tmux", "missing", "--run-token", "missing",
+            "--worker", "unknown", "--provider-process", "unknown",
+            "--heartbeat", "missing", "--checkpoint", "missing",
+            "--checkpoint-recoverable", "false", "--agent-session-known", "true",
+            "--inspect-processes", "true", "--worker-pid", pid,
+            "--provider-pid", pid, "--pane-pid", "-",
+        ]
+        for ready in ["2000-01-01T00:00:00Z", "-", "invalid"] {
+            let output = try DetachStateCommand.run(arguments: arguments + [
+                "--runtime-ready-at", ready,
+            ])
+            let result = try JSONDecoder().decode(SessionHealthAssessment.self, from: output)
+            XCTAssertEqual(result.effectiveStatus, ready.hasPrefix("2000") ? .stopped : .hung)
+            if !ready.hasPrefix("2000") { XCTAssertTrue(result.actions.isEmpty) }
+        }
+    }
+
     func testHealthSessionEmitsTypedPublicJSONAndHidesCollisionIdentity() throws {
         let evidence = [
             "--metadata-valid", "true",

--- a/app/Tests/DetachKitTests/SessionHealthTests.swift
+++ b/app/Tests/DetachKitTests/SessionHealthTests.swift
@@ -736,6 +736,35 @@ final class SessionHealthTests: XCTestCase {
         XCTAssertEqual(foreign, SessionProcessHealth(worker: .dead, provider: .dead))
     }
 
+    func testProcessInspectorDoesNotReviveFinishedRuntimeFromReusedPIDs() {
+        let ready = Date(timeIntervalSince1970: 100)
+        for tmux: TmuxHealthState in [.missing, .dead] {
+            let result = SessionProcessHealthInspector.inspect(
+                tmuxState: tmux, workerPID: "10", providerPID: "30",
+                panePID: "10", runtimeReadyAt: ready, userID: 501,
+                lookup: { pid in
+                    SessionProcessIdentity(
+                        parentPID: pid == 30 ? 10 : 1, userID: 501,
+                        startedAtSeconds: 101)
+                })
+            XCTAssertEqual(result, SessionProcessHealth(worker: .dead, provider: .dead))
+        }
+    }
+
+    func testProcessInspectorKeepsOriginalAndUncertainRuntimeProcesses() {
+        for started: UInt64? in [99, 100, nil] {
+            let result = SessionProcessHealthInspector.inspect(
+                tmuxState: .missing, workerPID: "10", providerPID: "30",
+                panePID: "-", runtimeReadyAt: Date(timeIntervalSince1970: 100),
+                userID: 501, lookup: { pid in
+                    SessionProcessIdentity(
+                        parentPID: pid == 30 ? 10 : 1, userID: 501,
+                        startedAtSeconds: started)
+                })
+            XCTAssertEqual(result, SessionProcessHealth(worker: .alive, provider: .alive))
+        }
+    }
+
     func testProcessInspectorKeepsInvalidPIDsUnknownAndBoundsCycles() {
         var reads = 0
         let invalid = SessionProcessHealthInspector.inspect(

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -6985,6 +6985,7 @@ session_health_envelope() {
       --worker-pid "${worker_pid:--}"
       --provider-pid "${provider_pid:--}"
       --pane-pid "${pane_pid:--}"
+      --runtime-ready-at "${runtime_ready_at:--}"
     )
   fi
   case "$output_mode" in

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -46,6 +46,9 @@ keeps sheet errors, and selects the new session. Start, Resume, and Recover open
 `detach <provider> attach --terminal-features sync <session>` in one visible
 PTY. Live-to-live selection keeps it and asks the public CLI to switch its exact
 tmux client. Closing the view ends the client.
+The PTY starts after the terminal has a window and a nonzero size. Selection
+changes during cold attach wait for the first tmux frame before client lookup.
+The latest selected session wins. A removed host cannot start a delayed PTY.
 
 Terminal I/O is event-driven. CoreGraphics repaints on changes and uses a
 steady cursor. No terminal poller or frame loop runs. `Command-C/V/F` provide

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -29,6 +29,9 @@ Checkpoint metadata cannot replace it.
 `list --json` reads Codex and Claude concurrently and emits that order. Each
 uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
 PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
+List compares process creation time with recorded runtime readiness. A process
+that started in a later second is a reused PID, not a surviving runtime.
+Missing readiness or creation time keeps the conservative identity result.
 Mutations recheck ownership, pane, run token, and process group. List jobs
 `exec` cores; cleanup signals PIDs.
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1302,7 +1302,7 @@ def main():
                 try:
                     banner = b"\x1b[?2004h" + sample + b"\r\n"
                     tm("new-session", "-d", "-s", name, shlex.join([
-                        "/usr/bin/python3", str(reader), str(output), banner.hex()]))
+                        sys.executable, str(reader), str(output), banner.hex()]))
                     tm("set-option", "-t", name, "mode-keys", key_mode)
                     tm("set-option", "-t", name, "@detach_copy_type_through",
                        str(int(enabled)))
@@ -1345,6 +1345,14 @@ def main():
                         assert output.read_bytes() == b""
                         assert tm("display-message", "-p", "-t", name,
                                   "#{pane_in_mode}").strip() == b"1"
+                except BaseException:
+                    print("terminal paste fixture:", name, file=sys.stderr)
+                    print("pane state:", tm("display-message", "-p", "-t", name,
+                          "#{pane_dead}|#{pane_dead_status}|#{pane_width}x#{pane_height}")
+                          .decode(errors="replace"), file=sys.stderr)
+                    print("pane output:", repr(tm("capture-pane", "-p", "-t", name)),
+                          file=sys.stderr)
+                    raise
                 finally:
                     tm("kill-session", "-t", name)
                     if child is not None:


### PR DESCRIPTION
Cold attachment could start the PTY before its visible size was known. A selection change could also look up the child PID while it still belonged to the attach wrapper. Start after window layout, wait for the first attach frame before switching, and use the latest selection. Remove a passive cached screen within one second, including when attachment produces no output. Cached text stays outside the live terminal buffer.

Retained sessions could enter Problems when macOS reused a recorded PID for another process under the same UID. Read-only health inspection now rejects a process created after the recorded runtime readiness time. Missing or invalid timestamps keep the conservative result. Runtime mutations retain their existing ownership checks.

Validation: real PTY initial-size and cancellation regression; delayed-attach selection regression; silent-screen expiry; PID reuse, timestamp precision, and command-boundary regressions. All eight selected local diagnostic stages passed: static, Swift (1,144 tests, one skipped), app build, UI smoke, quality contracts, Codex, Claude, and distribution. Changed Swift line coverage is 100%. Hosted repository quality-gates remains the merge authority.

The reported literal missing-client message was absent from the available tmux message history. The startup lookup race is covered; this does not claim that every possible missing-client cause has been reproduced. Manual release-only power and closed-lid checks were not run.

CI repair: the first hosted attempt failed before the clipboard fixture produced its initial banner or output file. The fixture now uses its own Python interpreter instead of hard-coded system Python and preserves pane diagnostics before cleanup. Clipboard assertions and time limits are unchanged. The repaired lifecycle test passed locally; the final hosted run must pass.
