### PR TITLE
Clamp helper acquire deadlines and restore owned lid on battery-read failure

### DIFF
--- a/app/Sources/DetachKit/PowerHelperLeaseService.swift
+++ b/app/Sources/DetachKit/PowerHelperLeaseService.swift
@@ -118,6 +118,9 @@ extension PowerHelperLeaseServiceError: LocalizedError {
 public final class PowerHelperLeaseService: @unchecked Sendable {
     public static let defaultLeaseTimeout: TimeInterval = 120
     public static let maximumLeaseCount = 256
+    /// Absolute server budget for an initial acquire. A client Unix
+    /// timestamp is never trusted as this budget.
+    public static let maximumAcquireDeadline: TimeInterval = 8
 
     private let store: any PowerHelperStateStoring
     private let backend: any ClosedLidProtectionControlling
@@ -260,9 +263,8 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
             try recordingFailureLocked {
                 try Self.validate(identity)
                 let instant = now()
-                if let requestDeadline, instant >= requestDeadline {
-                    throw PowerHelperLeaseServiceError.requestExpired
-                }
+                let requestDeadline = try Self.serverAcquireDeadline(
+                    requestDeadline, now: instant)
                 guard !isTerminating, !state.unregistrationPending else {
                     throw PowerHelperLeaseServiceError.serviceQuiescing
                 }
@@ -402,7 +404,16 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
             candidate.thermalSafety = thermalSafety
             try replaceState(candidate)
         }
-        let lowBattery = try batteryReader.isLowBattery()
+        let lowBattery: Bool
+        do {
+            lowBattery = try batteryReader.isLowBattery()
+        } catch {
+            // A battery-read failure must not leave Detach-owned closed-lid
+            // protection active. Restore first so the catch path cannot
+            // publish an inactive lid claim while ownership remains.
+            try restoreOwnedProtectionLocked()
+            throw error
+        }
         let liveLeases = PowerLeaseRegistry.liveLeases(
             state.leases, now: instant, timeout: leaseTimeout)
 
@@ -594,7 +605,7 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
             updateCachedStatus(status)
             return status
         } catch {
-            updateCachedStatus(Self.unavailableStatus)
+            publishFailureStatusLocked()
             throw error
         }
     }
@@ -605,9 +616,29 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
         do {
             return try operation()
         } catch {
-            updateCachedStatus(Self.unavailableStatus)
+            publishFailureStatusLocked()
             throw error
         }
+    }
+
+    /// Failure snapshots must not claim closed-lid protection is inactive
+    /// while Detach still owns the machine setting.
+    private func publishFailureStatusLocked() {
+        guard state.ownsClosedLidProtection else {
+            updateCachedStatus(Self.unavailableStatus)
+            return
+        }
+        updateCachedStatus(
+            PowerProtectionStatus(
+                state: .unavailable,
+                leaseCount: 0,
+                assertionActive: false,
+                closedLidProtectionActive: true,
+                helperReachable: false,
+                transitionInProgress: false,
+                lowBattery: false,
+                thermalState: .unknown,
+                thermalSafetyActive: false))
     }
 
     /// Called only while the mutation lock is held. `status()` takes only this
@@ -641,6 +672,24 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return try operation()
+    }
+
+    /// Rejects a past or non-finite client deadline and caps a far-future
+    /// instant at `now + maximumAcquireDeadline`.
+    private static func serverAcquireDeadline(
+        _ requestDeadline: Date?,
+        now instant: Date
+    ) throws -> Date? {
+        guard let requestDeadline else { return nil }
+        let raw = requestDeadline.timeIntervalSince1970
+        guard raw.isFinite else {
+            throw PowerHelperLeaseServiceError.requestExpired
+        }
+        if instant >= requestDeadline {
+            throw PowerHelperLeaseServiceError.requestExpired
+        }
+        let serverBudget = instant.addingTimeInterval(maximumAcquireDeadline)
+        return min(requestDeadline, serverBudget)
     }
 
     private static func validate(_ identity: PowerLeaseIdentity) throws {

--- a/app/Sources/DetachKit/PowerProtection.swift
+++ b/app/Sources/DetachKit/PowerProtection.swift
@@ -125,8 +125,8 @@ public struct PowerProtectionStatus: Equatable, Codable, Sendable {
         lowBattery = try container.decode(Bool.self, forKey: .lowBattery)
         thermalState = try container.decodeIfPresent(
             PowerThermalState.self, forKey: .thermalState) ?? .unknown
-        thermalSafetyActive = try container.decodeIfPresent(
-            Bool.self, forKey: .thermalSafetyActive) ?? false
+        thermalSafetyActive = try container.decode(
+            Bool.self, forKey: .thermalSafetyActive)
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
@@ -352,6 +352,49 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
         XCTAssertTrue(backend.writes.isEmpty)
     }
 
+    func testAcquireRejectsANonFiniteRequestDeadlineBeforePersisting() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let service = try makeService(store: store, backend: backend)
+
+        for raw in [TimeInterval.nan, .infinity, -.infinity] {
+            XCTAssertThrowsError(try service.acquireLease(
+                identity,
+                assertionActive: true,
+                requestDeadline: Date(timeIntervalSince1970: raw)
+            )) { error in
+                XCTAssertEqual(
+                    error as? PowerHelperLeaseServiceError,
+                    .requestExpired)
+            }
+        }
+        XCTAssertNil(store.state)
+        XCTAssertTrue(backend.writes.isEmpty)
+    }
+
+    func testBatteryReadFailureRestoresNothingWhenClosedLidIsNotOwned() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let battery = MutableBatteryReader()
+        let service = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: battery,
+            bootSessionReader: FakeBootSessionReader(identifier: "test-boot"),
+            now: { self.now },
+            leaseTimeout: 120)
+        XCTAssertEqual(try service.reconcile().state, .allowed)
+        battery.failure = ExpectedFailure.battery
+
+        XCTAssertThrowsError(try service.reconcile())
+
+        XCTAssertTrue(backend.writes.isEmpty)
+        XCTAssertEqual(store.state?.ownsClosedLidProtection, false)
+        let cached = try service.status()
+        XCTAssertEqual(cached.state, .unavailable)
+        XCTAssertFalse(cached.closedLidProtectionActive)
+    }
+
     func testAcquireRollsBackProtectionWhenDeadlineExpiresDuringMutation() throws {
         let clock = TestClock(now)
         let store = FakeStore()

--- a/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
@@ -276,6 +276,63 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
         XCTAssertFalse(cached.helperReachable)
     }
 
+    func testBatteryReadFailureRestoresOwnedProtectionAndDoesNotClaimLidInactive() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let battery = MutableBatteryReader()
+        let service = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: battery,
+            bootSessionReader: FakeBootSessionReader(identifier: "test-boot"),
+            now: { self.now },
+            leaseTimeout: 120)
+        XCTAssertEqual(
+            try service.acquireLease(identity, assertionActive: true).state,
+            .protected)
+        battery.failure = ExpectedFailure.battery
+
+        XCTAssertThrowsError(try service.reconcile())
+
+        XCTAssertEqual(backend.writes, [true, false])
+        XCTAssertFalse(backend.enabled)
+        XCTAssertEqual(store.state?.ownsClosedLidProtection, false)
+        let cached = try service.status()
+        XCTAssertEqual(cached.state, .unavailable)
+        XCTAssertFalse(cached.helperReachable)
+        // After restore, an inactive lid claim is honest. The failure
+        // snapshot must not have been published while ownership remained.
+        XCTAssertFalse(cached.closedLidProtectionActive)
+        XCTAssertNotEqual(store.state?.ownsClosedLidProtection, true)
+    }
+
+    func testBatteryReadFailureDoesNotClaimLidInactiveWhenOwnedRestoreFails() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let battery = MutableBatteryReader()
+        let service = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: battery,
+            bootSessionReader: FakeBootSessionReader(identifier: "test-boot"),
+            now: { self.now },
+            leaseTimeout: 120)
+        XCTAssertEqual(
+            try service.acquireLease(identity, assertionActive: true).state,
+            .protected)
+        backend.disablingFailure = ExpectedFailure.battery
+        battery.failure = ExpectedFailure.battery
+
+        XCTAssertThrowsError(try service.reconcile())
+
+        XCTAssertTrue(backend.enabled)
+        XCTAssertEqual(store.state?.ownsClosedLidProtection, true)
+        let cached = try service.status()
+        XCTAssertEqual(cached.state, .unavailable)
+        XCTAssertTrue(cached.closedLidProtectionActive)
+        XCTAssertFalse(cached.helperReachable)
+    }
+
     func testAcquireRejectsAnExpiredRequestBeforePersisting() throws {
         let store = FakeStore()
         let backend = FakeBackend(enabled: false)
@@ -353,6 +410,39 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
                 .requestExpired)
         }
         XCTAssertTrue(backend.writes.isEmpty)
+        XCTAssertFalse(backend.enabled)
+        XCTAssertEqual(store.state?.leases, [])
+        XCTAssertEqual(store.state?.ownsClosedLidProtection, false)
+    }
+
+    func testAcquireClampsAFarFutureClientDeadlineToTheServerBudget() throws {
+        let clock = TestClock(now)
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        backend.onSet = { enabled in
+            if enabled {
+                clock.date = self.now.addingTimeInterval(
+                    PowerHelperLeaseService.maximumAcquireDeadline + 1)
+            }
+        }
+        let service = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: FakeBatteryReader(lowBattery: false),
+            bootSessionReader: FakeBootSessionReader(identifier: "test-boot"),
+            now: { clock.date },
+            leaseTimeout: 120)
+
+        XCTAssertThrowsError(try service.acquireLease(
+            identity,
+            assertionActive: true,
+            requestDeadline: now.addingTimeInterval(10_000)
+        )) { error in
+            XCTAssertEqual(
+                error as? PowerHelperLeaseServiceError,
+                .requestExpired)
+        }
+        XCTAssertEqual(backend.writes, [true, false])
         XCTAssertFalse(backend.enabled)
         XCTAssertEqual(store.state?.leases, [])
         XCTAssertEqual(store.state?.ownsClosedLidProtection, false)

--- a/app/Tests/DetachKitTests/PowerProtectionTests.swift
+++ b/app/Tests/DetachKitTests/PowerProtectionTests.swift
@@ -361,6 +361,12 @@ final class PowerProtectionTests: XCTestCase {
             PowerProtectionStatus.self, from: Data(json.utf8)))
     }
 
+    func testLegacyPowerStatusDecodesUnknownThermalDetail() {
+        let json = #"{"state":"allowed","lease_count":0,"assertion_active":false,"closed_lid_protection_active":false,"helper_reachable":true,"transition_in_progress":false,"low_battery":false}"#
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            PowerProtectionStatus.self, from: Data(json.utf8)))
+    }
+
     func testCoordinatorOwnsAndRestoresClosedLidProtection() {
         let backend = FakeClosedLidBackend(enabled: false)
         var coordinator = PowerProtectionCoordinator()

--- a/app/Tests/DetachKitTests/PowerProtectionTests.swift
+++ b/app/Tests/DetachKitTests/PowerProtectionTests.swift
@@ -346,13 +346,19 @@ final class PowerProtectionTests: XCTestCase {
         XCTAssertTrue(status.thermalSafetyActive)
     }
 
-    func testLegacyPowerStatusDecodesUnknownThermalDetail() throws {
-        let json = #"{"state":"allowed","lease_count":0,"assertion_active":false,"closed_lid_protection_active":false,"helper_reachable":true,"transition_in_progress":false,"low_battery":false}"#
+    func testLegacyPowerStatusDecodesUnknownThermalStateWhenLatchIsPresent() throws {
+        let json = #"{"state":"allowed","lease_count":0,"assertion_active":false,"closed_lid_protection_active":false,"helper_reachable":true,"transition_in_progress":false,"low_battery":false,"thermal_safety_active":false}"#
         let status = try JSONDecoder().decode(
             PowerProtectionStatus.self, from: Data(json.utf8))
 
         XCTAssertEqual(status.thermalState, .unknown)
         XCTAssertFalse(status.thermalSafetyActive)
+    }
+
+    func testMissingThermalSafetyActiveDoesNotDecodeAsInactive() {
+        let json = #"{"state":"allowed","lease_count":0,"assertion_active":false,"closed_lid_protection_active":false,"helper_reachable":true,"transition_in_progress":false,"low_battery":false}"#
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            PowerProtectionStatus.self, from: Data(json.utf8)))
     }
 
     func testCoordinatorOwnsAndRestoresClosedLidProtection() {

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -191,6 +191,9 @@ user-specific path. Native power protection requires no Apple Events or
 Automation entitlement.
 
 The default initial acquire carries an eight-second absolute server deadline.
+The helper measures that deadline on its clock. It clamps every acquire
+deadline to at most eight seconds from now and rejects a past deadline. A
+client Unix timestamp is not the server budget.
 If protection is not confirmed before it, root rolls back only that request's
 persisted lease, restores a previous matching lease when applicable, and
 reconciles the owned setting before returning failure. This prevents a timed-out
@@ -204,9 +207,12 @@ status request every two seconds per session.
 The low-battery threshold is 10% while on battery power. The helper releases
 closed-lid protection it owns, the wrapper releases its IOKit assertion, and the
 provider is allowed to finish only while the Mac remains awake. Initial
-acquisition fails closed at low battery. A borrowed external setting cannot be
-turned off, so status must never falsely report the low-battery safe state while
-that setting remains active.
+acquisition fails closed at low battery. If the battery reader fails after
+Detach owns closed-lid protection, the helper restores that owned setting
+before it returns the failure. Cached status must not report that closed-lid
+protection is inactive while Detach still owns the setting. A borrowed
+external setting cannot be turned off, so status must never falsely report
+the low-battery safe state while that setting remains active.
 
 Thermal safety uses only public `ProcessInfo.thermalState`. `serious` and
 `critical` latch safety immediately: the helper restores Detach-owned
@@ -220,7 +226,9 @@ retained failure; a release that still fails stays surfaced. `nominal` and
 helper persists this cooldown across restart, and an unknown reading cannot
 clear it. The raw
 `nominal|fair|serious|critical|unknown` value and latch cross helper status, CLI
-JSON, watchdog, tmux, and app. Low battery wins the combined reason when both
+JSON, watchdog, tmux, and app. Typed status JSON requires
+`thermal_safety_active`. A missing field does not mean that thermal safety
+is inactive. Low battery wins the combined reason when both
 guards are active, while the thermal fields remain visible. Borrowed external
 `disablesleep` is never disabled, so neither safety state may falsely claim the
 Mac can sleep while it remains active.


### PR DESCRIPTION
## Contract delta

`docs/specs/power.md` **MODIFIED**:

- The helper measures the eight-second initial-acquire deadline on its clock. It clamps every acquire deadline to at most eight seconds from now and rejects a past deadline. A client Unix timestamp is not the server budget.
- If the battery reader fails after Detach owns closed-lid protection, the helper restores that owned setting before it returns the failure. Cached status must not report that closed-lid protection is inactive while Detach still owns the setting.
- Typed status JSON requires `thermal_safety_active`. A missing field does not mean that thermal safety is inactive.

`README.md` is unchanged.

## Durable decisions

- Deadline policy lives in `PowerHelperLeaseService`, not the XPC surface. The helper clock supplies the budget; a nil deadline (direct tests or renew) is unchanged. `renewLease` still has no deadline so this PR does not broaden XPC.
- After a battery-read throw, restore owned closed-lid protection first. Failure snapshots publish `closedLidProtectionActive: true` only while ownership remains; a successful restore may then report inactive lid honestly.
- `PowerProtectionStatus` requires `thermal_safety_active`. Missing `thermal_state` still decodes as `unknown`.

## Acceptance evidence

- Far-future client deadline is treated as now+8s and expires: `testAcquireClampsAFarFutureClientDeadlineToTheServerBudget` — pass.
- Battery-reader throw after owned protection is on restores the setting and does not publish an inactive lid claim while ownership remains: `testBatteryReadFailureRestoresOwnedProtectionAndDoesNotClaimLidInactive` and `testBatteryReadFailureDoesNotClaimLidInactiveWhenOwnedRestoreFails` — pass.
- Missing `thermal_safety_active` does not decode as false safety: `testMissingThermalSafetyActiveDoesNotDecodeAsInactive` — pass.
- `scripts/quality-gate --plan --explain` selected `static,swift,quality-contracts,app,ui-e2e` for power/docs impact.
- Focused local diagnostic: `cd app && swift test --disable-sandbox --filter 'PowerHelperLeaseServiceTests|PowerHelperXPCServiceTests|PowerProtectionTests|DetachPowerCommandTests'` — 136 tests, 0 failures (host macOS 15 used a local-only uncommitted deployment-target shim; not part of this commit).
- Hosted `quality-gates` remains merge authority. No real power tests, closed-lid hardware, signing, notarization, or publication were run.

Closes #233