### PR TITLE
Keep initializing sessions visible and reject a foreign resume UUID

### DIFF
--- a/app/Sources/DetachKit/DetachState.swift
+++ b/app/Sources/DetachKit/DetachState.swift
@@ -432,10 +432,11 @@ public enum TranscriptDocument {
         }
     }
 
-    /// Validates every non-empty JSONL record and the provider-specific root
+    /// Validates every non-empty JSONL record and the provider-specific
     /// identity contract. Claude permits records without `sessionId`, but at
-    /// least one record must identify the expected session and no record may
-    /// identify a different one.
+    /// least one record must identify the expected session. Codex requires
+    /// that identity on record 0. Later Codex records may omit it. No record
+    /// may identify a different session.
     public static func isValid(
         _ data: Data,
         provider: Provider,
@@ -499,13 +500,22 @@ public enum TranscriptDocument {
         ) { record, recordIndex in
             switch provider {
             case .codex:
-                guard recordIndex == 0 else { return true }
                 guard let payload = record["payload"] as? [String: Any] else {
-                    providerContractValid = false
-                    return false
+                    if recordIndex == 0 {
+                        providerContractValid = false
+                        return false
+                    }
+                    return true
                 }
                 let identifier = payload["id"] as? String
                     ?? payload["session_id"] as? String
+                if recordIndex == 0 {
+                    providerContractValid = identifier == expectedSessionID
+                    return providerContractValid
+                }
+                guard let identifier else {
+                    return true
+                }
                 providerContractValid = identifier == expectedSessionID
                 return providerContractValid
 

--- a/app/Tests/DetachKitTests/DetachStateTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateTests.swift
@@ -408,6 +408,22 @@ final class DetachStateTests: XCTestCase {
             expectedSessionID: "session-1"))
     }
 
+    func testCodexJSONLValidationSkipsLaterRecordsWithoutPayloadOrIdentity() {
+        let laterWithoutPayload = Data("""
+        {"payload":{"id":"session-1"}}
+        {"type":"event_msg"}
+        """.utf8)
+        let laterWithoutIdentity = Data("""
+        {"payload":{"id":"session-1"}}
+        {"payload":{"type":"task_started","turn_id":"turn-1"}}
+        """.utf8)
+
+        XCTAssertTrue(TranscriptDocument.isValid(
+            laterWithoutPayload, provider: .codex, expectedSessionID: "session-1"))
+        XCTAssertTrue(TranscriptDocument.isValid(
+            laterWithoutIdentity, provider: .codex, expectedSessionID: "session-1"))
+    }
+
     func testJSONLValidationStreamsGeneratedChunksWithoutRetainingTheTranscript() throws {
         let root = Data(#"{"payload":{"id":"session-1"}}"#.utf8)
         let event = Data(#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#.utf8)

--- a/app/Tests/DetachKitTests/DetachStateTests.swift
+++ b/app/Tests/DetachKitTests/DetachStateTests.swift
@@ -299,7 +299,11 @@ final class DetachStateTests: XCTestCase {
     }
 
     func testFileAndHandleTranscriptAPIsPreserveStreamingContracts() throws {
-        let data = Data("""
+        let valid = Data("""
+        {"payload":{"id":"session-1"}}
+        {"payload":{"session_id":"session-1"}}
+        """.utf8)
+        let scalar = Data("""
         {"payload":{"id":"session-1"}}
         {"payload":{"session_id":"fallback"}}
         """.utf8)
@@ -308,7 +312,7 @@ final class DetachStateTests: XCTestCase {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
         let transcript = directory.appendingPathComponent("rollout.jsonl")
-        try data.write(to: transcript)
+        try valid.write(to: transcript)
 
         XCTAssertEqual(
             try TranscriptDocument.firstScalar(inFileAt: transcript, paths: ["payload.id"]),
@@ -317,7 +321,7 @@ final class DetachStateTests: XCTestCase {
             fileAt: transcript, provider: .codex, expectedSessionID: "session-1"))
 
         let scalarPipe = Pipe()
-        scalarPipe.fileHandleForWriting.write(data)
+        scalarPipe.fileHandleForWriting.write(scalar)
         try scalarPipe.fileHandleForWriting.close()
         XCTAssertEqual(
             try TranscriptDocument.firstScalar(
@@ -325,7 +329,7 @@ final class DetachStateTests: XCTestCase {
             .string("fallback"))
 
         let validationPipe = Pipe()
-        validationPipe.fileHandleForWriting.write(data)
+        validationPipe.fileHandleForWriting.write(valid)
         try validationPipe.fileHandleForWriting.close()
         XCTAssertTrue(try TranscriptDocument.isValid(
             reading: validationPipe.fileHandleForReading,
@@ -342,6 +346,14 @@ final class DetachStateTests: XCTestCase {
         {"payload":{"id":"session-2"}}
         {"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}
         """.utf8)
+        let laterForeign = Data("""
+        {"payload":{"id":"session-1"}}
+        {"type":"event_msg","payload":{"id":"session-2","type":"task_started"}}
+        """.utf8)
+        let laterForeignSessionID = Data("""
+        {"payload":{"id":"session-1"}}
+        {"payload":{"session_id":"session-2"}}
+        """.utf8)
         let malformed = Data("""
         {"payload":{"id":"session-1"}}
         not-json
@@ -351,6 +363,10 @@ final class DetachStateTests: XCTestCase {
             valid, provider: .codex, expectedSessionID: "session-1"))
         XCTAssertFalse(TranscriptDocument.isValid(
             foreign, provider: .codex, expectedSessionID: "session-1"))
+        XCTAssertFalse(TranscriptDocument.isValid(
+            laterForeign, provider: .codex, expectedSessionID: "session-1"))
+        XCTAssertFalse(TranscriptDocument.isValid(
+            laterForeignSessionID, provider: .codex, expectedSessionID: "session-1"))
         XCTAssertFalse(TranscriptDocument.isValid(
             malformed, provider: .codex, expectedSessionID: "session-1"))
     }

--- a/bin/detach
+++ b/bin/detach
@@ -585,6 +585,9 @@ resume_auto() {
   local session_name
   local project_dir
   local live
+  local requested_name=""
+  local expect_requested_name=0
+  local bound_short=""
   local resume_args=( "$@" )
 
   [ "$#" -gt 0 ] || die "resume requires a session UUID"
@@ -666,6 +669,31 @@ resume_auto() {
   [ -n "$project_dir" ] && [ -d "$project_dir" ] || \
     die "saved project directory is unavailable: ${project_dir:-unknown}"
   cd -P "$project_dir" >/dev/null 2>&1 || die "could not enter saved project directory: $project_dir"
+  if [ "$has_name" -eq 1 ] && [ -n "$session_name" ]; then
+    requested_name=""
+    expect_requested_name=0
+    bound_short=""
+    for arg in "${resume_args[@]}"; do
+      if [ "$expect_requested_name" -eq 1 ]; then
+        requested_name="$arg"
+        break
+      fi
+      case "$arg" in
+        -n|--name)
+          expect_requested_name=1
+          ;;
+        --name=*)
+          requested_name="${arg#--name=}"
+          break
+          ;;
+      esac
+    done
+    bound_short="${session_name#detach-${provider}-}"
+    if [ "$requested_name" != "$session_name" ] && \
+       [ "$requested_name" != "$bound_short" ]; then
+      die "session UUID already belongs to a different session name: $session_name"
+    fi
+  fi
   if [ "$has_name" -eq 0 ] && [ -n "$session_name" ]; then
     exec_provider "$provider" resume --name "$session_name" "${resume_args[@]}"
   fi

--- a/bin/detach-core
+++ b/bin/detach-core
@@ -7275,12 +7275,19 @@ list_session_records() {
       fi
       continue
     fi
-    # `initializing` metadata exists only so the worker and starter can share
-    # one typed document. It is not a coherent list record until the worker has
-    # published its exact PID against the configured tmux run token.
+    # A private initializing handoff stays hidden. A managed pane or a recorded
+    # worker means the owner can still Attach or Stop, so List keeps the row.
     if [ "$META_LIFECYCLE_PHASE" = "initializing" ] && \
        [ "$META_PRESERVE_RECOVERY_UNTIL_READY" != "true" ]; then
-      continue
+      tmux_health_snapshot "$session"
+      case "$TMUX_HEALTH_STATE" in
+        live|dead) ;;
+        *)
+          case "$META_WORKER_PID" in
+            ''|*[!0-9]*) continue ;;
+          esac
+          ;;
+      esac
     fi
     health_status="$META_STATUS"
     health_id="$META_AGENT_SESSION_ID"

--- a/docs/specs/runtime.md
+++ b/docs/specs/runtime.md
@@ -108,8 +108,10 @@ detach-power run --session <name> --run-token <token>
 
 Metadata has a typed phase machine: `initializing`, `starting`, `running`,
 `stopping`, `finalizing`, `terminal`. Invalid transitions fail; `status` stores
-outcomes. List hides `initializing`. The worker emits `starting` only after its
-metadata and tmux identity match; only then can provider PID be absent. The
+outcomes. List hides `initializing` unless a managed pane or proven ownership
+remains, or `preserve_recovery_until_ready` is true. The worker emits
+`starting` only after its metadata and tmux identity match; only then can
+provider PID be absent. The
 power wrapper confirms both layers and publishes readiness and exact provider
 PID. The starter proves ancestry before `running` and prints `Started` last.
 HUP/INT/TERM forward while the wrapper releases its lease and assertion;
@@ -173,8 +175,9 @@ user thread (for example `/clear`), discovery rebinds identity, transcript, and
 checkpoints to the newest originator-matched thread within one heartbeat or
 checkpoint tick, records superseded thread IDs so the next switch stays
 unambiguous, and keeps the current binding on a creation-time tie. Subagent
-threads never rebind a session. Wrapper-owned provider flags are rejected;
-policy defaults apply only without an allowed override.
+threads never rebind a session. Public `resume --name` rejects a UUID that
+already belongs to a different session name. Wrapper-owned provider flags are
+rejected; policy defaults apply only without an allowed override.
 
 By default, a per-session lock protects a checkpoint every 300 s. It has
 metadata, validated provider JSONL, pane capture, and a repository root from a

--- a/docs/specs/state.md
+++ b/docs/specs/state.md
@@ -4,6 +4,8 @@
 
 `detach-state` is the JSON boundary. Never edit JSON in shell. It owns typed
 metadata, JSONL, health, reconcile, storage, emit, and event operations.
+Codex and Claude JSONL validation reject a record that names a different
+session.
 `meta snapshots` enumerates one owned sessions root through anchored directory
 descriptors. It rejects unsafe directories and opens only owned regular files
 of at most 1 MiB with `O_NOFOLLOW`. Storage metadata, checkpoint fallback

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2083,6 +2083,46 @@ expected_rollout="$("$STATE_HELPER" meta get "$meta" transcript_path)"
 [ -n "$expected_rollout" ]
 [ -f "$expected_rollout" ]
 
+# A crashed start can leave initializing metadata in front of a live pane.
+# List must keep that row so the owner can Attach or Stop.
+initializing_live_session=detach-codex-initializing-live
+initializing_live_dir="$DETACH_CODEX_STATE_ROOT/sessions/$initializing_live_session"
+mkdir -p "$initializing_live_dir"
+"$STATE_HELPER" meta create "$initializing_live_dir/meta.json" \
+  --integer schema 1 \
+  --string session_name "$initializing_live_session" \
+  --string project_dir "$ROOT" \
+  --string status starting \
+  --string lifecycle_phase initializing \
+  --string run_token initializing-live-token \
+  --integer health_schema 1
+initializing_live_pane="$(tmux -L "$SOCKET" new-session -d -P -F '#{pane_id}' \
+  -s "$initializing_live_session" -n initializing '/bin/sleep 30')"
+tmux -L "$SOCKET" set-option -q -t "=$initializing_live_session:" @detach 1
+tmux -L "$SOCKET" set-option -q -t "=$initializing_live_session:" @detach_provider codex
+tmux -L "$SOCKET" set-option -q -t "=$initializing_live_session:" \
+  @detach_run_token initializing-live-token
+tmux -L "$SOCKET" set-option -q -t "=$initializing_live_session:" \
+  @detach_pane_id "$initializing_live_pane"
+run_codex list --json | grep -F "\"session_name\":\"$initializing_live_session\"" >/dev/null
+tmux -L "$SOCKET" kill-session -t "=$initializing_live_session"
+rm -rf "$initializing_live_dir"
+
+# Public resume --name must not bind one UUID into a second session slot.
+foreign_resume_name=OTHER
+foreign_resume_session=detach-codex-OTHER
+foreign_resume_output="$TMP_ROOT/foreign-resume-name.out"
+if "$SCRIPT" resume --name "$foreign_resume_name" --detach "$expected_id" \
+     >"$foreign_resume_output" 2>&1; then
+  printf 'public resume --name rebound a bound session UUID\n' >&2
+  exit 1
+fi
+grep -F 'already belongs to a different session name' \
+  "$foreign_resume_output" >/dev/null
+! tmux -L "$SOCKET" has-session -t "=$foreign_resume_session" 2>/dev/null
+[ ! -e "$DETACH_CODEX_STATE_ROOT/sessions/$foreign_resume_session" ]
+[ "$("$STATE_HELPER" meta get "$meta" codex_session_id)" = "$expected_id" ]
+
 # Resume can reuse a harness name for a different provider UUID. Until that
 # replacement passes both readiness proofs, the complete checkpoint for the
 # previous UUID and its saved options must remain the Recover target.


### PR DESCRIPTION
## Contract delta

- `docs/specs/runtime.md` **MODIFIED**: List hides `initializing` unless a managed pane or proven ownership remains, or `preserve_recovery_until_ready` is true. Public `resume --name` rejects a UUID that already belongs to a different session name.
- `docs/specs/state.md` **MODIFIED**: Codex and Claude JSONL validation reject a record that names a different session.

## Durable decisions

- A private initializing handoff with no managed pane and no recorded worker stays hidden. A crashed start that still has a managed pane stays on List so the owner can Attach or Stop.
- Public `resume --name OTHER UUID` is rejected when that UUID is already bound. App `resume --detach <id>` is unchanged.
- Codex transcript identity is checked on every record, the same way Claude checks `sessionId`. Record 0 still requires a matching payload identity.

This PR overlaps `#243` on `bin/detach-core` and `#237` on `bin/detach`. It stays independently reviewable from `main` and does not change `list --json --quick` defaults, typed-state mutation I/O, or Claude restore/publish.

## Acceptance evidence

- `list --json` includes an initializing session that still has a live pane (`tests/run.sh` resume shard): PASS
- `resume --name OTHER <uuid>` fails when that uuid is already bound (`tests/run.sh` resume shard): PASS
- Codex JSONL with a foreign id after record 0 is rejected (`DetachStateTests`): not run locally (host macOS 15, binaries target 26; no deployment-target shim)
- Focused `DETACH_CODEX_TEST_PART=resume tests/run.sh`: PASS (`Codex detach integration tests passed (resume)`)
- Hosted `quality-gates`: not run (PR authority)

Closes #239