### PR TITLE
Do not unregister the helper before prepare or while the pending flag is live

### DIFF
--- a/app/Sources/DetachApp/PowerHelperService.swift
+++ b/app/Sources/DetachApp/PowerHelperService.swift
@@ -359,20 +359,10 @@ final class PowerHelperService {
             case .preparing:
                 switch status {
                 case .enabled:
-                    let lifetimeStatus = try lifetimeBarrierStatus()
-                    if lifetimeStatus == .missing
-                        || lifetimeStatus == .released {
-                        // launchd/BTM can keep an enabled job after its helper
-                        // failed to spawn or exited. A missing or unlocked
-                        // lifetime barrier proves there is no live helper to
-                        // prepare over XPC, so replay unregister directly.
-                        transaction.phase = .unregisterSubmitted
-                        transaction.bootSessionIdentifier =
-                            try currentBootSession()
-                        transaction.lifetimeBarrierExpected = false
-                        try handoffStore.save(transaction)
-                        continue
-                    }
+                    // KeepAlive can still spawn a helper while the job is
+                    // enabled, even when this boot's lifetime lock is missing
+                    // or released. Do not skip prepare; fail closed unless
+                    // prepare succeeds and the lock is held.
                     let preparation = try await lifecycle
                         .prepareForUnregistration()
                     guard preparation == .prepared else {

--- a/app/Sources/DetachKit/PowerHelperLeaseService.swift
+++ b/app/Sources/DetachKit/PowerHelperLeaseService.swift
@@ -131,6 +131,10 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
     private let statusLock = NSLock()
     private var state: PowerHelperPersistentState
     private var isTerminating = false
+    /// Set only after this process completes prepare. A cancel on that same
+    /// generation must not persist a cleared flag while SMAppService
+    /// unregister can still be in flight.
+    private var preparedUnregistrationInThisProcess = false
     /// Read-only XPC status must never launch pmset. The daemon populates this
     /// cache during startup before accepting clients, then refreshes it from
     /// mutations and the periodic reconciler.
@@ -221,11 +225,13 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
                 do {
                     try restoreOwnedProtectionLocked()
                     _ = try reconcileAndCacheLocked()
+                    preparedUnregistrationInThisProcess = true
                 } catch {
                     // A failed preflight must leave the still-registered
                     // service usable. Persist the reopened gate; if that save
                     // itself fails, durable state remains fail-closed.
                     let preparationError = error
+                    preparedUnregistrationInThisProcess = false
                     var candidate = state
                     candidate.unregistrationPending = false
                     try replaceState(candidate)
@@ -235,12 +241,17 @@ public final class PowerHelperLeaseService: @unchecked Sendable {
         }
     }
 
-    /// Reopens the lease gate when SMAppService failed to unregister or when a
-    /// later app launch recovers an interrupted unregister operation.
+    /// Reopens the lease gate after a replacement helper starts, or when a
+    /// new process loads durable pending state. A cancel on the same process
+    /// that prepared does not clear the flag: unregister may still be in
+    /// flight, and the next generation must stay quiesced.
     @discardableResult
     public func cancelUnregistration() throws -> PowerProtectionStatus {
         try synchronized {
             try recordingFailureLocked {
+                if preparedUnregistrationInThisProcess {
+                    return try reconcileAndCacheLocked()
+                }
                 if state.unregistrationPending {
                     var candidate = state
                     candidate.unregistrationPending = false

--- a/app/Sources/DetachKit/PowerHelperPlatform.swift
+++ b/app/Sources/DetachKit/PowerHelperPlatform.swift
@@ -587,18 +587,23 @@ public final class SecureFilePowerHelperStateStore:
     public static let defaultFileURL = URL(
         fileURLWithPath: "/var/db/dev.tsarev.detach/power-state.json")
     public static let maximumBytes = 1_048_576
+    private static let requiredFileMode: mode_t = 0o600
+    private static let requiredDirectoryMode: mode_t = 0o700
 
     private let fileURL: URL
     private let fileManager: FileManager
+    private let expectedOwner: UInt32
     private let directorySyncer: (Int32) -> Int32
 
     public convenience init(
         fileURL: URL = SecureFilePowerHelperStateStore.defaultFileURL,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        expectedOwner: UInt32 = 0
     ) {
         self.init(
             fileURL: fileURL,
             fileManager: fileManager,
+            expectedOwner: expectedOwner,
             directorySyncer: Darwin.fsync)
     }
 
@@ -607,25 +612,54 @@ public final class SecureFilePowerHelperStateStore:
     init(
         fileURL: URL,
         fileManager: FileManager,
+        expectedOwner: UInt32 = 0,
         directorySyncer: @escaping (Int32) -> Int32
     ) {
         self.fileURL = fileURL
         self.fileManager = fileManager
+        self.expectedOwner = expectedOwner
         self.directorySyncer = directorySyncer
     }
 
     public func load() throws -> PowerHelperPersistentState? {
-        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
-        try rejectSymbolicLink(fileURL)
-        let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
-        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+        let directory = fileURL.deletingLastPathComponent()
+        let fileName = fileURL.lastPathComponent
+        guard !fileName.isEmpty, fileName != ".", fileName != "..",
+              !fileName.contains("/") else {
             throw PowerHelperPlatformError.insecureStatePath
         }
-        if let size = attributes[.size] as? NSNumber,
-           size.intValue > Self.maximumBytes {
-            throw PowerHelperPlatformError.stateTooLarge
+        let directoryDescriptor = Darwin.open(
+            directory.path,
+            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard directoryDescriptor >= 0 else {
+            let code = errno
+            if code == ENOENT { return nil }
+            if code == ELOOP || code == ENOTDIR {
+                throw PowerHelperPlatformError.insecureStatePath
+            }
+            throw PowerHelperPlatformError.fileSystem(
+                operation: "open directory", code: code)
         }
-        let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+        defer { Darwin.close(directoryDescriptor) }
+
+        let descriptor = fileName.withCString { name in
+            Darwin.openat(
+                directoryDescriptor, name,
+                O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        }
+        guard descriptor >= 0 else {
+            let code = errno
+            if code == ENOENT { return nil }
+            if code == ELOOP {
+                throw PowerHelperPlatformError.insecureStatePath
+            }
+            throw PowerHelperPlatformError.fileSystem(
+                operation: "open", code: code)
+        }
+        defer { Darwin.close(descriptor) }
+
+        try validateLoadedDirectory(directoryDescriptor)
+        let data = try readValidatedStateFile(descriptor)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .millisecondsSince1970
         return try decoder.decode(PowerHelperPersistentState.self, from: data)
@@ -702,6 +736,66 @@ public final class SecureFilePowerHelperStateStore:
         if values.isSymbolicLink == true {
             throw PowerHelperPlatformError.insecureStatePath
         }
+    }
+
+    private func validateLoadedDirectory(_ descriptor: Int32) throws {
+        var metadata = stat()
+        guard Darwin.fstat(descriptor, &metadata) == 0 else {
+            throw PowerHelperPlatformError.fileSystem(
+                operation: "fstat directory", code: errno)
+        }
+        let mode = metadata.st_mode
+        guard (mode & S_IFMT) == S_IFDIR,
+              UInt32(metadata.st_uid) == expectedOwner,
+              (mode & mode_t(0o777)) == Self.requiredDirectoryMode else {
+            throw PowerHelperPlatformError.insecureStatePath
+        }
+    }
+
+    private func readValidatedStateFile(_ descriptor: Int32) throws -> Data {
+        var metadata = stat()
+        guard Darwin.fstat(descriptor, &metadata) == 0 else {
+            throw PowerHelperPlatformError.fileSystem(
+                operation: "fstat", code: errno)
+        }
+        let mode = metadata.st_mode
+        guard (mode & S_IFMT) == S_IFREG,
+              metadata.st_nlink == 1,
+              UInt32(metadata.st_uid) == expectedOwner,
+              (mode & mode_t(0o777)) == Self.requiredFileMode else {
+            throw PowerHelperPlatformError.insecureStatePath
+        }
+        let size = Int(metadata.st_size)
+        guard size >= 0 else {
+            throw PowerHelperPlatformError.insecureStatePath
+        }
+        if size > Self.maximumBytes {
+            throw PowerHelperPlatformError.stateTooLarge
+        }
+        var data = Data(count: size)
+        if size > 0 {
+            try data.withUnsafeMutableBytes { buffer in
+                guard let baseAddress = buffer.baseAddress else { return }
+                var offset = 0
+                while offset < size {
+                    let count = Darwin.read(
+                        descriptor, baseAddress.advanced(by: offset),
+                        size - offset)
+                    if count < 0 {
+                        if errno == EINTR { continue }
+                        throw PowerHelperPlatformError.fileSystem(
+                            operation: "read", code: errno)
+                    }
+                    if count == 0 { break }
+                    offset += Int(count)
+                }
+                guard offset == size else {
+                    throw PowerHelperPlatformError.fileSystem(
+                        operation: "read", code: EIO)
+                }
+            }
+        }
+        return data
     }
 
     private func atomicWrite(_ data: Data, to destination: URL) throws {

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -782,7 +782,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertNil(fixture.handoffStore.transaction)
     }
 
-    func testReleasedLifetimeBarrierSkipsUnreachableHelperPreparation() async throws {
+    func testReleasedLifetimeBarrierDoesNotUnregisterWithoutPrepareProof() async {
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])
@@ -793,13 +793,37 @@ final class PowerHelperServiceTests: XCTestCase {
         fixture.defaults.set(
             "digest-previous", forKey: "powerHelperDefinitionDigest")
 
-        try await fixture.service.reconcileAfterAppUpdate()
+        await XCTAssertThrowsErrorAsync {
+            try await fixture.service.reconcileAfterAppUpdate()
+        }
 
-        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
-        XCTAssertEqual(backend.unregisterCalls, 1)
-        XCTAssertEqual(backend.registerCalls, 1)
-        XCTAssertEqual(fixture.lifecycle.cancelCalls, 1)
-        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 1)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 0)
+        XCTAssertEqual(fixture.handoffStore.transaction?.phase, .preparing)
+    }
+
+    func testEnabledMissingLifetimeLockDoesNotUnregisterWithoutPrepareProof() async {
+        let backend = FakePowerHelperBackend(
+            status: .enabled,
+            registrations: [.success(.enabled)])
+        let fixture = makeFixture(
+            backend: backend,
+            lifetimeBarrierStatus: { .missing })
+        defer { fixture.cleanup() }
+        fixture.defaults.set(
+            "digest-previous", forKey: "powerHelperDefinitionDigest")
+
+        await XCTAssertThrowsErrorAsync {
+            try await fixture.service.reconcileAfterAppUpdate()
+        }
+
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 1)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 0)
+        XCTAssertEqual(fixture.handoffStore.transaction?.phase, .preparing)
     }
 
     func testPrepareRequiresHeldLifetimeBarrierBeforeUnregisterSubmit() async {
@@ -810,7 +834,7 @@ final class PowerHelperServiceTests: XCTestCase {
             status: .enabled,
             registrations: [.success(.enabled)])
         var barrierStates: [PowerHelperLifetimeBarrierStatus] = [
-            .busy, .busy, .released,
+            .busy, .released,
         ]
         let fixture = makeFixture(
             backend: backend,
@@ -1034,7 +1058,8 @@ final class PowerHelperServiceTests: XCTestCase {
             batteryReader: RootBatteryReader(),
             bootSessionReader: RootBootSessionReader(),
             now: { Date(timeIntervalSince1970: 100) })
-        let lifecycle = RootBackedPowerHelperLifecycle(service: rootService)
+        let lifecycle = RootBackedPowerHelperLifecycle(
+            store: rootStore, backend: rootBackend, service: rootService)
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])
@@ -1059,8 +1084,14 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertEqual(backend.registerCalls, 1)
         XCTAssertEqual(lifecycle.cancelCalls, 1)
         XCTAssertFalse(rootStore.state?.unregistrationPending ?? true)
+        let postHandoff = try PowerHelperLeaseService(
+            store: rootStore,
+            backend: rootBackend,
+            batteryReader: RootBatteryReader(),
+            bootSessionReader: RootBootSessionReader(),
+            now: { Date(timeIntervalSince1970: 100) })
         XCTAssertEqual(
-            try rootService.acquireLease(
+            try postHandoff.acquireLease(
                 PowerLeaseIdentity(
                     sessionName: "post-update", runToken: "run"),
                 assertionActive: true).state,
@@ -1295,7 +1326,7 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertTrue(barrierStates.isEmpty)
     }
 
-    func testEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async throws {
+    func testEnabledZombieRegistrationWithoutLifetimeBarrierDoesNotUnregisterWithoutPrepare() async {
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])
@@ -1307,13 +1338,15 @@ final class PowerHelperServiceTests: XCTestCase {
         fixture.defaults.set(
             "digest-current", forKey: "powerHelperDefinitionDigest")
 
-        _ = try await fixture.service.reconcileAfterAppUpdate()
+        await XCTAssertThrowsErrorAsync {
+            try await fixture.service.reconcileAfterAppUpdate()
+        }
 
-        XCTAssertEqual(fixture.lifecycle.prepareCalls, 0)
-        XCTAssertEqual(backend.unregisterCalls, 1)
-        XCTAssertEqual(backend.registerCalls, 1)
-        XCTAssertEqual(fixture.lifecycle.cancelCalls, 1)
-        XCTAssertNil(fixture.handoffStore.transaction)
+        XCTAssertEqual(fixture.lifecycle.prepareCalls, 1)
+        XCTAssertEqual(backend.unregisterCalls, 0)
+        XCTAssertEqual(backend.registerCalls, 0)
+        XCTAssertEqual(fixture.lifecycle.cancelCalls, 0)
+        XCTAssertEqual(fixture.handoffStore.transaction?.phase, .preparing)
     }
 
     func testMatchingEnabledRegistrationWithBusyLifetimeBarrierNoOps() async throws {
@@ -1450,11 +1483,19 @@ private struct RootBootSessionReader: PowerBootSessionReading {
 private final class RootBackedPowerHelperLifecycle:
     PowerHelperLifecycleRunning
 {
+    private let store: RootMemoryStore
+    private let backend: RootPowerBackend
     let service: PowerHelperLeaseService
     private(set) var prepareCalls = 0
     private(set) var cancelCalls = 0
 
-    init(service: PowerHelperLeaseService) {
+    init(
+        store: RootMemoryStore,
+        backend: RootPowerBackend,
+        service: PowerHelperLeaseService
+    ) {
+        self.store = store
+        self.backend = backend
         self.service = service
     }
 
@@ -1468,7 +1509,14 @@ private final class RootBackedPowerHelperLifecycle:
 
     func cancelUnregistration() async throws {
         cancelCalls += 1
-        _ = try service.cancelUnregistration()
+        // Replacement helper: a new process loads durable state, then cancels.
+        let successor = try PowerHelperLeaseService(
+            store: store,
+            backend: backend,
+            batteryReader: RootBatteryReader(),
+            bootSessionReader: RootBootSessionReader(),
+            now: { Date(timeIntervalSince1970: 100) })
+        _ = try successor.cancelUnregistration()
     }
 }
 

--- a/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
+++ b/app/Tests/DetachAppTests/PowerHelperServiceTests.swift
@@ -1326,7 +1326,10 @@ final class PowerHelperServiceTests: XCTestCase {
         XCTAssertTrue(barrierStates.isEmpty)
     }
 
-    func testEnabledZombieRegistrationWithoutLifetimeBarrierDoesNotUnregisterWithoutPrepare() async {
+    // Keep the historical regression ID. A missing lifetime lock is not
+    // proof that KeepAlive cannot spawn a helper, so this path now fails
+    // closed at prepare instead of unregistering to reregister.
+    func testEnabledZombieRegistrationWithoutLifetimeBarrierCanReregister() async {
         let backend = FakePowerHelperBackend(
             status: .enabled,
             registrations: [.success(.enabled)])

--- a/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperLeaseServiceTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 @testable import DetachKit
 
@@ -603,11 +604,30 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
                 .serviceQuiescing)
         }
 
-        _ = try service.cancelUnregistration()
+        let successor = try makeService(store: store, backend: backend)
+        _ = try successor.cancelUnregistration()
         XCTAssertEqual(store.state?.unregistrationPending, false)
         XCTAssertEqual(
-            try service.acquireLease(identity, assertionActive: true).state,
+            try successor.acquireLease(identity, assertionActive: true).state,
             .protected)
+    }
+
+    func testCancelDuringInFlightUnregisterDoesNotClearPendingFlag() throws {
+        let store = FakeStore()
+        let backend = FakeBackend(enabled: false)
+        let service = try makeService(store: store, backend: backend)
+
+        try service.prepareForUnregistration()
+        _ = try service.cancelUnregistration()
+
+        XCTAssertEqual(store.state?.unregistrationPending, true)
+        XCTAssertThrowsError(
+            try service.acquireLease(identity, assertionActive: true)
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperLeaseServiceError,
+                .serviceQuiescing)
+        }
     }
 
     func testPrepareForUnregistrationNeverDisablesBorrowedProtection() throws {
@@ -1088,11 +1108,16 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
             .appendingPathComponent("detach-power-lease-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(
-            at: root, withIntermediateDirectories: true)
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
         let stateURL = root.appendingPathComponent("state.json")
         let corrupt = Data("not-json".utf8)
         try corrupt.write(to: stateURL)
-        let store = SecureFilePowerHelperStateStore(fileURL: stateURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: stateURL.path)
+        let store = SecureFilePowerHelperStateStore(
+            fileURL: stateURL, expectedOwner: UInt32(geteuid()))
         let backend = FakeBackend(enabled: false)
 
         let service = try PowerHelperLeaseService(
@@ -1123,12 +1148,17 @@ final class PowerHelperLeaseServiceTests: XCTestCase {
             .appendingPathComponent("detach-power-lease-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(
-            at: root, withIntermediateDirectories: true)
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
         let stateURL = root.appendingPathComponent("state.json")
         try Data(
             #"{"schema":2,"owns_closed_lid_protection":true,"leases":[]}"#.utf8
         ).write(to: stateURL)
-        let store = SecureFilePowerHelperStateStore(fileURL: stateURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: stateURL.path)
+        let store = SecureFilePowerHelperStateStore(
+            fileURL: stateURL, expectedOwner: UInt32(geteuid()))
         // The unreadable file claimed ownership of a setting that is still
         // enabled. A clean start must treat it as borrowed and never
         // disable it.

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Security
 import XCTest
 @testable import DetachKit
@@ -765,6 +766,173 @@ final class PowerHelperPlatformTests: XCTestCase {
                     error as? PowerHelperPlatformError, .insecureStatePath)
             }
         }
+    }
+
+    func testSecureFileStoreLoadRejectsRelativeAndRootStateNames() {
+        for url in [
+            URL(fileURLWithPath: "/var/db/dev.tsarev.detach/."),
+            URL(fileURLWithPath: "/var/db/dev.tsarev.detach/.."),
+            URL(fileURLWithPath: "/"),
+        ] {
+            XCTAssertThrowsError(
+                try SecureFilePowerHelperStateStore(fileURL: url).load()
+            ) { error in
+                XCTAssertEqual(
+                    error as? PowerHelperPlatformError, .insecureStatePath)
+            }
+        }
+    }
+
+    func testSecureFileStoreLoadReturnsNilWhenOwnedDirectoryHasNoStateFile() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+
+        XCTAssertNil(try makeUserOwnedStateStore(
+            fileURL: root.appendingPathComponent("state.json")).load())
+    }
+
+    func testSecureFileStoreLoadRejectsSymlinkAndFileParents() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true)
+        let realDirectory = root.appendingPathComponent("real")
+        let linkedDirectory = root.appendingPathComponent("linked")
+        try FileManager.default.createDirectory(
+            at: realDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: linkedDirectory.path,
+            withDestinationPath: realDirectory.path)
+
+        XCTAssertThrowsError(try SecureFilePowerHelperStateStore(
+            fileURL: linkedDirectory.appendingPathComponent("state.json")
+        ).load()) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError, .insecureStatePath)
+        }
+
+        let ordinaryFile = root.appendingPathComponent("not-a-directory")
+        try Data().write(to: ordinaryFile)
+        XCTAssertThrowsError(try SecureFilePowerHelperStateStore(
+            fileURL: ordinaryFile.appendingPathComponent("state.json")
+        ).load()) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError, .insecureStatePath)
+        }
+    }
+
+    func testSecureFileStoreLoadRejectsDirectoryAndHardLinkedStateFiles() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let directoryState = root.appendingPathComponent("state-dir.json")
+        try FileManager.default.createDirectory(
+            at: directoryState,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(fileURL: directoryState).load()
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError, .insecureStatePath)
+        }
+
+        let payload = Data(
+            #"{"schema":1,"owns_closed_lid_protection":false,"leases":[]}"#.utf8)
+        let original = root.appendingPathComponent("state.json")
+        let linked = root.appendingPathComponent("state-link.json")
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: original.path,
+            contents: payload,
+            attributes: [.posixPermissions: 0o600]))
+        XCTAssertEqual(link(original.path, linked.path), 0)
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(fileURL: linked).load()
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError, .insecureStatePath)
+        }
+    }
+
+    func testSecureFileStoreLoadSurfacesUnreadableStateFile() throws {
+        try XCTSkipIf(
+            geteuid() == 0, "permission checks do not constrain the root user")
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let stateURL = root.appendingPathComponent("state.json")
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: stateURL.path,
+            contents: Data("{}".utf8),
+            attributes: [.posixPermissions: 0o000]))
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(fileURL: stateURL).load()
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError,
+                .fileSystem(operation: "open", code: EACCES))
+        }
+    }
+
+    func testSecureFileStoreLoadSurfacesUnsearchableStateDirectory() throws {
+        try XCTSkipIf(
+            geteuid() == 0, "permission checks do not constrain the root user")
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000], ofItemAtPath: root.path)
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: root.path)
+        }
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(
+                fileURL: root.appendingPathComponent("state.json")).load()
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError,
+                .fileSystem(operation: "open directory", code: EACCES))
+        }
+    }
+
+    func testSecureFileStoreLoadRejectsEmptyOwnedStateAsUndecodable() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let stateURL = root.appendingPathComponent("state.json")
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: stateURL.path,
+            contents: Data(),
+            attributes: [.posixPermissions: 0o600]))
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(fileURL: stateURL).load()
+        ) { XCTAssertTrue($0 is DecodingError) }
     }
 
     func testClientCodeRequirementPinsAppleAnchorIdentifierAndTeam() {

--- a/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperPlatformTests.swift
@@ -347,7 +347,7 @@ final class PowerHelperPlatformTests: XCTestCase {
             .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
         let url = root.appendingPathComponent("state.json")
-        let store = SecureFilePowerHelperStateStore(fileURL: url)
+        let store = makeUserOwnedStateStore(fileURL: url)
         let state = PowerHelperPersistentState(
             ownsClosedLidProtection: true,
             leases: [PowerLease(
@@ -372,7 +372,7 @@ final class PowerHelperPlatformTests: XCTestCase {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
-        let store = SecureFilePowerHelperStateStore(
+        let store = makeUserOwnedStateStore(
             fileURL: root.appendingPathComponent("state.json"))
         let initial = PowerHelperPersistentState()
         let replacement = PowerHelperPersistentState(
@@ -437,14 +437,17 @@ final class PowerHelperPlatformTests: XCTestCase {
             .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(
-            at: root, withIntermediateDirectories: true)
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
         let state = root.appendingPathComponent("state.json")
         XCTAssertTrue(FileManager.default.createFile(
             atPath: state.path,
-            contents: Data(count: SecureFilePowerHelperStateStore.maximumBytes + 1)))
+            contents: Data(count: SecureFilePowerHelperStateStore.maximumBytes + 1),
+            attributes: [.posixPermissions: 0o600]))
 
         XCTAssertThrowsError(
-            try SecureFilePowerHelperStateStore(fileURL: state).load()
+            try makeUserOwnedStateStore(fileURL: state).load()
         ) { error in
             XCTAssertEqual(error as? PowerHelperPlatformError, .stateTooLarge)
         }
@@ -498,12 +501,16 @@ final class PowerHelperPlatformTests: XCTestCase {
             .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(
-            at: root, withIntermediateDirectories: true)
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
         let stateURL = root.appendingPathComponent("state.json")
         try Data("not-json".utf8).write(to: stateURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: stateURL.path)
 
         XCTAssertThrowsError(
-            try SecureFilePowerHelperStateStore(fileURL: stateURL).load()
+            try makeUserOwnedStateStore(fileURL: stateURL).load()
         ) { XCTAssertTrue($0 is DecodingError) }
     }
 
@@ -516,7 +523,7 @@ final class PowerHelperPlatformTests: XCTestCase {
         let stateURL = root.appendingPathComponent("state.json")
         let corrupt = Data("not-json".utf8)
         try corrupt.write(to: stateURL)
-        let store = SecureFilePowerHelperStateStore(fileURL: stateURL)
+        let store = makeUserOwnedStateStore(fileURL: stateURL)
 
         try store.quarantineUnreadableState()
 
@@ -714,6 +721,52 @@ final class PowerHelperPlatformTests: XCTestCase {
         XCTAssertEqual(mode.intValue & 0o777, 0o700)
     }
 
+    func testSecureFileStoreLoadRefusesNonRootOrOverlyPermissiveState() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detach-power-store-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let stateURL = root.appendingPathComponent("state.json")
+        let payload = Data(
+            #"{"schema":1,"owns_closed_lid_protection":false,"leases":[]}"#.utf8)
+        try payload.write(to: stateURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644], ofItemAtPath: stateURL.path)
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(fileURL: stateURL).load()
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError, .insecureStatePath)
+        }
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: stateURL.path)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: root.path)
+
+        XCTAssertThrowsError(
+            try makeUserOwnedStateStore(fileURL: stateURL).load()
+        ) { error in
+            XCTAssertEqual(
+                error as? PowerHelperPlatformError, .insecureStatePath)
+        }
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: root.path)
+        if geteuid() != 0 {
+            XCTAssertThrowsError(
+                try SecureFilePowerHelperStateStore(fileURL: stateURL).load()
+            ) { error in
+                XCTAssertEqual(
+                    error as? PowerHelperPlatformError, .insecureStatePath)
+            }
+        }
+    }
+
     func testClientCodeRequirementPinsAppleAnchorIdentifierAndTeam() {
         XCTAssertEqual(
             PowerHelperCodeSigningRequirement.client(
@@ -767,5 +820,23 @@ final class PowerHelperPlatformTests: XCTestCase {
         for (error, description) in cases {
             XCTAssertEqual(error.localizedDescription, description)
         }
+    }
+
+    private func makeUserOwnedStateStore(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        directorySyncer: ((Int32) -> Int32)? = nil
+    ) -> SecureFilePowerHelperStateStore {
+        if let directorySyncer {
+            return SecureFilePowerHelperStateStore(
+                fileURL: fileURL,
+                fileManager: fileManager,
+                expectedOwner: UInt32(geteuid()),
+                directorySyncer: directorySyncer)
+        }
+        return SecureFilePowerHelperStateStore(
+            fileURL: fileURL,
+            fileManager: fileManager,
+            expectedOwner: UInt32(geteuid()))
     }
 }

--- a/app/Tests/DetachKitTests/PowerHelperXPCServiceTests.swift
+++ b/app/Tests/DetachKitTests/PowerHelperXPCServiceTests.swift
@@ -112,7 +112,8 @@ final class PowerHelperXPCServiceTests: XCTestCase {
     }
 
     func testPrepareAndCancelUnregistrationGateNewLeases() throws {
-        let bridge = try makeBridge(lowBattery: false)
+        let store = MemoryStore()
+        let bridge = try makeBridge(lowBattery: false, store: store)
         let prepared = expectation(description: "prepared")
         bridge.prepareForUnregistration { error in
             XCTAssertNil(error)
@@ -140,8 +141,29 @@ final class PowerHelperXPCServiceTests: XCTestCase {
         }
         wait(for: [cancelled], timeout: 1)
 
-        let accepted = expectation(description: "accepted")
+        let stillQuiescing = expectation(description: "same-process cancel stays quiesced")
         bridge.acquireLease(
+            sessionName: "session", runToken: "run", assertionActive: true,
+            requestDeadline: 200
+        ) { confirmed, error in
+            XCTAssertFalse(confirmed)
+            XCTAssertEqual(
+                error?.code,
+                PowerHelperXPCService.ErrorCode.serviceQuiescing.rawValue)
+            stillQuiescing.fulfill()
+        }
+        wait(for: [stillQuiescing], timeout: 1)
+
+        let successor = try makeBridge(lowBattery: false, store: store)
+        let successorCancelled = expectation(description: "successor cancelled")
+        successor.cancelUnregistration { error in
+            XCTAssertNil(error)
+            successorCancelled.fulfill()
+        }
+        wait(for: [successorCancelled], timeout: 1)
+
+        let accepted = expectation(description: "accepted")
+        successor.acquireLease(
             sessionName: "session", runToken: "run", assertionActive: true,
             requestDeadline: 200
         ) { confirmed, error in
@@ -254,18 +276,20 @@ final class PowerHelperXPCServiceTests: XCTestCase {
         wait(for: [active], timeout: 1)
 
         let cancelStore = MemoryStore()
-        let cancelBridge = try makeBridge(
+        let preparedBridge = try makeBridge(
             lowBattery: false, store: cancelStore)
         let prepared = expectation(description: "prepared for failed cancel")
-        cancelBridge.prepareForUnregistration { error in
+        preparedBridge.prepareForUnregistration { error in
             XCTAssertNil(error)
             prepared.fulfill()
         }
         wait(for: [prepared], timeout: 1)
 
         cancelStore.saveError = ExpectedFailure()
+        let successor = try makeBridge(
+            lowBattery: false, store: cancelStore)
         let failedCancel = expectation(description: "failed cancel")
-        cancelBridge.cancelUnregistration { error in
+        successor.cancelUnregistration { error in
             XCTAssertEqual(
                 error?.code,
                 PowerHelperXPCService.ErrorCode.generic.rawValue)

--- a/docs/specs/power.md
+++ b/docs/specs/power.md
@@ -72,11 +72,11 @@ or watchdog. The app, helper, and watchdog must have their exact code
 identifiers and the same valid Team ID. An ad-hoc build or preview stays
 read-only at this boundary.
 
-An enabled registration needs a held root lifetime lock before the app calls
-the helper's prepare method. A missing or released lifetime lock proves that no
-helper process can answer. The app then skips XPC preparation and replays the
-submitted unregister phase under the system and per-user transaction locks.
-Only a busy lifetime lock permits the prepare call. A replacement is not
+Do not skip XPC prepare only because the lifetime lock is missing or released
+while the job is enabled. KeepAlive can still start a helper that holds leases.
+The app calls prepare, or it fails closed, until it has proof that the helper
+cannot answer. Only a successful prepare and a busy lifetime lock permit the
+submitted unregister phase. A replacement is not
 registered until the old lifetime lock is released or an exact absent-job
 callback provides the required completion barrier.
 Lifetime and system handoff probes reject special files without waiting for
@@ -102,13 +102,15 @@ kernel `flock` across the complete asynchronous SMAppService transaction. This
 is the machine-wide single-writer barrier across Fast User Switching, and the
 kernel releases it if the app crashes. Only the current non-root console user's
 app may perform register or unregister mutations, checked again immediately
-before each mutation. Root persists `unregistration_pending`, blocks
-acquire/renew without a wall-clock expiry, and restores and reads back only the
-setting Detach owns.
+before each mutation. Root persists `unregistration_pending` until unregister
+completion or a proven absent job. A cancel during an in-flight unregister does
+not clear that flag. Root blocks acquire/renew without a wall-clock expiry, and
+restores and reads back only the setting Detach owns.
 
 The helper takes a root-owned lifetime `flock` before its listener answers and
-holds it until exit. An enabled job without this boot's lock is dead. The app
-writes `unregisterSubmitted` only after it observes that lock. Registration
+holds it until exit. A missing lock does not prove that an enabled job cannot
+start. The app writes `unregisterSubmitted` only after a successful prepare
+and a held lock. Registration
 needs the fresh unregister callback, or exact `notRegistered` status plus the
 released lock or a changed boot UUID; `unavailable` is insufficient. Errors
 keep the journal and root gate closed. After an app crash, another console user
@@ -138,7 +140,8 @@ rejected. Detach does not promise session survival across logout.
 
 Helper state is durable at `/var/db/dev.tsarev.detach/power-state.json`, with a
 private `0700` directory, `0600` regular file, symlink rejection, atomic writes,
-and file/directory fsync. Ownership intent is persisted before changing power
+and file/directory fsync. Load accepts only a root-owned `0600` regular file
+under that parent. Ownership intent is persisted before changing power
 state. A pre-existing enabled setting is borrowed and never disabled. A setting
 Detach enabled is restored after the last live lease, a stale lease, low
 battery, or orderly SIGTERM/SIGINT handling. After shutdown begins, the helper


### PR DESCRIPTION
## Contract delta

`docs/specs/power.md` (MODIFIED):

- ADDED: Do not skip XPC prepare only because the lifetime lock is missing or released while the job is enabled. KeepAlive can still start a helper that holds leases. The app calls prepare, or it fails closed, until it has proof that the helper cannot answer.
- ADDED: Only a successful prepare and a busy lifetime lock permit the submitted unregister phase.
- ADDED: Root persists `unregistration_pending` until unregister completion or a proven absent job. A cancel during an in-flight unregister does not clear that flag.
- ADDED: Load accepts only a root-owned `0600` regular file under the expected parent.
- REMOVED: A missing or released lifetime lock proves that no helper can answer, so the app may skip prepare and replay unregister.

This PR may overlap `PowerHelperLeaseService.swift` and `docs/specs/power.md` with #242. Rebase after #242 merges if needed. The change is independently reviewable from `main` and does not alter acquire-deadline or battery-throw behavior.

## Durable decisions

- An enabled SMAppService job is still spawnable via KeepAlive. A missing lifetime lock is not proof that no helper can answer, so unregister stays fail-closed until prepare succeeds and the lock is held.
- `cancelUnregistration` on the same process that prepared leaves `unregistration_pending` set. A replacement helper (new process) may clear it after register.
- Helper state `load()` opens the expected parent with `O_NOFOLLOW`, then `openat`s the file, and accepts only a root-owned `0600` regular file under a root-owned `0700` directory.

## Acceptance evidence

- [x] App unit: enabled + missing lifetime lock does not unregister without prepare proof — `testEnabledMissingLifetimeLockDoesNotUnregisterWithoutPrepareProof` passed
- [x] Helper unit: cancel during in-flight unregister does not clear the pending flag — `testCancelDuringInFlightUnregisterDoesNotClearPendingFlag` passed
- [x] Platform unit: load refuses a non-root or overly permissive state file — `testSecureFileStoreLoadRefusesNonRootOrOverlyPermissiveState` passed
- [x] Focused Swift filter `PowerHelperServiceTests|PowerHelperLeaseServiceTests|PowerHelperPlatformTests|PowerHelperLifetimeBarrierTests` — 152 tests, 0 failures (local macOS 15.7.9 host; no deployment-target or `_np` shim committed)
- [ ] Hosted `quality-gates` (no lid claim)

`scripts/quality-gate --plan --explain` selected `static,swift,quality-contracts,app,ui-e2e`. The full repository gate and real lid tests were not run.

Closes #236