### PR TITLE
Add a public SECURITY.md; do not add a security spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ checkpoint can still offer Resume or Recover.
 
 Checkpoints protect provider conversation state, not repository files. Detach
 does not roll source code back. It does not replace version control or backups.
+Report a vulnerability through the [Security policy](SECURITY.md).
 
 ## Repair, update, and uninstall
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security policy
+
+## Supported versions
+
+Only the latest signed GitHub Release is supported. Source builds and ad-hoc
+previews are research targets, not supported products.
+
+## Report a vulnerability
+
+Use GitHub private vulnerability reporting on this repository. Do not open a
+public issue for helper, state, or update bugs.
+
+Include the Detach version or commit, the macOS version, whether the helper is
+registered, and a minimal local repro. Do not attach live checkpoints or
+provider transcripts.
+
+## What we fix
+
+Privilege, ownership, private-state, and update-trust bugs in Detach. The
+owning contracts are `docs/specs/power.md`, `state.md`, `runtime.md`,
+`app-setup.md`, and `release.md`.
+
+Codex CLI, Claude Code, and Apple issues go to those vendors. Attacks that
+already have the console user's signed Detach identity, or that already have
+root, are out of scope.
+
+## Disclosure
+
+We aim to publish a short advisory 90 days after the report, or 7 days after
+a fixed signed release, whichever is first. The advisory names the affected
+versions, the fixed tag, and the user action. It does not include exploit
+steps.

--- a/quality/generated/policy.json
+++ b/quality/generated/policy.json
@@ -2015,6 +2015,13 @@
       "test_domain": "docs"
     },
     {
+      "pattern": "SECURITY.md",
+      "priority": 900,
+      "release_domain": "safe",
+      "spec": "docs/specs/documentation.md",
+      "test_domain": "docs"
+    },
+    {
       "pattern": ".gitignore",
       "priority": 900,
       "release_domain": "safe",
@@ -2343,6 +2350,7 @@
         "AGENTS.md",
         "CLAUDE.md",
         "README.md",
+        "SECURITY.md",
         "app/.gitignore",
         "docs/assets/*",
         "docs/quality-gates.md",

--- a/quality/generated/spec-traceability.md
+++ b/quality/generated/spec-traceability.md
@@ -25,6 +25,7 @@ It lists current specification ownership and verification links.
 - `AGENTS.md`
 - `CLAUDE.md`
 - `README.md`
+- `SECURITY.md`
 - `app/.gitignore`
 - `docs/assets/*`
 - `docs/quality-gates.md`

--- a/quality/policy.tsv
+++ b/quality/policy.tsv
@@ -246,6 +246,7 @@ route	500	tests/*	unknown	safe	docs/specs/documentation.md
 route	900	VERSION	release-tool	safe	docs/specs/release.md
 route	900	BUILD	release-tool	safe	docs/specs/release.md
 route	900	README.md	docs	safe	docs/specs/documentation.md
+route	900	SECURITY.md	docs	safe	docs/specs/documentation.md
 route	900	.gitignore	metadata	safe	docs/specs/documentation.md
 route	900	.gitattributes	metadata	safe	docs/specs/documentation.md
 route	800	.github/*	unknown	safe	docs/specs/documentation.md

--- a/tests/docs-contract.sh
+++ b/tests/docs-contract.sh
@@ -54,6 +54,7 @@ required=(
   docs/quality-gates.md
   docs/exec-plan-template.md
   .github/pull_request_template.md
+  SECURITY.md
 )
 for file in "${required[@]}"; do
   [ -f "$ROOT/$file" ] || fail "missing $file"


### PR DESCRIPTION
## Contract delta
- ADDED `SECURITY.md`: the owner supports the latest signed release; suspected security vulnerabilities use GitHub private vulnerability reporting; ordinary helper, state, and update bugs stay public issues; the owner disclosure clock is 90 days or 7 days after a fixed release.
- ADDED `README.md`: one link to that policy.
- No new file under `docs/specs/`.

## Durable decisions
- Intake for suspected security vulnerabilities is GitHub private reporting only. No public mailbox.
- Ordinary functional bugs in the helper, state, and update subsystems stay on public issues.
- Latest-signed-release support and the 90-day/7-day disclosure clock remain the #251 owner defaults and need an explicit owner accept.
- Helper, state, runtime, and release invariants stay in their owning specs.

## Acceptance evidence
- `tests/docs-contract.sh` passed.
- `scripts/quality-gate --plan --explain` selected `static`.
- `scripts/quality-gate --stage static` passed as a local diagnostic.
- `scripts/quality-policy generate --check` passed.
- Hosted `quality-gates` was not run.
- Origin private vulnerability reporting is still `enabled: false`. This change cannot enable that setting.

Closes #251