### PR TITLE
Download signed updates in the background and install them on quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,10 @@ does not roll source code back. It does not replace version control or backups.
 Detach.app handles updates. Settings shows installation health, CLI repair,
 helper status, and removal of Detach-owned components.
 
+Settings → Updates can check for a signed update in the background. When
+automatic download is on, Sparkle downloads that update and installs the app
+when Detach quits. Authorization can still require confirmation.
+
 Detach changes the active CLI only after it validates a complete payload. If an
 update fails, the active CLI does not change. A normal app update does not
 interrupt live sessions. If a working session holds a power lease, Detach keeps

--- a/app/Resources/en.lproj/Localizable.strings
+++ b/app/Resources/en.lproj/Localizable.strings
@@ -71,6 +71,7 @@
 "Automatic updates are unavailable: %@." = "Automatic updates are unavailable: %@.";
 "Automatic updates are unavailable: %@. This is expected for local development." = "Automatic updates are unavailable: %@. This is expected for local development.";
 "Automatically check for updates" = "Automatically check for updates";
+"Automatically download updates" = "Automatically download updates";
 "Available: Claude" = "Available: Claude";
 "Available: Codex" = "Available: Codex";
 "Available: Codex and Claude" = "Available: Codex and Claude";
@@ -177,6 +178,7 @@
 "Setting Up Detach…" = "Setting Up Detach…";
 "Something went wrong" = "Something went wrong";
 "Sparkle checks in the background on its own schedule." = "Sparkle checks in the background on its own schedule.";
+"Sparkle downloads a signed update and installs the app when Detach quits." = "Sparkle downloads a signed update and installs the app when Detach quits.";
 "Start a managed run in Detach." = "Start a managed run in Detach.";
 "Start Codex or Claude in Detach" = "Start Codex or Claude in Detach";
 "Start" = "Start";

--- a/app/Resources/ru.lproj/Localizable.strings
+++ b/app/Resources/ru.lproj/Localizable.strings
@@ -71,6 +71,7 @@
 "Automatic updates are unavailable: %@." = "Автообновления недоступны: %@.";
 "Automatic updates are unavailable: %@. This is expected for local development." = "Автообновления недоступны: %@. Для локальной разработки это нормально.";
 "Automatically check for updates" = "Автоматически проверять обновления";
+"Automatically download updates" = "Автоматически скачивать обновления";
 "Available: Claude" = "Доступен: Claude";
 "Available: Codex" = "Доступен: Codex";
 "Available: Codex and Claude" = "Доступны: Codex и Claude";
@@ -177,6 +178,7 @@
 "Setting Up Detach…" = "Настраиваем Detach…";
 "Something went wrong" = "Не получилось";
 "Sparkle checks in the background on its own schedule." = "Проверки выполняет Sparkle в фоне по собственному расписанию.";
+"Sparkle downloads a signed update and installs the app when Detach quits." = "Sparkle скачивает подписанное обновление и устанавливает приложение при выходе из Detach.";
 "Start a managed run in Detach." = "Запустите управляемую сессию в Detach.";
 "Start Codex or Claude in Detach" = "Запустить Codex или Claude в Detach";
 "Start" = "Запустить";

--- a/app/Sources/DetachApp/SettingsView.swift
+++ b/app/Sources/DetachApp/SettingsView.swift
@@ -177,7 +177,7 @@ private extension SettingsDestination {
         case .terminal: 460
         case .notifications: 350
         case .system: 780
-        case .updates: 420
+        case .updates: 500
         }
     }
 }
@@ -1323,6 +1323,14 @@ struct SettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(L10n.string(
                         "Sparkle checks in the background on its own schedule."))
+                        .settingsMessage()
+                    Toggle(L10n.string("Automatically download updates"), isOn: Binding(
+                        get: { updater.automaticallyDownloadsUpdates },
+                        set: { updater.setAutomaticallyDownloadsUpdates($0) }))
+                        .disabled(!updater.canAutomaticallyDownloadUpdates)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(L10n.string(
+                        "Sparkle downloads a signed update and installs the app when Detach quits."))
                         .settingsMessage()
                 } else {
                     Text(L10n.string("Automatic updates are unavailable"))

--- a/app/Sources/DetachApp/UpdaterService.swift
+++ b/app/Sources/DetachApp/UpdaterService.swift
@@ -41,6 +41,7 @@ final class UpdaterService: ObservableObject {
 
     @Published private(set) var canCheckForUpdates = false
     @Published private(set) var automaticallyChecksForUpdates = false
+    @Published private(set) var automaticallyDownloadsUpdates = false
     @Published private(set) var updateErrorMessage: String?
     @Published private(set) var lastCheckFoundNoUpdate = false
 
@@ -79,6 +80,7 @@ final class UpdaterService: ObservableObject {
 
         let updater = updaterController.updater
         automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
 
         updater.publisher(for: \.canCheckForUpdates)
             .sink { [weak self] value in
@@ -89,6 +91,12 @@ final class UpdaterService: ObservableObject {
         updater.publisher(for: \.automaticallyChecksForUpdates)
             .sink { [weak self] value in
                 self?.automaticallyChecksForUpdates = value
+            }
+            .store(in: &cancellables)
+
+        updater.publisher(for: \.automaticallyDownloadsUpdates)
+            .sink { [weak self] value in
+                self?.automaticallyDownloadsUpdates = value
             }
             .store(in: &cancellables)
 
@@ -126,6 +134,36 @@ final class UpdaterService: ObservableObject {
     func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
         guard isAvailable else { return }
         updaterController.updater.automaticallyChecksForUpdates = enabled
+    }
+
+    /// Sparkle consults automatic download only while automatic checks are on.
+    var canAutomaticallyDownloadUpdates: Bool {
+        Self.canAutomaticallyDownloadUpdates(
+            isAvailable: isAvailable,
+            checksEnabled: automaticallyChecksForUpdates)
+    }
+
+    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {
+        guard Self.canChangeAutomaticDownload(
+            enable: enabled,
+            isAvailable: isAvailable,
+            checksEnabled: automaticallyChecksForUpdates) else { return }
+        updaterController.updater.automaticallyDownloadsUpdates = enabled
+    }
+
+    static func canAutomaticallyDownloadUpdates(
+        isAvailable: Bool,
+        checksEnabled: Bool
+    ) -> Bool {
+        isAvailable && checksEnabled
+    }
+
+    static func canChangeAutomaticDownload(
+        enable: Bool,
+        isAvailable: Bool,
+        checksEnabled: Bool
+    ) -> Bool {
+        isAvailable && (!enable || checksEnabled)
     }
 
     private func recordUpdateCycleResult(_ error: Error?) {

--- a/app/Tests/DetachAppTests/UpdaterServiceTests.swift
+++ b/app/Tests/DetachAppTests/UpdaterServiceTests.swift
@@ -17,8 +17,29 @@ final class UpdaterServiceTests: XCTestCase {
 
         service.checkForUpdates()
         service.setAutomaticallyChecksForUpdates(true)
+        service.setAutomaticallyDownloadsUpdates(true)
         XCTAssertFalse(service.canCheckForUpdates)
         XCTAssertFalse(service.automaticallyChecksForUpdates)
+        XCTAssertFalse(service.automaticallyDownloadsUpdates)
+        XCTAssertFalse(service.canAutomaticallyDownloadUpdates)
+    }
+
+    func testAutomaticDownloadRequiresAvailableChecks() {
+        XCTAssertFalse(UpdaterService.canAutomaticallyDownloadUpdates(
+            isAvailable: false, checksEnabled: true))
+        XCTAssertFalse(UpdaterService.canAutomaticallyDownloadUpdates(
+            isAvailable: true, checksEnabled: false))
+        XCTAssertTrue(UpdaterService.canAutomaticallyDownloadUpdates(
+            isAvailable: true, checksEnabled: true))
+
+        XCTAssertFalse(UpdaterService.canChangeAutomaticDownload(
+            enable: true, isAvailable: false, checksEnabled: true))
+        XCTAssertFalse(UpdaterService.canChangeAutomaticDownload(
+            enable: true, isAvailable: true, checksEnabled: false))
+        XCTAssertTrue(UpdaterService.canChangeAutomaticDownload(
+            enable: false, isAvailable: true, checksEnabled: false))
+        XCTAssertTrue(UpdaterService.canChangeAutomaticDownload(
+            enable: true, isAvailable: true, checksEnabled: true))
     }
 
     func testExpectedNonFailureResultsDoNotOfferFallback() {

--- a/app/Tests/DetachKitTests/LocalizationTests.swift
+++ b/app/Tests/DetachKitTests/LocalizationTests.swift
@@ -125,6 +125,8 @@ final class LocalizationTests: XCTestCase {
             "Detach cannot update from this app location. Move Detach to /Applications. The active CLI did not change. Then try again.",
             "Detach could not prepare or download the update: %@. The active CLI did not change. Check the network connection and free disk space. Then try again.",
             "Detach rejected or could not install the update: %@. The active CLI did not change. Download the latest DMG. If the CLI does not match the app, open Detach settings, select System, and run Repair.",
+            "Automatically download updates",
+            "Sparkle downloads a signed update and installs the app when Detach quits.",
         ]
 
         for key in keys {

--- a/docs/specs/app-setup.md
+++ b/docs/specs/app-setup.md
@@ -57,9 +57,14 @@ Only ad-hoc builds disable library validation.
 32-byte Ed25519 public key.
 A generated or published appcast must contain exactly one arm64 hardware
 requirement, so Intel clients never see the update.
+Settings → Updates can enable automatic download only while automatic checks
+are on. The default is off. Sparkle then downloads a signed update in the
+background and installs the app when Detach quits. Authorization can still
+require confirmation. Do not set `SUAutomaticallyUpdate` in Info.plist.
 A Sparkle update replaces the app. Bootstrap activates the new
 immutable CLI payload before the watcher and first fresh list start. It does
-not rewrite live-session binaries. Sparkle errors
+not rewrite live-session binaries. Helper replacement stays deferred while a
+working lease exists. Sparkle errors
 for a disk image or App Translocation say to move Detach to
 `/Applications`. Temporary-directory and download errors say to check the
 network and free disk space, then retry. Archive, signature,


### PR DESCRIPTION
## Contract delta

- ADDED `README.md` and `docs/specs/app-setup.md`: Settings → Updates can enable automatic download only while automatic checks are on. Default off. Sparkle then downloads a signed update and installs the app when Detach quits.

## Durable decisions

- Do not set `SUAutomaticallyUpdate` in Info.plist.

## Acceptance evidence

- `tests/docs-contract.sh` passed.
- Hosted `quality-gates` was not run.

Closes #252