### PR TITLE
Open resumed terminals earlier at the visible window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ Start, Resume, and Recover run inside Detach and do not require an outer
 terminal. The selected external terminal remains available as a fallback for
 Attach, Resume, and Recover.
 
+Resume and Recover show the new terminal as soon as the session can accept an
+attachment. Startup checks continue, and Detach reports any startup error.
+With the current CLI, the provider receives the visible terminal size before
+its first output.
+
 The live terminal processes PTY input and output as events. Its stable
 CoreGraphics renderer repaints only when content changes. A steady cursor
 avoids an idle redraw timer. Switching between live sessions keeps the same

--- a/app/Sources/DetachApp/SessionAttachTerminalView.swift
+++ b/app/Sources/DetachApp/SessionAttachTerminalView.swift
@@ -693,6 +693,14 @@ final class SessionAttachController: NSObject, LocalProcessTerminalViewDelegate 
         NSFont.monospacedSystemFont(ofSize: max(pointSize, 1), weight: .regular)
     }
 
+    @MainActor
+    static func initialSize(surfaceSize: CGSize, fontPointSize: CGFloat) -> SessionTerminalSize? {
+        guard surfaceSize.width > 0, surfaceSize.height > 0 else { return nil }
+        let view = LocalProcessTerminalView(frame: CGRect(origin: .zero, size: surfaceSize))
+        view.font = terminalFont(pointSize: fontPointSize)
+        return SessionTerminalSize(columns: view.terminal.cols, rows: view.terminal.rows)
+    }
+
     static func terminate(process: LocalProcess, timeout: TimeInterval = 1) {
         let pid = process.shellPid
         process.terminate()

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -113,6 +113,8 @@ struct SessionDetailView: View {
     @State private var attachClientActive = true
     @State private var attachRequested = false
     @State private var preparingAction: SessionAction?
+    @State private var preparingSession: Session?
+    @State private var terminalSurfaceSize: CGSize = .zero
     @State private var interactionGeneration = UUID()
 
     var body: some View {
@@ -133,6 +135,7 @@ struct SessionDetailView: View {
             attachClientActive = true
             attachRequested = false
             preparingAction = nil
+            preparingSession = nil
         }
         .alert(L10n.string("Something went wrong"), isPresented: .init(
             get: { actionError != nil }, set: { if !$0 { actionError = nil } })) {
@@ -343,11 +346,11 @@ struct SessionDetailView: View {
     }
 
     private var showsEmbeddedTerminal: Bool {
-        attachRequested || (
-            preparingAction == nil
-                && SessionAttachInvocation.shouldEmbed(
-                    session,
-                    clientActive: attachClientActive))
+        attachRequested || SessionAttachInvocation.shouldEmbed(
+            session,
+            clientActive: attachClientActive
+                && (preparingSession == nil || store.hasFreshSnapshot),
+            replacing: preparingSession)
     }
 
     private var logTaskID: String {
@@ -455,6 +458,9 @@ struct SessionDetailView: View {
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 8))
+        .onGeometryChange(for: CGSize.self) { $0.size } action: {
+            terminalSurfaceSize = $0
+        }
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
         .background {
@@ -698,14 +704,20 @@ struct SessionDetailView: View {
         guard preparingAction == nil,
               action == .resume || action == .recover else { return }
         let sessionID = session.id
-        attachClientActive = false
+        attachClientActive = true
         preparingAction = action
+        preparingSession = session
         Task {
-            let message = await store.prepareInteractive(action, on: session)
+            let size = SessionAttachController.initialSize(
+                surfaceSize: terminalSurfaceSize, fontPointSize: fontPointSize)
+            let message = await store.prepareInteractive(
+                action, on: session, terminalSize: size)
             guard interactionGeneration == generation,
                   session.id == sessionID else { return }
             preparingAction = nil
+            preparingSession = nil
             if let message {
+                attachClientActive = false
                 actionError = message
                 return
             }

--- a/app/Sources/DetachApp/UIE2ETestDriver.swift
+++ b/app/Sources/DetachApp/UIE2ETestDriver.swift
@@ -451,10 +451,33 @@ enum UIE2ETestDriver {
                         .appendingPathComponent("fake/actions.log"),
                     encoding: .utf8)
                 return actions?.contains(
-                    "resume --detach a9f58f1d-1234-5678-9abc-def012342ed9") == true
+                    "claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9") == true
             }
             try await waitUntil("resumed session attaches in app", attempts: 80) {
-                find(identifier: "session-preview-terminal") != nil
+                let invocations = try? String(
+                    contentsOf: configuration.root.appendingPathComponent("fake/invocations.log"),
+                    encoding: .utf8)
+                return find(identifier: "session-preview-terminal") != nil
+                    && invocations?.contains(
+                        "claude attach --terminal-features sync detach-claude-ui-completed") == true
+            }
+            let resumeCompleted = configuration.root.appendingPathComponent("fake/resume-completed")
+            guard !FileManager.default.fileExists(atPath: resumeCompleted.path) else {
+                throw Failure(message:
+                    "Resume must show its terminal before the readiness command completes")
+            }
+            let initialSize = try String(
+                contentsOf: configuration.root.appendingPathComponent("fake/initial-terminal-size"),
+                encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let terminal = find(identifier: "session-preview-terminal")
+                as? LocalProcessTerminalView,
+                initialSize.split(separator: "x").first.flatMap({ Int($0) }) == terminal.terminal.cols
+            else {
+                throw Failure(message: "Resume must pass the visible terminal width before startup")
+            }
+            try Data().write(to: configuration.root.appendingPathComponent("fake/release-resume"))
+            try await waitUntil("resume readiness completes") {
+                FileManager.default.fileExists(atPath: resumeCompleted.path)
             }
             checks.append("resume-runs-in-app-with-terminal-fallback")
             let runningID = "detach-codex-ui-running"

--- a/app/Sources/DetachKit/SessionAttach.swift
+++ b/app/Sources/DetachKit/SessionAttach.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+/// Initial detached window grid. Attached clients supply later dimensions.
+public struct SessionTerminalSize: Equatable, Sendable {
+    public let columns: Int
+    public let rows: Int
+
+    public init?(columns: Int, rows: Int) {
+        guard (1...999).contains(columns), (1...999).contains(rows) else { return nil }
+        self.columns = columns
+        self.rows = rows
+    }
+
+    public var arguments: [String] { ["--terminal-size", "\(columns)x\(rows)"] }
+}
+
 /// Public attach invocation for an in-app PTY client.
 ///
 /// The client must run `detach <provider> attach <session>` as argv. It must
@@ -26,8 +40,23 @@ public struct SessionAttachInvocation: Equatable, Sendable {
         session.isLive && session.availableActions.contains(.attach)
     }
 
-    public static func shouldEmbed(_ session: Session, clientActive: Bool) -> Bool {
-        clientActive && isEligible(session)
+    public static func shouldEmbed(
+        _ session: Session,
+        clientActive: Bool,
+        replacing previous: Session? = nil
+    ) -> Bool {
+        guard clientActive, isEligible(session) else { return false }
+        guard let previous else { return true }
+        guard session.id == previous.id else { return false }
+        if let oldRun = previous.lifecycleID, let newRun = session.lifecycleID {
+            return oldRun != newRun
+        }
+        // Older records have no lifecycle ID. A later creation timestamp can
+        // prove replacement; missing identity waits for command completion.
+        guard let oldDate = previous.createdAt, let newDate = session.createdAt else {
+            return false
+        }
+        return newDate > oldDate
     }
 
     public static func arguments(for session: Session) -> [String] {

--- a/app/Sources/DetachKit/SessionStore.swift
+++ b/app/Sources/DetachKit/SessionStore.swift
@@ -642,19 +642,32 @@ public final class SessionStore {
     }
 
     /// Starts Resume or Recover without an outer terminal. The provider starts
-    /// detached; the app creates a separate attach-only PTY after this returns.
+    /// detached; a fresh starting snapshot can open its attach-only PTY while
+    /// this command still waits for full readiness.
     public func prepareInteractive(
         _ action: SessionAction,
-        on session: Session
+        on session: Session,
+        terminalSize: SessionTerminalSize? = nil
     ) async -> String? {
         let arguments: [String]
         let timeoutMessage: String
+        var projectDirectory: URL?
         switch action {
         case .resume:
             guard let sessionID = session.agentSessionId, !sessionID.isEmpty else {
                 return L10n.string("The session has no provider UUID to resume.")
             }
-            arguments = ["resume", "--detach", sessionID]
+            if let path = session.projectDir, path.hasPrefix("/") {
+                projectDirectory = URL(fileURLWithPath: path, isDirectory: true)
+                arguments = [
+                    session.provider.rawValue, "resume", "--name", session.sessionName,
+                    "--detach", sessionID,
+                ]
+            } else {
+                // Legacy rows can omit the project. Let the public resolver
+                // recover it instead of starting in the app's working directory.
+                arguments = ["resume", "--detach", sessionID]
+            }
             timeoutMessage = L10n.string("detach resume timed out")
         case .recover:
             arguments = [
@@ -671,7 +684,20 @@ public final class SessionStore {
         }
 
         do {
-            let result = try await cli.run(arguments: arguments, timeout: 120)
+            var result = try await cli.run(
+                arguments: (terminalSize?.arguments ?? []) + arguments, timeout: 120,
+                currentDirectoryURL: projectDirectory)
+            // A payload update can wait for existing sessions to finish. An
+            // older frontend rejects this prefix before dispatching startup.
+            // Retry only that exact pre-dispatch rejection, never a run error.
+            if terminalSize != nil, result.exitCode == 1, !result.timedOut,
+               result.stdout.isEmpty,
+               result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "detach: unknown command: --terminal-size" {
+                result = try await cli.run(
+                    arguments: arguments, timeout: 120,
+                    currentDirectoryURL: projectDirectory)
+            }
             await refresh()
             if result.timedOut {
                 return timeoutMessage

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -1313,6 +1313,15 @@ final class SessionAttachTerminalTests: XCTestCase {
             .split(whereSeparator: \.isWhitespace).compactMap { Int($0) }
         XCTAssertEqual(actual, [terminal.terminal.rows, terminal.terminal.cols])
         XCTAssertGreaterThan(terminal.terminal.rows, 24)
+        let initialSize = SessionAttachController.initialSize(
+            surfaceSize: terminal.bounds.size, fontPointSize: 13)
+        XCTAssertEqual(initialSize?.columns, terminal.terminal.cols)
+        XCTAssertEqual(initialSize?.rows, terminal.terminal.rows)
+        XCTAssertNil(SessionAttachController.initialSize(
+            surfaceSize: .zero, fontPointSize: 13))
+        let largerFontSize = SessionAttachController.initialSize(
+            surfaceSize: terminal.bounds.size, fontPointSize: 18)
+        XCTAssertLessThan(try XCTUnwrap(largerFontSize?.columns), terminal.terminal.cols)
 
         let cancelled = SessionAttachLocalProcessTerminalView(frame: .zero)
         var starts = 0

--- a/app/Tests/DetachKitTests/SessionAttachTests.swift
+++ b/app/Tests/DetachKitTests/SessionAttachTests.swift
@@ -2,6 +2,16 @@ import XCTest
 @testable import DetachKit
 
 final class SessionAttachTests: XCTestCase {
+    func testInitialSizeAcceptsOnlyBoundedPositiveDimensions() {
+        XCTAssertEqual(SessionTerminalSize(columns: 152, rows: 43)?.arguments,
+                       ["--terminal-size", "152x43"])
+        XCTAssertNotNil(SessionTerminalSize(columns: 1, rows: 999))
+        XCTAssertNil(SessionTerminalSize(columns: 0, rows: 43))
+        XCTAssertNil(SessionTerminalSize(columns: 152, rows: -1))
+        XCTAssertNil(SessionTerminalSize(columns: 1000, rows: 43))
+        XCTAssertNil(SessionTerminalSize(columns: 152, rows: 1000))
+    }
+
     func testPublicAttachUsesArgvAndNeverCallsTmux() {
         let invocation = SessionAttachInvocation(
             detachPath: "/Users/me/.local/bin/detach",
@@ -102,6 +112,42 @@ final class SessionAttachTests: XCTestCase {
             SessionAttachInvocation.shouldEmbed(session(status: .running), clientActive: false))
         XCTAssertFalse(
             SessionAttachInvocation.shouldEmbed(session(status: .stopped), clientActive: true))
+    }
+
+    func testResumeCanShowOnlyANewAttachableGenerationBeforeCompletion() {
+        var previous = session(status: .stopped)
+        previous.lifecycleID = "previous-run"
+        var starting = session(status: .starting)
+        starting.lifecycleID = "replacement-run"
+        XCTAssertTrue(SessionAttachInvocation.shouldEmbed(
+            starting, clientActive: true, replacing: previous))
+        XCTAssertFalse(SessionAttachInvocation.shouldEmbed(
+            starting, clientActive: false, replacing: previous),
+            "An exited early client must not restart while Resume is pending")
+        starting.lifecycleID = previous.lifecycleID
+        XCTAssertFalse(SessionAttachInvocation.shouldEmbed(
+            starting, clientActive: true, replacing: previous))
+        starting.lifecycleID = "replacement-run"
+        starting.sessionName = "detach-codex-other"
+        XCTAssertFalse(SessionAttachInvocation.shouldEmbed(
+            starting, clientActive: true, replacing: previous))
+        starting = previous
+        starting.lifecycleID = "replacement-run"
+        XCTAssertFalse(SessionAttachInvocation.shouldEmbed(
+            starting, clientActive: true, replacing: previous))
+    }
+
+    func testResumeLegacyGenerationRequiresALaterCreationTime() {
+        var previous = session(status: .stopped)
+        var starting = session(status: .starting)
+        XCTAssertFalse(SessionAttachInvocation.shouldEmbed(
+            starting, clientActive: true, replacing: previous))
+        previous.createdAt = Date(timeIntervalSince1970: 100)
+        for value in [99.0, 100.0, 101.0] {
+            starting.createdAt = Date(timeIntervalSince1970: value)
+            XCTAssertEqual(SessionAttachInvocation.shouldEmbed(
+                starting, clientActive: true, replacing: previous), value > 100)
+        }
     }
 
     private func session(

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -663,7 +663,10 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertNil(error)
         XCTAssertEqual(
             cli.calls,
-            [["list", "--json"], ["resume", "--detach", "u1"], ["list", "--json"]])
+            [["list", "--json"], ["codex", "resume", "--name", "detach-codex-p-1", "--detach", "u1"], ["list", "--json"]])
+        XCTAssertEqual(cli.currentDirectories.count, 1)
+        XCTAssertEqual(cli.currentDirectories.first ?? nil,
+                       URL(fileURLWithPath: "/tmp/p", isDirectory: true))
     }
 
     func testPrepareRecoverUsesProviderAndManagedName() async throws {
@@ -687,13 +690,85 @@ final class SessionStoreTests: XCTestCase {
         ]))
     }
 
+    func testPrepareActionsPassInitialTerminalSize() async throws {
+        for action in [SessionAction.resume, .recover] {
+            let cli = FakeCLI()
+            cli.responses["list --json"] = ok(line)
+            let store = SessionStore(cli: cli)
+            await store.refresh()
+            let error = await store.prepareInteractive(
+                action, on: try XCTUnwrap(store.sessions.first),
+                terminalSize: SessionTerminalSize(columns: 137, rows: 47))
+            XCTAssertNil(error)
+            XCTAssertEqual(Array(cli.calls[1].prefix(4)),
+                           ["--terminal-size", "137x47", "codex", action.rawValue])
+        }
+    }
+
+    func testInitialSizeRetriesOnlyAnOlderFrontendRejection() async throws {
+        for (stderr, stdout, timedOut, expectedCalls) in [
+            ("detach: unknown command: --terminal-size\n", "", false, 4),
+            ("provider startup failed", "", false, 3),
+            ("detach: unknown command: --terminal-size", "Started", false, 3),
+            ("detach: unknown command: --terminal-size", "", true, 3),
+        ] {
+            let cli = FakeCLI()
+            cli.responses["list --json"] = ok(line)
+            cli.responses["--terminal-size 137x47 codex resume --name detach-codex-p-1 --detach u1"] =
+                .success(CLIResult(exitCode: 1, stdout: stdout, stderr: stderr, timedOut: timedOut))
+            let store = SessionStore(cli: cli)
+            await store.refresh()
+            let error = await store.prepareInteractive(
+                .resume, on: try XCTUnwrap(store.sessions.first),
+                terminalSize: SessionTerminalSize(columns: 137, rows: 47))
+            XCTAssertEqual(cli.calls.count, expectedCalls)
+            if expectedCalls == 4 {
+                XCTAssertNil(error)
+                XCTAssertEqual(cli.calls[2],
+                    ["codex", "resume", "--name", "detach-codex-p-1", "--detach", "u1"])
+                XCTAssertEqual(cli.currentDirectories, Array(repeating:
+                    URL(fileURLWithPath: "/tmp/p", isDirectory: true), count: 2))
+            } else {
+                XCTAssertNotNil(error)
+            }
+        }
+    }
+
+    func testPrepareResumeKeepsTheSelectedClaudeSession() async throws {
+        let cli = FakeCLI()
+        cli.responses["list --json"] = ok(line.replacingOccurrences(of: "codex", with: "claude"))
+        let store = SessionStore(cli: cli)
+        await store.refresh()
+        let error = await store.prepareInteractive(.resume, on: try XCTUnwrap(store.sessions.first))
+        XCTAssertNil(error)
+        XCTAssertTrue(cli.calls.contains([
+            "claude", "resume", "--name", "detach-claude-p-1", "--detach", "u1",
+        ]))
+        XCTAssertFalse(cli.calls.contains { $0.first == "resume" })
+    }
+
+    func testPrepareResumeResolvesMissingLegacyProjectInsteadOfUsingAppDirectory() async throws {
+        for project in ["null", "\"relative/path\""] {
+            let cli = FakeCLI()
+            cli.responses["list --json"] = ok(line.replacingOccurrences(
+                of: #""project_dir":"/tmp/p""#, with: "\"project_dir\":\(project)"))
+            let store = SessionStore(cli: cli)
+            await store.refresh()
+            let error = await store.prepareInteractive(.resume, on: try XCTUnwrap(store.sessions.first))
+            XCTAssertNil(error)
+            XCTAssertTrue(cli.calls.contains(["resume", "--detach", "u1"]))
+            XCTAssertEqual(cli.currentDirectories.count, 1)
+            XCTAssertNil(cli.currentDirectories.first ?? nil)
+        }
+    }
+
     func testPrepareInteractiveReturnsTheBoundedCLIFailure() async throws {
         let cli = FakeCLI()
         let stopped = line.replacingOccurrences(
             of: #""effective_status":"running""#,
             with: #""effective_status":"stopped""#)
         cli.responses["list --json"] = ok(stopped)
-        cli.responses["resume --detach u1"] = .success(CLIResult(
+        cli.responses["codex resume --name detach-codex-p-1 --detach u1"] = .success(CLIResult(
             exitCode: 17,
             stdout: "",
             stderr: "resume refused",
@@ -725,7 +800,7 @@ final class SessionStoreTests: XCTestCase {
 
         let timeoutCLI = FakeCLI()
         timeoutCLI.responses["list --json"] = ok(line)
-        timeoutCLI.responses["resume --detach u1"] = .success(CLIResult(
+        timeoutCLI.responses["codex resume --name detach-codex-p-1 --detach u1"] = .success(CLIResult(
             exitCode: 124,
             stdout: "",
             stderr: "",
@@ -741,7 +816,7 @@ final class SessionStoreTests: XCTestCase {
 
         let failedCLI = FakeCLI()
         failedCLI.responses["list --json"] = ok(line)
-        failedCLI.responses["resume --detach u1"] = .failure(FakeError())
+        failedCLI.responses["codex resume --name detach-codex-p-1 --detach u1"] = .failure(FakeError())
         let failedStore = SessionStore(cli: failedCLI)
         await failedStore.refresh()
         let launchError = await failedStore.prepareInteractive(
@@ -778,7 +853,7 @@ final class SessionStoreTests: XCTestCase {
 
         let failureCLI = FakeCLI()
         failureCLI.responses["list --json"] = ok(line)
-        failureCLI.responses["resume --detach u1"] = .success(CLIResult(
+        failureCLI.responses["codex resume --name detach-codex-p-1 --detach u1"] = .success(CLIResult(
             exitCode: 23,
             stdout: "",
             stderr: " \n",

--- a/bin/detach
+++ b/bin/detach
@@ -17,6 +17,7 @@ die() {
 usage() {
   printf '%s\n' \
     'Usage:' \
+    '  detach [--terminal-size COLSxROWS] <provider> [start|resume|recover] [ARGS...]' \
     '  detach codex [COMMAND] [ARGS...]' \
     '  detach claude [COMMAND] [ARGS...]' \
     '  detach list [--json]' \
@@ -720,6 +721,19 @@ client_switch() {
 }
 
 main() {
+  # Startup dimensions are request-local. Do not reuse an inherited hint.
+  unset DETACH_INITIAL_TERMINAL_SIZE
+  if [ "${1:-}" = --terminal-size ]; then
+    [ "$#" -ge 3 ] || die "--terminal-size requires COLSxROWS and a startup command"
+    [[ "$2" =~ ^[1-9][0-9]{0,2}x[1-9][0-9]{0,2}$ ]] || \
+      die "terminal size must be COLSxROWS with each dimension from 1 to 999"
+    export DETACH_INITIAL_TERMINAL_SIZE="$2"
+    shift 2
+    case "${1:-}:${2:-}" in
+      resume:*|codex:start|codex:resume|codex:recover|claude:start|claude:resume|claude:recover) ;;
+      *) die "--terminal-size requires an explicit start, resume, or recover command" ;;
+    esac
+  fi
   local command="${1:-}"
   local repair_metadata="" local_repair_source="" local_repair_version=""
   local local_repair_installer=""

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -5899,6 +5899,7 @@ start_tmux_session() {
   local pane_id=""
   local legacy_env_file
   local env_args=()
+  local window_args=( -d )
   local session_color
   local default_base
   local power_ready_file
@@ -6035,9 +6036,14 @@ start_tmux_session() {
 
   # A newly daemonized tmux server inherits the client's cwd for its lifetime.
   # Anchor it in persistent Detach state instead of a removable project mount.
+  if [ -n "${DETACH_INITIAL_TERMINAL_SIZE:-}" ]; then
+    [[ "$DETACH_INITIAL_TERMINAL_SIZE" =~ ^[1-9][0-9]{0,2}x[1-9][0-9]{0,2}$ ]] || \
+      die "invalid initial terminal size"
+    window_args+=( -x "${DETACH_INITIAL_TERMINAL_SIZE%x*}" -y "${DETACH_INITIAL_TERMINAL_SIZE#*x}" )
+  fi
   pane_id="$(
     cd -P "$INSTALL_STATE_ROOT" >/dev/null 2>&1 &&
-      "${TMUX_CMD[@]}" new-session -d -P -F '#{pane_id}' -s "$session" -c "$cwd" -n "$PROVIDER"
+      "${TMUX_CMD[@]}" new-session "${window_args[@]}" -P -F '#{pane_id}' -s "$session" -c "$cwd" -n "$PROVIDER"
   )" || \
     die "could not create tmux session"
   [ -n "$pane_id" ] || die "tmux did not return a pane id"
@@ -6107,7 +6113,7 @@ start_tmux_session() {
     -t "$pane_id" \
     -c "$cwd" \
     "${env_args[@]}" \
-    "$ENV_BIN" -C "$INSTALL_STATE_ROOT" \
+    "$ENV_BIN" -u DETACH_INITIAL_TERMINAL_SIZE -C "$INSTALL_STATE_ROOT" \
       "$SELF" __worker "$session" "$cwd" "$start_ms" "$run_token" "$agent_bin" "$@" || \
       die "could not start $PROVIDER_LABEL in tmux"
 

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -49,6 +49,18 @@ tmux client. Closing the view ends the client.
 The PTY starts after the terminal has a window and a nonzero size. Selection
 changes during cold attach wait for the first tmux frame before client lookup.
 The latest selected session wins. A removed host cannot start a delayed PTY.
+Resume uses the selected project, provider, managed name, and provider UUID.
+If the project is missing, the public UUID resolver finds it. Resume and
+Recover can open the terminal from a fresh attachable snapshot of the new run
+before the command completes. The lifecycle ID must change, or a legacy row
+must have a later creation time. An old or unidentified run waits for command
+completion. An exited early client does not reconnect during preparation.
+The preparation command still reports readiness failures.
+Resume and Recover pass the visible terminal size before the provider starts.
+The app measures this size with the terminal font and SwiftTerm layout. This
+prevents initial output from wrapping at the default detached window width.
+If an older CLI rejects the size prefix before startup, the app retries without
+the hint. No startup failure or timeout permits this retry.
 
 Terminal I/O is event-driven. CoreGraphics repaints on changes and uses a
 steady cursor. No terminal poller or frame loop runs. `Command-C/V/F` provide

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -73,6 +73,12 @@ canonical project beneath the cleanup trap.
 
 Tmux environment arguments stay in memory; credentials never touch disk.
 
+The public `--terminal-size COLSxROWS` prefix accepts dimensions from 1 to 999
+for explicit Start, Resume, and Recover commands. It sets the initial detached
+window size before the provider starts. The hint crosses startup locks in
+memory. It is not saved with provider options or copied into the provider
+environment. Attached clients still control subsequent terminal dimensions.
+
 When the provider pane dies, tmux detaches its clients. External terminals
 return to their original shell.
 The completion hook requires the exact pane ID and run token. It targets the

--- a/tests/fake-claude
+++ b/tests/fake-claude
@@ -14,6 +14,9 @@ session_id=""
 full_task_value="${FAKE_CLAUDE_TASK_VALUE:-full-id}"
 
 printf '%s\n' "$@" >"$args_file"
+if [ -t 0 ]; then
+  stty size >"$args_file.terminal-size"
+fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in

--- a/tests/fake-codex
+++ b/tests/fake-codex
@@ -18,6 +18,10 @@ sqlite() {
 }
 
 printf '%s\n' "$@" >"$args_file"
+if [ -t 0 ]; then
+  stty size >"$args_file.terminal-size"
+  printf '%s\n' "${DETACH_INITIAL_TERMINAL_SIZE:-}" >"$args_file.initial-size-hint"
+fi
 if [ -n "${FAKE_CODEX_COLORTERM_FILE:-}" ]; then
   printf '%s\n' "${COLORTERM:-}" >"$FAKE_CODEX_COLORTERM_FILE"
 fi

--- a/tests/fake-ui-cli
+++ b/tests/fake-ui-cli
@@ -18,12 +18,18 @@ esac
 
 printf '%s\n' "$*" >>"$INVOCATIONS"
 
+if [ "${1:-}" = --terminal-size ]; then
+  [[ "${2:-}" =~ ^[1-9][0-9]{0,2}x[1-9][0-9]{0,2}$ ]] || exit 90
+  printf '%s\n' "$2" >"$ROOT/fake/initial-terminal-size"
+  shift 2
+fi
+
 if [ "$#" -eq 2 ] && [ "$1" = watch ] && [ "$2" = --json ]; then
   fixture_signature() {
     local marker
     printf '%s' "$(<"$STATE")"
     for marker in \
-      recovered resumed stopped-deleted new-session-started quick-chat-started; do
+      recovered resumed resume-completed stopped-deleted new-session-started quick-chat-started; do
       [ ! -e "$ROOT/fake/$marker" ] || printf ':%s' "$marker"
     done
   }
@@ -47,9 +53,12 @@ if [ "$#" -eq 2 ] && [ "$1" = list ] && [ "$2" = --json ]; then
     printf 'The session list is temporarily unavailable; retry from the dashboard.\n' >&2
     exit 75
   fi
-  completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"allowed","health_reason":"checkpoint_stale","health_actions":["resume","delete"]}'
+  completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","project_dir":"/tmp","effective_status":"completed","created_at":"2026-07-22T07:00:00Z","finished_at":"2026-07-22T07:30:00Z","exit_status":0,"agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"allowed","health_reason":"checkpoint_stale","health_actions":["resume","delete"]}'
   if [ -f "$ROOT/fake/resumed" ]; then
-    completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","effective_status":"running","created_at":"2026-07-22T07:00:00Z","agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"protected","health_actions":["attach","stop"]}'
+    completed='{"schema":1,"provider":"claude","session_name":"detach-claude-ui-completed","name":"UI Completed","project_dir":"/tmp","effective_status":"starting","created_at":"2026-07-22T09:00:00Z","agent_session_id":"a9f58f1d-1234-5678-9abc-def012342ed9","session_color":"#A855F7","power_protection_state":"unknown","health_actions":["attach","stop"]}'
+    if [ -f "$ROOT/fake/resume-completed" ]; then
+      completed="${completed/\"starting\"/\"running\"}"
+    fi
   fi
   recoverable='{"schema":1,"provider":"codex","session_name":"detach-codex-ui-recoverable","name":"UI Recoverable","model":"gpt-ui-fixture-long-model-name","context_used_tokens":185000,"context_window":200000,"effective_status":"recoverable","created_at":"2026-07-22T07:40:00Z","finished_at":"2026-07-22T07:50:00Z","exit_status":1,"session_color":"#F97316","power_protection_state":"allowed","health_actions":["recover","delete"]}'
   if [ -f "$ROOT/fake/recovered" ]; then
@@ -257,10 +266,21 @@ if [ "$#" -eq 3 ] && [ "$1" = codex ] && [ "$2" = attach ] \
   exec /bin/cat
 fi
 
-if [ "$#" -eq 3 ] && [ "$1" = resume ] && [ "$2" = --detach ] \
-    && [ "$3" = a9f58f1d-1234-5678-9abc-def012342ed9 ]; then
+if [ "$#" -eq 6 ] && [ "$1" = claude ] && [ "$2" = resume ] \
+    && [ "$3" = --name ] && [ "$4" = detach-claude-ui-completed ] \
+    && [ "$5" = --detach ] && [ "$6" = a9f58f1d-1234-5678-9abc-def012342ed9 ]; then
   : >"$ROOT/fake/resumed"
   printf '%s\n' "$*" >>"$ACTIONS"
+  attempts=0
+  while [ ! -f "$ROOT/fake/release-resume" ] && [ "$attempts" -lt 200 ]; do
+    attempts=$((attempts + 1))
+    sleep 0.05
+  done
+  [ -f "$ROOT/fake/release-resume" ] || {
+    printf 'Resume terminal did not attach before readiness\n' >&2
+    exit 75
+  }
+  : >"$ROOT/fake/resume-completed"
   exit 0
 fi
 

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -259,7 +259,9 @@ wait_for_fake_claude_ready() {
 
 wait_for_file_text() {
   local file="$1" text="$2" attempts=0
-  while [ "$attempts" -lt 100 ]; do
+  # Recovery can restore and sync the prior generation before fixture entry.
+  # Allow its entry wait to cover the runtime readiness window.
+  while [ "$attempts" -lt 400 ]; do
     if [ -f "$file" ] && grep -Fx -- "$text" "$file" >/dev/null 2>&1; then
       return 0
     fi
@@ -1076,8 +1078,9 @@ printf 'previous live tree\n' >"$stale_restore_destination.detach.old/sentinel"
 printf 'incomplete new tree\n' >"$stale_restore_destination.detach.tmp/sentinel"
 
 reset_fake_claude_ready
-"$SCRIPT" claude recover --detach "$human_label"
+"$SCRIPT" --terminal-size 123x41 claude recover --detach "$human_label"
 wait_for_fake_claude_ready
+[ "$(awk '{print $1, $2}' "$FAKE_CLAUDE_ARGS_FILE.terminal-size")" = '41 123' ]
 [ "$("$STATE_HELPER" meta get "$meta" display_name)" = "$human_label" ]
 grep -Fx -- '--resume' "$FAKE_CLAUDE_ARGS_FILE" >/dev/null
 grep -Fx -- "$session_id" "$FAKE_CLAUDE_ARGS_FILE" >/dev/null

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -494,6 +494,18 @@ test_sqlite() {
 }
 
 if codex_part_selected preflight; then
+for size in 0x24 80x0 1000x24 80x1000 080x24 80X24 '80x24;exit'; do
+  if "$DETACH" --terminal-size "$size" codex start --detach >"$TMP_ROOT/invalid-size.out" 2>&1; then
+    printf 'accepted invalid startup terminal size: %s\n' "$size" >&2
+    exit 1
+  fi
+  grep -F 'terminal size must be COLSxROWS' "$TMP_ROOT/invalid-size.out" >/dev/null
+done
+if "$DETACH" --terminal-size 80x24 codex stop >"$TMP_ROOT/invalid-size-command.out" 2>&1; then
+  printf 'accepted a startup terminal size on Stop\n' >&2
+  exit 1
+fi
+grep -F 'requires an explicit start, resume, or recover command' "$TMP_ROOT/invalid-size-command.out" >/dev/null
   bash -n "$SCRIPT"
   bash -n "$ROOT/bin/detach-core"
   [ "$($SCRIPT __version)" = "$(<"$ROOT/VERSION")" ]
@@ -2856,7 +2868,9 @@ mkdir -p "$other_cwd"
 # event.
 status_hint="$(cat "$DETACH_STATE_ROOT/session-change")"
 (cd "$other_cwd" && DETACH_CODEX_BIN="$uppercase_codex" \
-  "$DETACH" resume --name integration --detach "$uppercase_id")
+  "$DETACH" --terminal-size 137x47 resume --name integration --detach "$uppercase_id")
+[ "$(awk '{print $1, $2}' "$FAKE_CODEX_ARGS_FILE.terminal-size")" = '47 137' ]
+[ -z "$(cat "$FAKE_CODEX_ARGS_FILE.initial-size-hint")" ]
 : >"$uppercase_release"
 wait_for_tmux_option "$SESSION" @detach_status completed
 grep -Fx 'resume' "$FAKE_CODEX_ARGS_FILE" >/dev/null

--- a/tests/ui-e2e-contract.sh
+++ b/tests/ui-e2e-contract.sh
@@ -59,9 +59,11 @@ for invocation in \
   'codex attach --terminal-features sync detach-codex-ui-running' \
   'codex logs --ansi detach-codex-ui-recoverable' \
   'codex recover --detach detach-codex-ui-recoverable' \
+  '--terminal-size 137x47 codex recover --detach detach-codex-ui-recoverable' \
   'codex attach --terminal-features sync detach-codex-ui-recoverable' \
   'claude logs --ansi detach-claude-ui-completed' \
-  'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9' \
+  'claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9' \
+  '--terminal-size 137x47 claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9' \
   'claude attach --terminal-features sync detach-claude-ui-completed' \
   'claude --detach' \
   'claude attach --terminal-features sync detach-claude-ui-new' \
@@ -73,6 +75,9 @@ for invocation in \
 done
 
 for invocation in \
+  '--terminal-size 0x47 codex recover --detach detach-codex-ui-recoverable' \
+  '--terminal-size 1000x47 codex recover --detach detach-codex-ui-recoverable' \
+  '--terminal-size 137x47 codex stop detach-codex-ui-running' \
   'config tmux-style detach' \
   'config tmux-extended-keys on' \
   'storage cleanup --dry-run --json' \

--- a/tests/ui-e2e.sh
+++ b/tests/ui-e2e.sh
@@ -14,7 +14,16 @@ FAKE_CLI=""
 IDENTIFIER=""
 
 approved_invocation() {
-  case "$1" in
+  local invocation="$1"
+  if [[ "$invocation" =~ ^--terminal-size\ [1-9][0-9]{0,2}x[1-9][0-9]{0,2}\ (.*)$ ]]; then
+    invocation="${BASH_REMATCH[1]}"
+    case "$invocation" in
+      'codex recover --detach detach-codex-ui-recoverable'|\
+      'claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9') ;;
+      *) return 1 ;;
+    esac
+  fi
+  case "$invocation" in
     'list --json'|\
     'watch --json'|\
     'codex logs --ansi detach-codex-ui-running'|\
@@ -24,7 +33,7 @@ approved_invocation() {
     'codex recover --detach detach-codex-ui-recoverable'|\
     'codex attach --terminal-features sync detach-codex-ui-recoverable'|\
     'claude logs --ansi detach-claude-ui-completed'|\
-    'resume --detach a9f58f1d-1234-5678-9abc-def012342ed9'|\
+    'claude resume --name detach-claude-ui-completed --detach a9f58f1d-1234-5678-9abc-def012342ed9'|\
     'claude attach --terminal-features sync detach-claude-ui-completed'|\
     'claude --detach'|\
     'codex --detach'|\
@@ -583,7 +592,7 @@ done <"$FAKE_DIR/invocations.log"
 
 # Every scenario starts clean, so the main journey's records live in its
 # preserved per-scenario copy.
-recover_count="$(grep -Fxc 'codex recover --detach detach-codex-ui-recoverable' \
+recover_count="$(grep -Ec '^(--terminal-size [1-9][0-9]{0,2}x[1-9][0-9]{0,2} )?codex recover --detach detach-codex-ui-recoverable$' \
   "$TEST_ROOT/invocations-main.log" || true)"
 recover_attach_count="$(grep -Fxc \
   'codex attach --terminal-features sync detach-codex-ui-recoverable' \


### PR DESCRIPTION
Resume kept the previous screen visible until detached startup and a final list refresh completed. It also repeated provider discovery. The new provider started in a default-size detached tmux window, so its first output could retain narrow wrapping after the app attached at full size.

Resume now uses the selected provider, managed name, UUID, and project directory. Legacy rows without an absolute project path keep the public UUID resolver. Resume and Recover show an attachable new run from fresh typed state while startup checks continue. The same-session lifecycle ID, or a newer legacy creation time, must prove replacement. An early client exit prevents repeated attachment during preparation. Final startup errors still reach the user.

The app measures the terminal grid with its current font and SwiftTerm layout. It sends a validated `--terminal-size COLSxROWS` prefix to the public CLI. The startup locks preserve this request in memory, and tmux receives the dimensions before the provider starts. The hint is removed from the worker environment and is not saved in provider options. Attached clients still control later resizing. If activation of the new payload is deferred, the app retries without the size hint only when an older CLI returns its exact pre-dispatch unknown-command rejection. Startup failures and timeouts are never retried. Runtime ownership, recovery, locking, and power checks remain in place.

Regression evidence covers exact arguments and project directory, legacy fallback, new-run and exit guards, invalid dimensions, and initial dimensions observed inside both provider fixtures. The packaged UI journey keeps Resume blocked until it observes the replacement terminal and attach invocation, and checks that startup received the visible terminal width.

The first local run exposed a Claude fixture entry timeout: the entry marker appeared after its 10-second wait. The fixture now allows 40 seconds for recovery and startup before entry; runtime deadlines and failure assertions are unchanged. The selected local gate passed all eight stages, including the packaged UI journey, Codex Resume at 137x47, Claude Recover at 123x41, and distribution checks. The final compatibility addition then passed all 66 SessionStore tests. Hosted repository quality-gates must pass on the exact PR head before merge.

An isolated fake-provider profile measured automatic Resume at 5.484 s, followed by 0.312 s for refresh and 0.425 s for attach. Explicit Resume returned at 4.669 s and published starting at 2.969 s. These diagnostic timings exclude durability syncs and do not promise real-provider latency. Release-only hardware checks were not run.
