### PR TITLE
Keep the live payload until Repair staging and version proof succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ Detach.app handles updates. Settings shows installation health, CLI repair,
 helper status, and removal of Detach-owned components.
 
 Detach changes the active CLI only after it validates a complete payload. If an
-update fails, the active CLI does not change. A normal app update does not
+update or Repair fails, the active CLI and its payload stay in place. A normal app update does not
 interrupt live sessions. If a working session holds a power lease, Detach keeps
 the current helper and session dashboard. It retries the helper update after
 the leases are released and the app becomes active again. Repairing a damaged

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -5,13 +5,17 @@
 Detach.app installs an immutable payload below
 `~/.local/libexec/detach/versions/<semver>-<hash>/` and switches
 `~/.local/bin/detach` atomically. Payload order is `detach`, `detach-core`,
-`detach-install`, `detach-state`, `detach-power`, and `tmux`.
+`detach-install`, `detach-state`, `detach-power`, and `tmux`. Payload members
+are regular files.
 
-Install and Repair validate the payload before activation; failure keeps the
-active payload. A live or retained session defers replacement. One PATH entry
-supports all shells. `--keep-state` keeps checkpoints. `--purge-state`
-removes Detach state, not provider data. Uninstall restores an unchanged
-profile or removes only its entry. Source edits require app sync or Repair.
+Install and Repair stage and hash a replacement under `.incoming-*` before
+they replace a live version directory. They switch `~/.local/bin/detach` only
+after the version directory, install manifest, and direct `__version` proof
+succeed. Failure keeps the active payload. A live or retained session defers
+replacement. One PATH entry supports all shells. `--keep-state` keeps
+checkpoints. `--purge-state` removes Detach state, not provider data.
+Uninstall restores an unchanged profile or removes only its entry. Source
+edits require app sync or Repair.
 
 The app registers its power LaunchDaemon and per-user watchdog with
 `SMAppService`. The root helper needs one administrator approval. The portable

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -785,7 +785,77 @@ semver_compare() {
 }
 
 sha256_file() {
-  "$SHASUM_BIN" -a 256 "$1" | awk '{print $1}'
+  "$SHASUM_BIN" -a 256 "$1" | "$AWK_BIN" '{print $1}'
+}
+
+regular_executable() {
+  [ -f "$1" ] && [ ! -L "$1" ] && [ -x "$1" ]
+}
+
+require_payload_member() {
+  regular_executable "$1" || die "payload $2 must be a regular executable file"
+}
+
+INSTALL_INCOMING=""
+INSTALL_OUTGOING=""
+INSTALL_TARGET=""
+INSTALL_PREVIOUS_LINK=""
+INSTALL_SYMLINK_SWITCHED=0
+INSTALL_ACTIVATION_DONE=0
+
+rollback_install_activation() {
+  local link_tmp
+  [ "$INSTALL_ACTIVATION_DONE" -eq 0 ] || return 0
+  if [ "$INSTALL_SYMLINK_SWITCHED" -eq 1 ]; then
+    if [ -n "$INSTALL_PREVIOUS_LINK" ]; then
+      link_tmp="$BIN_DIR/.detach-link-rollback.$$"
+      "$RM_BIN" -f "$link_tmp"
+      if "$LN_BIN" -s "$INSTALL_PREVIOUS_LINK" "$link_tmp" && \
+         "$MV_BIN" -f "$link_tmp" "$BIN_DIR/detach"; then
+        :
+      else
+        "$RM_BIN" -f "$link_tmp"
+      fi
+    else
+      "$RM_BIN" -f "$BIN_DIR/detach"
+    fi
+    INSTALL_SYMLINK_SWITCHED=0
+  fi
+  if [ -n "$INSTALL_OUTGOING" ] && [ -d "$INSTALL_OUTGOING" ] && \
+     [ -n "$INSTALL_TARGET" ]; then
+    case "$INSTALL_TARGET" in
+      "$LIBEXEC_ROOT/versions/"*)
+        if [ -e "$INSTALL_TARGET" ] || [ -L "$INSTALL_TARGET" ]; then
+          "$RM_BIN" -rf "$INSTALL_TARGET"
+        fi
+        "$MV_BIN" "$INSTALL_OUTGOING" "$INSTALL_TARGET" || true
+        ;;
+    esac
+    INSTALL_OUTGOING=""
+  fi
+  if [ -n "$INSTALL_INCOMING" ] && [ -d "$INSTALL_INCOMING" ]; then
+    case "$INSTALL_INCOMING" in
+      "$LIBEXEC_ROOT/versions/.incoming-"*)
+        "$RM_BIN" -rf "$INSTALL_INCOMING" || true
+        ;;
+    esac
+    INSTALL_INCOMING=""
+  fi
+}
+
+commit_install_activation() {
+  INSTALL_ACTIVATION_DONE=1
+  trap - EXIT
+  if [ -n "$INSTALL_OUTGOING" ] && [ -d "$INSTALL_OUTGOING" ]; then
+    case "$INSTALL_OUTGOING" in
+      "$LIBEXEC_ROOT/versions/.outgoing-"*)
+        "$RM_BIN" -rf "$INSTALL_OUTGOING" || die "cannot remove outgoing payload"
+        ;;
+      *) die "unsafe outgoing path" ;;
+    esac
+  fi
+  INSTALL_OUTGOING=""
+  INSTALL_INCOMING=""
 }
 
 current_version() {
@@ -1062,6 +1132,7 @@ install_locked() {
   local payload_id target
   local installed_version installed_build installed_payload comparison stage link_tmp current
   local active_dir manifest_version manifest_build manifest_payload manifest_executable
+  local payload_ready=0
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -1103,11 +1174,14 @@ install_locked() {
   require_executable "$ID_BIN" id
   require_executable "$LAUNCHCTL_BIN" launchctl
   require_executable "$PLUTIL_BIN" plutil
-  [ -x "$payload_dir/detach" ] || die "payload detach is missing or not executable"
-  [ -x "$payload_dir/detach-core" ] || die "payload detach-core is missing or not executable"
-  [ -x "$payload_dir/detach-state" ] || die "payload detach-state is missing or not executable"
-  [ -x "$payload_dir/detach-power" ] || die "payload detach-power is missing or not executable"
-  [ -x "$payload_dir/tmux" ] || die "payload tmux is missing or not executable"
+  require_payload_member "$payload_dir/detach" detach
+  require_payload_member "$payload_dir/detach-core" detach-core
+  require_payload_member "$payload_dir/detach-state" detach-state
+  require_payload_member "$payload_dir/detach-power" detach-power
+  require_payload_member "$payload_dir/tmux" tmux
+  if [ -e "$payload_dir/detach-install" ] || [ -L "$payload_dir/detach-install" ]; then
+    require_payload_member "$payload_dir/detach-install" detach-install
+  fi
   [ -f "$version_file" ] || die "version file not found: $version_file"
 
   IFS= read -r version <"$version_file" || die "cannot read version file"
@@ -1129,7 +1203,7 @@ install_locked() {
   payload_id="$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
     "$version" "$build" "$detach_hash" "$core_hash" "$installer_hash" \
     "$state_hash" "$power_hash" "$tmux_hash" | \
-    "$SHASUM_BIN" -a 256 | awk '{print $1}')"
+    "$SHASUM_BIN" -a 256 | "$AWK_BIN" '{print $1}')"
   [ "${#payload_id}" -eq 64 ] || die "cannot calculate payload id"
   target="$LIBEXEC_ROOT/versions/$version-${payload_id:0:12}"
 
@@ -1207,12 +1281,17 @@ install_locked() {
   ensure_tmux_socket_dir
 
   if [ -d "$target" ]; then
-    if [ -x "$target/detach" ] && [ -x "$target/detach-core" ] && \
-       [ -x "$target/detach-install" ] && [ -x "$target/detach-state" ] && \
-       [ -x "$target/detach-power" ] && [ -x "$target/tmux" ] && \
-       [ -f "$target/VERSION" ] && \
-       [ -f "$target/BUILD" ] && [ "$(head -n 1 "$target/BUILD")" = "$build" ] && \
-       [ -f "$target/PAYLOAD_ID" ] && [ "$(head -n 1 "$target/PAYLOAD_ID")" = "$payload_id" ] && \
+    if regular_executable "$target/detach" && \
+       regular_executable "$target/detach-core" && \
+       regular_executable "$target/detach-install" && \
+       regular_executable "$target/detach-state" && \
+       regular_executable "$target/detach-power" && \
+       regular_executable "$target/tmux" && \
+       [ -f "$target/VERSION" ] && [ ! -L "$target/VERSION" ] && \
+       [ -f "$target/BUILD" ] && [ ! -L "$target/BUILD" ] && \
+       [ "$(head -n 1 "$target/BUILD")" = "$build" ] && \
+       [ -f "$target/PAYLOAD_ID" ] && [ ! -L "$target/PAYLOAD_ID" ] && \
+       [ "$(head -n 1 "$target/PAYLOAD_ID")" = "$payload_id" ] && \
        [ "$(sha256_file "$target/detach")" = "$detach_hash" ] && \
        [ "$(sha256_file "$target/detach-core")" = "$core_hash" ] && \
        [ "$(sha256_file "$target/detach-install")" = "$installer_hash" ] && \
@@ -1220,18 +1299,22 @@ install_locked() {
        [ "$(sha256_file "$target/detach-power")" = "$power_hash" ] && \
        [ "$(sha256_file "$target/tmux")" = "$tmux_hash" ] && \
        [ "$("$target/detach" __version 2>/dev/null)" = "$version" ]; then
-      :
+      payload_ready=1
     else
       [ "$repair" -eq 1 ] || die "existing immutable payload is invalid: $target (run Repair)"
       managed_sessions_present && \
         die "Repair is unsafe while a detach tmux session is present; stop or delete it first"
-      "$RM_BIN" -rf "$target" || die "cannot remove invalid payload"
     fi
   fi
 
-  if [ ! -d "$target" ]; then
+  if [ "$payload_ready" -eq 0 ]; then
+    INSTALL_TARGET="$target"
+    INSTALL_ACTIVATION_DONE=0
+    INSTALL_SYMLINK_SWITCHED=0
+    trap rollback_install_activation EXIT
     stage="$LIBEXEC_ROOT/versions/.incoming-$version-${payload_id:0:12}-$$"
     case "$stage" in "$LIBEXEC_ROOT/versions/.incoming-"*) ;; *) die "unsafe staging path" ;; esac
+    INSTALL_INCOMING="$stage"
     "$RM_BIN" -rf "$stage" || die "cannot clear staging directory"
     "$INSTALL_BIN" -d -m 0755 "$stage" || die "cannot create staging directory"
     "$INSTALL_BIN" -m 0755 "$payload_dir/detach" "$stage/detach" || die "cannot stage detach"
@@ -1239,7 +1322,7 @@ install_locked() {
     "$INSTALL_BIN" -m 0755 "$payload_dir/detach-state" "$stage/detach-state" || die "cannot stage detach-state"
     "$INSTALL_BIN" -m 0755 "$payload_dir/detach-power" "$stage/detach-power" || die "cannot stage detach-power"
     "$INSTALL_BIN" -m 0755 "$payload_dir/tmux" "$stage/tmux" || die "cannot stage tmux"
-    if [ -x "$payload_dir/detach-install" ]; then
+    if regular_executable "$payload_dir/detach-install"; then
       "$INSTALL_BIN" -m 0755 "$payload_dir/detach-install" "$stage/detach-install" || die "cannot stage installer"
     else
       "$INSTALL_BIN" -m 0755 "$SELF" "$stage/detach-install" || die "cannot stage installer"
@@ -1257,7 +1340,17 @@ install_locked() {
     [ "$(sha256_file "$stage/detach-power")" = "$power_hash" ] || die "staged detach-power hash mismatch"
     [ "$(sha256_file "$stage/tmux")" = "$tmux_hash" ] || die "staged tmux hash mismatch"
     [ "$("$stage/detach" __version 2>/dev/null)" = "$version" ] || die "staged CLI version mismatch"
+    if [ -d "$target" ]; then
+      INSTALL_OUTGOING="$LIBEXEC_ROOT/versions/.outgoing-$version-${payload_id:0:12}-$$"
+      case "$INSTALL_OUTGOING" in
+        "$LIBEXEC_ROOT/versions/.outgoing-"*) ;;
+        *) die "unsafe outgoing path" ;;
+      esac
+      "$RM_BIN" -rf "$INSTALL_OUTGOING" || die "cannot clear outgoing directory"
+      "$MV_BIN" "$target" "$INSTALL_OUTGOING" || die "cannot displace live payload"
+    fi
     "$MV_BIN" "$stage" "$target" || die "cannot activate payload directory"
+    INSTALL_INCOMING=""
   fi
 
   # Profile setup does not execute the CLI, so finish it before switching the
@@ -1265,16 +1358,31 @@ install_locked() {
   configure_shell_path
   cleanup_legacy_cli_watchdog
 
+  write_manifest "$version" "$build" "$payload_id" "$source" "$target" \
+    "$payload_dir" "$version_file" "$SELF" || die "cannot write install manifest"
+  migrate_config || die "cannot migrate Detach configuration"
+  [ "$("$target/detach" __version 2>/dev/null)" = "$version" ] || \
+    die "activated payload failed validation"
+
+  if [ -L "$BIN_DIR/detach" ]; then
+    INSTALL_PREVIOUS_LINK="$(readlink "$BIN_DIR/detach")"
+  else
+    INSTALL_PREVIOUS_LINK=""
+  fi
+  if [ -z "${INSTALL_TARGET:-}" ]; then
+    INSTALL_TARGET="$target"
+    INSTALL_ACTIVATION_DONE=0
+    trap rollback_install_activation EXIT
+  fi
   link_tmp="$BIN_DIR/.detach-link.$$"
   "$RM_BIN" -f "$link_tmp"
   "$LN_BIN" -s "$target/detach" "$link_tmp" || die "cannot create CLI symlink"
   "$MV_BIN" -f "$link_tmp" "$BIN_DIR/detach" || die "cannot switch CLI symlink"
-  write_manifest "$version" "$build" "$payload_id" "$source" "$target" \
-    "$payload_dir" "$version_file" "$SELF" || die "cannot write install manifest"
-  migrate_config || die "cannot migrate Detach configuration"
+  INSTALL_SYMLINK_SWITCHED=1
 
   current="$("$BIN_DIR/detach" __version 2>/dev/null || true)"
   [ "$current" = "$version" ] || die "activated CLI failed validation"
+  commit_install_activation
   printf 'Installed detach %s (build %s, payload %s)\n' "$version" "$build" "${payload_id:0:12}"
   printf 'CLI: %s\n' "$BIN_DIR/detach"
   printf 'Command: detach (open a new Terminal window)\n'

--- a/tests/distribution.sh
+++ b/tests/distribution.sh
@@ -301,6 +301,58 @@ if "$bad_payload/detach-install" install --source app --payload-dir "$bad_payloa
 fi
 [ "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")" = "$old_target" ]
 
+# Symlink payload members are rejected the same way verify-app.sh requires
+# regular files. The public CLI must stay on the proven payload.
+symlink_payload="$(make_payload symlink-member 0.1.4)"
+mv "$symlink_payload/tmux" "$symlink_payload/tmux.bin"
+ln -s "$symlink_payload/tmux.bin" "$symlink_payload/tmux"
+if "$symlink_payload/detach-install" install --source app \
+    --payload-dir "$symlink_payload" --version-file "$symlink_payload/VERSION" \
+    >"$TMP_ROOT/symlink-member.stdout" 2>"$TMP_ROOT/symlink-member.stderr"; then
+  printf 'symlink payload member unexpectedly installed\n' >&2
+  exit 1
+fi
+grep -F 'payload tmux must be a regular executable file' \
+  "$TMP_ROOT/symlink-member.stderr" >/dev/null
+[ "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")" = "$old_target" ]
+[ "$("$DETACH_INSTALL_BIN_DIR/detach" __version)" = 0.1.0 ]
+
+# sha256_file and payload-id hashing must use $AWK_BIN, not PATH awk.
+mkdir -p "$TMP_ROOT/bad-awk"
+cat >"$TMP_ROOT/bad-awk/awk" <<'SH'
+#!/bin/bash
+printf 'path awk must not hash install payloads\n' >&2
+exit 1
+SH
+chmod 0755 "$TMP_ROOT/bad-awk/awk"
+PATH="$TMP_ROOT/bad-awk:$DETACH_INSTALL_BIN_DIR:/usr/bin:/bin" \
+  "$payload_v1/detach-install" install --source app --payload-dir "$payload_v1" \
+  --version-file "$payload_v1/VERSION"
+[ "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")" = "$old_target" ]
+[ "$("$DETACH_INSTALL_BIN_DIR/detach" __version)" = 0.1.0 ]
+
+# A failed manifest write must not switch the public symlink onto an unproven
+# payload, even after the version directory is in place.
+mkdir -p "$TMP_ROOT/bin"
+cat >"$TMP_ROOT/bin/fail-manifest-mv" <<'SH'
+#!/bin/bash
+dest="${@: -1}"
+case "$dest" in
+  */install.json) exit 1 ;;
+esac
+exec /bin/mv "$@"
+SH
+chmod 0755 "$TMP_ROOT/bin/fail-manifest-mv"
+unproven_payload="$(make_payload unproven 0.1.8)"
+if DETACH_MV_BIN="$TMP_ROOT/bin/fail-manifest-mv" \
+  "$unproven_payload/detach-install" install --source app \
+    --payload-dir "$unproven_payload" --version-file "$unproven_payload/VERSION"; then
+  printf 'install unexpectedly switched after a manifest write failure\n' >&2
+  exit 1
+fi
+[ "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")" = "$old_target" ]
+[ "$("$DETACH_INSTALL_BIN_DIR/detach" __version)" = 0.1.0 ]
+
 # Updating must stop before the public CLI changes while any old managed
 # session remains on either historical tmux socket. Retained panes are
 # intentionally included because their logs still belong to the old CLI.
@@ -533,6 +585,41 @@ if FAKE_TMUX_CURRENT_MODE=managed-retained \
   exit 1
 fi
 grep -F '# corruption' "$active_dir/detach-core" >/dev/null
+
+# Repair must keep the live same-version directory if staging fails.
+cat >"$TMP_ROOT/bin/fail-incoming-install" <<'SH'
+#!/bin/bash
+for arg in "$@"; do
+  case "$arg" in
+    */.incoming-*|.incoming-*) exit 1 ;;
+  esac
+done
+exec /usr/bin/install "$@"
+SH
+chmod 0755 "$TMP_ROOT/bin/fail-incoming-install"
+if DETACH_INSTALL_BIN="$TMP_ROOT/bin/fail-incoming-install" \
+  "$DETACH_INSTALL_BIN_DIR/detach" repair; then
+  printf 'repair unexpectedly removed the live payload after a staging failure\n' >&2
+  exit 1
+fi
+[ -d "$active_dir" ]
+[ -x "$active_dir/detach" ]
+grep -F '# corruption' "$active_dir/detach-core" >/dev/null
+[ "$(cd -P "$(dirname "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")")" && pwd)" = \
+  "$active_dir" ]
+
+# A failed manifest during Repair must restore the displaced live directory
+# and leave the public symlink off the unproven replacement.
+if DETACH_MV_BIN="$TMP_ROOT/bin/fail-manifest-mv" \
+  "$DETACH_INSTALL_BIN_DIR/detach" repair; then
+  printf 'repair unexpectedly activated a payload after a manifest write failure\n' >&2
+  exit 1
+fi
+[ -d "$active_dir" ]
+grep -F '# corruption' "$active_dir/detach-core" >/dev/null
+[ "$(cd -P "$(dirname "$(readlink "$DETACH_INSTALL_BIN_DIR/detach")")" && pwd)" = \
+  "$active_dir" ]
+[ ! -e "$DETACH_INSTALL_LIBEXEC_ROOT/versions/.outgoing-"* ]
 "$DETACH_INSTALL_BIN_DIR/detach" repair
 [ "$(shasum -a 256 "$active_dir/detach-core" | awk '{print $1}')" = \
   "$(shasum -a 256 "$payload_v2/detach-core" | awk '{print $1}')" ]
@@ -565,11 +652,14 @@ env -u DETACH_TMUX_BIN -u DETACH_STATE_BIN -u DETACH_POWER_BIN \
 plutil -extract schema raw -o - "$doctor_json" | grep -qx 1
 plutil -extract checks.1.id raw -o - "$doctor_json" | grep -qx cli
 doctor_check_index() {
-  local report="$1" id="$2"
-  plutil -p "$report" | awk -v wanted="$id" '
-  $1 ~ /^[0-9]+$/ && $2 == "=>" && $3 == "{" { idx = $1 }
-  $2 == "=>" && $3 == "\"" wanted "\"" { print idx; exit }
-'
+  local report="$1" id="$2" index=0 found
+  while found="$(plutil -extract "checks.$index.id" raw -o - "$report" 2>/dev/null)"; do
+    if [ "$found" = "$id" ]; then
+      printf '%s\n' "$index"
+      return 0
+    fi
+    index=$((index + 1))
+  done
 }
 watchdog_index="$(doctor_check_index "$doctor_json" watchdog)"
 [ -n "$watchdog_index" ]


### PR DESCRIPTION
## Contract delta

- `docs/specs/runtime.md` **MODIFIED**: Install and Repair must stage and hash under `.incoming-*` before they replace a live version directory. They switch `~/.local/bin/detach` only after the version directory, install manifest, and payload `__version` proof succeed. Failure keeps the active payload and its install manifest. A first install that fails after it writes the manifest removes the new manifest. Payload members must be regular files.
- `README.md` **MODIFIED**: If an update or Repair fails, the active CLI, its payload, and the install manifest stay in place.

## Durable decisions

- Same-directory Repair moves the live tree to `.outgoing-*` only after the incoming tree is hashed and proven. A later failure restores that live tree before the installer exits.
- Hash extraction uses `$AWK_BIN`, not PATH `awk`. Symlink payload members are rejected before hashing, matching `verify-app.sh`.
- The installer copies `install.json` aside before it replaces that file. Activation rollback restores the previous manifest, or removes a first-install manifest when none existed.

## Acceptance evidence

- Repair keeps a damaged same-version directory when staging fails (`tests/distribution.sh` / SC-INSTALL-REPAIR): PASS
- A failed `install.json` write does not switch `~/.local/bin/detach` onto an unproven payload, and Repair restores the displaced live directory: PASS
- Install succeeds when PATH `awk` exits 1, so hashing uses `$AWK_BIN`: PASS
- A symlink payload member is rejected and the public CLI stays on the proven payload: PASS
- A failed public-CLI switch after a successful manifest write restores the previous CLI version, manifest version, payload ID, and executable path: PASS
- First-install cleanup after that switch failure removes the new `install.json` and does not leave a public CLI: PASS
- Repair restores the previous manifest when the public-CLI switch fails: PASS
- Focused `DETACH_DISTRIBUTION_TEST_PART=runtime tests/distribution.sh`: PASS (`Detach distribution tests passed (runtime)`)
- Hosted `quality-gates`: PASS on `7085f1f` ([run 35343523842](https://github.com/iltsarev/detach/actions/runs/35343523842))

Closes #234