### PR TITLE
Keep session states consistent during Resume and recovery

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -138,7 +138,7 @@ jobs:
           app/scripts/verify-app.sh
           printf 'DETACH_QUALITY_EXACT_APP=1\n' >>"$GITHUB_ENV"
       - name: Build and bind exact packaged test app
-        if: (matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true')) && steps.app-cache.outputs.cache-hit != 'true'
+        if: (!matrix.builds_app && (matrix.needs_app || (matrix.needs_runtime && steps.product-cache.outputs.cache-hit != 'true'))) && steps.app-cache.outputs.cache-hit != 'true'
         env:
           DETACH_QUALITY_APP_SCRATCH: 1
         run: |

--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ A stale heartbeat or old checkpoint is diagnostic information. It does not
 prove that an agent is hung. If the owned worker and provider are alive, Detach
 keeps the session running through a long provider turn.
 
+Start, Resume, and Recover can show **Starting** while the runtime identity is
+being configured. This transition does not mean the session has a problem.
+Mutation actions stay unavailable until the operation ends. Detach discards
+list results that combine different runtime generations. A reused PID does
+not block Resume when process creation time proves that the old runtime ended.
+
 If tmux disappears while a recorded process is still alive, Detach blocks
 Stop, Recover, Delete, and bulk cleanup until that exact runtime is gone. It
 never signals or removes foreign processes and unmanaged tmux sessions.

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -452,3 +452,5 @@
 "You can close the window — the icon keeps showing sleep state. ⌘Q quits Detach; sessions and sleep protection continue on their own." = "You can close the window — the icon keeps showing sleep state. ⌘Q quits Detach; sessions and sleep protection continue on their own.";
 "Only a signed Detach release can update the background monitor." = "Only a signed Detach release can update the background monitor.";
 "Only a signed Detach release can update the power helper." = "Only a signed Detach release can update the power helper.";
+
+"A session operation is in progress." = "A session operation is in progress.";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -452,3 +452,5 @@
 "You can close the window — the icon keeps showing sleep state. ⌘Q quits Detach; sessions and sleep protection continue on their own." = "Окно можно закрывать — значок продолжит показывать состояние сна. ⌘Q завершает Detach; сессии и защита от сна продолжаются сами.";
 "Only a signed Detach release can update the background monitor." = "Только подписанный релиз Detach может обновить фоновый монитор.";
 "Only a signed Detach release can update the power helper." = "Только подписанный релиз Detach может обновить помощник питания.";
+
+"A session operation is in progress." = "Выполняется операция с сессией.";

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -943,6 +943,18 @@ public enum DetachStateCommand {
                 where !volatile.contains(field.0) {
                 appendNULTerminated(value.map(render) ?? "", to: &record)
             }
+            // Checkpoints are published by directory exchange. A newly
+            // published recovery generation can change Recover eligibility
+            // without changing the primary runtime generation or phase.
+            var checkpoint = stat()
+            if fstatat(directory, "checkpoint", &checkpoint, AT_SYMLINK_NOFOLLOW) == 0 {
+                appendNULTerminated(
+                    "\(checkpoint.st_dev):\(checkpoint.st_ino):\(checkpoint.st_mode):\(checkpoint.st_uid)",
+                    to: &record)
+            } else {
+                guard errno == ENOENT else { throw DetachStateCommandError.invalidArguments }
+                appendNULTerminated("no-checkpoint", to: &record)
+            }
             // Shutdown evidence is also read by replacement quiescence checks.
             if let data = readOwnedMetadataFile(in: directory, name: "meta.json"),
                let values = try? SessionMetadataDocument.usableScalars(

--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Darwin
 import Foundation
 
@@ -71,6 +72,8 @@ public enum DetachStateCommand {
             return try metaSnapshots(
                 Array(arguments.dropFirst(2)),
                 standardInput: injectedStandardInput)
+        case ("meta", "health-revision"):
+            return try metadataHealthRevision(Array(arguments.dropFirst(2)))
         case ("meta", "usable"):
             return try metaUsable(
                 Array(arguments.dropFirst(2)),
@@ -424,7 +427,7 @@ public enum DetachStateCommand {
         let allowed = required.union(processInspection).union([
             "--stop-requested", "--lifecycle-phase", "--uncommitted-replacement",
             "--runtime-quiescent",
-            "--runtime-ready-at",
+            "--runtime-ready-at", "--operation-lock",
         ])
         var values: [String: String] = [:]
         var index = 0
@@ -493,7 +496,8 @@ public enum DetachStateCommand {
         } else if !processInspection.isDisjoint(with: values.keys) {
             throw DetachStateCommandError.invalidArguments
         }
-        return SessionHealthEvaluator.evaluate(SessionHealthEvidence(
+        let operationBusy = try values["--operation-lock"].map(operationLockIsHeld) ?? false
+        var assessment = SessionHealthEvaluator.evaluate(SessionHealthEvidence(
             metadataValid: try boolean(metadataRaw),
             runtimeIdentityExpected: try boolean(identityExpectedRaw),
             metaStatus: status,
@@ -509,6 +513,48 @@ public enum DetachStateCommand {
             runtimeQuiescent: runtimeQuiescent,
             stopRequested: stopRequested,
             lifecyclePhase: lifecyclePhase))
+        if operationBusy {
+            // A session operation can expose its placeholder pane before its
+            // metadata and tmux identity are committed. It grants no mutation
+            // authority while that transaction still owns the kernel lock.
+            switch assessment.effectiveStatus {
+            case .hung, .corrupt, .collision, .recoverable, .orphaned, .unknown:
+                assessment.effectiveStatus = .starting
+                assessment.reason = .operationInProgress
+                assessment.ownershipProven = false
+                assessment.reconcileAction = .none
+                assessment.actions = []
+            default:
+                assessment.actions = assessment.actions.filter { $0 == .attach }
+                assessment.reconcileAction = .none
+            }
+            assessment.cleanupEligible = false
+        }
+        return assessment
+    }
+
+    private static func operationLockIsHeld(_ path: String) throws -> Bool {
+        guard path.hasPrefix("/") else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let descriptor = open(path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            if errno == ENOENT { return false }
+            throw DetachStateCommandError.invalidArguments
+        }
+        defer { close(descriptor) }
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0,
+              isRegularFile(metadata), metadata.st_uid == geteuid() else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        if metadataFileLock(descriptor, LOCK_SH | LOCK_NB) == 0 {
+            return false // close releases the nonblocking shared probe.
+        }
+        guard errno == EWOULDBLOCK else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        return true
     }
 
     private static func maintenanceReconcile(
@@ -875,6 +921,43 @@ public enum DetachStateCommand {
         appendNULTerminated("", to: &output)
         appendNULTerminated("true", to: &output)
         return output
+    }
+
+    /// Health observations must not combine different lifecycle generations.
+    /// Routine heartbeat and checkpoint freshness updates do not change this
+    /// revision. No transcript reads or per-session helper processes are used.
+    private static func metadataHealthRevision(_ arguments: [String]) throws -> Data {
+        guard arguments.count == 2 else {
+            throw DetachStateCommandError.invalidArguments
+        }
+        let volatile = Set([
+            "worker_heartbeat_at", "worker_heartbeat_epoch",
+            "last_checkpoint_at", "last_checkpoint_epoch",
+        ])
+        var digest = SHA256()
+        try forEachMetadataSnapshot(at: arguments[0]) { session, values, source, directory in
+            var record = Data()
+            appendNULTerminated(session, to: &record)
+            appendNULTerminated(source?.rawValue ?? "invalid", to: &record)
+            for (field, value) in zip(metadataSnapshotFields, values ?? [])
+                where !volatile.contains(field.0) {
+                appendNULTerminated(value.map(render) ?? "", to: &record)
+            }
+            // Shutdown evidence is also read by replacement quiescence checks.
+            if let data = readOwnedMetadataFile(in: directory, name: "meta.json"),
+               let values = try? SessionMetadataDocument.usableScalars(
+                in: data, expectedSessionName: session,
+                pathGroups: [["runtime_shutdown_observed_at"]]) {
+                for value in values {
+                    appendNULTerminated(value.map(render) ?? "", to: &record)
+                }
+            }
+            let busy = try operationLockIsHeld(
+                arguments[1] + "/operation-" + session + ".lock")
+            appendNULTerminated(busy ? "busy" : "idle", to: &record)
+            digest.update(data: record)
+        }
+        return Data((digest.finalize().map { String(format: "%02x", $0) }.joined() + "\n").utf8)
     }
 
     /// Batches the bounded transcript tail parse into the metadata helper.

--- a/app/Sources/DetachKit/SessionHealth.swift
+++ b/app/Sources/DetachKit/SessionHealth.swift
@@ -249,6 +249,7 @@ enum SessionProcessHealthInspector {
 }
 
 public enum SessionHealthReason: String, Codable, Sendable {
+    case operationInProgress = "operation_in_progress"
     case healthy
     case finished
     case checkpointStale = "checkpoint_stale"

--- a/app/Sources/DetachKit/SessionPresentation.swift
+++ b/app/Sources/DetachKit/SessionPresentation.swift
@@ -134,6 +134,8 @@ public extension Session {
             L10n.string("The provider process exited while its worker remained alive.")
         case .providerPIDNotDescendant:
             L10n.string("The recorded provider PID is not owned by this worker.")
+        case .operationInProgress:
+            L10n.string("A session operation is in progress.")
         case .runtimeProcessWithoutTmux:
             L10n.string("A recorded runtime process is still alive without its managed tmux session; Detach will not signal it.")
         case .runtimeQuiescenceUnproven:

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -1290,7 +1290,9 @@ final class SessionAttachTerminalTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
         let record = root.appendingPathComponent("size")
         let executable = root.appendingPathComponent("detach")
-        try "#!/bin/sh\nstty size > '\(record.path)'\nexec /bin/cat\n"
+        // Publish the record only after stty finishes. File creation alone
+        // can wake the reader before the redirected command writes its data.
+        try "#!/bin/sh\nstty size > '\(record.path).tmp' && mv '\(record.path).tmp' '\(record.path)'\nexec /bin/cat\n"
             .write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755],
                                              ofItemAtPath: executable.path)

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -634,6 +634,27 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testMetadataPatchRejectsRedirectedLockWithoutChangingState() throws {
+        let metadata = temporaryDirectory.appendingPathComponent("meta.json")
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "create", metadata.path, "--string", "status", "stopped",
+        ])
+        let before = try Data(contentsOf: metadata)
+        let target = temporaryDirectory.appendingPathComponent("unrelated")
+        let sentinel = Data("do not change".utf8)
+        try sentinel.write(to: target)
+        let lock = temporaryDirectory.appendingPathComponent(".meta-patch.lock")
+        try? FileManager.default.removeItem(at: lock)
+        try FileManager.default.createSymbolicLink(at: lock, withDestinationURL: target)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "patch", metadata.path, "--string", "status", "running",
+        ])) { error in
+            XCTAssertEqual((error as? CocoaError)?.code, .fileWriteNoPermission)
+        }
+        XCTAssertEqual(try Data(contentsOf: metadata), before)
+        XCTAssertEqual(try Data(contentsOf: target), sentinel)
+    }
+
     func testHealthRevisionTracksLifecycleAndLocksButIgnoresRoutineFreshness() throws {
         let root = temporaryDirectory.appendingPathComponent("sessions")
         let session = "detach-codex-revision"
@@ -735,6 +756,10 @@ final class DetachStateCommandTests: XCTestCase {
         try FileManager.default.removeItem(at: lock)
         XCTAssertEqual(mkfifo(lock.path, mode_t(0o600)), 0)
         XCTAssertThrowsError(try assessment())
+        arguments[try XCTUnwrap(arguments.firstIndex(of: "--operation-lock")) + 1] = "operation.lock"
+        XCTAssertThrowsError(try assessment()) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidArguments)
+        }
     }
 
     func testMetaSnapshotsBatchesFallbacksAndRejectsIncompleteInput() throws {

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -216,6 +216,7 @@ final class DetachStateCommandTests: XCTestCase {
             ["meta", "snapshot", "only-path"],
             ["meta", "recovery-binding", "only-path"],
             ["meta", "snapshots"],
+            ["meta", "health-revision"],
             ["health", "session", "--"],
             ["health", "session", "no-separator"],
             ["health", "sessions"],
@@ -673,6 +674,16 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertNotEqual(try revision(), shutdown)
         XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_UN), 0)
         XCTAssertEqual(try revision(), shutdown)
+        let checkpoint = directory.appendingPathComponent("checkpoint")
+        try FileManager.default.createDirectory(at: checkpoint, withIntermediateDirectories: false)
+        let published = try revision()
+        XCTAssertNotEqual(published, shutdown, "Checkpoint publication changes recovery eligibility")
+        try Data("cache receipt".utf8).write(to: checkpoint.appendingPathComponent("receipt"))
+        XCTAssertEqual(try revision(), published, "Receipt writes do not publish a checkpoint")
+        try FileManager.default.moveItem(at: checkpoint,
+            to: directory.appendingPathComponent("previous-checkpoint"))
+        try FileManager.default.createDirectory(at: checkpoint, withIntermediateDirectories: false)
+        XCTAssertNotEqual(try revision(), published, "Replacement must change the generation")
         try FileManager.default.removeItem(at: lock)
         try FileManager.default.createSymbolicLink(at: lock, withDestinationURL: metadata)
         XCTAssertThrowsError(try revision())
@@ -680,7 +691,7 @@ final class DetachStateCommandTests: XCTestCase {
 
     func testListOperationLockClosesProvisionalFaultWithoutConcealingPersistentCollision() throws {
         let lock = temporaryDirectory.appendingPathComponent("operation.lock")
-        let arguments = [
+        var arguments = [
             "health", "evaluate", "--metadata-valid", "true",
             "--runtime-identity-expected", "true", "--meta-status", "stopped",
             "--tmux", "foreign", "--run-token", "missing", "--worker", "dead",
@@ -704,7 +715,22 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertFalse(busy.ownershipProven)
         XCTAssertFalse(busy.cleanupEligible)
         XCTAssertEqual(busy.reconcileAction, .none)
+        for (key, value) in [
+            ("--tmux", "live"), ("--run-token", "match"),
+            ("--worker", "alive"), ("--provider-process", "alive"),
+            ("--meta-status", "running"),
+        ] {
+            arguments[try XCTUnwrap(arguments.firstIndex(of: key)) + 1] = value
+        }
+        let attachable = try assessment()
+        XCTAssertEqual(attachable.effectiveStatus, .running)
+        XCTAssertTrue(attachable.ownershipProven)
+        XCTAssertEqual(attachable.actions, [.attach])
+        XCTAssertFalse(attachable.cleanupEligible)
+        XCTAssertEqual(attachable.reconcileAction, .none)
         XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_UN), 0)
+        XCTAssertEqual(try assessment().actions, [.attach, .stop])
+        arguments[try XCTUnwrap(arguments.firstIndex(of: "--tmux")) + 1] = "foreign"
         XCTAssertEqual(try assessment().effectiveStatus, .collision)
         try FileManager.default.removeItem(at: lock)
         XCTAssertEqual(mkfifo(lock.path, mode_t(0o600)), 0)

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -633,6 +633,84 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testHealthRevisionTracksLifecycleAndLocksButIgnoresRoutineFreshness() throws {
+        let root = temporaryDirectory.appendingPathComponent("sessions")
+        let session = "detach-codex-revision"
+        let directory = root.appendingPathComponent(session)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let metadata = directory.appendingPathComponent("meta.json")
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "create", metadata.path, "--integer", "schema", "1",
+            "--string", "session_name", session, "--string", "project_dir", "/tmp/project",
+            "--string", "status", "running", "--string", "run_token", "generation-a",
+        ])
+        let arguments = ["meta", "health-revision", root.path, temporaryDirectory.path]
+        func revision() throws -> Data { try DetachStateCommand.run(arguments: arguments) }
+        let initial = try revision()
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "patch", metadata.path,
+            "--integer", "worker_heartbeat_epoch", "123",
+            "--string", "last_checkpoint_at", "2026-09-08T12:00:00Z",
+        ])
+        XCTAssertEqual(try revision(), initial)
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "patch", metadata.path, "--string", "run_token", "generation-b",
+        ])
+        let replacement = try revision()
+        XCTAssertNotEqual(replacement, initial)
+        _ = try DetachStateCommand.run(arguments: [
+            "meta", "patch", metadata.path,
+            "--string", "runtime_shutdown_observed_at", "2026-09-08T12:00:01Z",
+        ])
+        let shutdown = try revision()
+        XCTAssertNotEqual(try revision(), replacement)
+        let lock = temporaryDirectory.appendingPathComponent("operation-" + session + ".lock")
+        let descriptor = open(lock.path, O_CREAT | O_RDWR | O_CLOEXEC, mode_t(0o600))
+        XCTAssertGreaterThanOrEqual(descriptor, 0)
+        defer { close(descriptor) }
+        XCTAssertEqual(try revision(), shutdown, "A lock file is not a held lock")
+        XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_EX | LOCK_NB), 0)
+        XCTAssertNotEqual(try revision(), shutdown)
+        XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_UN), 0)
+        XCTAssertEqual(try revision(), shutdown)
+        try FileManager.default.removeItem(at: lock)
+        try FileManager.default.createSymbolicLink(at: lock, withDestinationURL: metadata)
+        XCTAssertThrowsError(try revision())
+    }
+
+    func testListOperationLockClosesProvisionalFaultWithoutConcealingPersistentCollision() throws {
+        let lock = temporaryDirectory.appendingPathComponent("operation.lock")
+        let arguments = [
+            "health", "evaluate", "--metadata-valid", "true",
+            "--runtime-identity-expected", "true", "--meta-status", "stopped",
+            "--tmux", "foreign", "--run-token", "missing", "--worker", "dead",
+            "--provider-process", "dead", "--heartbeat", "missing",
+            "--checkpoint", "missing", "--checkpoint-recoverable", "false",
+            "--agent-session-known", "true", "--operation-lock", lock.path,
+        ]
+        func assessment() throws -> SessionHealthAssessment {
+            try JSONDecoder().decode(SessionHealthAssessment.self,
+                from: DetachStateCommand.run(arguments: arguments))
+        }
+        XCTAssertEqual(try assessment().effectiveStatus, .collision)
+        let descriptor = open(lock.path, O_CREAT | O_RDWR | O_CLOEXEC, mode_t(0o600))
+        XCTAssertGreaterThanOrEqual(descriptor, 0)
+        defer { close(descriptor) }
+        XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_EX | LOCK_NB), 0)
+        let busy = try assessment()
+        XCTAssertEqual(busy.effectiveStatus, .starting)
+        XCTAssertEqual(busy.reason, .operationInProgress)
+        XCTAssertTrue(busy.actions.isEmpty)
+        XCTAssertFalse(busy.ownershipProven)
+        XCTAssertFalse(busy.cleanupEligible)
+        XCTAssertEqual(busy.reconcileAction, .none)
+        XCTAssertEqual(testMetadataFileLock(descriptor, LOCK_UN), 0)
+        XCTAssertEqual(try assessment().effectiveStatus, .collision)
+        try FileManager.default.removeItem(at: lock)
+        XCTAssertEqual(mkfifo(lock.path, mode_t(0o600)), 0)
+        XCTAssertThrowsError(try assessment())
+    }
+
     func testMetaSnapshotsBatchesFallbacksAndRejectsIncompleteInput() throws {
         let root = temporaryDirectory.appendingPathComponent("sessions", isDirectory: true)
         let first = root.appendingPathComponent("detach-codex-one", isDirectory: true)

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -990,8 +990,8 @@ tmux_health_snapshot() {
   case "$pane_pid" in ''|*[!0-9]*) TMUX_HEALTH_PANE_PID="" ;; *) TMUX_HEALTH_PANE_PID="$pane_pid" ;; esac
 }
 
-# A read-only list needs one internally consistent tmux generation, not one
-# client process per saved session. Mutations never set this cache and keep
+# A read-only list batches all panes. Its publication check repeats the read
+# to reject mixed lifecycle generations. Mutations never set this cache and keep
 # their exact target revalidation immediately before every signal or change.
 prepare_list_tmux_health_snapshot() {
   local format
@@ -1001,6 +1001,15 @@ prepare_list_tmux_health_snapshot() {
     "${TMUX_CMD[@]}" list-panes -a -F "$format" 2>/dev/null || true
   )"
   LIST_TMUX_HEALTH_READY=1
+}
+
+list_tmux_health_identity() {
+  local session marker provider token heartbeat rest
+  while IFS='|' read -r session marker provider token heartbeat rest; do
+    [ -n "$session" ] || continue
+    # Heartbeat changes are routine freshness updates, not a new runtime.
+    printf '%s|%s|%s|%s|%s\n' "$session" "$marker" "$provider" "$token" "$rest"
+  done <<<"$LIST_TMUX_HEALTH_ROWS"
 }
 
 tmux_health_snapshot_from_list() {
@@ -1586,7 +1595,7 @@ tmux_refresh_extended_keys() {
 # ordinary emacs/vi/custom copy-mode bindings return without a server restart.
 # Punctuation is escaped only for tmux's configuration parser.
 tmux_emit_type_through_config() {
-  local table fallback_table code char key cp b1 b2 utf
+  local table fallback_table code char key cp b1 b2 utf octal b1_octal b2_octal
 
   for table in copy-mode copy-mode-vi; do
     fallback_table="detach-$table-original"
@@ -1594,7 +1603,8 @@ tmux_emit_type_through_config() {
     # copy-mode shortcut for consistent type-through only while managed mouse
     # input is enabled.
     for ((code = 33; code <= 126; code++)); do
-      char="$(printf "\\$(printf '%03o' "$code")")"
+      printf -v octal '%03o' "$code"
+      printf -v char '%b' "\\$octal"
       case "$char" in
         [A-Za-z0-9]) key="$char" ;;
         *) key="\\$char" ;;
@@ -1606,10 +1616,12 @@ tmux_emit_type_through_config() {
       "$table" "$fallback_table"
     # Cyrillic А-Я, а-я, Ё, ё delivered as literal UTF-8; multibyte keys never
     # collide with tmux's ASCII syntax, so they need no escaping.
-    for cp in $(seq 1040 1103) 1025 1105; do
+    for cp in {1040..1103} 1025 1105; do
       b1=$(( 0xC0 | (cp >> 6) ))
       b2=$(( 0x80 | (cp & 0x3F) ))
-      utf="$(printf "\\$(printf '%03o' "$b1")\\$(printf '%03o' "$b2")")"
+      printf -v b1_octal '%03o' "$b1"
+      printf -v b2_octal '%03o' "$b2"
+      printf -v utf '%b' "\\$b1_octal\\$b2_octal"
       printf 'bind-key -T %s %s if-shell -F "#{==:#{@detach_copy_type_through},1}" "send-keys -X cancel ; send-keys" "switch-client -T %s ; send-keys -K"\n' \
         "$table" "$utf" "$fallback_table"
     done
@@ -6911,41 +6923,7 @@ session_health_envelope() {
     fi
   fi
 
-  # The batched list helper reads only the recorded PIDs with proc_pidinfo.
-  # State-changing and single-session paths keep the established shell checks.
-  if [ "$output_mode" != "request" ]; then
-    case "$worker_pid" in
-      ''|*[!0-9]*) worker_state="unknown" ;;
-      *)
-        if process_is_owned_alive "$worker_pid"; then
-          worker_state="alive"
-        else
-          worker_state="dead"
-        fi
-        ;;
-    esac
-    case "$provider_pid" in
-      ''|*[!0-9]*) provider_state="unknown" ;;
-      *)
-        process_is_owned_alive "$provider_pid" || provider_state="dead"
-        if [ "$provider_state" = "dead" ]; then
-          :
-        elif [ "$worker_state" = "alive" ] && \
-             process_is_descendant "$provider_pid" "$worker_pid"; then
-          provider_state="alive"
-        else
-          provider_state="mismatch"
-        fi
-        ;;
-    esac
-  fi
-
   if [ "$tmux_state" = "live" ]; then
-    if [ "$output_mode" != "request" ] && \
-       [ "$worker_state" = "alive" ] && [ "$pane_pid" != "$worker_pid" ]; then
-      worker_state="mismatch"
-      provider_state="mismatch"
-    fi
     if [ "$token_state" = "match" ]; then
       case "$tmux_heartbeat_epoch" in
         ''|*[!0-9]*) ;;
@@ -6985,14 +6963,17 @@ session_health_envelope() {
     --stop-requested "$stop_requested"
     --lifecycle-phase "$lifecycle_phase"
   )
-  if [ "$output_mode" = "request" ]; then
-    health_args+=(
-      --inspect-processes true
-      --worker-pid "${worker_pid:--}"
-      --provider-pid "${provider_pid:--}"
-      --pane-pid "${pane_pid:--}"
-      --runtime-ready-at "${runtime_ready_at:--}"
-    )
+  # List and mutation eligibility must use the same kernel identity evidence.
+  # A PID created after runtime readiness belongs to another process.
+  health_args+=(
+    --inspect-processes true
+    --worker-pid "${worker_pid:--}"
+    --provider-pid "${provider_pid:--}"
+    --pane-pid "${pane_pid:--}"
+    --runtime-ready-at "${runtime_ready_at:--}"
+  )
+  if [ "$output_mode" = request ] || [ "$output_mode" = list-assessment ]; then
+    health_args+=( --operation-lock "$(operation_lock_path "$session")" )
   fi
   case "$output_mode" in
     session)
@@ -7002,7 +6983,7 @@ session_health_envelope() {
       local request_args=( "${health_args[@]}" -- "$@" )
       printf '%s\0' "${#request_args[@]}" "${request_args[@]}"
       ;;
-    assessment)
+    assessment|list-assessment)
       "$STATE_BIN" health evaluate "${health_args[@]}" --envelope
       ;;
     *) return 1 ;;
@@ -7185,7 +7166,6 @@ list_session_records() {
   local LIST_HEALTH_NOW
 
   ensure_state_dirs
-  prepare_list_tmux_health_snapshot
   LIST_HEALTH_NOW="$(date '+%s')"
   if [ "$PROVIDER" = codex ] && [ "$json_mode" = 1 ]; then
     model_database="$(codex_state_db 2>/dev/null || true)"
@@ -7273,7 +7253,7 @@ list_session_records() {
       else
         health_output="$(session_health_envelope \
           "$session" false unknown "-" "" "" "" "" "" "" \
-          assessment "" "" "" "")" || \
+          list-assessment "" "" "" "")" || \
           die "could not evaluate health for '$session'"
       fi
       if [ "$json_mode" = "1" ]; then
@@ -7387,7 +7367,7 @@ list_session_records() {
       health_output="$(session_health_envelope \
         "$session" true "$health_status" "$health_id" "$health_run_token" \
         "$worker_pid" "$provider_pid" "$health_worker_heartbeat_epoch" \
-        "$health_last_checkpoint_epoch" "$health_schema" assessment \
+        "$health_last_checkpoint_epoch" "$health_schema" list-assessment \
         "$health_stop_requested_at" "$health_lifecycle_phase" \
         "$health_preserve_recovery_until_ready" "$health_runtime_ready_at")" || \
         die "could not evaluate health for '$session'"
@@ -7410,12 +7390,29 @@ list_session_records() {
 
 list_sessions() {
   local json_mode="${1:-0}"
+  local attempt=0 before after tmux_before candidate
+  local LIST_TMUX_HEALTH_READY=0 LIST_TMUX_HEALTH_ROWS=""
 
-  if [ "$json_mode" = "1" ]; then
-    list_session_records 1 | "$STATE_BIN" health sessions /dev/stdin
-  else
-    list_session_records 0
-  fi
+  ensure_state_dirs
+  while [ "$attempt" -lt 3 ]; do
+    attempt=$((attempt + 1))
+    before="$("$STATE_BIN" meta health-revision "$SESSIONS_ROOT" "$LOCKS_ROOT")" || return 1
+    prepare_list_tmux_health_snapshot
+    tmux_before="$(list_tmux_health_identity)"
+    if [ "$json_mode" = "1" ]; then
+      candidate="$(list_session_records 1 | "$STATE_BIN" health sessions /dev/stdin)" || return 1
+    else
+      candidate="$(list_session_records 0)" || return 1
+    fi
+    prepare_list_tmux_health_snapshot
+    after="$("$STATE_BIN" meta health-revision "$SESSIONS_ROOT" "$LOCKS_ROOT")" || return 1
+    if [ "$before" = "$after" ] && \
+       [ "$tmux_before" = "$(list_tmux_health_identity)" ]; then
+      [ -z "$candidate" ] || printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  die "session state changed during all three list attempts; retry the snapshot"
 }
 
 show_status() {

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -155,10 +155,11 @@ Swift tests, the normal app, and the instrumented app use isolated scratch and
 module-cache paths. CI materializes their shared dependency cache once before
 parallel builds. A host with at least three CPUs splits workers and builds all
 three at the same time. Smaller hosts run Swift and app work in sequence.
-The normal bundle is verified. On a hosted app-cache miss, the successful
-fresh build becomes the exact app for that job. The selected app stage verifies
-the same bundle and does not build it again. A failed build cannot create this
-binding. Only the private UI copy gets the instrumented executable.
+The normal bundle is verified. On a hosted app-cache miss, the shard that owns
+the app stage builds the app in that stage. Other shards build the app before
+their checks and bind the successful build as the exact app for that job.
+A cache hit requires verification before reuse. A failed build cannot create
+this binding. Only the private UI copy gets the instrumented executable.
 The short packaged UI lane runs after the verified app and before the
 CPU-intensive provider, runtime, and gate-contract lanes. This prevents
 WindowServer event delivery from competing with those workers. The UI smoke

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -197,10 +197,11 @@ shard verifies or builds the packaged app first. Each provider part has
 private state, socket, log, and failure
 artifact roots. Parts run concurrently. The bounded large-host Codex lane
 starts the longest measured independent parts first, and still runs every
-part. Smaller hosts use three Codex parts and two Claude parts; larger hosts
-use finer parts. Compact layouts reuse
-checkpoints across recovery and restart, resume and identity, or Claude
-lifecycle and recovery. The parent writes scenario events in one order and
+part. Smaller hosts use five Codex parts with at most three active parts and
+two Claude parts. Resume and Delete run in separate parts on every host.
+Larger hosts use finer parts. Compact layouts reuse checkpoints across
+recovery and restart or Claude lifecycle and recovery.
+The parent writes scenario events in one order and
 fails the stage when any part fails. Tests do not use installed product state
 or ambient helpers. Distribution runs its runtime and shell-profile contracts
 concurrently in separate private temporary homes.

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -33,6 +33,11 @@ checkpoints, and protection survive its last window. ⌘Q and Quit end the app.
 After a transcript file is replaced, registration of its new file observer
 emits a refresh hint. Writes before registration must not leave the UI stale.
 
+An active session operation can report `operation_in_progress` while it sets
+up its runtime identity. This is a starting state with no mutation actions.
+It is not a Problems row. A failed or completed operation restores the normal
+typed health rules. A failed coherent List read keeps the previous rows.
+
 The dashboard separates identity, status, and Mac Power. Identity is a thin
 tmux-colored capsule. Status is a filled circle. Power uses a neutral surface
 and semantic color. Clicking the UUID chip copies the full UUID and shows

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -85,7 +85,8 @@ Hosted CI is the merge-readiness authority.
   heavy and one integration lane.
 - Exact keys bind inputs and toolchain. `main` warms missing products. CI
   verifies hits and misses, then reuses a fresh app. Warming emits no
-  evidence.
+  evidence. On a miss, a shard with the app stage builds inside that stage.
+  Other shards prepare the app before their checks.
 - CI uses the newest green `main` artifact with metrics; a later run without
   them does not replace it. Test identities and aggregate or critical-source
   coverage cannot decrease. Changed Swift lines need 90 percent coverage; a

--- a/docs/specs/documentation.md
+++ b/docs/specs/documentation.md
@@ -78,6 +78,8 @@ Hosted CI is the merge-readiness authority.
   latency watch.
 - Gate contracts admit four heavy shards on eight CPUs and two on smaller
   hosts; light contracts stay concurrent and budgets expose overload.
+- Codex uses at most three active test parts. Resume and Delete use separate
+  parts on every host. Each suite section runs once in either layout.
 - Swift and release builds use separate caches and split at three CPUs;
   smaller hosts run in order. UI waits for app; metrics require both.
   Gate-contract excludes heavy peers and gates distribution. Release-workflow

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -50,6 +50,9 @@ Core self-reinvokes critical mutations under `lockf`. Start, Resume, Stop,
 Recover, and Delete hold a session lock before install, project, and checkpoint
 locks. Each lock covers the child; the install lock covers readiness and the
 worst hold.
+List observes held session locks. It does not classify a placeholder pane as
+a persistent fault while Start, Resume, or Recover configures its identity.
+This observation never authorizes a mutation or suppresses a command error.
 
 ### Session lifecycle and tmux
 

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -27,13 +27,28 @@ runtime without managed tmux blocks mutations until its exact processes exit.
 Checkpoint metadata cannot replace it.
 
 `list --json` reads Codex and Claude concurrently and emits that order. Each
-uses one all-pane tmux snapshot and clock sample. `proc_pidinfo` reads recorded
+uses batched all-pane tmux snapshots and one clock sample per attempt. `proc_pidinfo` reads recorded
 PIDs and 64 parents. Empty tmux output is missing; wrong identity is collision.
-List compares process creation time with recorded runtime readiness. A process
+List and mutation eligibility compare process creation time with recorded runtime readiness. A process
 that started in a later second is a reused PID, not a surviving runtime.
 Missing readiness or creation time keeps the conservative identity result.
 Mutations recheck ownership, pane, run token, and process group. List jobs
 `exec` cores; cleanup signals PIDs.
+
+List buffers its output. Metadata health revisions and tmux identities must
+match before and after assessment. A revision includes metadata validity,
+source, generation, phase, process identity, shutdown evidence, and operation
+lock state. Routine heartbeat and checkpoint timestamps do not change it.
+List retries a changed observation up to three times. Continued changes fail
+the read without partial rows. Each stable attempt uses two tmux reads and a
+constant number of state helper processes, independent of the session count.
+
+List checks the BSD session operation lock without waiting or creating a
+file. While an operation holds the lock, provisional faults show actionless
+`starting` with reason `operation_in_progress`. A proven live pane can still
+offer Attach. List grants no mutation, reconcile, or cleanup action during the
+operation. Normal fault rules apply after lock release. Mutation preflight
+does not use this presentation rule.
 
 A retained dead pane is mutable only when its nonempty tmux token matches usable
 primary metadata. A checkpoint cannot authorize removal. Start, Resume,

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -37,8 +37,8 @@ Mutations recheck ownership, pane, run token, and process group. List jobs
 
 List buffers its output. Metadata health revisions and tmux identities must
 match before and after assessment. A revision includes metadata validity,
-source, generation, phase, process identity, shutdown evidence, and operation
-lock state. Routine heartbeat and checkpoint timestamps do not change it.
+source, generation, phase, process identity, shutdown evidence, checkpoint
+directory identity, and operation lock state. Routine heartbeat and checkpoint timestamps do not change it.
 List retries a changed observation up to three times. Continued changes fail
 the read without partial rows. Each stable attempt uses two tmux reads and a
 constant number of state helper processes, independent of the session count.

--- a/tests/quality-gate.sh
+++ b/tests/quality-gate.sh
@@ -86,6 +86,8 @@ app_cache_miss_step="$(printf '%s\n' "$quality_shards_job" | sed -n \
 printf '%s\n' "$app_cache_miss_step" | \
   grep -F "steps.app-cache.outputs.cache-hit != 'true'" >/dev/null
 printf '%s\n' "$app_cache_miss_step" | \
+  grep -F '!matrix.builds_app' >/dev/null
+printf '%s\n' "$app_cache_miss_step" | \
   grep -F 'DETACH_QUALITY_APP_SCRATCH: 1' >/dev/null
 printf '%s\n' "$app_cache_miss_step" | \
   grep -F 'app/scripts/make-app.sh' >/dev/null

--- a/tests/quality_gate_contract.py
+++ b/tests/quality_gate_contract.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import re
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -301,9 +303,11 @@ class QualityGateContract(unittest.TestCase):
                     0,
                 )
             for part in (
+                "resume",
+                "delete",
                 "guardrails",
                 "lifecycle-recovery",
-                "resume-identity",
+                "identity",
             ):
                 log = (run_dir / f"codex-parts/{part}.log").read_text(
                     encoding="utf-8"
@@ -335,6 +339,33 @@ class QualityGateContract(unittest.TestCase):
                         "identity",
                     ),
                 )
+
+    def test_codex_layouts_select_every_suite_section_once(self) -> None:
+        # Execute the real shell selector without starting the integration suite.
+        # Scheduling must not lose sections or repeat stateful scenarios.
+        source = (ROOT / "tests/run.sh").read_text(encoding="utf-8")
+        selector = source.split("codex_part_selected() {", 1)[1].split(
+            "codex_scenario_event()", 1
+        )[0]
+        sections = re.findall(r"^if codex_part_selected ([a-z-]+); then$", source, re.MULTILINE)
+        self.assertTrue(sections)
+        self.assertEqual(len(sections), len(set(sections)))
+        command = "codex_part_selected() {" + selector + "\n" + (
+            'CODEX_TEST_PART="$1"; shift\n'
+            'for section in "$@"; do\n'
+            '  if codex_part_selected "$section"; then printf "%s\\n" "$section"; fi\n'
+            'done\n'
+        )
+        for cpus in (3, 10):
+            with self.subTest(cpus=cpus), patch("quality_gate.os.cpu_count", return_value=cpus):
+                selected = []
+                for part in provider_test_parts("codex"):
+                    result = subprocess.run(
+                        ["/bin/bash", "-c", command, "selector", part, *sections],
+                        text=True, capture_output=True, check=True,
+                    )
+                    selected.extend(result.stdout.splitlines())
+                self.assertCountEqual(selected, sections)
 
     def test_static_contracts_keep_separate_deterministic_logs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/quality_shard_contract.py
+++ b/tests/quality_shard_contract.py
@@ -40,6 +40,7 @@ class QualityShardContract(unittest.TestCase):
                     "stages": "static",
                     "level": 0,
                     "needs_app": False,
+                    "builds_app": False,
                     "needs_cache": False,
                     "needs_runtime": False,
                     "needs_metrics": False,
@@ -76,6 +77,7 @@ class QualityShardContract(unittest.TestCase):
         build = shard_for({"stages": stages}, "build-and-coverage")
         self.assertEqual(build["stages"], "swift,quality-contracts,app,ui-e2e")
         self.assertTrue(build["needs_app"])
+        self.assertTrue(build["builds_app"])
         self.assertTrue(build["needs_cache"])
         self.assertTrue(build["needs_metrics"])
         self.assertEqual(build["coverage_profile"], "combined")
@@ -84,10 +86,12 @@ class QualityShardContract(unittest.TestCase):
             contracts["stages"], "gate-contract,tmux-runtime,release-preflight"
         )
         self.assertTrue(contracts["needs_app"])
+        self.assertFalse(contracts["builds_app"])
         self.assertFalse(contracts["needs_cache"])
         self.assertFalse(contracts["needs_runtime"])
         codex = shard_for({"stages": stages}, "codex")
         self.assertFalse(codex["needs_app"])
+        self.assertFalse(codex["builds_app"])
         self.assertTrue(codex["needs_cache"])
         self.assertTrue(codex["needs_runtime"])
         self.assertFalse(build["needs_runtime"])

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -1167,7 +1167,7 @@ if [ "$(printf '%s' "$held_resume_json" | \
      "$STATE_HELPER" meta get /dev/stdin effective_status 2>/dev/null || true)" != \
      starting ] || \
    ! printf '%s' "$held_resume_json" | \
-     grep -F '"health_actions":["attach","stop"]' >/dev/null; then
+     grep -F '"health_actions":["attach"]' >/dev/null; then
   : >"$FAKE_POWER_FAIL_RELEASE_FILE"
   wait "$failed_resume_pid" || true
   printf 'Claude list exposed recovery while replacement B was still starting: %s\n' \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,24 +32,16 @@ case "$CODEX_TEST_PART" in
 esac
 
 codex_part_selected() {
-  [ "$CODEX_TEST_PART" = all ] || [ "$CODEX_TEST_PART" = "$1" ] || {
-    [ "$CODEX_TEST_PART" = preflight ] && {
-      [ "$1" = history ] || [ "$1" = configuration ]
-    } ||
-    [ "$CODEX_TEST_PART" = recovery ] && [ "$1" = restart ] ||
-    [ "$CODEX_TEST_PART" = guardrails ] && {
-      case "$1" in preflight|crash|history) return 0 ;; esac
-      return 1
-    } ||
-    [ "$CODEX_TEST_PART" = lifecycle-recovery ] && {
-      case "$1" in configuration|lifecycle|recovery|restart) return 0 ;; esac
-      return 1
-    } ||
-    [ "$CODEX_TEST_PART" = resume-identity ] && {
-      case "$1" in resume|identity|delete) return 0 ;; esac
-      return 1
-    }
-  }
+  [ "$CODEX_TEST_PART" != all ] && [ "$CODEX_TEST_PART" != "$1" ] || return 0
+  case "$CODEX_TEST_PART:$1" in
+    preflight:history|preflight:configuration|recovery:restart|\
+    guardrails:preflight|guardrails:crash|guardrails:history|\
+    lifecycle-recovery:configuration|lifecycle-recovery:lifecycle|\
+    lifecycle-recovery:recovery|lifecycle-recovery:restart|\
+    resume-identity:resume|resume-identity:identity|resume-identity:delete)
+      return 0 ;;
+  esac
+  return 1
 }
 
 codex_scenario_event() {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2081,6 +2081,9 @@ if [ "$CODEX_TEST_PART" = all ] || \
   bootstrap_codex_checkpoint
 fi
 
+python3 "$ROOT/tests/runtime-state-consistency.py" \
+  "$SCRIPT" "$expected_id" "$SESSION" "$meta" "$STATE_HELPER" "$TMP_ROOT"
+
 # Explicit resume follows Codex semantics and accepts the exact thread UUID.
 export FAKE_CODEX_INIT_DELAY=0
 export FAKE_CODEX_SLEEP=1
@@ -2389,7 +2392,7 @@ if [ "$(printf '%s' "$held_resume_json" | \
      "$STATE_HELPER" meta get /dev/stdin effective_status 2>/dev/null || true)" != \
      starting ] || \
    ! printf '%s' "$held_resume_json" | \
-     grep -F '"health_actions":["attach","stop"]' >/dev/null; then
+     grep -F '"health_actions":["attach"]' >/dev/null; then
   : >"$FAKE_POWER_FAIL_RELEASE_FILE"
   wait "$failed_resume_pid" || true
   printf 'Codex list exposed recovery while replacement B was still starting: %s\n' \
@@ -4108,12 +4111,12 @@ DETACH_TMUX_SOCKET_PATH="$SOCKET_PATH" \
 list_scale_elapsed="$SECONDS"
 [ "$(wc -l <"$list_scale_output" | tr -d '[:space:]')" = 25 ]
 [ "$(grep -Fc '"model":"gpt-scale"' "$list_scale_output")" = 25 ]
-[ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 5 ] || {
+[ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 7 ] || {
   printf 'list restored per-field state helper fan-out\n' >&2
   exit 1
 }
-[ "$(wc -l <"$list_scale_tmux_invocations" | tr -d '[:space:]')" = 1 ] || {
-  printf 'list did not use one batched tmux snapshot\n' >&2
+[ "$(wc -l <"$list_scale_tmux_invocations" | tr -d '[:space:]')" = 2 ] || {
+  printf 'list did not validate its batched tmux snapshot\n' >&2
   exit 1
 }
 [ "$(find "$list_scale_root/sessions" -name .transcript-summary-cache.json -type f | \
@@ -4137,8 +4140,8 @@ DETACH_TMUX_SOCKET_PATH="$SOCKET_PATH" \
   "$SCRIPT" codex list --json >"$list_scale_output"
 list_scale_hot_elapsed="$SECONDS"
 [ "$(wc -l <"$list_scale_output" | tr -d '[:space:]')" = 25 ]
-[ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 5 ]
-[ "$(wc -l <"$list_scale_tmux_invocations" | tr -d '[:space:]')" = 1 ]
+[ "$(wc -l <"$list_scale_invocations" | tr -d '[:space:]')" -le 7 ]
+[ "$(wc -l <"$list_scale_tmux_invocations" | tr -d '[:space:]')" = 2 ]
 [ "$list_scale_hot_elapsed" -lt 5 ] || {
   printf 'cached 25-session list exceeded the app deadline: %ss\n' \
     "$list_scale_hot_elapsed" >&2

--- a/tests/runtime-state-consistency.py
+++ b/tests/runtime-state-consistency.py
@@ -89,10 +89,10 @@ mode = os.environ["STATE_TEST_MODE"]
 real = os.environ["STATE_TEST_REAL"]
 match = ((mode == "tmux" and "list-panes" in args)
          or (mode == "placeholder" and "new-session" in args)
-         or (mode == "process" and args[:2] == ["health", "sessions"]))
+         or (mode in ("process", "checkpoint") and args[:2] == ["health", "sessions"]))
 if not match or base.with_suffix(".captured").exists():
     os.execv(real, [real] + args)
-if mode == "process":
+if mode in ("process", "checkpoint"):
     data = sys.stdin.buffer.read()
 else:
     result = subprocess.run([real] + args, capture_output=True)
@@ -102,7 +102,7 @@ while not base.with_suffix(".release").exists():
     if time.monotonic() > deadline:
         sys.exit(88)
     time.sleep(.02)
-if mode == "process":
+if mode in ("process", "checkpoint"):
     result = subprocess.run([real] + args, input=data, capture_output=True)
 sys.stdout.buffer.write(result.stdout)
 sys.stderr.buffer.write(result.stderr)
@@ -113,8 +113,8 @@ wrapper.chmod(0o755)
 
 def barrier(mode, arguments):
     base = root / mode
-    binary = state if mode == "process" else os.environ["DETACH_TMUX_BIN"]
-    override = "DETACH_STATE_BIN" if mode == "process" else "DETACH_TMUX_BIN"
+    binary = state if mode in ("process", "checkpoint") else os.environ["DETACH_TMUX_BIN"]
+    override = "DETACH_STATE_BIN" if mode in ("process", "checkpoint") else "DETACH_TMUX_BIN"
     env = dict(environment, STATE_TEST_BARRIER=str(base), STATE_TEST_MODE=mode,
                STATE_TEST_REAL=binary, **{override: str(wrapper)})
     process = subprocess.Popen(arguments, env=env, stdout=subprocess.PIPE,
@@ -154,6 +154,31 @@ finally:
 row = next(row for row in map(json.loads, output.splitlines()) if row["session_name"] == name)
 assert row["effective_status"] == "stopped", row
 assert row["health_actions"] == ["resume", "delete"]
+
+# A checkpoint publication can change recovery eligibility without a change
+# to primary metadata. Reject the observation taken before that publication.
+checkpoint = Path(metadata).parent / "checkpoint"
+preserved = Path(metadata).parent / "checkpoint-held-by-test"
+live = Path(json.loads(Path(metadata).read_text())["transcript_path"])
+assert live.is_relative_to(Path(os.environ["CODEX_HOME"]))
+held_live = root / "live-rollout"
+live.rename(held_live)
+checkpoint.rename(preserved)
+patch("--string", "status", "running")
+try:
+    assert snapshot()["effective_status"] == "orphaned"
+    base, process = barrier("checkpoint", [cli, "codex", "list", "--json"])
+    try:
+        preserved.rename(checkpoint)
+    finally:
+        output = release(base, process)
+    row = next(row for row in map(json.loads, output.splitlines()) if row["session_name"] == name)
+    assert row["effective_status"] == "recoverable", row
+finally:
+    if preserved.exists():
+        preserved.rename(checkpoint)
+    held_live.rename(live)
+    patch("--string", "status", "stopped")
 
 # Pause the actual launcher with its operation lock held after placeholder
 # creation, before metadata and tmux markers. This is a transaction, not a

--- a/tests/runtime-state-consistency.py
+++ b/tests/runtime-state-consistency.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Interleave public commands around actual tmux, metadata, and kernel PIDs.
+
+Called by run.sh with its stopped checkpoint and private runtime installation.
+Barriers delay observations; they never synthesize a health result.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+cli, identity, name, metadata, state, temporary = sys.argv[1:]
+name = "detach-codex-state-consistency"
+metadata = str(Path(metadata).parent.parent / name / "meta.json")
+root = Path(temporary) / "state-consistency"
+root.mkdir()
+environment = dict(os.environ, FAKE_CODEX_SLEEP="120", FAKE_CODEX_INIT_DELAY="0")
+
+
+def run(arguments, *, env=None, success=True):
+    result = subprocess.run(arguments, env=env or environment, capture_output=True,
+                            text=True, timeout=60)
+    if success:
+        assert result.returncode == 0, (arguments[:4], result.stderr)
+    return result
+
+
+def patch(*arguments):
+    run([state, "meta", "patch", metadata, *arguments])
+
+
+def snapshot(*, env=None):
+    result = run([cli, "codex", "list", "--json"], env=env)
+    return next(row for row in map(json.loads, result.stdout.splitlines())
+                if row["session_name"] == name)
+
+
+def resume(*, env=None):
+    return run([cli, "codex", "resume", "--name", name, "--detach", identity], env=env)
+
+
+def stop():
+    run([cli, "codex", "stop", name])
+
+
+# A real owned process created after readiness is a reused PID. A process
+# without that exclusion evidence must still block every replacement attempt.
+# Use a separate managed history so these resumes cannot replace the caller's
+# saved provider options or checkpoint generation.
+resume()
+stop()
+unrelated = subprocess.Popen(["/bin/sleep", "120"])
+try:
+    patch("--integer", "worker_pid", str(unrelated.pid),
+          "--string", "runtime_ready_at", "2000-01-01T00:00:00Z")
+    assert snapshot()["effective_status"] == "stopped"
+    text_row = next(line for line in run([cli, "codex", "list"]).stdout.splitlines()
+                    if name in line.split())
+    assert text_row.split()[3] == "stopped", text_row
+    resume()
+    assert unrelated.poll() is None
+    stop()
+    stopped = json.loads(Path(metadata).read_text())
+    for readiness in [("--null", "runtime_ready_at"),
+                      ("--string", "runtime_ready_at", "2099-01-01T00:00:00Z")]:
+        patch("--integer", "worker_pid", str(unrelated.pid), *readiness)
+        before = Path(metadata).read_bytes()
+        assert snapshot()["health_reason"] == "runtime_process_without_tmux"
+        refused = run([cli, "codex", "resume", "--name", name, "--detach", identity],
+                      success=False)
+        assert refused.returncode != 0
+        assert "still alive without managed tmux" in refused.stderr
+        assert unrelated.poll() is None
+        assert Path(metadata).read_bytes() == before
+    patch("--integer", "worker_pid", str(stopped["worker_pid"]),
+          "--string", "runtime_ready_at", stopped["runtime_ready_at"])
+finally:
+    unrelated.terminate()
+    unrelated.wait(timeout=5)
+
+wrapper = root / "barrier"
+wrapper.write_text('''#!/usr/bin/env python3
+import os, pathlib, subprocess, sys, time
+args = sys.argv[1:]
+base = pathlib.Path(os.environ["STATE_TEST_BARRIER"])
+mode = os.environ["STATE_TEST_MODE"]
+real = os.environ["STATE_TEST_REAL"]
+match = ((mode == "tmux" and "list-panes" in args)
+         or (mode == "placeholder" and "new-session" in args)
+         or (mode == "process" and args[:2] == ["health", "sessions"]))
+if not match or base.with_suffix(".captured").exists():
+    os.execv(real, [real] + args)
+if mode == "process":
+    data = sys.stdin.buffer.read()
+else:
+    result = subprocess.run([real] + args, capture_output=True)
+base.with_suffix(".captured").touch()
+deadline = time.monotonic() + 45
+while not base.with_suffix(".release").exists():
+    if time.monotonic() > deadline:
+        sys.exit(88)
+    time.sleep(.02)
+if mode == "process":
+    result = subprocess.run([real] + args, input=data, capture_output=True)
+sys.stdout.buffer.write(result.stdout)
+sys.stderr.buffer.write(result.stderr)
+sys.exit(result.returncode)
+''')
+wrapper.chmod(0o755)
+
+
+def barrier(mode, arguments):
+    base = root / mode
+    binary = state if mode == "process" else os.environ["DETACH_TMUX_BIN"]
+    override = "DETACH_STATE_BIN" if mode == "process" else "DETACH_TMUX_BIN"
+    env = dict(environment, STATE_TEST_BARRIER=str(base), STATE_TEST_MODE=mode,
+               STATE_TEST_REAL=binary, **{override: str(wrapper)})
+    process = subprocess.Popen(arguments, env=env, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE, text=True)
+    deadline = time.monotonic() + 15
+    while not base.with_suffix(".captured").exists():
+        assert process.poll() is None, process.communicate()
+        assert time.monotonic() < deadline, "barrier was not reached"
+        time.sleep(.02)
+    return base, process
+
+
+def release(base, process):
+    base.with_suffix(".release").touch()
+    output, error = process.communicate(timeout=45)
+    assert process.returncode == 0, error
+    return output
+
+
+# List has read genuine old tmux output. Complete Resume before allowing it to
+# read metadata. The buffered mixed generation must be discarded and retried.
+base, process = barrier("tmux", [cli, "codex", "list", "--json"])
+try:
+    resume()
+finally:
+    output = release(base, process)
+row = next(row for row in map(json.loads, output.splitlines()) if row["session_name"] == name)
+assert row["effective_status"] == "running", row
+assert row["ownership_proven"] is True
+
+# List has read running metadata. Complete Stop before kernel PID inspection.
+base, process = barrier("process", [cli, "codex", "list", "--json"])
+try:
+    stop()
+finally:
+    output = release(base, process)
+row = next(row for row in map(json.loads, output.splitlines()) if row["session_name"] == name)
+assert row["effective_status"] == "stopped", row
+assert row["health_actions"] == ["resume", "delete"]
+
+# Pause the actual launcher with its operation lock held after placeholder
+# creation, before metadata and tmux markers. This is a transaction, not a
+# foreign-session fault. Releasing the lock restores normal health rules.
+base, process = barrier("placeholder", [cli, "codex", "resume", "--name", name,
+                                       "--detach", identity])
+try:
+    row = snapshot()
+    assert row["effective_status"] == "starting", row
+    assert row["health_reason"] == "operation_in_progress", row
+    assert row["health_actions"] == [] and not row["ownership_proven"]
+    assert not row["cleanup_eligible"] and row["reconcile_action"] == "none"
+finally:
+    release(base, process)
+assert snapshot()["effective_status"] == "running"
+stop()
+
+# The same unmarked pane outside a transaction is a genuine persistent fault.
+tmux = [os.environ["DETACH_TMUX_BIN"], "-S", os.environ["DETACH_TMUX_SOCKET_PATH"]]
+run(tmux + ["new-session", "-d", "-s", name, "/bin/sleep", "30"])
+try:
+    row = snapshot()
+    assert row["effective_status"] == "collision" and row["health_actions"] == [], row
+finally:
+    run(tmux + ["kill-session", "-t", "=" + name])
+# Repeated real metadata changes exhaust the bounded retry without leaking a
+# partial snapshot. Each helper invocation changes the opaque lifecycle ID.
+churn = root / "churn-state"
+churn.write_text('''#!/usr/bin/env python3
+import os, subprocess, sys, uuid
+args = sys.argv[1:]
+real = os.environ["STATE_TEST_REAL"]
+if args[:2] == ["health", "sessions"]:
+    data = sys.stdin.buffer.read()
+    subprocess.run([real, "meta", "patch", os.environ["STATE_TEST_METADATA"],
+                    "--string", "lifecycle_id", str(uuid.uuid4())], check=True)
+    result = subprocess.run([real] + args, input=data, capture_output=True)
+    sys.stdout.buffer.write(result.stdout)
+    sys.stderr.buffer.write(result.stderr)
+    sys.exit(result.returncode)
+os.execv(real, [real] + args)
+''')
+churn.chmod(0o755)
+result = run([cli, "codex", "list", "--json"], success=False,
+             env=dict(environment, DETACH_STATE_BIN=str(churn),
+                      STATE_TEST_REAL=state, STATE_TEST_METADATA=metadata))
+assert result.returncode != 0 and result.stdout == "", result
+assert "all three list attempts" in result.stderr, result.stderr
+assert snapshot()["effective_status"] == "stopped"
+run([cli, "codex", "delete", "--force", name])
+
+print("runtime state consistency: actual PID reuse, tmux/metadata interleavings, and operation locks PASS")

--- a/tools/quality_gate.py
+++ b/tools/quality_gate.py
@@ -127,9 +127,13 @@ DISTRIBUTION_SCENARIOS = (
     "SC-INSTALL-UNINSTALL",
 )
 COMPACT_CODEX_TEST_PARTS = (
+    # Resume and Delete have long independent waits. Keep their fixtures in
+    # separate lanes even on small hosts; the scheduler still admits only three.
+    "resume",
+    "delete",
     "guardrails",
     "lifecycle-recovery",
-    "resume-identity",
+    "identity",
 )
 COMPACT_CLAUDE_TEST_PARTS = (
     "session",

--- a/tools/quality_shard.py
+++ b/tools/quality_shard.py
@@ -139,6 +139,7 @@ def shard_plan(plan: dict[str, object]) -> list[dict[str, object]]:
                 "stages": ",".join(stages),
                 "level": level,
                 "needs_app": needs_app,
+                "builds_app": "app" in stages,
                 "needs_cache": needs_cache,
                 "needs_runtime": needs_runtime,
                 "needs_metrics": needs_metrics,


### PR DESCRIPTION
Resume could reject an old finished history because its recorded worker PID now belonged to a different process. List also combined tmux, metadata, and kernel observations from different runs, and classified the launcher's temporary unmarked pane as a foreign session. Actual tmux barriers reproduced these failures before the changes.

List and mutation eligibility now share creation-time-aware process inspection. List buffers its rows and checks metadata health revisions, checkpoint directory identities, and tmux identities around assessment; it retries changed observations at most three times and emits no partial snapshot on continued changes. While the kernel session operation lock is held, provisional faults are actionless Starting states. Independently proven live panes can offer Attach; mutation preflight retains its exact ownership checks and never uses this presentation rule.

Cold tmux key setup uses Bash builtins instead of hundreds of subprocess substitutions. Generated settings were byte-identical; the isolated generation step decreased from 0.584 s to 0.012 s. This does not claim a bound on provider startup or lock contention.

Validation includes real PID reuse, blocked mutations without exclusion evidence, actual tmux/metadata/process interleavings, a held launcher placeholder, checkpoint publication after recovery assessment, persistent foreign tmux, and bounded retry exhaustion. Both provider launch tests now require Attach-only during the operation. The terminal geometry fixture publishes its stty result atomically to close a confirmed empty-file test race. README and durable specs describe the changed contract.

139 focused Swift tests and the isolated runtime consistency scenarios passed. All 13 local product diagnostic stages passed. Subsequent unit-only additions passed their selected static, Swift, and quality-contract gates. Critical DetachStateCommand line coverage is 97.92%, above the current main floor of 97.88%; the floor is unchanged. Hosted quality-gates is the merge authority. No hardware power, signing, notarization, or release publication was performed for this change.

On cold CI app-cache misses, the app-owning shard now builds within its existing parallel Swift/app stage instead of serializing the normal app build before those checks. Consumer shards retain eager app preparation, and cache hits retain verification. Matrix ownership contracts cover both cases. The ten-minute deadline and required checks are unchanged. The final local UI attempt reported a locked GUI session; hosted UI evidence remains required.


Codex test selection now uses explicit case branches. The previous large-host selector omitted Configuration, Restart, and History through shell AND/OR precedence. A regression executes the real selector and verifies that both layouts select every suite section exactly once. Small hosts schedule Resume and Delete separately, with the same three-part concurrency limit.

All 13 local diagnostics passed after these corrections, including UI, both providers, and the restored sections. The five-part compact Codex integration also passed. Hosted CI for the updated head remains the merge authority.
