### PR TITLE
Derive session Power claims from the watchdog heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ retained transcript tail.
 
 Power status is event-driven too. An atomic watchdog report wakes the app when
 it changes. One deadline marks a silent report stale. The menu bar, Settings,
-and notifications do not poll the same file on repeating timers.
+session Mac Power, and notifications share this heartbeat. They do not poll
+the same file on repeating timers.
 
 <details>
 <summary><strong>How a new in-app session starts</strong></summary>
@@ -223,7 +224,8 @@ Codex and Claude Code share one dashboard. Each managed session includes:
 - an interactive terminal for a live session and ANSI-aware retained logs for
   session history;
 - safe **Attach**, **Stop**, **Resume**, **Recover**, and **Delete** actions
-  selected from the proven session state;
+  selected from the proven session state; an omitted health action list
+  grants no mutations;
 - checkboxes in **Finished** for one-confirmation deletion of eligible
   sessions; a failed deletion does not stop the remaining deletions;
 - optional notifications for an answer, completion, failure, or recovery;

--- a/app/Sources/DetachApp/RootView.swift
+++ b/app/Sources/DetachApp/RootView.swift
@@ -73,6 +73,7 @@ struct RootView: View {
                                 session: session,
                                 store: store,
                                 detachPath: detachPath,
+                                powerProtectionState: installation.powerProtectionState,
                                 sessionLogSnapshots: sessionLogSnapshots,
                                 terminalScreens: terminalScreens)
                         } else {
@@ -209,6 +210,7 @@ struct SessionDetailSwitcher: View {
     let session: Session
     let store: SessionStore
     let detachPath: String
+    let powerProtectionState: PowerProtectionState
     let sessionLogSnapshots: SessionLogSnapshotCache
     let terminalScreens: SessionTerminalScreenCache
 
@@ -219,12 +221,14 @@ struct SessionDetailSwitcher: View {
         session: Session,
         store: SessionStore,
         detachPath: String,
+        powerProtectionState: PowerProtectionState,
         sessionLogSnapshots: SessionLogSnapshotCache,
         terminalScreens: SessionTerminalScreenCache
     ) {
         self.session = session
         self.store = store
         self.detachPath = detachPath
+        self.powerProtectionState = powerProtectionState
         self.sessionLogSnapshots = sessionLogSnapshots
         self.terminalScreens = terminalScreens
         _transition = State(initialValue: SessionDetailTransitionState(
@@ -236,6 +240,7 @@ struct SessionDetailSwitcher: View {
             session: transition.presented,
             store: store,
             detachPath: detachPath,
+            powerProtectionState: powerProtectionState,
             terminalScreens: terminalScreens,
             cachedLog: cachedLog(for: transition.presented),
             retainedFrame: transition.outgoing.flatMap {

--- a/app/Sources/DetachApp/SessionDetailView.swift
+++ b/app/Sources/DetachApp/SessionDetailView.swift
@@ -91,6 +91,8 @@ struct SessionDetailView: View {
     let session: Session
     let store: SessionStore
     let detachPath: String
+    /// Fresh watchdog heartbeat. Session Mac Power does not use the last list row.
+    var powerProtectionState: PowerProtectionState = .unknown
     let terminalScreens: SessionTerminalScreenCache
     /// Supplied before the first body pass so a warm non-live log cannot flash
     /// an empty placeholder while `.task` starts its background refresh.
@@ -398,6 +400,10 @@ struct SessionDetailView: View {
 #if DEBUG
     var logContentForTesting: NSAttributedString { logContent }
 
+    var displayedPowerStateForTesting: PowerProtectionState {
+        displayedPowerState
+    }
+
     func refreshVisibleLogForTesting() async { await refreshVisibleLog() }
 
     func refreshVisibleLogForTesting(
@@ -472,19 +478,31 @@ struct SessionDetailView: View {
 // quality-coverage:end ui-e2e-instrumentation
     }
 
+    private var displayedPowerState: PowerProtectionState {
+        SessionPowerPresentation.displayedState(heartbeat: powerProtectionState)
+    }
+
+    private var displayedPowerLabel: String {
+        SessionPowerPresentation.label(for: displayedPowerState)
+    }
+
+    private var displayedPowerImage: String {
+        SessionPowerPresentation.systemImage(for: displayedPowerState)
+    }
+
     private var embeddedTerminalPowerChip: some View {
         Label(
-            session.powerProtectionLabel,
-            systemImage: session.powerProtectionSystemImage)
+            displayedPowerLabel,
+            systemImage: displayedPowerImage)
             .font(.system(size: 10, weight: .medium))
             .lineLimit(1)
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
             .background(Capsule().fill(.quaternary.opacity(0.6)))
             .foregroundStyle(SessionDetailSignalPresentation.powerColor(
-                for: session.powerProtectionState))
+                for: displayedPowerState))
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text(session.powerProtectionLabel))
+            .accessibilityLabel(Text(displayedPowerLabel))
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
             .background {
@@ -531,17 +549,17 @@ struct SessionDetailView: View {
                     .accessibilityHidden(true)
 
                 Label(
-                    session.powerProtectionLabel,
-                    systemImage: session.powerProtectionSystemImage)
+                    displayedPowerLabel,
+                    systemImage: displayedPowerImage)
                     .font(.system(size: 10, weight: .medium))
                     .lineLimit(1)
                     .padding(.horizontal, 8)
                     .frame(minHeight: 18)
                     .background(Color(nsColor: ANSIParser.terminalBackground))
                     .foregroundStyle(SessionDetailSignalPresentation.powerColor(
-                        for: session.powerProtectionState))
+                        for: displayedPowerState))
                     .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(Text(session.powerProtectionLabel))
+                    .accessibilityLabel(Text(displayedPowerLabel))
 // quality-coverage:begin ui-e2e-instrumentation
 #if !DEBUG
                     .background {

--- a/app/Sources/DetachKit/SessionPresentation.swift
+++ b/app/Sources/DetachKit/SessionPresentation.swift
@@ -74,19 +74,7 @@ public extension Session {
     }
 
     var availableActions: [SessionAction] {
-        if let healthActions { return healthActions }
-        return switch effectiveStatus {
-        case .running, .starting, .recovering, .hung:
-            [.attach, .stop]
-        case .completed, .failed, .interrupted, .stopped, .orphaned:
-            agentSessionId != nil ? [.resume, .delete] : [.delete]
-        case .recoverable:
-            [.recover, .delete]
-        case .corrupt, .unknown:
-            [.delete]
-        case .collision:
-            []
-        }
+        healthActions ?? []
     }
 
     var displayTitle: String {
@@ -169,7 +157,26 @@ public extension Session {
     /// Human-readable sleep policy. Text is the primary signal because a
     /// moon/shield glyph alone is easy to interpret in opposite ways.
     var powerProtectionLabel: String {
-        switch powerProtectionState ?? .unknown {
+        SessionPowerPresentation.label(for: powerProtectionState ?? .unknown)
+    }
+
+    /// Temporary SF Symbols; the adjacent label carries the meaning.
+    var powerProtectionSystemImage: String {
+        SessionPowerPresentation.systemImage(for: powerProtectionState ?? .unknown)
+    }
+}
+
+/// Session Mac Power follows the fresh watchdog heartbeat. A list row is not
+/// a claim source.
+public enum SessionPowerPresentation {
+    public static func displayedState(
+        heartbeat: PowerProtectionState
+    ) -> PowerProtectionState {
+        heartbeat
+    }
+
+    public static func label(for state: PowerProtectionState) -> String {
+        switch state {
         case .protected: L10n.string("Mac stays awake")
         case .allowed: L10n.string("Mac can sleep")
         case .transitioning: L10n.string("Enabling sleep protection")
@@ -180,9 +187,8 @@ public extension Session {
         }
     }
 
-    /// Temporary SF Symbols; the adjacent label carries the meaning.
-    var powerProtectionSystemImage: String {
-        switch powerProtectionState ?? .unknown {
+    public static func systemImage(for state: PowerProtectionState) -> String {
+        switch state {
         case .protected: "shield.fill"
         case .allowed: "moon.zzz"
         case .transitioning: "arrow.triangle.2.circlepath"

--- a/app/Sources/DetachKit/WatchdogCLI.swift
+++ b/app/Sources/DetachKit/WatchdogCLI.swift
@@ -1,0 +1,125 @@
+import Darwin
+import Foundation
+
+/// Resolves the installed public CLI the same way production does: a regular
+/// payload command under `libexec/detach/versions`, sibling `detach-core`, and
+/// no inherited `DETACH_*_BIN` or `DYLD_*`.
+public enum WatchdogCLI {
+    public struct Resolution: Equatable, Sendable {
+        public let executableURL: URL
+        public let environment: [String: String]
+
+        public init(executableURL: URL, environment: [String: String]) {
+            self.executableURL = executableURL
+            self.environment = environment
+        }
+    }
+
+    public enum ResolutionFailure: Error, Equatable, Sendable {
+        case missing
+        case notRegularPayload
+    }
+
+    public static func resolve(
+        home: URL,
+        environment: [String: String],
+        powerStateRoot: String,
+        fileManager: FileManager = .default
+    ) -> Result<Resolution, ResolutionFailure> {
+        let publicCommand = home.appendingPathComponent(".local/bin/detach")
+        guard fileManager.fileExists(atPath: publicCommand.path) else {
+            return .failure(.missing)
+        }
+        guard let resolved = resolvePath(publicCommand, fileManager: fileManager),
+              isRegularExecutable(resolved),
+              isInstalledPayloadCommand(resolved, home: home),
+              isRegularExecutable(
+                resolved.deletingLastPathComponent()
+                    .appendingPathComponent("detach-core"))
+        else {
+            return .failure(.notRegularPayload)
+        }
+        return .success(Resolution(
+            executableURL: resolved,
+            environment: childEnvironment(
+                from: environment,
+                home: home.path,
+                powerStateRoot: powerStateRoot)))
+    }
+
+    public static func childEnvironment(
+        from environment: [String: String],
+        home: String,
+        powerStateRoot: String
+    ) -> [String: String] {
+        var sanitized = environment
+        for key in Array(sanitized.keys) {
+            if key.hasPrefix("DYLD_")
+                || (key.hasPrefix("DETACH_") && key.hasSuffix("_BIN")) {
+                sanitized.removeValue(forKey: key)
+            }
+        }
+        sanitized["PATH"] = [
+            "\(home)/.local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
+        ].joined(separator: ":")
+        sanitized["DETACH_POWER_STATE_ROOT"] = powerStateRoot
+        return sanitized
+    }
+
+    static func resolvePath(
+        _ source: URL,
+        fileManager: FileManager
+    ) -> URL? {
+        var current = source
+        var depth = 0
+        while true {
+            guard depth <= 40 else { return nil }
+            guard fileManager.fileExists(atPath: current.path) else {
+                return nil
+            }
+            if let destination = try? fileManager.destinationOfSymbolicLink(
+                atPath: current.path
+            ) {
+                if destination.hasPrefix("/") {
+                    current = URL(fileURLWithPath: destination)
+                } else {
+                    current = current.deletingLastPathComponent()
+                        .appendingPathComponent(destination)
+                }
+                depth += 1
+                continue
+            }
+            let directory = current.deletingLastPathComponent()
+                .resolvingSymlinksInPath()
+            return directory.appendingPathComponent(current.lastPathComponent)
+        }
+    }
+
+    static func isRegularExecutable(_ url: URL) -> Bool {
+        var metadata = stat()
+        guard lstat(url.path, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG else {
+            return false
+        }
+        return FileManager.default.isExecutableFile(atPath: url.path)
+    }
+
+    static func isInstalledPayloadCommand(_ url: URL, home: URL) -> Bool {
+        guard url.lastPathComponent == "detach" else { return false }
+        let versionsRoot = home
+            .appendingPathComponent(".local/libexec/detach/versions", isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let command = url.standardizedFileURL
+        let versionDirectory = command.deletingLastPathComponent()
+        let versions = versionDirectory.deletingLastPathComponent()
+            .standardizedFileURL
+        guard versions.path == versionsRoot.path else { return false }
+        let versionID = versionDirectory.lastPathComponent
+        return !versionID.isEmpty
+            && versionID != "."
+            && versionID != ".."
+            && !versionID.hasPrefix(".")
+            && !versionID.contains("/")
+    }
+}

--- a/app/Sources/DetachWatchdog/main.swift
+++ b/app/Sources/DetachWatchdog/main.swift
@@ -142,21 +142,25 @@ do {
     let log = try FileHandle(forWritingTo: logURL)
     try log.seekToEnd()
 
-    guard fileManager.isExecutableFile(atPath: detachURL.path) else {
+    let command: URL
+    let childEnvironment: [String: String]
+    switch WatchdogCLI.resolve(
+        home: URL(fileURLWithPath: home, isDirectory: true),
+        environment: environment,
+        powerStateRoot: stateRoot
+    ) {
+    case .success(let resolution):
+        command = resolution.executableURL
+        childEnvironment = resolution.environment
+    case .failure:
         let message = "DetachWatchdog: CLI is not installed at \(detachURL.path)\n"
         try log.write(contentsOf: Data(message.utf8))
         recordHeartbeat(state: "cli_missing", exitStatus: 0)
         exit(0)
     }
 
-    var childEnvironment = environment
-    let commonPath = [
-        "\(home)/.local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin",
-    ].joined(separator: ":")
-    childEnvironment["PATH"] = commonPath
-    childEnvironment["DETACH_POWER_STATE_ROOT"] = stateRoot
     let statusResult = try BoundedProcessRunner().run(BoundedProcessRequest(
-        executableURL: detachURL,
+        executableURL: command,
         arguments: ["power", "status", "--json"],
         environment: childEnvironment,
         timeout: 5,

--- a/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
+++ b/app/Tests/DetachAppTests/SessionAttachTerminalTests.swift
@@ -1607,8 +1607,19 @@ final class SessionAttachTerminalTests: XCTestCase {
         let created = createdAt.map { "\"\($0)\"" } ?? "null"
         let lifecycle = lifecycleID.map { "\"\($0)\"" } ?? "null"
         return SessionListParser.parse("""
-        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":\(created),"lifecycle_id":\(lifecycle),"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
+        {"schema":1,"provider":"codex","session_name":"\(name)","name":"proj-abcd1234","effective_status":"\(status)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":\(created),"lifecycle_id":\(lifecycle),"last_checkpoint_at":null,"exit_status":null,"finished_at":null,"health_actions":\(healthActionsJSON(for: status))}
         """).sessions.first
+    }
+
+    private static func healthActionsJSON(for status: String) -> String {
+        switch status {
+        case "starting", "running", "recovering", "hung":
+            return #"["attach","stop"]"#
+        case "recoverable":
+            return #"["recover","delete"]"#
+        default:
+            return #"["resume","delete"]"#
+        }
     }
 
     private static func invocation() -> SessionAttachInvocation {

--- a/app/Tests/DetachAppTests/SessionIdentityTests.swift
+++ b/app/Tests/DetachAppTests/SessionIdentityTests.swift
@@ -84,8 +84,42 @@ final class SessionIdentityTests: XCTestCase {
                        accuracy: 0.001, file: file, line: line)
         XCTAssertEqual(actualRGB.blueComponent, expectedRGB.blueComponent,
                        accuracy: 0.001, file: file, line: line)
-        XCTAssertEqual(actualRGB.alphaComponent, expectedRGB.alphaComponent,
+            XCTAssertEqual(actualRGB.alphaComponent, expectedRGB.alphaComponent,
                        accuracy: 0.001, file: file, line: line)
+    }
+}
+
+private final class SilentPowerChipCLI: DetachCLIRunning, @unchecked Sendable {
+    func run(arguments: [String], timeout: TimeInterval) async throws -> CLIResult {
+        CLIResult(exitCode: 0, stdout: "", stderr: "", timedOut: false)
+    }
+}
+
+@MainActor
+final class SessionDetailPowerChipTests: XCTestCase {
+    func testSessionPowerChipFollowsHeartbeatNotStaleListRow() throws {
+        let json = """
+        {"schema":1,"provider":"codex","session_name":"work","name":"work",\
+        "effective_status":"running","power_protection_state":"protected"}
+        """
+        let session = try XCTUnwrap(SessionListParser.parse(json).sessions.first)
+        XCTAssertEqual(session.powerProtectionState, .protected)
+
+        let view = SessionDetailView(
+            session: session,
+            store: SessionStore(cli: SilentPowerChipCLI()),
+            detachPath: "/tmp/detach",
+            powerProtectionState: .allowed,
+            terminalScreens: SessionTerminalScreenCache(),
+            cachedLog: nil)
+
+        XCTAssertEqual(view.displayedPowerStateForTesting, .allowed)
+        XCTAssertEqual(
+            SessionPowerPresentation.label(for: view.displayedPowerStateForTesting),
+            L10n.string("Mac can sleep"))
+        XCTAssertNotEqual(
+            SessionPowerPresentation.label(for: view.displayedPowerStateForTesting),
+            session.powerProtectionLabel)
     }
 }
 

--- a/app/Tests/DetachKitTests/SessionAttachTests.swift
+++ b/app/Tests/DetachKitTests/SessionAttachTests.swift
@@ -156,7 +156,18 @@ final class SessionAttachTests: XCTestCase {
         name: String = "detach-codex-proj-abcd1234"
     ) -> Session {
         SessionListParser.parse("""
-        {"schema":1,"provider":"\(provider.rawValue)","session_name":"\(name)","name":"proj","effective_status":"\(status.rawValue)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":null,"last_checkpoint_at":null,"exit_status":null,"finished_at":null}
+        {"schema":1,"provider":"\(provider.rawValue)","session_name":"\(name)","name":"proj","effective_status":"\(status.rawValue)","meta_status":null,"agent_session_id":"1111-2222","project_dir":"/tmp/p","created_at":null,"last_checkpoint_at":null,"exit_status":null,"finished_at":null,"health_actions":\(healthActionsJSON(for: status))}
         """).sessions[0]
+    }
+
+    private func healthActionsJSON(for status: EffectiveStatus) -> String {
+        switch status {
+        case .starting, .running, .recovering, .hung:
+            return #"["attach","stop"]"#
+        case .recoverable:
+            return #"["recover","delete"]"#
+        default:
+            return #"["resume","delete"]"#
+        }
     }
 }

--- a/app/Tests/DetachKitTests/SessionPresentationTests.swift
+++ b/app/Tests/DetachKitTests/SessionPresentationTests.swift
@@ -42,54 +42,81 @@ final class SessionPresentationTests: XCTestCase {
 
     func testEveryEffectiveStatusHasConsistentLifecyclePresentation() {
         let cases: [(
-            EffectiveStatus, String, Bool, SessionSection, [SessionAction]
+            EffectiveStatus, String, Bool, SessionSection
         )] = [
-            (.starting, "starting", true, .active, [.attach, .stop]),
-            (.running, "running", true, .active, [.attach, .stop]),
-            (.recovering, "recovering", true, .active, [.attach, .stop]),
-            (.hung, "hung", true, .problems, [.attach, .stop]),
-            (.completed, "completed", false, .finished, [.resume, .delete]),
-            (.failed, "failed", false, .finished, [.resume, .delete]),
-            (.interrupted, "interrupted", false, .finished, [.resume, .delete]),
-            (.stopped, "stopped", false, .finished, [.resume, .delete]),
-            (.recoverable, "recoverable", false, .problems, [.recover, .delete]),
-            (.orphaned, "orphaned", false, .problems, [.resume, .delete]),
-            (.corrupt, "corrupt", false, .problems, [.delete]),
-            (.collision, "name collision", false, .problems, []),
-            (.unknown, "unknown", false, .problems, [.delete]),
+            (.starting, "starting", true, .active),
+            (.running, "running", true, .active),
+            (.recovering, "recovering", true, .active),
+            (.hung, "hung", true, .problems),
+            (.completed, "completed", false, .finished),
+            (.failed, "failed", false, .finished),
+            (.interrupted, "interrupted", false, .finished),
+            (.stopped, "stopped", false, .finished),
+            (.recoverable, "recoverable", false, .problems),
+            (.orphaned, "orphaned", false, .problems),
+            (.corrupt, "corrupt", false, .problems),
+            (.collision, "name collision", false, .problems),
+            (.unknown, "unknown", false, .problems),
         ]
 
-        for (status, displayStatus, isLive, section, actions) in cases {
+        for (status, displayStatus, isLive, section) in cases {
             let session = make(status)
             XCTAssertEqual(session.displayStatus, L10n.string(displayStatus), "status=\(status)")
             XCTAssertEqual(session.isLive, isLive, "status=\(status)")
             XCTAssertEqual(session.section, section, "status=\(status)")
-            XCTAssertEqual(session.availableActions, actions, "status=\(status)")
+            XCTAssertEqual(session.availableActions, [], "status=\(status)")
+            XCTAssertNil(session.healthActions, "status=\(status)")
         }
     }
 
-    func testActions() {
-        XCTAssertEqual(make(.running).availableActions, [.attach, .stop])
-        XCTAssertEqual(make(.completed).availableActions, [.resume, .delete])
-        XCTAssertEqual(make(.completed, uuid: nil).availableActions, [.delete])
-        XCTAssertEqual(make(.stopped).availableActions, [.resume, .delete])
-        XCTAssertEqual(make(.recoverable).availableActions, [.recover, .delete])
-        XCTAssertEqual(make(.orphaned, uuid: nil).availableActions, [.delete])
-        XCTAssertEqual(make(.corrupt).availableActions, [.delete])
-        XCTAssertEqual(make(.collision).availableActions, [])
+    func testOmittedAndNullHealthActionsOfferNoMutations() {
+        XCTAssertNil(make(.running).healthActions)
+        XCTAssertEqual(make(.running).availableActions, [])
+        XCTAssertEqual(make(.completed).availableActions, [])
+        XCTAssertEqual(make(.recoverable).availableActions, [])
+        XCTAssertFalse(make(.completed).canDeleteFromFinishedList)
+
+        let nullActions = #"{"schema":1,"provider":"codex","session_name":"detach-codex-null","name":"null","effective_status":"running","health_actions":null}"#
+        let session = SessionListParser.parse(nullActions).sessions[0]
+        XCTAssertNil(session.healthActions)
+        XCTAssertEqual(session.availableActions, [])
+    }
+
+    func testTypedHealthActionsAreTheOnlyMutations() {
+        var session = make(.running)
+        session.healthActions = [.attach, .stop]
+        XCTAssertEqual(session.availableActions, [.attach, .stop])
+        session.healthActions = [.resume, .delete]
+        XCTAssertEqual(session.availableActions, [.resume, .delete])
+        session.healthActions = []
+        XCTAssertEqual(session.availableActions, [])
     }
 
     func testFinishedBulkDeleteUsesTypedDeletePermission() {
-        XCTAssertTrue(make(.completed).canDeleteFromFinishedList)
-        XCTAssertTrue(make(.failed).canDeleteFromFinishedList)
-        XCTAssertTrue(make(.interrupted).canDeleteFromFinishedList)
-        XCTAssertTrue(make(.stopped).canDeleteFromFinishedList)
-        XCTAssertFalse(make(.running).canDeleteFromFinishedList)
-        XCTAssertFalse(make(.recoverable).canDeleteFromFinishedList)
+        var completed = make(.completed)
+        completed.healthActions = [.resume, .delete]
+        var failed = make(.failed)
+        failed.healthActions = [.resume, .delete]
+        var interrupted = make(.interrupted)
+        interrupted.healthActions = [.resume, .delete]
+        var stopped = make(.stopped)
+        stopped.healthActions = [.resume, .delete]
+        var running = make(.running)
+        running.healthActions = [.attach, .stop]
+        var recoverable = make(.recoverable)
+        recoverable.healthActions = [.recover, .delete]
+
+        XCTAssertTrue(completed.canDeleteFromFinishedList)
+        XCTAssertTrue(failed.canDeleteFromFinishedList)
+        XCTAssertTrue(interrupted.canDeleteFromFinishedList)
+        XCTAssertTrue(stopped.canDeleteFromFinishedList)
+        XCTAssertFalse(running.canDeleteFromFinishedList)
+        XCTAssertFalse(recoverable.canDeleteFromFinishedList)
 
         var blocked = make(.completed)
         blocked.healthActions = []
         XCTAssertFalse(blocked.canDeleteFromFinishedList)
+        XCTAssertFalse(make(.completed).canDeleteFromFinishedList)
     }
 
     func testTypedHealthActionsOverrideLegacyStatusHeuristics() throws {
@@ -169,11 +196,13 @@ final class SessionPresentationTests: XCTestCase {
     }
 
     func testWaitingTurnHasAttentionStatusWhileRemainingActive() {
-        let waiting = make(.running, turnState: .waiting)
+        var waiting = make(.running, turnState: .waiting)
         XCTAssertTrue(waiting.isWaitingForUser)
         XCTAssertTrue(waiting.isLive)
         XCTAssertEqual(waiting.displayStatus, L10n.string("answer ready"))
         XCTAssertEqual(waiting.section, .answerReady)
+        XCTAssertEqual(waiting.availableActions, [])
+        waiting.healthActions = [.attach, .stop]
         XCTAssertEqual(waiting.availableActions, [.attach, .stop])
     }
 
@@ -204,6 +233,24 @@ final class SessionPresentationTests: XCTestCase {
         XCTAssertEqual(
             make(.running).powerProtectionLabel,
             L10n.string("Sleep status unknown"))
+    }
+
+    func testSessionPowerChipFollowsHeartbeatNotListRow() {
+        let session = make(.running, powerState: .protected)
+        XCTAssertEqual(session.powerProtectionState, .protected)
+        XCTAssertEqual(session.powerProtectionLabel, L10n.string("Mac stays awake"))
+
+        let displayed = SessionPowerPresentation.displayedState(heartbeat: .allowed)
+        XCTAssertEqual(displayed, .allowed)
+        XCTAssertEqual(
+            SessionPowerPresentation.label(for: displayed),
+            L10n.string("Mac can sleep"))
+        XCTAssertEqual(
+            SessionPowerPresentation.systemImage(for: displayed),
+            "moon.zzz")
+        XCTAssertNotEqual(
+            SessionPowerPresentation.label(for: displayed),
+            session.powerProtectionLabel)
     }
 
     func testPowerStatusCoversTransitionsAndEverySystemImage() {

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -870,9 +870,13 @@ final class SessionStoreTests: XCTestCase {
 
     func testBulkFinishedDeleteContinuesAfterFailureAndRefreshesOnce() async throws {
         let cli = FakeCLI()
-        let firstLine = line.replacingOccurrences(
-            of: #""effective_status":"running""#,
-            with: #""effective_status":"completed""#)
+        let firstLine = line
+            .replacingOccurrences(
+                of: #""effective_status":"running""#,
+                with: #""effective_status":"completed""#)
+            .replacingOccurrences(
+                of: #""health_actions":["attach","stop"]"#,
+                with: #""health_actions":["resume","delete"]"#)
         let secondLine = firstLine
             .replacingOccurrences(of: "codex", with: "claude")
             .replacingOccurrences(of: "detach-claude-p-1", with: "detach-claude-p-2")

--- a/app/Tests/DetachKitTests/SessionStoreTests.swift
+++ b/app/Tests/DetachKitTests/SessionStoreTests.swift
@@ -270,7 +270,7 @@ private actor CancellableSleepProbe {
 @MainActor
 final class SessionStoreTests: XCTestCase {
     let line = """
-    {"schema":1,"provider":"codex","session_name":"detach-codex-p-1","name":"p-1","effective_status":"running","meta_status":"running","agent_session_id":"u1","project_dir":"/tmp/p","created_at":"2026-07-10T10:00:00Z","last_checkpoint_at":null,"exit_status":null,"finished_at":null}
+    {"schema":1,"provider":"codex","session_name":"detach-codex-p-1","name":"p-1","effective_status":"running","meta_status":"running","agent_session_id":"u1","project_dir":"/tmp/p","created_at":"2026-07-10T10:00:00Z","last_checkpoint_at":null,"exit_status":null,"finished_at":null,"health_actions":["attach","stop"]}
     """
 
     func ok(_ stdout: String) -> Result<CLIResult, Error> {

--- a/app/Tests/DetachKitTests/WatchdogCLITests.swift
+++ b/app/Tests/DetachKitTests/WatchdogCLITests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import XCTest
+@testable import DetachKit
+
+final class WatchdogCLITests: XCTestCase {
+    private var home: URL!
+
+    override func setUpWithError() throws {
+        home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-watchdog-cli-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: home, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let home {
+            try? FileManager.default.removeItem(at: home)
+        }
+        home = nil
+    }
+
+    func testResolvesInstalledPayloadAndStripsInheritedOverrides() throws {
+        let payload = try installPayload()
+        let result = try XCTUnwrap(
+            WatchdogCLI.resolve(
+                home: home,
+                environment: [
+                    "HOME": home.path,
+                    "PATH": "/usr/bin:/bin",
+                    "DETACH_STATE_BIN": "/old/detach-state",
+                    "DETACH_POWER_BIN": "/old/detach-power",
+                    "DETACH_TMUX_BIN": "/old/tmux",
+                    "DYLD_INSERT_LIBRARIES": "/evil.dylib",
+                    "DYLD_LIBRARY_PATH": "/evil/lib",
+                    "UNRELATED_SETTING": "kept",
+                ],
+                powerStateRoot: "/private/tmp/watchdog-power").get())
+
+        XCTAssertEqual(result.executableURL.standardizedFileURL, payload)
+        XCTAssertNil(result.environment["DETACH_STATE_BIN"])
+        XCTAssertNil(result.environment["DETACH_POWER_BIN"])
+        XCTAssertNil(result.environment["DETACH_TMUX_BIN"])
+        XCTAssertNil(result.environment["DYLD_INSERT_LIBRARIES"])
+        XCTAssertNil(result.environment["DYLD_LIBRARY_PATH"])
+        XCTAssertEqual(result.environment["DETACH_POWER_STATE_ROOT"], "/private/tmp/watchdog-power")
+        XCTAssertEqual(result.environment["UNRELATED_SETTING"], "kept")
+        XCTAssertEqual(
+            result.environment["PATH"],
+            "\(home.path)/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+    }
+
+    func testRejectsANonPayloadPublicCommand() throws {
+        let bin = home.appendingPathComponent(".local/bin")
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let unmanaged = bin.appendingPathComponent("detach")
+        try writeExecutable(unmanaged)
+
+        let result = WatchdogCLI.resolve(
+            home: home,
+            environment: [:],
+            powerStateRoot: "/private/tmp/watchdog-power")
+
+        guard case .failure(.notRegularPayload) = result else {
+            XCTFail("expected a non-payload command to be rejected")
+            return
+        }
+    }
+
+    func testRejectsAPublicCommandThatResolvesOutsideThePayload() throws {
+        let bin = home.appendingPathComponent(".local/bin")
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let other = home.appendingPathComponent("other/detach")
+        try FileManager.default.createDirectory(
+            at: other.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try writeExecutable(other)
+        try FileManager.default.createSymbolicLink(
+            at: bin.appendingPathComponent("detach"),
+            withDestinationURL: other)
+
+        let result = WatchdogCLI.resolve(
+            home: home,
+            environment: [:],
+            powerStateRoot: "/private/tmp/watchdog-power")
+
+        guard case .failure(.notRegularPayload) = result else {
+            XCTFail("expected a non-payload symlink target to be rejected")
+            return
+        }
+    }
+
+    func testRejectsAPayloadWithoutSiblingCore() throws {
+        let payload = try installPayload(includeCore: false)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: payload.path))
+
+        let result = WatchdogCLI.resolve(
+            home: home,
+            environment: [:],
+            powerStateRoot: "/private/tmp/watchdog-power")
+
+        guard case .failure(.notRegularPayload) = result else {
+            XCTFail("expected a missing sibling detach-core to be rejected")
+            return
+        }
+    }
+
+    func testReportsAMissingPublicCommand() {
+        let result = WatchdogCLI.resolve(
+            home: home,
+            environment: [:],
+            powerStateRoot: "/private/tmp/watchdog-power")
+
+        guard case .failure(.missing) = result else {
+            XCTFail("expected a missing public command")
+            return
+        }
+    }
+
+    func testChildEnvironmentKeepsPowerStateRootAfterStrippingBins() {
+        let environment = WatchdogCLI.childEnvironment(
+            from: [
+                "DETACH_POWER_BIN": "/old/detach-power",
+                "DETACH_SQLITE_BIN": "/old/sqlite3",
+                "DYLD_FRAMEWORK_PATH": "/evil",
+                "DETACH_POWER_STATE_ROOT": "/old/power",
+            ],
+            home: "/Users/test",
+            powerStateRoot: "/watchdog/power")
+
+        XCTAssertNil(environment["DETACH_POWER_BIN"])
+        XCTAssertNil(environment["DETACH_SQLITE_BIN"])
+        XCTAssertNil(environment["DYLD_FRAMEWORK_PATH"])
+        XCTAssertEqual(environment["DETACH_POWER_STATE_ROOT"], "/watchdog/power")
+    }
+
+    private func installPayload(includeCore: Bool = true) throws -> URL {
+        let version = home
+            .appendingPathComponent(".local/libexec/detach/versions/1.0.0-testhash")
+        try FileManager.default.createDirectory(
+            at: version, withIntermediateDirectories: true)
+        let payload = version.appendingPathComponent("detach")
+        try writeExecutable(payload)
+        if includeCore {
+            try writeExecutable(version.appendingPathComponent("detach-core"))
+        }
+        let bin = home.appendingPathComponent(".local/bin")
+        try FileManager.default.createDirectory(
+            at: bin, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: bin.appendingPathComponent("detach"),
+            withDestinationURL: payload)
+        return payload.standardizedFileURL
+    }
+
+    private func writeExecutable(_ url: URL) throws {
+        try "#!/bin/sh\nexit 0\n".write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+}

--- a/bin/detach
+++ b/bin/detach
@@ -428,7 +428,7 @@ list_all() {
   local status=0
   local provider_status
   local power_status=""
-  local DETACH_LIST_POWER_STATE="unavailable"
+  local DETACH_LIST_POWER_STATE="unknown"
   local temporary_base temporary_root codex_output claude_output
   local codex_pid claude_pid codex_status=0 claude_status=0
 
@@ -441,7 +441,7 @@ list_all() {
     fi
     case "$DETACH_LIST_POWER_STATE" in
       allowed|transitioning|protected|low_battery|temperature|unavailable|unknown) ;;
-      *) DETACH_LIST_POWER_STATE="unavailable" ;;
+      *) DETACH_LIST_POWER_STATE="unknown" ;;
     esac
     export DETACH_LIST_POWER_STATE
   fi

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -7149,7 +7149,7 @@ list_session_records() {
   local session_color
   local power_status
   local reported_power_state
-  local power_state="unavailable"
+  local power_state="unknown"
   local health_output
   local health_payload
   local worker_pid

--- a/docs/specs/app.md
+++ b/docs/specs/app.md
@@ -40,8 +40,10 @@ typed health rules. A failed coherent List read keeps the previous rows.
 
 The dashboard separates identity, status, and Mac Power. Identity is a thin
 tmux-colored capsule. Status is a filled circle. Power uses a neutral surface
-and semantic color. Clicking the UUID chip copies the full UUID and shows
-**Copied**.
+and semantic color. Session Mac Power uses the fresh watchdog heartbeat.
+It does not use the last list row. An omitted or null `health_actions`
+list grants no mutations. Clicking the UUID chip copies the full UUID and
+shows **Copied**.
 
 **Finished** bulk Delete stays outside `List`, uses typed Delete, asks once,
 tolerates failures, and keeps transcripts. Select/Done keeps 12-point clearance.

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -172,9 +172,9 @@ contracts and existing deadlines.
 The app observes atomic watchdog heartbeat replacements from the nearest
 existing parent directory. It moves the watch closer as missing state
 directories appear. Each document replaces one freshness deadline; the
-deadline publishes `unknown` if the watchdog stops. Menu bar, Settings, and
-temperature notifications share this state and run no repeating heartbeat
-reader.
+deadline publishes `unknown` if the watchdog stops. Menu bar, Settings,
+session Mac Power, and temperature notifications share this state and run
+no repeating heartbeat reader.
 
 The watchdog heartbeat carries the effective power state and typed raw
 thermal state/latch. With notifications enabled, the app emits one
@@ -183,12 +183,17 @@ transition, including when borrowed external protection makes the effective
 power state unavailable; repeated documents never duplicate the warning.
 
 The watchdog is a signed per-user LaunchAgent with an embedded
-`__TEXT,__info_plist`. It resolves `~/.local/bin/detach` at runtime, calls
-`detach power status --json` through the same process-group runner with a
-five-second deadline, and writes private health state. The privileged
-daemon is a distinct demand-launched LaunchDaemon. Neither plist may contain a
-user-specific path. Native power protection requires no Apple Events or
-Automation entitlement.
+`__TEXT,__info_plist`. It resolves the installed regular payload command
+at `~/.local/bin/detach`. The resolved path must be a regular file under
+`~/.local/libexec/detach/versions/<semver>-<hash>/` with sibling
+`detach-core`. The child does not inherit `DETACH_*_BIN` or `DYLD_*`.
+The watchdog may pass `DETACH_POWER_STATE_ROOT`. A non-payload or
+non-regular path is rejected. It calls `detach power status --json`
+through the same process-group runner with a five-second deadline, and
+writes private health state. The privileged daemon is a distinct
+demand-launched LaunchDaemon. Neither plist may contain a user-specific
+path. Native power protection requires no Apple Events or Automation
+entitlement.
 
 The default initial acquire carries an eight-second absolute server deadline.
 If protection is not confirmed before it, root rolls back only that request's

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -565,6 +565,8 @@ grep -F 'requires an explicit start, resume, or recover command' "$TMP_ROOT/inva
     "$STATE_HELPER" meta get /dev/stdin effective_status)" = stopped ]
   [ "$(printf '%s\n' "$public_list_output" | sed -n '1p' | \
     "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
+  [ "$(printf '%s\n' "$public_list_output" | sed -n '1p' | \
+    "$STATE_HELPER" meta get /dev/stdin power_protection_state)" = unknown ]
   [ -z "$(find "$public_list_tmp" -mindepth 1 -print -quit)" ]
 
   # A caller can terminate the public frontend by PID (for example during app


### PR DESCRIPTION
## Contract delta

- **ADDED** (`docs/specs/power.md`): the watchdog resolves the installed regular payload command under `~/.local/libexec/detach/versions/<semver>-<hash>/` with sibling `detach-core`. The child does not inherit `DETACH_*_BIN` or `DYLD_*`. It may pass `DETACH_POWER_STATE_ROOT`. A non-payload or non-regular path is rejected.
- **MODIFIED** (`docs/specs/power.md`, `docs/specs/app.md`, `README.md`): menu bar, Settings, and session Mac Power share the fresh watchdog heartbeat. Session Mac Power does not use the last list row.
- **ADDED** (`docs/specs/app.md`, `README.md`): an omitted or null `health_actions` list grants no mutations.
- **MODIFIED** (`bin/detach`, `bin/detach-core`): `list --json --quick` publishes `unknown` when power status cannot be read. The previous default was `unavailable`.

Closes #237.

## Durable decisions

- Watchdog CLI resolution lives in `WatchdogCLI` so unit tests can reject inherited `DETACH_*_BIN` / `DYLD_*` and a non-payload path without a large harness. The helper still owns `pmset`.
- Session Power chip presentation uses `installation.powerProtectionState` (heartbeat) through `SessionPowerPresentation`. List-row `session.powerProtectionState` is not a claim source.
- Omitted and null `healthActions` match `[]`: no synthesized Attach/Stop/Delete.

## Acceptance evidence

- `scripts/quality-gate --plan --explain`: change-mode stages `static,swift,quality-contracts,app,ui-e2e,codex,claude,distribution`. Did not run the full repository gate.
- `cd app && swift test --disable-sandbox --filter 'SessionPresentationTests|DispatchPowerHeartbeatRunnerTests|PowerHeartbeatReaderTests|WatchdogServiceTests|WatchdogCLITests|SessionDetailPowerChipTests'`: compile succeeded. The xctest helper could not load the bundle on this host (`built for macOS 26.0 which is newer than running OS` on macOS 15.7.9). Hosted `quality-gates` remains authority.
- New unit coverage: inherited `DETACH_*_BIN` / `DYLD_*` stripped; non-payload path rejected; session chip follows heartbeat; omitted/null `healthActions` offer no mutations; existing `tests/run.sh` list-json case with `/usr/bin/false` now asserts `power_protection_state=unknown`.
- Manual release gates not run: real power, signing, notarization, tagging, upload, publication. UI e2e/smoke not run.

## Test plan

- [ ] Hosted `quality-gates` PASS
- [ ] Session Mac Power matches Settings/menu heartbeat when the last list row is stale
- [ ] Watchdog heartbeat still comes from the installed payload CLI, not an inherited `DETACH_*_BIN`
- [ ] `detach list --json` publishes `unknown` when `--quick` status cannot be read
- [ ] A session JSON row with omitted or null `health_actions` offers no Attach/Stop/Delete