### PR TITLE
Keep release tag and appcast checks when ambient DETACH env is set

### DIFF
--- a/app/scripts/publish-release.sh
+++ b/app/scripts/publish-release.sh
@@ -19,7 +19,6 @@ DOWNLOAD_URL_PREFIX="${DETACH_SPARKLE_DOWNLOAD_URL_PREFIX:-https://github.com/$R
 DOWNLOAD_URL="${DETACH_DOWNLOAD_URL:-https://github.com/$REPOSITORY/releases/latest}"
 FEED_URL="${DETACH_SPARKLE_FEED_URL:-https://github.com/$REPOSITORY/releases/latest/download/appcast.xml}"
 RELEASE_TARGET="${DETACH_GITHUB_RELEASE_TARGET:-}"
-SEPARATE_RELEASE_REPOSITORY="${DETACH_SEPARATE_RELEASE_REPOSITORY:-0}"
 PUBLISH_CONFIRMATION="${DETACH_CONFIRM_PUBLISH:-}"
 ORCHESTRATED_COMMIT="${DETACH_RELEASE_EXPECTED_COMMIT:-}"
 RESUME_DRAFT="${DETACH_RESUME_DRAFT:-0}"
@@ -162,10 +161,6 @@ if [ -n "$RELEASE_TARGET" ]; then
     exit 1
   }
 fi
-[[ "$SEPARATE_RELEASE_REPOSITORY" = 0 || "$SEPARATE_RELEASE_REPOSITORY" = 1 ]] || {
-  printf 'DETACH_SEPARATE_RELEASE_REPOSITORY must be 0 or 1\n' >&2
-  exit 1
-}
 [[ "$RESUME_DRAFT" = 0 || "$RESUME_DRAFT" = 1 ]] || {
   printf 'DETACH_RESUME_DRAFT must be 0 or 1\n' >&2
   exit 1
@@ -335,14 +330,13 @@ verify_clean_worktree
 gh auth status >/dev/null
 
 # GitHub otherwise creates a missing tag from the repository's default branch.
-# An existing remote tag is explicit and is verified by `gh`. A separate
-# downloads repository may instead opt into creating the tag from a named,
-# resolved target; no implicit default-branch tag is allowed.
+# An existing remote tag is explicit and is verified by `gh`. A missing remote
+# tag requires an explicit resolved target. The tag or target commit must equal
+# the built source commit.
 REMOTE_TAG_COMMIT="$(gh api "repos/$REPOSITORY/commits/$TAG" --jq .sha 2>/dev/null || true)"
 release_tag_args=()
 if [ -n "$REMOTE_TAG_COMMIT" ]; then
-  [ "$SEPARATE_RELEASE_REPOSITORY" = 1 ] || \
-    [ "$REMOTE_TAG_COMMIT" = "$GIT_COMMIT" ] || {
+  [ "$REMOTE_TAG_COMMIT" = "$GIT_COMMIT" ] || {
     printf 'Remote tag %s does not point to the built source commit\n' "$TAG" >&2
     exit 1
   }
@@ -359,8 +353,7 @@ else
     printf 'Cannot resolve GitHub release target: %s\n' "$RELEASE_TARGET" >&2
     exit 1
   }
-  [ "$SEPARATE_RELEASE_REPOSITORY" = 1 ] || \
-    [ "$REMOTE_TARGET_COMMIT" = "$GIT_COMMIT" ] || {
+  [ "$REMOTE_TARGET_COMMIT" = "$GIT_COMMIT" ] || {
     printf 'GitHub release target does not match the built source commit\n' >&2
     exit 1
   }

--- a/app/scripts/release.sh
+++ b/app/scripts/release.sh
@@ -2,6 +2,20 @@
 
 set -euo pipefail
 
+INITIAL_RELEASE=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --initial-release)
+      INITIAL_RELEASE=1
+      ;;
+    *)
+      printf 'Unexpected argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 APP_ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 REPO_ROOT="$(cd -P "$APP_ROOT/.." && pwd)"
 VERSION="${DETACH_VERSION:-$(<"$REPO_ROOT/VERSION")}"
@@ -16,7 +30,6 @@ REPOSITORY="${DETACH_GITHUB_REPOSITORY:-}"
 TAG="${DETACH_RELEASE_TAG:-v$VERSION}"
 DOWNLOAD_URL_PREFIX="${DETACH_SPARKLE_DOWNLOAD_URL_PREFIX:-}"
 DOWNLOAD_URL="${DETACH_DOWNLOAD_URL:-}"
-INITIAL_RELEASE="${DETACH_INITIAL_RELEASE:-0}"
 APP="$APP_ROOT/build/Detach.app"
 DMG="$APP_ROOT/build/Detach.dmg"
 NOTARY_ZIP="$APP_ROOT/build/Detach-$VERSION-notarization.zip"
@@ -58,10 +71,6 @@ esac
 }
 [[ "$BUILD_VERSION" =~ ^[1-9][0-9]*$ ]] || {
   printf 'DETACH_BUILD_VERSION is required and must be a positive monotonic integer\n' >&2
-  exit 1
-}
-[[ "$INITIAL_RELEASE" = 0 || "$INITIAL_RELEASE" = 1 ]] || {
-  printf 'DETACH_INITIAL_RELEASE must be 0 or 1\n' >&2
   exit 1
 }
 [[ "$SPARKLE_PUBLIC_ED_KEY" =~ ^[A-Za-z0-9+/]{43}=$ ]] || {
@@ -195,7 +204,7 @@ if curl --fail --location --silent --show-error --max-time 30 \
 else
   rm -f "$NOTARY_EVIDENCE/previous-appcast.xml"
   [ "$INITIAL_RELEASE" = 1 ] || {
-    printf 'Cannot verify the previous appcast; retry or set DETACH_INITIAL_RELEASE=1 for the first release\n' >&2
+    printf 'Cannot verify the previous appcast; retry or pass --initial-release to scripts/release-version for the first release\n' >&2
     exit 1
   }
 fi

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -102,6 +102,14 @@ change real power state, upload assets, or claim publication.
 - The release orchestrator gives the lower-level publisher the exact manifest
   commit. The publisher requires the tag to match it and the current `HEAD` to
   contain it. The orchestrator separately rejects all other descendants.
+- The publisher requires the remote tag or explicit release target to resolve
+  to the built source commit. `DETACH_SEPARATE_RELEASE_REPOSITORY` does not
+  skip that identity check.
+- A failed live appcast fetch stops the release. The owner may pass
+  `--initial-release` to `scripts/release-version` for the first release.
+  That flag is the only authorization to skip live-appcast monotonicity.
+  The entry point gives the flag only to its artifact child. Ambient
+  `DETACH_INITIAL_RELEASE` is not authorization.
 - Sparkle remains pinned and signed inside-out. Production builds never carry
   the development library-validation exception. Appcasts contain exactly one
   arm64 hardware requirement.

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -7,12 +7,15 @@ export LC_ALL=C
 # The owner runs this in a terminal for the closed-lid confirmation. No Git
 # or GitHub output may wait in a pager.
 export GIT_PAGER=cat PAGER=cat GH_PAGER=cat
+# Leftover owner-shell DETACH_* skip flags must not reach child scripts.
+unset DETACH_INITIAL_RELEASE DETACH_SEPARATE_RELEASE_REPOSITORY
 
 ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
 APP_ROOT="$ROOT/app"
 ENV_FILE="$ROOT/.env.release"
 IMPACT_SCRIPT="$ROOT/scripts/release-impact"
 TEST_MODE="${DETACH_RELEASE_TEST_MODE:-0}"
+INITIAL_RELEASE=0
 LOCKED=0
 LID_WRAPPER_PID=""
 INSTALL_TEMP=""
@@ -181,7 +184,7 @@ load_release_environment() {
       DETACH_SPARKLE_ED_KEY_FILE|DETACH_SPARKLE_KEY_ACCOUNT|\
       DETACH_GITHUB_REPOSITORY|DETACH_SPARKLE_FEED_URL|\
       DETACH_SPARKLE_DOWNLOAD_URL_PREFIX|DETACH_DOWNLOAD_URL|\
-      DETACH_GITHUB_RELEASE_TARGET|DETACH_SEPARATE_RELEASE_REPOSITORY)
+      DETACH_GITHUB_RELEASE_TARGET)
         ;;
       *) die "unsupported variable in .env.release: $key" ;;
     esac
@@ -887,11 +890,15 @@ build_release_artifacts() {
   if ! release_artifacts_valid; then
     verify_artifact_credentials
     note "building, signing and notarizing Detach $VERSION (build $BUILD)"
+    release_script_args=()
+    if [ "$INITIAL_RELEASE" = 1 ]; then
+      release_script_args+=(--initial-release)
+    fi
     DETACH_VERSION="$VERSION" \
       DETACH_BUILD_VERSION="$BUILD" \
       DETACH_RELEASE_TAG="$TAG" \
       DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
-      "$APP_ROOT/scripts/release.sh"
+      "$APP_ROOT/scripts/release.sh" "${release_script_args[@]}"
   fi
   release_artifacts_valid || die 'release artifact validation failed'
   has_stage artifacts || record_stage artifacts
@@ -1172,7 +1179,7 @@ verify_published_release() {
 
 run_locked() {
   VERSION="$1"
-  valid_semver "$VERSION" || die 'usage: scripts/release-version X.Y.Z[-prerelease][+build]'
+  valid_semver "$VERSION" || die 'usage: scripts/release-version [--initial-release] X.Y.Z[-prerelease][+build]'
   load_release_environment
   validate_configuration
   if has_stage preflight; then
@@ -1209,18 +1216,30 @@ run_locked() {
 
 if [ "${1:-}" = __locked ]; then
   shift
+  if [ "${1:-}" = --initial-release ]; then
+    INITIAL_RELEASE=1
+    shift
+  fi
   [ "$#" -eq 1 ] || die 'internal lock invocation is invalid'
   LOCKED=1
   run_locked "$1"
   exit 0
 fi
 
-[ "$#" -eq 1 ] || die 'usage: scripts/release-version X.Y.Z[-prerelease][+build]'
-valid_semver "$1" || die 'usage: scripts/release-version X.Y.Z[-prerelease][+build]'
+if [ "${1:-}" = --initial-release ]; then
+  INITIAL_RELEASE=1
+  shift
+fi
+[ "$#" -eq 1 ] || die 'usage: scripts/release-version [--initial-release] X.Y.Z[-prerelease][+build]'
+valid_semver "$1" || die 'usage: scripts/release-version [--initial-release] X.Y.Z[-prerelease][+build]'
 mkdir -p "$APP_ROOT/build/release-workflow/$1"
 [ -d "$APP_ROOT/build/release-workflow/$1" ] && \
   [ ! -L "$APP_ROOT/build/release-workflow/$1" ] || \
   die 'invalid release workflow lock directory'
 chmod 0700 "$APP_ROOT/build/release-workflow/$1"
+lock_args=(__locked)
+if [ "$INITIAL_RELEASE" = 1 ]; then
+  lock_args+=(--initial-release)
+fi
 exec /usr/bin/lockf -t 0 "$APP_ROOT/build/release-workflow/$1/workflow.lock" \
-  "$0" __locked "$1"
+  "$0" "${lock_args[@]}" "$1"

--- a/scripts/release-version
+++ b/scripts/release-version
@@ -890,15 +890,19 @@ build_release_artifacts() {
   if ! release_artifacts_valid; then
     verify_artifact_credentials
     note "building, signing and notarizing Detach $VERSION (build $BUILD)"
-    release_script_args=()
     if [ "$INITIAL_RELEASE" = 1 ]; then
-      release_script_args+=(--initial-release)
+      DETACH_VERSION="$VERSION" \
+        DETACH_BUILD_VERSION="$BUILD" \
+        DETACH_RELEASE_TAG="$TAG" \
+        DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
+        "$APP_ROOT/scripts/release.sh" --initial-release
+    else
+      DETACH_VERSION="$VERSION" \
+        DETACH_BUILD_VERSION="$BUILD" \
+        DETACH_RELEASE_TAG="$TAG" \
+        DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
+        "$APP_ROOT/scripts/release.sh"
     fi
-    DETACH_VERSION="$VERSION" \
-      DETACH_BUILD_VERSION="$BUILD" \
-      DETACH_RELEASE_TAG="$TAG" \
-      DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
-      "$APP_ROOT/scripts/release.sh" "${release_script_args[@]}"
   fi
   release_artifacts_valid || die 'release artifact validation failed'
   has_stage artifacts || record_stage artifacts
@@ -1237,9 +1241,9 @@ mkdir -p "$APP_ROOT/build/release-workflow/$1"
   [ ! -L "$APP_ROOT/build/release-workflow/$1" ] || \
   die 'invalid release workflow lock directory'
 chmod 0700 "$APP_ROOT/build/release-workflow/$1"
-lock_args=(__locked)
 if [ "$INITIAL_RELEASE" = 1 ]; then
-  lock_args+=(--initial-release)
+  exec /usr/bin/lockf -t 0 "$APP_ROOT/build/release-workflow/$1/workflow.lock" \
+    "$0" __locked --initial-release "$1"
 fi
 exec /usr/bin/lockf -t 0 "$APP_ROOT/build/release-workflow/$1/workflow.lock" \
-  "$0" "${lock_args[@]}" "$1"
+  "$0" __locked "$1"

--- a/tests/publish-preflight.sh
+++ b/tests/publish-preflight.sh
@@ -32,6 +32,11 @@ grep -F '"$APPCAST_VERIFIER" "$APPCAST"' \
   printf 'publish must verify arm64 appcast hardware requirements\n' >&2
   exit 1
 }
+if grep -F '[ "$SEPARATE_RELEASE_REPOSITORY" = 1 ]' \
+    "$TEST_APP/scripts/publish-release.sh" >/dev/null; then
+  printf 'publish must not skip tag identity for a separate-release env\n' >&2
+  exit 1
+fi
 printf '%s\n' 'app/build/' >"$TEST_REPO/.gitignore"
 printf '%s\n' 'publish fixture' >"$TEST_REPO/README.md"
 git -C "$TEST_REPO" init -q
@@ -460,6 +465,86 @@ fi
   exit 1
 }
 grep -Fx 'auth status' "$GH_LOG" >/dev/null
+
+WRONG_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+cat >"$FAKE_BIN/gh" <<'SH'
+#!/bin/bash
+set -eu
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+grep -F 'spctl|--assess --type open --context context:primary-signature --verbose=2' \
+  "${FAKE_VALIDATION_LOG:?}" >/dev/null || exit 96
+case "${1:-} ${2:-}" in
+  'auth status') exit 0 ;;
+  'api repos/'*)
+    printf '%s\n' "${FAKE_REMOTE_COMMIT:?}"
+    ;;
+  *) exit 64 ;;
+esac
+SH
+chmod 0755 "$FAKE_BIN/gh"
+rm -f "$GH_LOG"
+: >"$TMP_ROOT/validation.log"
+if PATH="$FAKE_BIN:/usr/bin:/bin" \
+    FAKE_GH_LOG="$GH_LOG" \
+    FAKE_VALIDATION_LOG="$TMP_ROOT/validation.log" \
+    FAKE_REMOTE_COMMIT="$WRONG_COMMIT" \
+    DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
+    DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
+    DETACH_RELEASE_EXPECTED_COMMIT="$GIT_COMMIT" \
+    DETACH_SEPARATE_RELEASE_REPOSITORY=1 \
+    "$TEST_APP/scripts/publish-release.sh" \
+    >"$TMP_ROOT/separate-tag.stdout" 2>"$TMP_ROOT/separate-tag.stderr"; then
+  printf 'publish skipped remote-tag identity with ambient separate-release env\n' >&2
+  exit 1
+fi
+grep -F "Remote tag $TAG does not point to the built source commit" \
+  "$TMP_ROOT/separate-tag.stderr" >/dev/null
+if grep -E 'release create|release upload|release edit' "$GH_LOG" >/dev/null; then
+  printf 'publish mutated a release after tag identity failure\n' >&2
+  exit 1
+fi
+
+cat >"$FAKE_BIN/gh" <<'SH'
+#!/bin/bash
+set -eu
+printf '%s\n' "$*" >>"${FAKE_GH_LOG:?}"
+grep -F 'spctl|--assess --type open --context context:primary-signature --verbose=2' \
+  "${FAKE_VALIDATION_LOG:?}" >/dev/null || exit 96
+case "${1:-} ${2:-}" in
+  'auth status') exit 0 ;;
+  'api repos/'*)
+    case " $* " in
+      *"/${FAKE_MISSING_TAG:?} "*) exit 1 ;;
+    esac
+    printf '%s\n' "${FAKE_REMOTE_COMMIT:?}"
+    ;;
+  *) exit 64 ;;
+esac
+SH
+chmod 0755 "$FAKE_BIN/gh"
+rm -f "$GH_LOG"
+: >"$TMP_ROOT/validation.log"
+if PATH="$FAKE_BIN:/usr/bin:/bin" \
+    FAKE_GH_LOG="$GH_LOG" \
+    FAKE_VALIDATION_LOG="$TMP_ROOT/validation.log" \
+    FAKE_REMOTE_COMMIT="$WRONG_COMMIT" \
+    FAKE_MISSING_TAG="$TAG" \
+    DETACH_GITHUB_REPOSITORY="$REPOSITORY" \
+    DETACH_CONFIRM_PUBLISH="$EXPECTED_CONFIRMATION" \
+    DETACH_RELEASE_EXPECTED_COMMIT="$GIT_COMMIT" \
+    DETACH_GITHUB_RELEASE_TARGET=other-ref \
+    DETACH_SEPARATE_RELEASE_REPOSITORY=1 \
+    "$TEST_APP/scripts/publish-release.sh" \
+    >"$TMP_ROOT/separate-target.stdout" 2>"$TMP_ROOT/separate-target.stderr"; then
+  printf 'publish skipped release-target identity with ambient separate-release env\n' >&2
+  exit 1
+fi
+grep -F 'GitHub release target does not match the built source commit' \
+  "$TMP_ROOT/separate-target.stderr" >/dev/null
+if grep -E 'release create|release upload|release edit' "$GH_LOG" >/dev/null; then
+  printf 'publish mutated a release after target identity failure\n' >&2
+  exit 1
+fi
 
 # A safe retry may encounter a draft created by a previous interrupted upload.
 # It must validate every existing digest, upload only missing allowlisted files,

--- a/tests/release-preflight.sh
+++ b/tests/release-preflight.sh
@@ -26,6 +26,7 @@ install -m 0755 "$MAKE_DMG" "$TEST_APP/scripts/make-dmg.sh"
 install -m 0644 "$BUNDLE_MODE_POLICY" "$TEST_APP/scripts/bundle-modes.sh"
 install -m 0755 /usr/bin/true "$SPARKLE_BIN/generate_appcast"
 printf '%s\n' 1.2.3 >"$TEST_REPO/VERSION"
+printf '%s\n' 'app/build/' >"$TEST_REPO/.gitignore"
 
 [ -x "$APPCAST_VERIFIER" ]
 bash -n "$APPCAST_VERIFIER" "$MAKE_DMG" "$BUNDLE_MODE_POLICY"
@@ -112,6 +113,24 @@ grep -F 'DETACH_DMG_VERIFY_PRODUCTION=1' \
   printf 'release must enable production verification in the DMG builder\n' >&2
   exit 1
 }
+if grep -F 'INITIAL_RELEASE="${DETACH_INITIAL_RELEASE:-0}"' \
+    "$TEST_APP/scripts/release.sh" >/dev/null; then
+  printf 'release must not treat ambient DETACH_INITIAL_RELEASE as authorization\n' >&2
+  exit 1
+fi
+grep -F -- '--initial-release' "$TEST_APP/scripts/release.sh" >/dev/null || {
+  printf 'release must accept an explicit --initial-release flag\n' >&2
+  exit 1
+}
+grep -F -- '[--initial-release]' "$ROOT/scripts/release-version" >/dev/null || {
+  printf 'release-version must document the --initial-release flag\n' >&2
+  exit 1
+}
+grep -F 'unset DETACH_INITIAL_RELEASE DETACH_SEPARATE_RELEASE_REPOSITORY' \
+  "$ROOT/scripts/release-version" >/dev/null || {
+  printf 'release-version must drop ambient release skip flags\n' >&2
+  exit 1
+}
 for public_mode_contract in \
   'chmod 0644 "$UPDATE_ZIP"' \
   'chmod 0644 "$DMG"' \
@@ -189,7 +208,6 @@ if (
     DETACH_SPARKLE_PUBLIC_ED_KEY="$PUBLIC_KEY" \
     DETACH_SPARKLE_DOWNLOAD_URL_PREFIX=https://example.invalid/releases/v1.2.3/ \
     DETACH_DOWNLOAD_URL=https://example.invalid/releases \
-    DETACH_INITIAL_RELEASE=1 \
     "$TEST_APP/scripts/release.sh"
 ) >"$release_stdout" 2>"$release_stderr"; then
   printf 'release preflight unexpectedly completed successfully\n' >&2
@@ -210,6 +228,89 @@ grep -F 'Developer ID signing identity is not installed or valid' \
 }
 grep -Fx -- '-p --account dev.tsarev.detach' "$TMP_ROOT/generate-keys.log" >/dev/null || {
   printf 'release used an unexpected default Sparkle key account\n' >&2
+  exit 1
+}
+
+if "$ROOT/scripts/release-version" \
+    >"$TMP_ROOT/release-version-usage.stdout" \
+    2>"$TMP_ROOT/release-version-usage.stderr"; then
+  printf 'release-version accepted a missing version\n' >&2
+  exit 1
+fi
+grep -F -- '--initial-release' "$TMP_ROOT/release-version-usage.stderr" >/dev/null || {
+  printf 'release-version usage must name --initial-release\n' >&2
+  exit 1
+}
+
+cat >"$FAKE_BIN/security" <<'SH'
+#!/bin/bash
+printf '%s\n' '  1) ABCD "Developer ID Application: Detach Tests"'
+SH
+cat >"$FAKE_BIN/xcrun" <<'SH'
+#!/bin/bash
+if [ "${1:-}" = notarytool ] && [ "${2:-}" = history ]; then
+  printf '%s\n' '{}'
+  exit 0
+fi
+exit 64
+SH
+cat >"$FAKE_BIN/curl" <<'SH'
+#!/bin/bash
+exit 22
+SH
+chmod 0755 "$FAKE_BIN/security" "$FAKE_BIN/xcrun" "$FAKE_BIN/curl"
+
+run_release_appcast_preflight() {
+  local label="$1"
+  shift
+  (
+    cd -P "$TMP_ROOT"
+    env -i \
+      PATH="$FAKE_BIN:/usr/bin:/bin" \
+      HOME="$TMP_ROOT/home" \
+      CLANG_MODULE_CACHE_PATH="$TMP_ROOT/module-cache" \
+      SWIFTPM_MODULECACHE_OVERRIDE="$TMP_ROOT/module-cache" \
+      FAKE_GENERATE_KEYS_LOG="$TMP_ROOT/generate-keys-appcast.log" \
+      FAKE_PUBLIC_KEY="$PUBLIC_KEY" \
+      FAKE_SWIFT_LOG="$TMP_ROOT/swift-appcast.log" \
+      DETACH_CODESIGN_IDENTITY='Developer ID Application: Detach Tests' \
+      DETACH_NOTARY_PROFILE=detach-tests \
+      DETACH_BUILD_VERSION=1 \
+      DETACH_SPARKLE_FEED_URL=https://example.invalid/appcast.xml \
+      DETACH_SPARKLE_PUBLIC_ED_KEY="$PUBLIC_KEY" \
+      DETACH_SPARKLE_DOWNLOAD_URL_PREFIX=https://example.invalid/releases/v1.2.3/ \
+      DETACH_DOWNLOAD_URL=https://example.invalid/releases \
+      "$@"
+  ) >"$TMP_ROOT/$label.stdout" 2>"$TMP_ROOT/$label.stderr"
+}
+
+if run_release_appcast_preflight appcast-ambient \
+    DETACH_INITIAL_RELEASE=1 \
+    "$TEST_APP/scripts/release.sh"; then
+  printf 'release skipped appcast monotonicity from ambient DETACH_INITIAL_RELEASE\n' >&2
+  exit 1
+fi
+grep -F 'Cannot verify the previous appcast' \
+  "$TMP_ROOT/appcast-ambient.stderr" >/dev/null || {
+  printf 'ambient DETACH_INITIAL_RELEASE did not fail closed on appcast fetch\n' >&2
+  sed -n '1,20p' "$TMP_ROOT/appcast-ambient.stderr" >&2
+  exit 1
+}
+
+if run_release_appcast_preflight appcast-flag \
+    "$TEST_APP/scripts/release.sh" --initial-release; then
+  printf 'release unexpectedly completed after --initial-release\n' >&2
+  exit 1
+fi
+if grep -F 'Cannot verify the previous appcast' \
+    "$TMP_ROOT/appcast-flag.stderr" >/dev/null; then
+  printf 'explicit --initial-release still blocked on a failed appcast fetch\n' >&2
+  sed -n '1,20p' "$TMP_ROOT/appcast-flag.stderr" >&2
+  exit 1
+fi
+grep -F 'make-app.sh' "$TMP_ROOT/appcast-flag.stderr" >/dev/null || {
+  printf 'explicit --initial-release did not continue past appcast preflight\n' >&2
+  sed -n '1,20p' "$TMP_ROOT/appcast-flag.stderr" >&2
   exit 1
 }
 

--- a/tests/release-workflow.sh
+++ b/tests/release-workflow.sh
@@ -126,6 +126,15 @@ SH
   write_executable "$REPO/app/scripts/release.sh" <<'SH'
 #!/bin/bash
 set -euo pipefail
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --initial-release) shift ;;
+    *)
+      printf 'Unexpected argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
 root="$(cd -P "$(dirname "$0")/../.." && pwd)"
 version="${DETACH_VERSION:?}"
 build="${DETACH_BUILD_VERSION:?}"


### PR DESCRIPTION
## Contract delta

`docs/specs/release.md` (ADDED):
- The publisher requires the remote tag or explicit release target to resolve to the built source commit. `DETACH_SEPARATE_RELEASE_REPOSITORY` does not skip that identity check.
- A failed live appcast fetch stops the release unless the owner passes `--initial-release` to `scripts/release-version`. That flag is the only authorization to skip live-appcast monotonicity, and the entry point gives it only to the artifact child. Ambient `DETACH_INITIAL_RELEASE` is not authorization.

`scripts/release-version` remains the only normal release entry.

## Durable decisions

- Remove the `DETACH_SEPARATE_RELEASE_REPOSITORY` identity bypass instead of adding a second confirmation path. A separate downloads repository must still prove tag or target commit equals the built source commit.
- First-release appcast skip uses an explicit `--initial-release` flag, not an inherited `DETACH_INITIAL_RELEASE=1` value. `release-version` unsets leftover skip flags and passes the flag only to `app/scripts/release.sh`.

## Acceptance evidence

- Ambient `DETACH_SEPARATE_RELEASE_REPOSITORY=1` still requires remote-tag and release-target identity: `tests/publish-preflight.sh` PASS.
- Failed appcast fetch does not skip monotonicity without `--initial-release`; ambient `DETACH_INITIAL_RELEASE=1` is ignored: `tests/release-preflight.sh` PASS.
- `scripts/quality-gate --plan --explain` selected `static`, `gate-contract`, `app`, `release-preflight`, `publish-preflight`, and `release-workflow`. Ran the matching publish/release preflight scripts only.
- Hosted `quality-gates` is readiness authority.
- Did not run real signing, notarization, tagging, upload, or publication.

Closes #240