### PR TITLE
Preserve retained checkpoints until recovery is rebuilt

### DIFF
--- a/bin/detach-core
+++ b/bin/detach-core
@@ -2374,7 +2374,13 @@ materialize_selected_recovery_checkpoint() (
     esac
   fi
 
-  scavenge_checkpoint_stages "$session" "$session_path" || return 1
+  # A valid live source can repair an incomplete canonical checkpoint. Keep
+  # retained generations until that replacement is durably published; the
+  # normal scavenger correctly refuses to delete them before that point.
+  for source in "$session_path"/.checkpoint-stage-*; do
+    [ -e "$source" ] || [ -L "$source" ] || continue
+    owned_plain_checkpoint_directory "$source" || return 1
+  done
   stage_name=".checkpoint-stage-preserve-$stage_token-$$"
   checkpoint_stage_name_is_safe "$stage_name" || return 1
   stage="$session_path/$stage_name"
@@ -2492,7 +2498,8 @@ materialize_selected_recovery_checkpoint() (
     return 1
   fi
   remove_checkpoint_stage "$session_path" "$stage" || return 1
-  [ "$SYNC_ENABLED" = "0" ] || /bin/sync
+  [ "$SYNC_ENABLED" = "0" ] || /bin/sync || return 1
+  scavenge_checkpoint_stages "$session" "$session_path"
 )
 
 reset_checkpoint_generation() (

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -67,6 +67,12 @@ conversations. Public operations reject symlinked or foreign-owned mutable
 roots before traversal. The checked Codex SQLite backup is never restored
 automatically.
 
+Recover can rebuild an incomplete checkpoint from a valid live journal even
+when an interrupted publication left staging directories. It validates those
+directories before staging. It removes retained generations only after the
+replacement checkpoint passes validation, atomic publication, and required
+writeback. A failure before publication preserves the retained generations.
+
 Bulk cleanup selects only fully scanned `stopped` or `orphaned` sessions.
 Before deletion, the app re-reads and matches the shown status and byte
 counts. The provider command waits up to 30 s for the checkpoint lock,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2485,6 +2485,10 @@ cp -Rp "$codex_session_dir" "$missing_backup_dir"
 "$STATE_HELPER" meta patch "$missing_backup_dir/checkpoint/meta.json" \
   --string session_name "$missing_backup_session" \
   --string display_name "$missing_backup_name"
+# An interrupted publication can retain an older complete generation. Recover
+# must preserve it until the valid live source has rebuilt canonical recovery.
+missing_backup_retained="$missing_backup_dir/.checkpoint-stage-retained-recovery"
+cp -Rp "$missing_backup_dir/checkpoint" "$missing_backup_retained"
 rm -f "$missing_backup_dir/checkpoint/rollout.jsonl"
 missing_backup_json="$(run_codex list --json | \
   grep -F "\"session_name\":\"$missing_backup_session\"")"
@@ -2494,9 +2498,46 @@ missing_backup_json="$(run_codex list --json | \
   "$STATE_HELPER" meta get /dev/stdin agent_session_id)" = "$expected_id" ]
 printf '%s' "$missing_backup_json" | \
   grep -F '"health_actions":["recover","delete"]' >/dev/null
+# Reject unsafe retained paths without touching the saved generation.
+missing_backup_unsafe="$missing_backup_dir/.checkpoint-stage-unsafe"
+missing_backup_retained_copy="$TMP_ROOT/retained-recovery-copy"
+cp -Rp "$missing_backup_retained" "$missing_backup_retained_copy"
+ln -s "$missing_backup_retained_copy" "$missing_backup_unsafe"
+if run_codex recover --detach "$missing_backup_name" \
+    >"$TMP_ROOT/unsafe-retained-recover.out" 2>&1; then
+  printf 'Recover accepted a symlinked retained checkpoint stage\n' >&2
+  exit 1
+fi
+[ -L "$missing_backup_unsafe" ]
+diff -qr "$missing_backup_retained_copy" "$missing_backup_retained" >/dev/null
+[ ! -e "$missing_backup_dir/checkpoint/rollout.jsonl" ]
+rm "$missing_backup_unsafe"
+# Force publication to fail after the live source was staged. Old retained
+# data must survive, and the next ordinary Recover must still succeed.
+missing_backup_state_wrapper="$TMP_ROOT/retained-recovery-state"
+missing_backup_exchange_attempt="$TMP_ROOT/retained-recovery-exchange-attempt"
+{
+  printf '#!/bin/bash\n'
+  printf 'if [ "$1:$2" = checkpoint:exchange ] && [ "$3" = %q ]; then\n' "$missing_backup_dir"
+  printf '  : >%q\n  exit 1\nfi\n' "$missing_backup_exchange_attempt"
+  printf 'exec %q "$@"\n' "$STATE_HELPER"
+} >"$missing_backup_state_wrapper"
+chmod 0700 "$missing_backup_state_wrapper"
+if DETACH_STATE_BIN="$missing_backup_state_wrapper" \
+    run_codex recover --detach "$missing_backup_name" \
+    >"$TMP_ROOT/retained-publication-failure.out" 2>&1; then
+  printf 'Recover accepted a failed checkpoint publication\n' >&2
+  exit 1
+fi
+[ -f "$missing_backup_exchange_attempt" ]
+diff -qr "$missing_backup_retained_copy" "$missing_backup_retained" >/dev/null
+[ ! -e "$missing_backup_dir/checkpoint/rollout.jsonl" ]
 export FAKE_CODEX_SLEEP=20
 run_codex recover --detach "$missing_backup_name"
 wait_for_tmux_option "$missing_backup_session" @detach_status running
+[ ! -e "$missing_backup_retained" ]
+"$STATE_HELPER" jsonl validate codex \
+  "$missing_backup_dir/checkpoint/rollout.jsonl" "$expected_id"
 require_file_line "$FAKE_CODEX_ARGS_FILE" resume
 require_file_line "$FAKE_CODEX_ARGS_FILE" "$expected_id"
 require_file_line "$FAKE_CODEX_ARGS_FILE" detach-recovery-model


### PR DESCRIPTION
Recover could reject a valid live journal when its canonical checkpoint had no backup and an interrupted publication had left a staging directory. List offered Recover, but preparation tried to scavenge the retained generation before rebuilding canonical recovery and failed with "could not initialize session metadata".

Recovery now validates retained directories without deleting them, builds and validates the selected source, publishes and writes back the new checkpoint, and then scavenges retained generations. Unsafe directories still fail closed. Failed publication retains the previous recovery data, and writeback failures remain errors.

The same isolated public Recover fixture failed before the change and succeeded afterward. Regression coverage adds a retained generation to the missing-backup case, rejects a symlink without changing retained data, forces checkpoint exchange to fail and proves retained data survives, then verifies ordinary recovery and cleanup. All five selected local diagnostics passed (static, app, Codex, Claude, distribution); hosted quality-gates remains the merge authority. No release artifacts have been signed or published for this change.
