### PR TITLE
Open typed-state mutations without following FIFOs or skipping the metadata lock

### DIFF
--- a/app/Sources/DetachKit/DetachStateCommand.swift
+++ b/app/Sources/DetachKit/DetachStateCommand.swift
@@ -1389,16 +1389,15 @@ public enum DetachStateCommand {
         return ManagedTranscriptRegistry(all: all, live: live)
     }
 
-    private static func readOwnedMetadataFile(
-        in directory: Int32,
-        name: String
+    private static let maximumOwnedRegularFileBytes: off_t = 1_048_576
+
+    /// Reads an already-opened owned regular file of at most 1 MiB.
+    /// The caller must open with `O_NONBLOCK|O_NOFOLLOW` before type checks.
+    private static func readOpenedOwnedRegularFile(
+        _ descriptor: Int32,
+        maximumBytes: off_t = maximumOwnedRegularFileBytes
     ) -> Data? {
-        let descriptor = openat(
-            directory, name, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
-        guard descriptor >= 0 else { return nil }
-        defer { close(descriptor) }
         var item = stat()
-        let maximumBytes: off_t = 1_048_576
         guard fstat(descriptor, &item) == 0,
               isRegularFile(item),
               item.st_uid == geteuid(),
@@ -1418,6 +1417,43 @@ public enum DetachStateCommand {
             return true
         }
         return complete ? data : nil
+    }
+
+    /// Opens an owned regular file without following a final-component symlink
+    /// or blocking on a FIFO that waits for a writer.
+    private static func openOwnedRegularFile(atPath path: String) throws -> Int32 {
+        let descriptor = open(path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            throw CocoaError(.fileReadNoSuchFile)
+        }
+        var item = stat()
+        guard fstat(descriptor, &item) == 0,
+              isRegularFile(item),
+              item.st_uid == geteuid() else {
+            close(descriptor)
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return descriptor
+    }
+
+    private static func readOwnedRegularFile(atPath path: String) throws -> Data {
+        let descriptor = try openOwnedRegularFile(atPath: path)
+        defer { close(descriptor) }
+        guard let data = readOpenedOwnedRegularFile(descriptor) else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        return data
+    }
+
+    private static func readOwnedMetadataFile(
+        in directory: Int32,
+        name: String
+    ) -> Data? {
+        let descriptor = openat(
+            directory, name, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else { return nil }
+        defer { close(descriptor) }
+        return readOpenedOwnedRegularFile(descriptor)
     }
 
     private static func isDirectory(_ item: stat) -> Bool {
@@ -1543,7 +1579,7 @@ public enum DetachStateCommand {
             allowRunToken: true)
         let url = fileURL(path)
         try withMetadataPatchLock(for: url) {
-            let original = try Data(contentsOf: url)
+            let original = try readOwnedRegularFile(atPath: path)
             let updated = try SessionMetadataDocument.patch(
                 original,
                 expectedRunToken: mutation.expectedRunToken,
@@ -1692,8 +1728,11 @@ public enum DetachStateCommand {
                     reading: .standardInput, paths: paths)
             }
         } else {
+            let descriptor = try openOwnedRegularFile(atPath: path)
+            defer { close(descriptor) }
+            let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
             scalar = try TranscriptDocument.firstScalar(
-                inFileAt: fileURL(path), paths: paths)
+                reading: handle, paths: paths)
         }
         guard let scalar else {
             return Data()
@@ -1725,8 +1764,16 @@ public enum DetachStateCommand {
                     expectedSessionID: expectedSessionID)
             }
         } else {
+            let descriptor: Int32
+            do {
+                descriptor = try openOwnedRegularFile(atPath: path)
+            } catch {
+                throw DetachStateCommandError.invalidTranscript
+            }
+            defer { close(descriptor) }
+            let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
             valid = try TranscriptDocument.isValid(
-                fileAt: fileURL(path),
+                reading: handle,
                 provider: provider,
                 expectedSessionID: expectedSessionID)
         }
@@ -2014,7 +2061,7 @@ public enum DetachStateCommand {
         standardInput: Data?
     ) throws -> Data {
         guard path == "/dev/stdin" || path == "-" else {
-            return try Data(contentsOf: fileURL(path))
+            return try readOwnedRegularFile(atPath: path)
         }
         if let standardInput {
             return standardInput
@@ -2073,9 +2120,9 @@ public enum DetachStateCommand {
             return boundedTail
         }
 
-        let url = fileURL(path)
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
+        let descriptor = try openOwnedRegularFile(atPath: path)
+        defer { close(descriptor) }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
         let size = try handle.seekToEnd()
         try handle.seek(toOffset: size > maximumByteCount ? size - maximumByteCount : 0)
         return try handle.readToEnd() ?? Data()

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -1505,6 +1505,31 @@ final class DetachStateCommandTests: XCTestCase {
         XCTAssertTrue(completedAfterUnlock)
     }
 
+    func testMetaPatchRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = temporaryDirectory.appendingPathComponent("fifo-meta.json")
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "meta", "patch", fifo.path, "--string", "status", "running",
+            ]))
+        }
+    }
+
+    func testMetaPatchRejectsFinalComponentSymlink() throws {
+        let target = temporaryDirectory.appendingPathComponent("target-meta.json")
+        let link = temporaryDirectory.appendingPathComponent("link-meta.json")
+        try Data(#"{"schema":1,"session_name":"s","project_dir":"/tmp/p","run_token":"current","status":"stopped"}"#.utf8)
+            .write(to: target)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "patch", link.path,
+            "--run-token", "current",
+            "--string", "status", "running",
+        ]))
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: target)) as? [String: Any])
+        XCTAssertEqual(object["status"] as? String, "stopped")
+    }
+
     func testMetaPatchEnforcesTheRuntimeLifecycleGraph() throws {
         let file = temporaryDirectory.appendingPathComponent("lifecycle-meta.json")
         try Data(#"{"schema":1,"session_name":"s","project_dir":"/tmp/p","run_token":"current","status":"starting","lifecycle_phase":"initializing"}"#.utf8)
@@ -1662,6 +1687,29 @@ final class DetachStateCommandTests: XCTestCase {
             "jsonl", "validate", "other", "-", "session",
         ])) { error in
             XCTAssertEqual(error as? DetachStateCommandError, .invalidProvider("other"))
+        }
+    }
+
+    func testJSONLValidateRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = temporaryDirectory.appendingPathComponent("fifo.jsonl")
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "jsonl", "validate", "codex", fifo.path, "session-1",
+            ])) { error in
+                XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
+            }
+        }
+    }
+
+    func testJSONLValidateRejectsFinalComponentSymlink() throws {
+        let target = temporaryDirectory.appendingPathComponent("target.jsonl")
+        let link = temporaryDirectory.appendingPathComponent("link.jsonl")
+        try Data(#"{"payload":{"id":"session-1"}}"#.utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "jsonl", "validate", "codex", link.path, "session-1",
+        ])) { error in
+            XCTAssertEqual(error as? DetachStateCommandError, .invalidTranscript)
         }
     }
 
@@ -2573,6 +2621,32 @@ final class DetachStateCommandTests: XCTestCase {
             result[index] = newValue
         }
         return result
+    }
+
+    /// A regression must fail within a bound and leave no blocked test thread.
+    /// The rescue writer opens only after that failure and never supplies data.
+    private func checkWithoutWriter(
+        _ fifo: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        operation: @escaping @Sendable () throws -> Void
+    ) throws {
+        XCTAssertEqual(mkfifo(fifo.path, 0o644), 0, file: file, line: line)
+        let completed = DispatchGroup()
+        completed.enter()
+        DispatchQueue.global().async {
+            defer { completed.leave() }
+            do { try operation() }
+            catch { XCTFail("Unexpected error: \(error)", file: file, line: line) }
+        }
+        let result = completed.wait(timeout: .now() + 1)
+        XCTAssertEqual(result, .success, "File validation waited for a FIFO writer", file: file, line: line)
+        if result == .timedOut {
+            let rescue = open(fifo.path, O_RDWR | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+            if rescue >= 0 { close(rescue) }
+            XCTAssertGreaterThanOrEqual(rescue, 0, file: file, line: line)
+            XCTAssertEqual(completed.wait(timeout: .now() + 1), .success, file: file, line: line)
+        }
     }
 
     private func storageReport(

--- a/app/Tests/DetachKitTests/DetachStateCommandTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateCommandTests.swift
@@ -1701,6 +1701,36 @@ final class DetachStateCommandTests: XCTestCase {
         }
     }
 
+    func testJSONLFirstRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = temporaryDirectory.appendingPathComponent("fifo-first.jsonl")
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "jsonl", "first", fifo.path, "payload.id",
+            ]))
+        }
+    }
+
+    func testMetaGetRejectsFIFOWithoutWaitingForAWriter() throws {
+        let fifo = temporaryDirectory.appendingPathComponent("fifo-get.json")
+        try checkWithoutWriter(fifo) {
+            XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+                "meta", "get", fifo.path, "status",
+            ]))
+        }
+    }
+
+    func testInputDataRejectsAnOwnedRegularFileLargerThanOneMebibyte() throws {
+        let file = temporaryDirectory.appendingPathComponent("oversized.json")
+        var data = Data(#"{"status":"stopped"}"#.utf8)
+        data.append(contentsOf: repeatElement(UInt8(0x20), count: 1_048_577))
+        try data.write(to: file)
+        XCTAssertThrowsError(try DetachStateCommand.run(arguments: [
+            "meta", "get", file.path, "status",
+        ])) { error in
+            XCTAssertEqual((error as? CocoaError)?.code, .fileReadUnknown)
+        }
+    }
+
     func testJSONLValidateRejectsFinalComponentSymlink() throws {
         let target = temporaryDirectory.appendingPathComponent("target.jsonl")
         let link = temporaryDirectory.appendingPathComponent("link.jsonl")

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -354,7 +354,7 @@ ensure_owned_state_directory() {
     *) die "$label must be absolute: $path" ;;
   esac
   case "$path" in
-    *$'\n'*|*$'\r'*|*/|*/./*|*/../*) die "$label is unsafe: $path" ;;
+    *$'\n'*|*$'\r'*|*/|*/./*|*/../*|*/.|*/..) die "$label is unsafe: $path" ;;
   esac
   [ ! -L "$path" ] || die "$label must not be a symlink: $path"
   if [ ! -e "$path" ]; then
@@ -2692,10 +2692,14 @@ write_initial_meta() {
     rm -f -- "$tmp"
     return 1
   }
-  mv -f -- "$tmp" "$meta" || {
+  # Hold the same flock as meta patch across the replace so a concurrent
+  # patch cannot publish over an in-flight first write. lockf releases the
+  # lock when this command exits, including on failure.
+  if ! "$LOCKF_BIN" -k -t 30 "$dir/.meta-patch.lock" \
+      /bin/mv -f -- "$tmp" "$meta"; then
     rm -f -- "$tmp"
     return 1
-  }
+  fi
   safe_owned_plain_file "$meta" && \
     "$STATE_BIN" meta snapshot "$meta" "$session" >/dev/null 2>&1
 }
@@ -2946,7 +2950,7 @@ valid_claude_transcript() {
   local path="$1"
   local expected_id="$2"
 
-  [ -s "$path" ] && \
+  safe_owned_plain_file "$path" && [ -s "$path" ] && \
     "$STATE_BIN" jsonl validate claude "$path" "$expected_id" >/dev/null 2>&1
 }
 

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -7,9 +7,10 @@ metadata, JSONL, health, reconcile, storage, emit, and event operations.
 `meta snapshots` enumerates one owned sessions root through anchored directory
 descriptors. It rejects unsafe directories and opens only owned regular files
 of at most 1 MiB with `O_NOFOLLOW`. Storage metadata, checkpoint fallback
-metadata, and cached transcript validation use nonblocking file opens before
-they check the file type. This includes validation receipts. A FIFO cannot
-delay these reads while it waits for a writer.
+metadata, cached transcript validation, metadata patches, helper file input,
+and non-cached JSONL reads use nonblocking file opens before they check the
+file type. This includes validation receipts. A FIFO cannot delay these reads
+while it waits for a writer. A final-component symlink is not followed.
 Integer conversion must not trap. Storage reports allocated and logical bytes,
 excludes provider storage, does not follow symlinks, and authorizes cleanup
 only after a complete scan with explicit `cleanup_eligible: true`.
@@ -17,10 +18,12 @@ only after a complete scan with explicit `cleanup_eligible: true`.
 Per-session `meta.json` schema 1 stores internal `session_name`, optional
 `display_name`, and `run_token`; older documents remain valid. Each patch locks
 its read-change-atomic-replace transaction, so concurrent writers keep disjoint
-fields. Run tokens stop stale workers from overwriting replacement runs. New
-runs publish `health_schema=1`, exact worker/provider PIDs, heartbeat, and
-checkpoint epoch. Health combines tmux, run token, PID ownership, metadata, and
-checkpoint freshness. Stale data cannot make a proven live provider hung. A
+fields. The first metadata publication for a run holds `.meta-patch.lock`
+across replacement of `meta.json`. Run tokens stop stale workers from
+overwriting replacement runs. New runs publish `health_schema=1`, exact
+worker/provider PIDs, heartbeat, and checkpoint epoch. Health combines tmux,
+run token, PID ownership, metadata, and checkpoint freshness. Stale data cannot
+make a proven live provider hung. A
 runtime without managed tmux blocks mutations until its exact processes exit.
 `preserve_recovery_until_ready` is Boolean; `runtime_ready_at` and
 `runtime_shutdown_observed_at` are strings. A mistyped primary is unusable.
@@ -64,8 +67,10 @@ mtime. An unchanged identity skips the 256 KiB tail read.
 State is private (`umask 077`) under
 `~/.local/state/detach/{codex,claude}/sessions/<name>/` and contains full
 conversations. Public operations reject symlinked or foreign-owned mutable
-roots before traversal. The checked Codex SQLite backup is never restored
-automatically.
+roots before traversal. A mutable root path that contains a `.` or `..`
+component, including a trailing component, is rejected. Claude transcript
+validation requires a non-empty owned regular file that is not a symlink.
+The checked Codex SQLite backup is never restored automatically.
 
 Recover can rebuild an incomplete checkpoint from a valid live journal even
 when an interrupted publication left staging directories. It validates those

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4198,6 +4198,73 @@ fi
 grep -Fx 'do not touch' "$unsafe_provider_target/sentinel" >/dev/null
 [ ! -e "$unsafe_provider_target/sessions" ]
 
+# A trailing . or .. component must fail before mkdir can walk to a parent
+# or chmod that parent.
+dot_parent="$TMP_ROOT/owned-dot-parent"
+mkdir -p "$dot_parent/dir"
+printf 'parent sentinel\n' >"$dot_parent/sentinel"
+if DETACH_CODEX_STATE_ROOT="$dot_parent/dir/.." run_codex list --json >/dev/null 2>&1; then
+  printf 'list accepted a provider state root that ends in /..\n' >&2
+  exit 1
+fi
+grep -Fx 'parent sentinel' "$dot_parent/sentinel" >/dev/null
+[ ! -e "$dot_parent/sessions" ]
+if DETACH_CODEX_STATE_ROOT="$dot_parent/dir/." run_codex list --json >/dev/null 2>&1; then
+  printf 'list accepted a provider state root that ends in /.\n' >&2
+  exit 1
+fi
+[ ! -e "$dot_parent/dir/sessions" ]
+
+# First publication of meta.json waits for the same .meta-patch.lock that
+# meta patch uses. A concurrent patch cannot replace disjoint fields.
+initial_lock_state="$TMP_ROOT/initial-meta-lock-state"
+initial_lock_session=detach-codex-initial-meta-lock
+initial_lock_dir="$initial_lock_state/sessions/$initial_lock_session"
+mkdir -p "$initial_lock_dir"
+"$STATE_HELPER" meta create "$initial_lock_dir/meta.json" \
+  --integer schema 1 \
+  --string session_name "$initial_lock_session" \
+  --string project_dir "$ROOT" \
+  --string status stopped \
+  --string sentinel_field keep-me
+initial_lock="$initial_lock_dir/.meta-patch.lock"
+: >"$initial_lock"
+/usr/bin/lockf -k -w "$initial_lock" /bin/sleep 60 &
+initial_lock_holder=$!
+initial_lock_wait=0
+while /usr/bin/lockf -k -w -t 0 "$initial_lock" true >/dev/null 2>&1; do
+  initial_lock_wait=$((initial_lock_wait + 1))
+  [ "$initial_lock_wait" -lt 100 ] || {
+    printf 'could not hold metadata patch lock for the publication test\n' >&2
+    kill "$initial_lock_holder" 2>/dev/null || true
+    exit 1
+  }
+  sleep 0.05
+done
+DETACH_CODEX_STATE_ROOT="$initial_lock_state" \
+  run_codex __write_initial_meta \
+    "$initial_lock_session" "$ROOT" "" 1 "$DETACH_CODEX_BIN" "" "" \
+    initial-meta-lock-run 0 >/dev/null 2>&1 &
+initial_lock_writer=$!
+initial_tmp_wait=0
+while ! ls -1 "$initial_lock_dir"/.meta-*.tmp >/dev/null 2>&1; do
+  if ! kill -0 "$initial_lock_writer" 2>/dev/null; then
+    break
+  fi
+  initial_tmp_wait=$((initial_tmp_wait + 1))
+  [ "$initial_tmp_wait" -lt 400 ] || break
+  sleep 0.05
+done
+[ "$("$STATE_HELPER" meta get "$initial_lock_dir/meta.json" sentinel_field)" = keep-me ]
+kill "$initial_lock_holder" 2>/dev/null || true
+wait "$initial_lock_holder" 2>/dev/null || true
+wait "$initial_lock_writer" || {
+  printf 'write_initial_meta failed after metadata patch lock release\n' >&2
+  exit 1
+}
+[ -z "$("$STATE_HELPER" meta get "$initial_lock_dir/meta.json" sentinel_field)" ]
+[ "$("$STATE_HELPER" meta get "$initial_lock_dir/meta.json" run_token)" = initial-meta-lock-run ]
+
 unsafe_list_state="$TMP_ROOT/unsafe-list-state"
 unsafe_list_target="$TMP_ROOT/unsafe-list-target"
 mkdir -p "$unsafe_list_state" "$unsafe_list_target"


### PR DESCRIPTION
## Contract delta

`docs/specs/state.md` (MODIFIED):

- Metadata patches, helper file input, and non-cached JSONL reads use the same nonblocking `O_NOFOLLOW` owned-regular-file open as snapshots. A FIFO cannot delay those reads. A final-component symlink is not followed. Full-file helper reads stay at most 1 MiB.
- The first metadata publication for a run holds `.meta-patch.lock` across replacement of `meta.json`, so concurrent writers keep disjoint fields.
- A mutable root path that contains a `.` or `..` component, including a trailing component, is rejected.
- Claude transcript validation requires a non-empty owned regular file that is not a symlink.

## Durable decisions

- Reuse the existing `O_NONBLOCK|O_NOFOLLOW` open helper for mutation reads. JSONL validate and tail stream after that open; they do not load a whole transcript into a 1 MiB buffer.
- `write_initial_meta` holds the same flock as Swift `meta patch` via `lockf` on `session/.meta-patch.lock` around the `mv`. The lock is released when that command exits, including on failure.
- No public `detach-state` command was added. Codex SQLite restore policy is unchanged.

## Acceptance evidence

- Swift: `DetachStateCommandTests` refuse a FIFO and a final-component symlink for `meta patch` and `jsonl validate` without waiting for a writer.
- `tests/run.sh` history shard: `ensure_owned_state_directory` rejects `.../dir/..` and `.../dir/.`; `write_initial_meta` waits for `.meta-patch.lock` and then publishes a new run token.
- Focused local Swift filter and the history shard were selected. Hosted `quality-gates` is readiness authority.

Closes #235