### PR TITLE
Keep expected CLI refusals off the provider-suite log

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -124,8 +124,9 @@
   temporary state and tmux server for inspection. Use
   `DETACH_CLAUDE_TEST_KEEP=1` with the Claude command.
 - Long-lived provider fixtures use bounded release files. They do not use a
-  fixed sleep window for liveness checks. Failure artifacts identify the
-  failing test line.
+  fixed sleep window for liveness checks. On a suite failure, the suite log
+  prints the failing command, then the line, then the artifact path. Expected
+  public-CLI refusals do not print unmarked `die` text on the suite log.
 - `tests/distribution.sh` — immutable install/upgrade/repair/doctor/uninstall
   coverage for the fixed payload (`detach`, `detach-core`, `detach-install`,
   `detach-state`, `detach-power`, and `tmux`) with a temporary home.

--- a/tests/run-claude.sh
+++ b/tests/run-claude.sh
@@ -75,6 +75,20 @@ tmux() {
   "$TMUX_TEST_BIN" "$@"
 }
 
+expect_cli_refusal() {
+  local label="$1"
+  shift
+  local stdout_file="$TMP_ROOT/expected-refusal.stdout"
+  local stderr_file="$TMP_ROOT/expected-refusal.stderr"
+  if "$@" >"$stdout_file" 2>"$stderr_file"; then
+    printf 'expected CLI refusal succeeded: %s\n' "$label" >&2
+    cat "$stderr_file" >&2
+    return 1
+  fi
+  printf 'expected CLI refusal: %s\n' "$label" >&2
+  return 0
+}
+
 # Mirrors blend_session_color in detach-core so the tint contract is pinned
 # independently of the implementation.
 expected_tint() {
@@ -113,6 +127,9 @@ preserve_failure_diagnostics() {
   find "$TMP_ROOT" -maxdepth 3 -type f -print 2>/dev/null | \
     sed "s#^$TMP_ROOT#TMP_ROOT#" | LC_ALL=C sort >"$ARTIFACT_DIR/file-inventory.txt"
   chmod 0600 "$ARTIFACT_DIR/file-inventory.txt"
+  if [ -n "$FAILURE_COMMAND" ]; then
+    printf 'Claude test failed command: %s\n' "$FAILURE_COMMAND" >&2
+  fi
   [ -z "$FAILURE_LINE" ] || printf 'Claude test failed at line %s\n' "$FAILURE_LINE" >&2
   printf 'Claude diagnostics preserved at %s\n' "$ARTIFACT_DIR" >&2
 }
@@ -526,10 +543,8 @@ TMUX_TMPDIR="$TMP_ROOT/unrelated-tmux-tmpdir" \
 
 # Exercise cross-provider routing while the fake Claude worker is definitely
 # live; the later metadata and checkpoint assertions intentionally do more IO.
-if "$SCRIPT" codex --name cross-provider --detach -- 'must not run beside Claude'; then
-  printf 'Codex unexpectedly started beside a running Claude task\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'Codex start beside Claude' \
+  "$SCRIPT" codex --name cross-provider --detach -- 'must not run beside Claude'
 "$STATE_HELPER" meta matches "$meta" claude "$session_id"
 test_sqlite "$CODEX_HOME/state_5.sqlite" \
   'CREATE TABLE IF NOT EXISTS threads (id TEXT PRIMARY KEY, rollout_path TEXT NOT NULL, created_at_ms INTEGER, updated_at_ms INTEGER, source TEXT, thread_source TEXT, cwd TEXT);'
@@ -553,10 +568,8 @@ rm -f "$CLAUDE_CONFIG_DIR/projects/foreign/$codex_only_id.jsonl"
 
 test_sqlite "$CODEX_HOME/state_5.sqlite" \
   "INSERT INTO threads (id, rollout_path, source, thread_source, cwd) VALUES ('$session_id', '/tmp/not-used.jsonl', 'cli', 'user', '$ROOT');"
-if "$SCRIPT" resume --detach "$session_id"; then
-  printf 'Cross-provider resume accepted a UUID shared by both providers\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'cross-provider UUID' \
+  "$SCRIPT" resume --detach "$session_id"
 test_sqlite "$CODEX_HOME/state_5.sqlite" "DELETE FROM threads WHERE id = '$session_id';"
 
 require_session_json() {
@@ -878,10 +891,8 @@ printf '{"type":"user","sessionId":"%s","cwd":"%s","message":{"role":"user","con
   >"$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl"
 unsafe_resume_live_hash="$(shasum -a 256 \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" | awk '{print $1}')"
-if "$SCRIPT" claude resume --name "$human_label" --detach "$session_id"; then
-  printf 'Claude Resume accepted an unsafe recovery destination\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'unsafe recovery destination' \
+  "$SCRIPT" claude resume --name "$human_label" --detach "$session_id"
 [ "$(shasum -a 256 "$checkpoint/claude-session.tar" | awk '{print $1}')" = \
   "$unsafe_resume_archive_hash" ]
 [ "$(shasum -a 256 "$checkpoint/meta.json" | awk '{print $1}')" = \
@@ -902,10 +913,8 @@ unsafe_restore_json="$("$SCRIPT" claude list --json | \
 [ "$(printf '%s' "$unsafe_restore_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
 printf '%s' "$unsafe_restore_json" | grep -F '"health_actions":["delete"]' >/dev/null
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted a symlink below its canonical config root\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'symlink below config root' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 grep -Fx 'outside sentinel' "$unsafe_claude_outside/sentinel" >/dev/null
@@ -933,10 +942,8 @@ malicious_archive_json="$("$SCRIPT" claude list --json | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
 printf '%s' "$malicious_archive_json" | \
   grep -F '"health_actions":["delete"]' >/dev/null
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted a special entry in its checkpoint archive\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'special archive entry' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
@@ -969,10 +976,8 @@ conflicting_archive_json="$("$SCRIPT" claude list --json | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
 printf '%s' "$conflicting_archive_json" | \
   grep -F '"health_actions":["delete"]' >/dev/null
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted a structurally conflicting archive\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'conflicting archive' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 ! tmux -L "$SOCKET" has-session -t "=$session" 2>/dev/null
@@ -1004,10 +1009,8 @@ identity_archive_json="$("$SCRIPT" claude list --json | \
   grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$identity_archive_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted another session in its archive\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'foreign session in archive' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 diff -qr "$foreign_team_guard" "$foreign_team" >/dev/null
@@ -1019,10 +1022,8 @@ identity_destination_json="$("$SCRIPT" claude list --json | \
   grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$identity_destination_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover replaced a team owned by another session\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'foreign-owned team' \
+  "$SCRIPT" claude recover --detach "$human_label"
 diff -qr "$foreign_team_guard" "$foreign_team" >/dev/null
 mv -f "$identity_archive_good" "$checkpoint/claude-session.tar"
 rm -rf "$identity_archive_stage" "$foreign_team" "$foreign_team_guard"
@@ -1038,10 +1039,8 @@ unsafe_legacy_json="$("$SCRIPT" claude list --json | \
 [ "$(printf '%s' "$unsafe_legacy_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
 printf '%s' "$unsafe_legacy_json" | grep -F '"health_actions":["delete"]' >/dev/null
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted an unsafe legacy companion source\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'unsafe legacy companion' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 rm "$checkpoint/claude-file-history"
@@ -1054,10 +1053,8 @@ dangling_legacy_json="$("$SCRIPT" claude list --json | \
   grep -F "\"session_name\":\"$session\"")"
 [ "$(printf '%s' "$dangling_legacy_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted a dangling legacy companion symlink\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'dangling legacy companion' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx '{damaged transcript' \
   "$CLAUDE_CONFIG_DIR/projects/fake/$session_id.jsonl" >/dev/null
 rm "$checkpoint/claude-file-history"
@@ -1402,18 +1399,14 @@ fi
 mkdir -p "$CLAUDE_CONFIG_DIR/projects/copy"
 cp -p "$CLAUDE_CONFIG_DIR/projects/fake/$second_id.jsonl" \
   "$CLAUDE_CONFIG_DIR/projects/copy/$second_id.jsonl"
-if "$SCRIPT" claude resume --name duplicate --detach "$second_id"; then
-  printf 'Claude resume accepted an ambiguous duplicate transcript\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'ambiguous duplicate transcript' \
+  "$SCRIPT" claude resume --name duplicate --detach "$second_id"
 
 outside="$TMP_ROOT/must-not-overwrite.jsonl"
 printf 'outside sentinel\n' >"$outside"
 "$STATE_HELPER" meta patch "$meta" --string transcript_path "$outside"
-if "$SCRIPT" claude recover --detach "$human_label"; then
-  printf 'Claude recover accepted an unsafe transcript path\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'unsafe transcript path' \
+  "$SCRIPT" claude recover --detach "$human_label"
 grep -Fx 'outside sentinel' "$outside" >/dev/null
 
 "$SCRIPT" claude delete --force "$human_label"
@@ -1470,10 +1463,8 @@ mkdir -p "$unsafe_team_dir"
 printf '{"leadSessionId":"unrelated"}\n' >"$unsafe_team_target"
 ln -s "$unsafe_team_target" "$unsafe_team_dir/config.json"
 : >"$FAKE_CLAUDE_ARGS_FILE"
-if "$SCRIPT" resume --detach "$empty_id" >/dev/null 2>&1; then
-  printf 'metadata-only Resume ignored an unsafe team config\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'unsafe metadata-only team' \
+  "$SCRIPT" resume --detach "$empty_id"
 [ ! -s "$FAKE_CLAUDE_ARGS_FILE" ]
 ! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
 rm -rf "$unsafe_team_dir"
@@ -1618,10 +1609,8 @@ blank_invalid_json="$("$SCRIPT" claude list --json | \
   "$STATE_HELPER" meta get /dev/stdin health_reason)" = finished ]
 reset_fake_claude_ready
 : >"$FAKE_CLAUDE_ARGS_FILE"
-if "$SCRIPT" resume --detach "$empty_id"; then
-  printf 'Resume treated a present invalid transcript as metadata-only\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'invalid transcript as metadata-only' \
+  "$SCRIPT" resume --detach "$empty_id"
 [ ! -s "$FAKE_CLAUDE_ARGS_FILE" ]
 ! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
 
@@ -1638,10 +1627,8 @@ rm -f \
   "$DETACH_CLAUDE_STATE_ROOT/sessions/$empty_session/checkpoint/transcript.jsonl"
 reset_fake_claude_ready
 : >"$FAKE_CLAUDE_ARGS_FILE"
-if "$SCRIPT" resume --detach "$empty_id"; then
-  printf 'Resume started Claude from a present invalid transcript\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'invalid bound transcript' \
+  "$SCRIPT" resume --detach "$empty_id"
 [ ! -s "$FAKE_CLAUDE_ARGS_FILE" ]
 ! tmux -L "$SOCKET" has-session -t "=$empty_session" 2>/dev/null
 "$SCRIPT" claude delete --force "$empty_label"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -101,6 +101,20 @@ run_codex() {
   "$SCRIPT" codex "$@"
 }
 
+expect_cli_refusal() {
+  local label="$1"
+  shift
+  local stdout_file="$TMP_ROOT/expected-refusal.stdout"
+  local stderr_file="$TMP_ROOT/expected-refusal.stderr"
+  if "$@" >"$stdout_file" 2>"$stderr_file"; then
+    printf 'expected CLI refusal succeeded: %s\n' "$label" >&2
+    cat "$stderr_file" >&2
+    return 1
+  fi
+  printf 'expected CLI refusal: %s\n' "$label" >&2
+  return 0
+}
+
 # Mirrors blend_session_color in detach-core so the tint contract is pinned
 # independently of the implementation.
 expected_tint() {
@@ -139,6 +153,9 @@ preserve_failure_diagnostics() {
   find "$TMP_ROOT" -maxdepth 3 -type f -print 2>/dev/null | \
     sed "s#^$TMP_ROOT#TMP_ROOT#" | LC_ALL=C sort >"$ARTIFACT_DIR/file-inventory.txt"
   chmod 0600 "$ARTIFACT_DIR/file-inventory.txt"
+  if [ -n "$FAILURE_COMMAND" ]; then
+    printf 'Codex test failed command: %s\n' "$FAILURE_COMMAND" >&2
+  fi
   [ -z "$FAILURE_LINE" ] || printf 'Codex test failed at line %s\n' "$FAILURE_LINE" >&2
   printf 'Codex diagnostics preserved at %s\n' "$ARTIFACT_DIR" >&2
 }
@@ -791,11 +808,9 @@ grep -F 'requires an explicit start, resume, or recover command' "$TMP_ROOT/inva
   printf '%s\n' "$delete_source" | \
     grep -F 'publish_session_event' >/dev/null
 
-if FAKE_POWER_STATE=unavailable run_codex --name power-preflight --detach -- \
-  'must not start without power protection' >/dev/null 2>&1; then
-  printf 'start unexpectedly passed an unavailable power preflight\n' >&2
-  exit 1
-fi
+FAKE_POWER_STATE=unavailable expect_cli_refusal 'start without power protection' \
+  run_codex --name power-preflight --detach -- \
+  'must not start without power protection'
 ! tmux -L "$SOCKET" has-session -t '=detach-codex-power-preflight' 2>/dev/null
 
 readiness_output=""
@@ -820,17 +835,13 @@ if grep -F 'tmux_environment_args >' "$ROOT/bin/detach-core" >/dev/null; then
   printf 'runtime still writes tmux environment arguments to disk\n' >&2
   exit 1
 fi
-if FAKE_POWER_STATE=low_battery run_codex --name power-preflight --detach -- \
-  'must not start at low battery' >/dev/null 2>&1; then
-  printf 'start unexpectedly passed the low-battery power preflight\n' >&2
-  exit 1
-fi
+FAKE_POWER_STATE=low_battery expect_cli_refusal 'start at low battery' \
+  run_codex --name power-preflight --detach -- \
+  'must not start at low battery'
 ! tmux -L "$SOCKET" has-session -t '=detach-codex-power-preflight' 2>/dev/null
-if FAKE_POWER_STATE=temperature run_codex --name power-preflight --detach -- \
-  'must not start during thermal safety' >/dev/null 2>&1; then
-  printf 'start unexpectedly passed the temperature power preflight\n' >&2
-  exit 1
-fi
+FAKE_POWER_STATE=temperature expect_cli_refusal 'start during thermal safety' \
+  run_codex --name power-preflight --detach -- \
+  'must not start during thermal safety'
 ! tmux -L "$SOCKET" has-session -t '=detach-codex-power-preflight' 2>/dev/null
 
 # A tmux server keeps the cwd from which it was first daemonized. Simulate an
@@ -1890,10 +1901,8 @@ cp -p "$resume_rollout" "$live_rollout_copy"
 # the missing checkpoint as proof that the provider data is usable.
 rm -f "$checkpoint/rollout.jsonl"
 printf '{damaged rollout\n' >"$resume_rollout"
-if run_codex recover --detach integration; then
-  printf 'Codex Recover accepted an invalid live rollout without a checkpoint\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'invalid live rollout without checkpoint' \
+  run_codex recover --detach integration
 ! tmux -L "$SOCKET" has-session -t "=$SESSION" 2>/dev/null
 cp -p "$live_rollout_copy" "$resume_rollout"
 cp -p "$resume_checkpoint_copy" "$checkpoint/rollout.jsonl"
@@ -2054,10 +2063,8 @@ fresh_lifecycle_id="$("$STATE_HELPER" meta get "$meta" lifecycle_id)"
 [ -n "$fresh_lifecycle_id" ]
 [ "$fresh_lifecycle_id" != "$previous_lifecycle_id" ]
 [ "$fresh_lifecycle_id" != "$fresh_run_token" ]
-if run_codex --name integration --detach -- 'must not replace a running task'; then
-  printf 'new default start unexpectedly replaced a running task\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'start over running task' \
+  run_codex --name integration --detach -- 'must not replace a running task'
 [ "$("$STATE_HELPER" meta get "$meta" run_token)" = "$fresh_run_token" ]
 run_codex stop integration
 
@@ -2556,10 +2563,8 @@ missing_args_json="$(run_codex list --json | \
 [ "$(printf '%s' "$missing_args_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
 printf '%s' "$missing_args_json" | grep -F '"health_actions":["delete"]' >/dev/null
-if run_codex recover --detach integration >/dev/null 2>&1; then
-  printf 'Codex Recover accepted a missing saved-options file\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'missing saved-options file' \
+  run_codex recover --detach integration
 grep -Fx '{damaged rollout' "$expected_rollout" >/dev/null
 cmp -s "$missing_args_meta_copy" "$meta"
 mv "$missing_args_copy" "$resume_args_file"
@@ -2572,10 +2577,8 @@ torn_args_json="$(run_codex list --json | \
 [ "$(printf '%s' "$torn_args_json" | \
   "$STATE_HELPER" meta get /dev/stdin effective_status)" = orphaned ]
 printf '%s' "$torn_args_json" | grep -F '"health_actions":["delete"]' >/dev/null
-if run_codex recover --detach integration >/dev/null 2>&1; then
-  printf 'Codex Recover accepted a torn saved-options file\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'torn saved-options file' \
+  run_codex recover --detach integration
 grep -Fx '{damaged rollout' "$expected_rollout" >/dev/null
 cmp -s "$missing_args_meta_copy" "$meta"
 mv "$valid_args_copy" "$resume_args_file"
@@ -2611,10 +2614,8 @@ launch_gap_json="$(run_codex list --json | \
 [ "$(printf '%s' "$launch_gap_json" | \
   "$STATE_HELPER" meta get /dev/stdin health_reason)" = runtime_quiescence_unproven ]
 printf '%s' "$launch_gap_json" | grep -F '"health_actions":[]' >/dev/null
-if run_codex recover --detach integration >/dev/null 2>&1; then
-  printf 'Codex Recover accepted a launch gap without provider identity\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'launch gap without provider identity' \
+  run_codex recover --detach integration
 [ -f "$launch_gap_ready" ]
 diff -qr "$launch_gap_checkpoint_copy" "$checkpoint" >/dev/null
 rm -f "$launch_gap_ready"
@@ -2646,14 +2647,10 @@ prelaunch_unknown_json="$(run_codex list --json | \
 [ "$(printf '%s' "$prelaunch_unknown_json" | \
   "$STATE_HELPER" meta get /dev/stdin health_reason)" = runtime_quiescence_unproven ]
 printf '%s' "$prelaunch_unknown_json" | grep -F '"health_actions":[]' >/dev/null
-if run_codex recover --detach integration >/dev/null 2>&1; then
-  printf 'Codex Recover inferred shutdown from missing launch artifacts\n' >&2
-  exit 1
-fi
-if run_codex delete --force integration >/dev/null 2>&1; then
-  printf 'Codex Delete inferred shutdown from missing launch artifacts\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'recover missing launch artifacts' \
+  run_codex recover --detach integration
+expect_cli_refusal 'delete missing launch artifacts' \
+  run_codex delete --force integration
 [ -z "$("$STATE_HELPER" meta get "$meta" \
   runtime_shutdown_observed_at 2>/dev/null || true)" ]
 cmp -s "$prelaunch_unknown_meta_copy" "$meta"
@@ -2768,16 +2765,10 @@ for ready_typed_case in preserve ready shutdown; do
   [ "$(printf '%s' "$ready_typed_json" | \
     "$STATE_HELPER" meta get /dev/stdin effective_status)" = corrupt ]
   printf '%s' "$ready_typed_json" | grep -F '"health_actions":[]' >/dev/null
-  if run_codex recover --detach "$ready_name" >/dev/null 2>&1; then
-    printf 'Codex Recover accepted mistyped %s metadata\n' \
-      "$ready_typed_case" >&2
-    exit 1
-  fi
-  if run_codex delete --force "$ready_name" >/dev/null 2>&1; then
-    printf 'Codex Delete accepted mistyped %s metadata\n' \
-      "$ready_typed_case" >&2
-    exit 1
-  fi
+  expect_cli_refusal "mistyped $ready_typed_case recover" \
+    run_codex recover --detach "$ready_name"
+  expect_cli_refusal "mistyped $ready_typed_case delete" \
+    run_codex delete --force "$ready_name"
   diff -qr "$ready_typed_checkpoint_copy" "$ready_checkpoint" >/dev/null
   cp -p "$ready_typed_meta_copy" "$ready_meta"
 done
@@ -3222,10 +3213,8 @@ if "$DETACH" storage cleanup --dry-run --json --session "$SESSION" >/dev/null 2>
   printf 'storage cleanup unexpectedly planned a running session\n' >&2
   exit 1
 fi
-if run_codex delete --force integration; then
-  printf 'delete unexpectedly removed a running session\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'delete running session' \
+  run_codex delete --force integration
 tmux -L "$SOCKET" has-session -t "=$SESSION"
 run_codex stop integration
 storage_report="$("$DETACH" storage --json)"
@@ -3774,26 +3763,18 @@ worker_crash_json="$(run_codex list --json | \
   runtime_process_without_tmux ]
 [ "$(printf '%s' "$worker_crash_json" | "$STATE_HELPER" meta get /dev/stdin cleanup_eligible)" = false ]
 printf '%s' "$worker_crash_json" | grep -F '"health_actions":[]' >/dev/null
-if run_codex stop "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'stop unexpectedly changed state while a provider survived its worker\n' >&2
-  exit 1
-fi
-if run_codex recover --detach "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'recover unexpectedly started over a surviving provider\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'stop over surviving provider' \
+  run_codex stop "$worker_crash_name"
+expect_cli_refusal 'recover over surviving provider' \
+  run_codex recover --detach "$worker_crash_name"
 tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
 [ "$(tmux -L "$SOCKET" display-message -p \
   -t "$worker_crash_pane" '#{pane_dead}')" = "1" ]
-if run_codex delete --force "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'delete unexpectedly removed state for a surviving provider\n' >&2
-  exit 1
-fi
-if run_codex --name "$worker_crash_name" --detach -- \
-    'must not start over a surviving provider' >/dev/null 2>&1; then
-  printf 'start unexpectedly replaced state for a surviving provider\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'delete surviving provider' \
+  run_codex delete --force "$worker_crash_name"
+expect_cli_refusal 'start over surviving provider' \
+  run_codex --name "$worker_crash_name" --detach -- \
+  'must not start over a surviving provider'
 kill -0 "$worker_crash_provider_pid"
 ! "$DETACH" reconcile --dry-run --json | grep -F "$worker_crash_session" >/dev/null
 ! "$DETACH" cleanup --dry-run --json | grep -F "$worker_crash_session" >/dev/null
@@ -3825,14 +3806,10 @@ worker_crash_fallback_json="$(run_codex list --json | \
 [ "$(printf '%s' "$worker_crash_fallback_json" | \
   "$STATE_HELPER" meta get /dev/stdin reconcile_action)" = none ]
 printf '%s' "$worker_crash_fallback_json" | grep -F '"health_actions":[]' >/dev/null
-if run_codex recover --detach "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'recover used fallback checkpoint metadata to remove retained tmux\n' >&2
-  exit 1
-fi
-if run_codex delete --force "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'delete used fallback checkpoint metadata to remove retained tmux\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'recover via fallback checkpoint metadata' \
+  run_codex recover --detach "$worker_crash_name"
+expect_cli_refusal 'delete via fallback checkpoint metadata' \
+  run_codex delete --force "$worker_crash_name"
 tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
 diff -qr "$worker_crash_checkpoint_copy" \
   "$(dirname "$worker_crash_checkpoint")" >/dev/null
@@ -3847,24 +3824,16 @@ worker_crash_mismatch_json="$(run_codex list --json | \
 [ "$(printf '%s' "$worker_crash_mismatch_json" | \
   "$STATE_HELPER" meta get /dev/stdin health_reason)" = run_token_mismatch ]
 printf '%s' "$worker_crash_mismatch_json" | grep -F '"health_actions":[]' >/dev/null
-if run_codex recover --detach "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'recover removed a retained tmux run with a mismatched token\n' >&2
-  exit 1
-fi
-if run_codex delete --force "$worker_crash_name" >/dev/null 2>&1; then
-  printf 'delete removed a retained tmux run with a mismatched token\n' >&2
-  exit 1
-fi
-if run_codex --name "$worker_crash_name" --detach -- \
-    'must not replace mismatched retained tmux' >/dev/null 2>&1; then
-  printf 'start replaced a retained tmux run with a mismatched token\n' >&2
-  exit 1
-fi
-if run_codex resume --name "$worker_crash_name" --detach \
-    "$worker_crash_id" >/dev/null 2>&1; then
-  printf 'resume replaced a retained tmux run with a mismatched token\n' >&2
-  exit 1
-fi
+expect_cli_refusal 'recover mismatched retained tmux' \
+  run_codex recover --detach "$worker_crash_name"
+expect_cli_refusal 'delete mismatched retained tmux' \
+  run_codex delete --force "$worker_crash_name"
+expect_cli_refusal 'start over mismatched retained tmux' \
+  run_codex --name "$worker_crash_name" --detach -- \
+  'must not replace mismatched retained tmux'
+expect_cli_refusal 'resume mismatched retained tmux' \
+  run_codex resume --name "$worker_crash_name" --detach \
+  "$worker_crash_id"
 tmux -L "$SOCKET" has-session -t "=$worker_crash_session"
 cmp -s "$worker_crash_meta_copy" "$worker_crash_meta"
 diff -qr "$worker_crash_checkpoint_copy" \


### PR DESCRIPTION
## Contract delta
- No contract change: this is a test-harness and diagnostic-log change only. User-visible CLI `die` text is unchanged.
- MODIFIED `docs/testing.md`: on a suite failure, the suite log prints the failing command, then the line, then the artifact path. Expected public-CLI refusals do not print unmarked `die` text on the suite log.

## Durable decisions
- Duplicate `expect_cli_refusal` in both provider suites. Do not add a shared shell library.
- Capture expected-refusal stdout and stderr off the suite log, and print a labeled line. A Recover, Resume, or start that must succeed still prints its real `die` text.
- On suite failure, print the recorded command on stderr before the line and the artifact path. Keep writing `failure-command.txt`.
- Leave Swift XCTest runner verbosity unchanged.

## Acceptance evidence
- `scripts/quality-gate --plan --explain` selected `static`, `gate-contract`, `codex`, and `claude`.
- `tests/docs-contract.sh` passed.
- `scripts/quality-gate --stage static` passed as a local diagnostic.
- A forced later bootstrap failure printed `Claude test failed command:` on stderr before the line and the artifact path, and wrote `failure-command.txt`.
- A green `DETACH_CLAUDE_TEST_PART=recovery-guardrails` run was not completed here: the debug `detach-state` is built for macOS 26, and the packaged helper is too old for current metadata arguments.
- Hosted `quality-gates` was not run.

Closes #249